### PR TITLE
feat: add code quality and lefthook setup

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,104 @@
+version: "2"
+run:
+  timeout: 5m
+  modules-download-mode: readonly
+linters:
+  enable:
+    # Bugs
+    - errcheck
+    - govet
+    - staticcheck
+    - nilerr
+    # Style
+    - revive
+    - misspell
+    # Performance
+    - prealloc
+    - unconvert
+    # Security
+    - gosec
+    # Error handling
+    - errorlint
+    - wrapcheck
+    # Maintenance
+    - unparam
+    - gocritic
+    - nolintlint
+  exclusions:
+    # Default exclusion presets
+    presets:
+      - common-false-positives
+    # Path exclusions
+    paths:
+      # Generated protobuf code — not hand-written, don't lint
+      - gen/
+    rules:
+      # Test files can have longer functions and more complexity
+      - path: '_test\.go'
+        linters:
+          - gocritic
+          - wrapcheck
+          - errcheck
+      # Main package doesn't need to wrap errors
+      - path: cmd/
+        linters:
+          - wrapcheck
+  settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment # Optimization hint, not a bug - can be addressed later
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: if-return
+        - name: increment-decrement
+        - name: var-naming
+        - name: var-declaration
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+        - name: empty-block
+        - name: superfluous-else
+        - name: unused-parameter
+        - name: unreachable-code
+        - name: redefines-builtin-id
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - style
+        - performance
+    gosec:
+      excludes:
+        - G104 # Audit errors not checked (handled by errcheck)
+    wrapcheck:
+      ignore-sigs:
+        - .Errorf(
+        - errors.New(
+        - errors.Unwrap(
+        - errors.Join(
+        - .Wrap(
+        - .Wrapf(
+        - .WithMessage(
+        - .WithMessagef(
+        - .WithStack(
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,38 @@
+# rumdl configuration
+# https://github.com/rvben/rumdl
+
+[global]
+# Disabled rules
+disable = [
+  "MD013", # Line length - disabled for prose
+  "MD033", # Inline HTML (badges, complex formatting)
+  "MD034", # Bare URLs
+  "MD036", # Emphasis as pseudo-headings
+  "MD044", # Proper names capitalization (too noisy)
+  "MD057", # Relative link validation (TODO: re-enable after fixing broken links)
+  "MD060", # Table column alignment (too strict for complex tables)
+]
+
+exclude = [
+  ".git",
+  ".worktrees",
+  ".beads",
+  ".claude",
+  ".serena",
+  "dist",
+  "node_modules",
+  "vendor",
+]
+
+respect-gitignore = true
+
+# MD024: siblings_only=true is rumdl's default — matches our needs
+
+[MD026]
+punctuation = ".,;:!。，；：！"
+
+[MD046]
+style = "fenced"
+
+[MD048]
+style = "backtick"

--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,0 +1,2 @@
+SPDX-License-Identifier: MIT
+Copyright 2026 Sean Brandt

--- a/cog.toml
+++ b/cog.toml
@@ -1,0 +1,23 @@
+# Cocogitto configuration
+# https://docs.cocogitto.io/
+#
+# NOTE: Cocogitto is used ONLY for commit message validation.
+# Release-please handles versioning, changelog, and releases.
+
+[settings]
+# Disable version tagging (release-please handles this)
+ignore_merge_commits = true
+
+# Allowed commit types for validation
+[commit_types]
+feat = {}
+fix = {}
+docs = {}
+style = {}
+refactor = {}
+perf = {}
+test = {}
+build = {}
+ci = {}
+chore = {}
+revert = {}

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://dprint.dev/schemas/v0.json",
+  "incremental": true,
+  "json": {
+    "indentWidth": 2,
+    "useTabs": false
+  },
+  "toml": {
+    "indentWidth": 2
+  },
+  "includes": [
+    "**/*.json",
+    "**/*.toml"
+  ],
+  "excludes": [
+    "**/node_modules",
+    "**/vendor",
+    "**/dist",
+    "**/.git",
+    "**/.beads"
+  ],
+  "plugins": [
+    "https://plugins.dprint.dev/json-0.19.3.wasm",
+    "https://plugins.dprint.dev/toml-0.6.3.wasm"
+  ]
+}

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,0 +1,61 @@
+# Lefthook configuration
+# https://github.com/evilmartians/lefthook
+#
+# Prerequisites:
+# - rumdl: Install via `cargo install rumdl`, Homebrew (`brew install rumdl`), or download from GitHub Releases
+#
+# set because we chain through beads (bd) in spots
+no_auto_install: true
+pre-commit:
+  parallel: true
+  exclude:
+    - ".worktrees/**"
+  commands:
+    license-headers:
+      glob: "*.{go,sh,py,proto}"
+      exclude: "*.pb.go"
+      run: |
+        set -euo pipefail
+
+        # Verify LICENSE_HEADER exists
+        if [[ ! -f LICENSE_HEADER ]]; then
+          echo "ERROR: LICENSE_HEADER file not found in repository root"
+          echo "Please ensure LICENSE_HEADER exists before committing"
+          exit 1
+        fi
+
+        # Install addlicense if needed
+        if ! command -v addlicense >/dev/null 2>&1; then
+          echo "Installing addlicense..."
+          if ! go install github.com/google/addlicense@latest; then
+            echo "ERROR: Failed to install addlicense"
+            echo "Please run: go install github.com/google/addlicense@latest"
+            exit 1
+          fi
+        fi
+
+        addlicense -f LICENSE_HEADER {staged_files}
+      stage_fixed: true
+    lint-go:
+      glob: "*.go"
+      run: golangci-lint run --new-from-rev=HEAD~1
+      stage_fixed: true
+    lint-markdown:
+      glob: "*.md"
+      run: rumdl check {staged_files}
+    fmt-markdown:
+      glob: "*.md"
+      run: rumdl fmt {staged_files}
+      stage_fixed: true
+    lint-yaml:
+      glob: "*.{yaml,yml}"
+      run: yamlfmt -lint {staged_files}
+    lint-actions:
+      glob: ".github/workflows/*.{yaml,yml}"
+      run: actionlint {staged_files}
+    format-check:
+      run: dprint check
+commit-msg:
+  commands:
+    conventional-commit:
+      run: cog verify --file {1}


### PR DESCRIPTION
## Summary

- Add lefthook pre-commit hooks (go lint, markdown lint/fmt, yaml lint, license headers, dprint format check, actionlint)
- Add lefthook commit-msg hook with cocogitto conventional commit validation
- Add golangci-lint config (12+ linters, gen/ excluded for protobuf)
- Add rumdl, dprint, and MIT license header configs

Duplicated from holomush/holomush and adapted for specgraph (MIT license, gen/ exclusions, no site/ or plugins/ paths).

## Test plan

- [x] `lefthook install` syncs hooks
- [x] `yamlfmt -lint` passes on all YAML files
- [x] `dprint check` passes
- [x] `cog verify` validates conventional commit messages
- [ ] `golangci-lint run` passes on Go source (manual verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)