### PR TITLE
feat(cli): add report-progress, report-blocker, report-completion commands

### DIFF
--- a/cmd/specgraph/report.go
+++ b/cmd/specgraph/report.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	"github.com/spf13/cobra"
+)
+
+const reportTimeout = 30 * time.Second
+
+// --- report-progress ---
+
+var reportProgressCmd = &cobra.Command{
+	Use:   "report-progress <slug>",
+	Short: "Report execution progress for a claimed spec",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runReportProgress,
+}
+
+var (
+	reportProgressAgent   string
+	reportProgressMessage string
+)
+
+// --- report-blocker ---
+
+var reportBlockerCmd = &cobra.Command{
+	Use:   "report-blocker <slug>",
+	Short: "Report a blocker on a claimed spec",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runReportBlocker,
+}
+
+var (
+	reportBlockerAgent       string
+	reportBlockerDescription string
+)
+
+// --- report-completion ---
+
+var reportCompletionCmd = &cobra.Command{
+	Use:   "report-completion <slug>",
+	Short: "Report completion of a claimed spec (transitions to done)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runReportCompletion,
+}
+
+var reportCompletionAgent string
+
+func init() {
+	reportProgressCmd.Flags().StringVar(&reportProgressAgent, "agent", "", "agent identifier (required)")
+	reportProgressCmd.Flags().StringVar(&reportProgressMessage, "message", "", "progress message (required)")
+	cobra.CheckErr(reportProgressCmd.MarkFlagRequired("agent"))
+	cobra.CheckErr(reportProgressCmd.MarkFlagRequired("message"))
+	rootCmd.AddCommand(reportProgressCmd)
+
+	reportBlockerCmd.Flags().StringVar(&reportBlockerAgent, "agent", "", "agent identifier (required)")
+	reportBlockerCmd.Flags().StringVar(&reportBlockerDescription, "description", "", "blocker description (required)")
+	cobra.CheckErr(reportBlockerCmd.MarkFlagRequired("agent"))
+	cobra.CheckErr(reportBlockerCmd.MarkFlagRequired("description"))
+	rootCmd.AddCommand(reportBlockerCmd)
+
+	reportCompletionCmd.Flags().StringVar(&reportCompletionAgent, "agent", "", "agent identifier (required)")
+	cobra.CheckErr(reportCompletionCmd.MarkFlagRequired("agent"))
+	rootCmd.AddCommand(reportCompletionCmd)
+}
+
+func runReportProgress(cmd *cobra.Command, args []string) error {
+	client, err := executionClient()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(cmd.Context(), reportTimeout)
+	defer cancel()
+	_, err = client.ReportProgress(ctx, connect.NewRequest(&specv1.ReportProgressRequest{
+		Slug:    args[0],
+		Agent:   reportProgressAgent,
+		Message: reportProgressMessage,
+	}))
+	if err != nil {
+		return fmt.Errorf("report progress: %w", err)
+	}
+	fmt.Printf("Progress reported: %s\n", args[0])
+	return nil
+}
+
+func runReportBlocker(cmd *cobra.Command, args []string) error {
+	client, err := executionClient()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(cmd.Context(), reportTimeout)
+	defer cancel()
+	_, err = client.ReportBlocker(ctx, connect.NewRequest(&specv1.ReportBlockerRequest{
+		Slug:        args[0],
+		Agent:       reportBlockerAgent,
+		Description: reportBlockerDescription,
+	}))
+	if err != nil {
+		return fmt.Errorf("report blocker: %w", err)
+	}
+	fmt.Printf("Blocker reported: %s\n", args[0])
+	return nil
+}
+
+func runReportCompletion(cmd *cobra.Command, args []string) error {
+	client, err := executionClient()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(cmd.Context(), reportTimeout)
+	defer cancel()
+	resp, err := client.ReportCompletion(ctx, connect.NewRequest(&specv1.ReportCompletionRequest{
+		Slug:  args[0],
+		Agent: reportCompletionAgent,
+	}))
+	if err != nil {
+		return fmt.Errorf("report completion: %w", err)
+	}
+	fmt.Printf("Completion reported: %s → %s\n", args[0], resp.Msg.NewStage)
+	return nil
+}

--- a/e2e/cli/pipeline_test.go
+++ b/e2e/cli/pipeline_test.go
@@ -69,17 +69,36 @@ var _ = Describe("CLI Pipeline", Ordered, func() {
 		Expect(result.Stdout).NotTo(BeEmpty())
 	})
 
-	It("shows execution events (empty)", func() {
-		result := cli.RunInDir(workDir, "progress", slug)
+	It("reports progress", func() {
+		result := cli.RunInDir(workDir, "report-progress", slug, "--agent", "cli-e2e-agent", "--message", "implementing slice 1")
 		Expect(result.ExitCode).To(Equal(0), "stderr: %s", result.Stderr)
-		// No events have been written via CLI, so expect empty or "No execution events found."
-		Expect(result.Stdout).To(ContainSubstring("No execution events found"))
+		Expect(result.Stdout).To(ContainSubstring("Progress reported"))
 	})
 
-	It("shows the spec with correct stage", func() {
+	It("reports a blocker", func() {
+		result := cli.RunInDir(workDir, "report-blocker", slug, "--agent", "cli-e2e-agent", "--description", "waiting on dependency")
+		Expect(result.ExitCode).To(Equal(0), "stderr: %s", result.Stderr)
+		Expect(result.Stdout).To(ContainSubstring("Blocker reported"))
+	})
+
+	It("reports completion", func() {
+		result := cli.RunInDir(workDir, "report-completion", slug, "--agent", "cli-e2e-agent")
+		Expect(result.ExitCode).To(Equal(0), "stderr: %s", result.Stderr)
+		Expect(result.Stdout).To(ContainSubstring("done"))
+	})
+
+	It("shows execution events", func() {
+		result := cli.RunInDir(workDir, "progress", slug)
+		Expect(result.ExitCode).To(Equal(0), "stderr: %s", result.Stderr)
+		Expect(result.Stdout).To(ContainSubstring("EXECUTION_EVENT_TYPE_PROGRESS"))
+		Expect(result.Stdout).To(ContainSubstring("EXECUTION_EVENT_TYPE_BLOCKER"))
+		Expect(result.Stdout).To(ContainSubstring("EXECUTION_EVENT_TYPE_COMPLETION"))
+	})
+
+	It("shows the spec is done", func() {
 		result := cli.RunInDir(workDir, "show", slug)
 		Expect(result.ExitCode).To(Equal(0), "stderr: %s", result.Stderr)
 		Expect(result.Stdout).To(ContainSubstring(slug))
-		Expect(result.Stdout).To(ContainSubstring("approved"))
+		Expect(result.Stdout).To(ContainSubstring("done"))
 	})
 })


### PR DESCRIPTION
## Summary

Adds three CLI commands that close the execution event reporting gap:

- `specgraph report-progress <slug> --agent <agent> --message <msg>`
- `specgraph report-blocker <slug> --agent <agent> --description <desc>`
- `specgraph report-completion <slug> --agent <agent>` (transitions to done, releases claim)

These wrap the existing `ReportProgress`, `ReportBlocker`, and `ReportCompletion` RPCs. Previously only available via ConnectRPC — now accessible from CLI and agent skills.

## Test plan

- [x] `task check` passes
- [ ] CI green
- [ ] Manual: `specgraph report-progress <slug> --agent test --message "working"`
- [ ] Manual: `specgraph report-completion <slug> --agent test` shows `→ done`

Closes spgr-7u6. Unblocks spgr-pjz (CLI E2E tests for execution events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three CLI commands to report progress, blockers, and completion for a spec; each accepts a spec slug and required flags, sends the report, and prints a confirmation on success.

* **Tests**
  * Added/updated end-to-end CLI tests to verify progress/blocker/completion reporting and adjusted final status expectation to "done".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->