### PR TITLE
test(integration): add DISTINCT regression test for GetExecutionEvents

### DIFF
--- a/internal/storage/memgraph/execution_test.go
+++ b/internal/storage/memgraph/execution_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/seanb4t/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -147,6 +148,56 @@ func TestExecution(t *testing.T) {
 		// Verify claim was released — reclaiming should succeed.
 		_, err = store.ClaimSpec(ctx, "lifecycle", "agent-2", 10*time.Minute)
 		require.NoError(t, err)
+	})
+
+	t.Run("GetExecutionEvents_DeduplicatesPaths", func(t *testing.T) {
+		// Regression test for DISTINCT fix: GetExecutionEvents must return
+		// each event exactly once even when the graph has multiple paths
+		// from Project to Spec (e.g., duplicate BELONGS_TO edges).
+		// Note: the original duplicates were observed in E2E tests with
+		// multi-project scoping through ProjectMiddleware; injecting a
+		// duplicate edge here is a best-effort reproduction. The DISTINCT
+		// is defensive — if this test passes without it, the protection
+		// is still warranted for the E2E scenario.
+		clearGraph(t, boltURI)
+		ctx := context.Background()
+		store, err := newStore(ctx, boltURI)
+		require.NoError(t, err)
+		defer store.Close(ctx)
+
+		// Set up: create spec, approve, claim, record 2 events.
+		_, err = store.CreateSpec(ctx, "dedup-test", "Dedup test spec", "p1", "medium")
+		require.NoError(t, err)
+		_, err = store.UpdateSpec(ctx, "dedup-test", nil, ptr("approved"), nil, nil, nil)
+		require.NoError(t, err)
+		_, err = store.ClaimSpec(ctx, "dedup-test", "agent-dedup", 15*time.Minute)
+		require.NoError(t, err)
+		require.NoError(t, store.RecordProgress(ctx, "dedup-test", "agent-dedup", "working"))
+		require.NoError(t, store.RecordBlocker(ctx, "dedup-test", "agent-dedup", "stuck"))
+
+		// Inject a duplicate BELONGS_TO edge to create a second path
+		// from Project to Spec — this is the graph topology that caused
+		// GetExecutionEvents to return duplicated rows before DISTINCT was added.
+		driver, dErr := neo4j.NewDriverWithContext(boltURI, neo4j.NoAuth())
+		require.NoError(t, dErr)
+		defer driver.Close(ctx)
+		_, dErr = neo4j.ExecuteQuery(ctx, driver,
+			`MATCH (p:Project {slug: $project}), (s:Spec {slug: "dedup-test"})
+			 CREATE (s)-[:BELONGS_TO]->(p)`,
+			map[string]any{"project": "e2e-test"},
+			neo4j.EagerResultTransformer)
+		require.NoError(t, dErr)
+
+		// Verify: should still return exactly 2 events, not 4.
+		events, evtErr := store.GetExecutionEvents(ctx, "dedup-test", 10)
+		require.NoError(t, evtErr)
+		require.Len(t, events, 2, "DISTINCT should deduplicate events from multiple BELONGS_TO paths")
+
+		idSet := map[string]bool{}
+		for _, e := range events {
+			require.False(t, idSet[e.ID], "duplicate event ID: %s", e.ID)
+			idSet[e.ID] = true
+		}
 	})
 
 	t.Run("GetPrimeData", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds `GetExecutionEvents_DeduplicatesPaths` integration test that:
1. Creates a spec with execution events
2. Injects a duplicate `BELONGS_TO` edge to create multiple graph paths
3. Verifies `GetExecutionEvents` returns each event exactly once

This is a regression test for the `RETURN DISTINCT` fix added in PR #32. The test documents the defensive nature of the fix — the original duplicates were observed in E2E tests with multi-project scoping through ProjectMiddleware.

Closes spgr-xs6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test verifying execution events are deduplicated so each event appears only once even when multiple graph paths exist, ensuring unique event results and preventing duplicate entries in query outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->