### PR TITLE
feat(auth): add authentication and authorization interceptor

### DIFF
--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -12,6 +12,9 @@ import (
 	"syscall"
 	"time"
 
+	"connectrpc.com/connect"
+
+	"github.com/seanb4t/specgraph/internal/auth"
 	"github.com/seanb4t/specgraph/internal/config"
 	"github.com/seanb4t/specgraph/internal/docker"
 	"github.com/seanb4t/specgraph/internal/drift"
@@ -75,21 +78,28 @@ func runServe(_ *cobra.Command, _ []string) error {
 		sweeperCtx, stopSweeper := context.WithCancel(ctx)
 		defer stopSweeper()
 
-		mux := server.NewMux(store)
-		server.RegisterHealthService(mux)
-		server.RegisterDecisionService(mux, store)
-		server.RegisterGraphService(mux, store)
-		server.RegisterClaimService(mux, store)
-		server.RegisterConstitutionService(mux, store)
-		server.RegisterAuthoringService(mux, store)
-		server.RegisterExecutionService(mux, store)
+		authStore, err := auth.NewConfigStore(cfg.Auth)
+		if err != nil {
+			return fmt.Errorf("auth config: %w", err)
+		}
+		interceptor := auth.NewAuthInterceptor(authStore)
+		opts := connect.WithInterceptors(interceptor)
+
+		mux := server.NewMux(store, opts)
+		server.RegisterHealthService(mux, opts)
+		server.RegisterDecisionService(mux, store, opts)
+		server.RegisterGraphService(mux, store, opts)
+		server.RegisterClaimService(mux, store, opts)
+		server.RegisterConstitutionService(mux, store, opts)
+		server.RegisterAuthoringService(mux, store, opts)
+		server.RegisterExecutionService(mux, store, opts)
 		driftEngine := drift.NewEngine(store, nil)
 		lintEngine := linter.NewEngine(store, nil)
-		server.RegisterLifecycleService(mux, store, driftEngine, lintEngine, nil)
+		server.RegisterLifecycleService(mux, store, driftEngine, lintEngine, nil, opts)
 
 		// TODO(slice-7): Project root for inject should come from request context,
 		// not daemon CWD. Pass empty string; inject handler needs rework.
-		syncHandler := server.RegisterSyncService(mux, store, "")
+		syncHandler := server.RegisterSyncService(mux, store, "", opts)
 		runner := syncpkg.NewExecRunner()
 		syncHandler.RegisterAdapter(syncpkg.NewBeadsAdapter(runner))
 		syncHandler.RegisterAdapter(syncpkg.NewGitHubAdapter(runner, ""))

--- a/docs/plans/2026-03-18-auth-interceptor-design.md
+++ b/docs/plans/2026-03-18-auth-interceptor-design.md
@@ -1,0 +1,437 @@
+# Authentication & Authorization Design
+
+**Date:** 2026-03-18
+**Epic:** spgr-5wb (Authentication & Authorization)
+**Status:** Approved
+
+## Overview
+
+Add authentication and authorization to SpecGraph via a single ConnectRPC
+interceptor. Local-first design: when no API keys are configured, the system
+creates an implicit admin identity from the OS user. Adding any API key
+immediately enforces auth on all RPCs except Health.
+
+## Goals
+
+- Single enforcement point for all RPC auth (interceptor, not per-handler)
+- Zero-config local dev experience (implicit OS-user admin identity)
+- API keys as the first auth primitive, transmitted via `Authorization: Bearer`
+- JWT/OIDC-ready: interceptor detects JWT-shaped tokens, rejects with
+  `Unimplemented` until OIDC support is added
+- Fine-grained permissions (`service:action`) with roles as convenience bundles
+- Default-deny: unknown RPCs without permission mappings are rejected
+
+## Non-Goals
+
+- OIDC provider integration (Entra ID, GitHub) — future work (spgr-0az)
+- Memgraph connection auth/TLS — infrastructure concern (spgr-fn3)
+- BeadsAdapter auth semantics — depends on bd/dolt (spgr-sau)
+- Per-project authorization scoping — designed for but not implemented
+- Dynamic API key management (create/revoke at runtime)
+
+## Identity Model
+
+### Identity Type
+
+```go
+type Identity struct {
+    Subject     string          // "local:<os-user>" | "apikey:<key-id>" | future "oidc:<sub>"
+    DisplayName string          // human-friendly name
+    Role        Role            // role name (built-in or custom)
+    Permissions map[string]bool // resolved: "spec:write" → true
+    Source      string          // "local" | "apikey" | future "oidc"
+}
+```
+
+The `Subject` field uses a `source:identifier` namespace to prevent collisions
+between local users, API keys, and future OIDC subjects.
+
+### Roles
+
+Three built-in roles. Custom roles can be defined in config.
+
+| Role | Permissions |
+|------|------------|
+| `reader` | `*:read` |
+| `writer` | `*:read`, `*:write` |
+| `admin` | `*:*` (wildcard — matches any permission) |
+
+The `writer` role explicitly excludes `delete`. `RemoveEdge` is the only RPC
+that currently requires a `delete` permission. `UnclaimSpec` remains a `write`
+operation because claims are transient leases, not persistent data removal.
+State transitions (Abandon, Supersede, Amend) are also `write` operations.
+
+## Permission Model
+
+### Actions
+
+Two common permission actions per service: `read` and `write`. A third action
+`delete` exists only where data is physically removed (not state transitions).
+
+### Wildcard Resolution
+
+Role permission bundles support wildcards. Permission checking algorithm
+(evaluated at request time, not load time):
+
+```text
+func hasPermission(perms map[string]bool, required string) bool:
+    if perms["*:*"]           → true   // full wildcard
+    if perms[required]        → true   // exact match
+    service, action = split(required, ":")
+    if perms[service+":*"]   → true   // service wildcard (e.g., "spec:*")
+    if perms["*:"+action]    → true   // action wildcard (e.g., "*:read")
+    return false
+```
+
+This avoids expanding wildcards into the map (which would require knowing all
+permissions up front). The `Permissions` map stores the raw entries from the
+role definition; the check function handles wildcard matching.
+
+Custom roles MAY use wildcards in their permission lists.
+
+### RPC → Permission Mapping (in code)
+
+Static table mapping each ConnectRPC procedure to its required permission.
+Defined in code because the mapping is a fact about the API, not a deployment
+policy. A missing entry is a bug caught by tests and rejected at runtime.
+
+```text
+# SpecService
+/specgraph.v1.SpecService/GetSpec         → spec:read
+/specgraph.v1.SpecService/ListSpecs       → spec:read
+/specgraph.v1.SpecService/CreateSpec      → spec:write
+/specgraph.v1.SpecService/UpdateSpec      → spec:write
+
+# DecisionService
+/specgraph.v1.DecisionService/GetDecision      → decision:read
+/specgraph.v1.DecisionService/ListDecisions    → decision:read
+/specgraph.v1.DecisionService/CreateDecision   → decision:write
+/specgraph.v1.DecisionService/UpdateDecision   → decision:write
+
+# GraphService
+/specgraph.v1.GraphService/GetDependencies     → graph:read
+/specgraph.v1.GraphService/GetTransitiveDeps   → graph:read
+/specgraph.v1.GraphService/GetImpact           → graph:read
+/specgraph.v1.GraphService/GetReady            → graph:read
+/specgraph.v1.GraphService/GetCriticalPath     → graph:read
+/specgraph.v1.GraphService/ListEdges           → graph:read
+/specgraph.v1.GraphService/AddEdge             → graph:write
+/specgraph.v1.GraphService/RemoveEdge          → graph:delete
+
+# ClaimService
+/specgraph.v1.ClaimService/ClaimSpec           → claim:write
+/specgraph.v1.ClaimService/Heartbeat           → claim:write
+/specgraph.v1.ClaimService/UnclaimSpec         → claim:write
+
+# ConstitutionService
+/specgraph.v1.ConstitutionService/GetConstitution    → constitution:read
+/specgraph.v1.ConstitutionService/CheckViolation     → constitution:read
+/specgraph.v1.ConstitutionService/UpdateConstitution → constitution:write
+/specgraph.v1.ConstitutionService/EmitToolFiles      → constitution:write
+
+# AuthoringService
+/specgraph.v1.AuthoringService/GetPrompts    → authoring:read
+/specgraph.v1.AuthoringService/Spark         → authoring:write
+/specgraph.v1.AuthoringService/Shape         → authoring:write
+/specgraph.v1.AuthoringService/Specify       → authoring:write
+/specgraph.v1.AuthoringService/Decompose     → authoring:write
+/specgraph.v1.AuthoringService/Approve       → authoring:write
+/specgraph.v1.AuthoringService/Amend         → authoring:write
+/specgraph.v1.AuthoringService/Supersede     → authoring:write
+
+# ExecutionService
+/specgraph.v1.ExecutionService/GenerateBundle     → execution:read
+/specgraph.v1.ExecutionService/GetPrime           → execution:read
+/specgraph.v1.ExecutionService/GetExecutionEvents → execution:read
+/specgraph.v1.ExecutionService/ReportProgress     → execution:write
+/specgraph.v1.ExecutionService/ReportBlocker      → execution:write
+/specgraph.v1.ExecutionService/ReportCompletion   → execution:write
+
+# LifecycleService
+/specgraph.v1.LifecycleService/CheckDrift          → lifecycle:read
+/specgraph.v1.LifecycleService/Lint                → lifecycle:read
+/specgraph.v1.LifecycleService/AcknowledgeDrift    → lifecycle:write
+/specgraph.v1.LifecycleService/TransitionAmend     → lifecycle:write
+/specgraph.v1.LifecycleService/TransitionSupersede → lifecycle:write
+/specgraph.v1.LifecycleService/TransitionAbandon   → lifecycle:write
+
+# SyncService
+/specgraph.v1.SyncService/GetSyncStatus   → sync:read
+/specgraph.v1.SyncService/SyncBeads       → sync:write
+/specgraph.v1.SyncService/SyncGitHub      → sync:write
+/specgraph.v1.SyncService/Inject          → sync:write
+```
+
+Note: Lifecycle transitions (Amend, Supersede, Abandon) are `write` operations
+because they change spec state — they do not remove data. Claims (including
+UnclaimSpec) are also `write` — a claim is a transient lease, not persistent
+data. The `delete` action is reserved for actual data removal (RemoveEdge).
+
+### Role → Permission Bundles (in config)
+
+Defined in the config file as operational policy. Operators can create custom
+roles or override defaults per deployment.
+
+```yaml
+auth:
+  roles:
+    ci-readonly:
+      permissions: ["spec:read", "decision:read", "graph:read"]
+    deployer:
+      permissions: ["spec:read", "spec:write", "sync:write"]
+```
+
+When the `roles` section is omitted, the three built-in defaults are used.
+Custom roles are **additive** — they extend the built-in set. The three
+built-in roles (`reader`, `writer`, `admin`) are always available. If an
+operator defines a custom role with the same name as a built-in, the custom
+definition wins (explicit override).
+
+### Exempt RPCs
+
+```text
+/specgraph.v1.ServerService/Health — always unauthenticated
+```
+
+No other RPCs are exempt. OTel is a separate endpoint outside ConnectRPC.
+
+## IdentityStore Interface
+
+```go
+type IdentityStore interface {
+    ResolveAPIKey(ctx context.Context, key string) (*Identity, error)
+    HasKeys() bool
+}
+```
+
+Initial implementation: config-file backed. The interface allows future
+implementations backed by a database, OIDC provider, or external identity
+service.
+
+## Auth Interceptor Flow
+
+```text
+1. Exempt RPC? → pass through (no identity on context)
+2. Extract Bearer token from Authorization header
+3. Token present?
+   a. store.ResolveAPIKey(token)
+      - Found → identity from store
+      - Unknown + JWT-shaped (3 dot-separated segments) → Unimplemented
+      - Unknown + non-JWT → Unauthenticated
+4. No token?
+   a. store.HasKeys() == false → implicit local identity (OS user, admin)
+   b. store.HasKeys() == true → Unauthenticated
+5. Check permission: rpcPermissions[procedure] against identity.Permissions
+   - Allowed → inject identity into context, call handler
+   - Denied → PermissionDenied
+   - Unknown procedure → Internal ("unconfigured RPC permission")
+```
+
+## Configuration
+
+### Config Schema
+
+```go
+type AuthConfig struct {
+    APIKeys []APIKeyConfig        `yaml:"api_keys"`
+    Roles   map[string]RoleConfig `yaml:"roles"`
+}
+
+type APIKeyConfig struct {
+    ID   string `yaml:"id"`
+    Key  string `yaml:"key"`
+    Name string `yaml:"name"`
+    Role string `yaml:"role"`
+}
+
+type RoleConfig struct {
+    Permissions []string `yaml:"permissions"`
+}
+```
+
+Added to the existing `Config` struct as `Auth AuthConfig`.
+
+### Example Config
+
+```yaml
+auth:
+  api_keys:
+    - id: "key-1"
+      key: "<example-api-key-1>"
+      name: "CI Pipeline"
+      role: writer
+    - id: "key-2"
+      key: "<example-api-key-2>"
+      name: "Sean's dev key"
+      role: admin
+  roles:
+    # Custom roles (optional — built-in reader/writer/admin used if omitted)
+    ci-readonly:
+      permissions: ["spec:read", "decision:read", "graph:read"]
+```
+
+### Local Identity Fallback
+
+When no API keys are configured (`auth.api_keys` absent or empty):
+
+- `Subject`: `"local:<os/user.Current().Username>"`
+- `DisplayName`: OS username
+- `Role`: `admin`
+- `Source`: `"local"`
+
+This is not a "mode" — it is the natural behavior of an empty config. The
+moment any API key is added, unauthenticated requests begin failing.
+
+### Known Limitations
+
+- **Plaintext API keys in config:** v1 stores keys as plaintext in the YAML
+  config file. Acceptable for local-first tooling. Future iterations may add
+  hashed key comparison or environment variable substitution
+  (`key: ${SPECGRAPH_API_KEY_1}`).
+- **ConfigStore is immutable after construction:** No hot-reload of auth config.
+  Changing keys or roles requires a server restart. This avoids TOCTOU races
+  between `HasKeys()` and key resolution. Hot-reload is out of scope.
+- **Constant-time key comparison:** `ResolveAPIKey` MUST use `subtle.ConstantTimeCompare`
+  for key matching, even for plaintext v1. This prevents timing side-channels
+  and is the right habit before hashed keys are added.
+- **Duplicate key values are a startup error:** Two API keys with the same secret
+  string but different IDs/roles would be ambiguous. Both duplicate IDs and
+  duplicate key values are rejected at config load time.
+
+## Server Wiring
+
+The auth interceptor is passed to each service handler registration via
+ConnectRPC handler options. The current `Register*Service()` functions need to
+accept `connect.HandlerOption` varargs and propagate them to handler
+constructors.
+
+```go
+authCfg := config.Auth
+store := auth.NewConfigStore(authCfg)
+interceptor := auth.NewAuthInterceptor(store)
+opts := connect.WithInterceptors(interceptor)
+
+mux := server.NewMux(scoper, opts)
+// Register*Service calls pass opts to New*ServiceHandler
+```
+
+### Middleware Ordering
+
+```text
+HTTP Request
+  → ProjectMiddleware (HTTP level: extracts X-Specgraph-Project, sets ctx)
+  → ConnectRPC dispatch
+    → Auth Interceptor (ConnectRPC level: validates token, checks permission)
+    → Handler (has both project and identity on context)
+```
+
+ProjectMiddleware remains at the HTTP level. The auth interceptor runs inside
+ConnectRPC dispatch where it has access to the procedure name for permission
+mapping.
+
+### Audit Logging
+
+The interceptor logs auth decisions at structured log levels:
+
+- `slog.Info`: successful authentication (subject, procedure)
+- `slog.Warn`: authentication failure (reason, procedure, remote addr)
+- `slog.Warn`: permission denied (subject, procedure, required permission)
+
+## Testing Strategy
+
+### Unit Tests (internal/auth/)
+
+**Interceptor tests** with fake IdentityStore:
+
+- Valid API key → identity on context, handler called
+- Invalid API key → Unauthenticated, handler not called
+- No token + no keys configured → local identity (admin)
+- No token + keys configured → Unauthenticated
+- Valid key, insufficient permission → PermissionDenied
+- Exempt RPC (Health) → passes without auth
+- Unknown RPC not in permission table → Internal error
+- JWT-shaped token → Unimplemented
+
+**Permission table completeness test:**
+Iterates all registered ConnectRPC procedures, asserts each is either in
+`rpcPermissions` or `exemptProcedures`. Catches missing mappings at test time.
+
+**Role resolution tests:**
+
+- Built-in roles expand correctly
+- Custom roles from config load correctly
+- `*:*` wildcard matches any permission
+- API key referencing unknown role → startup error
+
+**Config store tests:**
+
+- Valid config → correct identities
+- Empty config → HasKeys() false
+- Duplicate key IDs → startup error
+- Duplicate key values (same secret, different IDs) → startup error
+- API key uses constant-time comparison
+
+### E2E Tests (e2e/api/)
+
+Add auth scenarios to existing Ginkgo suite:
+
+- Keys configured: no Bearer → Unauthenticated on all RPCs except Health
+- Keys configured: reader key can GetSpec, cannot CreateSpec
+- Keys configured: custom role with specific permissions works correctly
+- No keys configured: all requests succeed (local identity)
+- Health always responds regardless of auth config
+
+### Not Tested
+
+- OIDC flows (not implemented)
+- Per-project authorization (not implemented)
+- Dynamic key management (config-file store is static)
+
+## Epic Impact
+
+### Beads Resolved
+
+| Bead | Title | Coverage |
+|------|-------|----------|
+| spgr-dpi (P1) | LifecycleService auth middleware | Interceptor covers all LifecycleService RPCs |
+| spgr-ous (P2) | Destructive ops auth middleware | Same interceptor; TransitionAbandon/TransitionSupersede → lifecycle:write |
+| spgr-4r8 (P2) | AuthoringService auth | Same interceptor; all authoring RPCs get permissions |
+
+### Partially Advanced
+
+| Bead | Title | Status |
+|------|-------|--------|
+| spgr-0az (P2) | OIDC providers | JWT detection hook in place; IdentityStore interface ready for OIDC impl |
+
+### Correctly Deferred
+
+| Bead | Title | Reason |
+|------|-------|--------|
+| spgr-fn3 (P4) | Memgraph auth + TLS | Infrastructure concern, independent of RPC auth |
+| spgr-sau (P3) | BeadsAdapter auth | Depends on bd/dolt auth semantics, not SpecGraph auth |
+
+## Future Evolution
+
+1. **OIDC support:** Add `OIDCIdentityStore` implementing `IdentityStore`.
+   Interceptor's JWT detection branch calls it instead of rejecting. No
+   interceptor changes needed.
+2. **Per-project authorization:** Identity resolution function receives project
+   context (already available on ctx from ProjectMiddleware). Role/permission
+   lookup becomes project-scoped.
+3. **Per-service roles (C-level granularity):** Operators define custom roles in
+   config with specific `service:action` permissions. The interceptor already
+   checks at this granularity — only the role definitions change.
+4. **Dynamic key management:** Replace `ConfigStore` with a database-backed
+   `IdentityStore`. Interface unchanged.
+
+## Package Layout
+
+```text
+internal/auth/
+├── auth.go          # Identity type, Role constants, permission helpers
+├── context.go       # IdentityFromContext / WithIdentity
+├── interceptor.go   # NewAuthInterceptor, permission table, exempt set
+├── permissions.go   # rpcPermissions table, role default bundles
+├── store.go         # IdentityStore interface
+└── config_store.go  # Config-file IdentityStore implementation
+```

--- a/docs/plans/2026-03-18-auth-interceptor-plan.md
+++ b/docs/plans/2026-03-18-auth-interceptor-plan.md
@@ -1,0 +1,1435 @@
+# Auth Interceptor Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add authentication and authorization to all SpecGraph ConnectRPC services via a single interceptor with API key support and implicit local identity fallback.
+
+**Architecture:** A ConnectRPC unary interceptor resolves identity from Bearer tokens (API keys now, JWT/OIDC later), checks fine-grained `service:action` permissions against the RPC procedure name, and injects the identity into request context. When no API keys are configured, the system creates an implicit admin identity from the OS user.
+
+**Tech Stack:** Go, ConnectRPC interceptors, `crypto/subtle` for constant-time key comparison, `log/slog` for audit logging, `gopkg.in/yaml.v3` for config.
+
+**Spec:** `docs/plans/2026-03-18-auth-interceptor-design.md`
+
+---
+
+## File Structure
+
+### New files (`internal/auth/`)
+
+| File | Responsibility |
+|------|---------------|
+| `internal/auth/auth.go` | `Identity` type, `Role` constants, `HasPermission()` helper |
+| `internal/auth/context.go` | `IdentityFromContext()` / `WithIdentity()` context helpers |
+| `internal/auth/store.go` | `IdentityStore` interface, `ErrUnknownKey` sentinel |
+| `internal/auth/config_store.go` | Config-file-backed `IdentityStore` implementation |
+| `internal/auth/permissions.go` | `rpcPermissions` table, `exemptProcedures` set, default role bundles |
+| `internal/auth/interceptor.go` | `NewAuthInterceptor()` — the ConnectRPC unary interceptor |
+
+### New test files
+
+| File | Tests |
+|------|-------|
+| `internal/auth/auth_test.go` | `HasPermission()` wildcard resolution |
+| `internal/auth/config_store_test.go` | Config store: resolve, HasKeys, duplicates, constant-time |
+| `internal/auth/permissions_test.go` | Permission table completeness, role resolution |
+| `internal/auth/interceptor_test.go` | Full interceptor flow (8 scenarios from spec) |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `internal/config/global.go` | Add `Auth AuthConfig` to `GlobalConfig`, add `AuthConfig`/`APIKeyConfig`/`RoleConfig` types |
+| `internal/server/server.go` | `NewMux()` accepts `...connect.HandlerOption`, passes to handler constructors |
+| `internal/server/health_handler.go` | `RegisterHealthService()` accepts `...connect.HandlerOption` |
+| `internal/server/decision_handler.go` | `RegisterDecisionService()` accepts `...connect.HandlerOption` |
+| `internal/server/graph_handler.go` | `RegisterGraphService()` accepts `...connect.HandlerOption` |
+| `internal/server/claim_handler.go` | `RegisterClaimService()` accepts `...connect.HandlerOption` |
+| `internal/server/constitution_handler.go` | `RegisterConstitutionService()` accepts `...connect.HandlerOption` |
+| `internal/server/authoring_handler.go` | `RegisterAuthoringService()` accepts `...connect.HandlerOption` |
+| `internal/server/execution_handler.go` | `RegisterExecutionService()` accepts `...connect.HandlerOption` |
+| `internal/server/lifecycle_handler.go` | `RegisterLifecycleService()` accepts `...connect.HandlerOption` |
+| `internal/server/sync_handler.go` | `RegisterSyncService()` accepts `...connect.HandlerOption` |
+| `cmd/specgraph/serve.go` | Create interceptor from config, pass as handler option |
+| `e2e/testutil/server.go` | Wire interceptor in E2E test server |
+
+---
+
+## Chunk 1: Identity Model & Permission Helpers
+
+### Task 1: Identity Type and HasPermission
+
+**Files:**
+
+- Create: `internal/auth/auth.go`
+- Create: `internal/auth/auth_test.go`
+
+- [ ] **Step 1: Write failing tests for HasPermission wildcard resolution**
+
+```go
+// internal/auth/auth_test.go
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/seanb4t/specgraph/internal/auth"
+)
+
+func TestHasPermission_ExactMatch(t *testing.T) {
+	perms := map[string]bool{"spec:read": true, "spec:write": true}
+	if !auth.HasPermission(perms, "spec:read") {
+		t.Fatal("expected spec:read to match")
+	}
+	if auth.HasPermission(perms, "spec:delete") {
+		t.Fatal("expected spec:delete to not match")
+	}
+}
+
+func TestHasPermission_FullWildcard(t *testing.T) {
+	perms := map[string]bool{"*:*": true}
+	if !auth.HasPermission(perms, "spec:read") {
+		t.Fatal("expected *:* to match spec:read")
+	}
+	if !auth.HasPermission(perms, "lifecycle:delete") {
+		t.Fatal("expected *:* to match lifecycle:delete")
+	}
+}
+
+func TestHasPermission_ActionWildcard(t *testing.T) {
+	perms := map[string]bool{"*:read": true}
+	if !auth.HasPermission(perms, "spec:read") {
+		t.Fatal("expected *:read to match spec:read")
+	}
+	if auth.HasPermission(perms, "spec:write") {
+		t.Fatal("expected *:read to not match spec:write")
+	}
+}
+
+func TestHasPermission_ServiceWildcard(t *testing.T) {
+	perms := map[string]bool{"spec:*": true}
+	if !auth.HasPermission(perms, "spec:read") {
+		t.Fatal("expected spec:* to match spec:read")
+	}
+	if !auth.HasPermission(perms, "spec:delete") {
+		t.Fatal("expected spec:* to match spec:delete")
+	}
+	if auth.HasPermission(perms, "decision:read") {
+		t.Fatal("expected spec:* to not match decision:read")
+	}
+}
+
+func TestHasPermission_EmptyPerms(t *testing.T) {
+	if auth.HasPermission(nil, "spec:read") {
+		t.Fatal("nil perms should deny everything")
+	}
+	if auth.HasPermission(map[string]bool{}, "spec:read") {
+		t.Fatal("empty perms should deny everything")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/auth/ -run TestHasPermission -v`
+Expected: FAIL — package does not exist yet
+
+- [ ] **Step 3: Write Identity type, Role constants, and HasPermission**
+
+```go
+// internal/auth/auth.go
+package auth
+
+import "strings"
+
+// Role represents a named authorization role.
+type Role string
+
+const (
+	RoleAdmin  Role = "admin"
+	RoleWriter Role = "writer"
+	RoleReader Role = "reader"
+)
+
+// Identity represents an authenticated principal.
+type Identity struct {
+	Subject     string          // "local:<user>" | "apikey:<id>" | "oidc:<sub>"
+	DisplayName string          // human-friendly name
+	Role        Role            // role name (built-in or custom)
+	Permissions map[string]bool // raw entries from role definition
+	Source      string          // "local" | "apikey" | "oidc"
+}
+
+// HasPermission checks whether perms satisfies the required permission.
+// Supports wildcards: "*:*" (full), "*:read" (action), "spec:*" (service).
+func HasPermission(perms map[string]bool, required string) bool {
+	if len(perms) == 0 {
+		return false
+	}
+	if perms["*:*"] {
+		return true
+	}
+	if perms[required] {
+		return true
+	}
+	parts := strings.SplitN(required, ":", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	service, action := parts[0], parts[1]
+	if perms[service+":*"] {
+		return true
+	}
+	if perms["*:"+action] {
+		return true
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/auth/ -run TestHasPermission -v`
+Expected: PASS (all 5 tests)
+
+- [ ] **Step 5: Commit**
+
+```text
+feat(auth): add Identity type and HasPermission with wildcard resolution
+```
+
+### Task 2: Context Helpers
+
+**Files:**
+
+- Create: `internal/auth/context.go`
+
+- [ ] **Step 1: Write context.go with IdentityFromContext and WithIdentity**
+
+```go
+// internal/auth/context.go
+package auth
+
+import "context"
+
+type contextKey struct{}
+
+// WithIdentity returns a new context carrying the given identity.
+func WithIdentity(ctx context.Context, id *Identity) context.Context {
+	return context.WithValue(ctx, contextKey{}, id)
+}
+
+// IdentityFromContext extracts the identity from the context.
+// Returns nil, false if no identity is present (e.g., exempt RPCs).
+func IdentityFromContext(ctx context.Context) (*Identity, bool) {
+	id, ok := ctx.Value(contextKey{}).(*Identity)
+	return id, ok
+}
+```
+
+No test needed — trivial context value wrapper, tested transitively by interceptor tests.
+
+- [ ] **Step 2: Commit**
+
+```text
+feat(auth): add context helpers for Identity injection/extraction
+```
+
+### Task 3: IdentityStore Interface
+
+**Files:**
+
+- Create: `internal/auth/store.go`
+
+- [ ] **Step 1: Write store.go with interface and sentinel error**
+
+```go
+// internal/auth/store.go
+package auth
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrUnknownKey is returned when an API key is not recognized.
+var ErrUnknownKey = errors.New("unknown API key")
+
+// IdentityStore resolves authentication tokens to identities.
+type IdentityStore interface {
+	// ResolveAPIKey returns the identity for the given API key.
+	// Returns ErrUnknownKey if the key is not recognized.
+	ResolveAPIKey(ctx context.Context, key string) (*Identity, error)
+
+	// HasKeys reports whether any API keys are configured.
+	// When false, unauthenticated requests fall back to the implicit local identity.
+	HasKeys() bool
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```text
+feat(auth): add IdentityStore interface and ErrUnknownKey sentinel
+```
+
+---
+
+## Chunk 2: Config Store Implementation
+
+### Task 4: Auth Config Types
+
+**Files:**
+
+- Modify: `internal/config/global.go`
+
+- [ ] **Step 1: Add AuthConfig types to global.go**
+
+Add to `GlobalConfig`:
+
+```go
+type GlobalConfig struct {
+	Server ServerSection `yaml:"server"`
+	Client ClientConfig  `yaml:"client"`
+	Auth   AuthConfig    `yaml:"auth"`
+}
+```
+
+Add new types:
+
+```go
+// AuthConfig configures authentication and authorization.
+type AuthConfig struct {
+	APIKeys []APIKeyConfig        `yaml:"api_keys"`
+	Roles   map[string]RoleConfig `yaml:"roles"`
+}
+
+// APIKeyConfig defines a single API key and its associated role.
+type APIKeyConfig struct {
+	ID   string `yaml:"id"`
+	Key  string `yaml:"key"`
+	Name string `yaml:"name"`
+	Role string `yaml:"role"`
+}
+
+// RoleConfig defines a custom role with explicit permissions.
+type RoleConfig struct {
+	Permissions []string `yaml:"permissions"`
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go build ./...`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```text
+feat(config): add AuthConfig types for API keys and custom roles
+```
+
+### Task 5: Config-File IdentityStore
+
+**Files:**
+
+- Create: `internal/auth/config_store.go`
+- Create: `internal/auth/config_store_test.go`
+
+- [ ] **Step 1: Write failing tests for ConfigStore**
+
+```go
+// internal/auth/config_store_test.go
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/seanb4t/specgraph/internal/auth"
+	"github.com/seanb4t/specgraph/internal/config"
+)
+
+func TestConfigStore_ResolveAPIKey(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Test Key", Role: "admin"},
+		},
+	}
+	store, err := auth.NewConfigStore(cfg)
+	if err != nil {
+		t.Fatalf("NewConfigStore: %v", err)
+	}
+
+	id, err := store.ResolveAPIKey(context.Background(), "spgr_sk_abc")
+	if err != nil {
+		t.Fatalf("ResolveAPIKey: %v", err)
+	}
+	if id.Subject != "apikey:k1" {
+		t.Errorf("subject = %q, want apikey:k1", id.Subject)
+	}
+	if id.Role != auth.RoleAdmin {
+		t.Errorf("role = %q, want admin", id.Role)
+	}
+	if id.Source != "apikey" {
+		t.Errorf("source = %q, want apikey", id.Source)
+	}
+}
+
+func TestConfigStore_UnknownKey(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Test Key", Role: "admin"},
+		},
+	}
+	store, err := auth.NewConfigStore(cfg)
+	if err != nil {
+		t.Fatalf("NewConfigStore: %v", err)
+	}
+
+	_, err = store.ResolveAPIKey(context.Background(), "wrong_key")
+	if !errors.Is(err, auth.ErrUnknownKey) {
+		t.Errorf("err = %v, want ErrUnknownKey", err)
+	}
+}
+
+func TestConfigStore_HasKeys(t *testing.T) {
+	empty, err := auth.NewConfigStore(config.AuthConfig{})
+	if err != nil {
+		t.Fatalf("NewConfigStore: %v", err)
+	}
+	if empty.HasKeys() {
+		t.Error("HasKeys() = true for empty config")
+	}
+
+	withKey, err := auth.NewConfigStore(config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Key", Role: "reader"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewConfigStore: %v", err)
+	}
+	if !withKey.HasKeys() {
+		t.Error("HasKeys() = false for config with keys")
+	}
+}
+
+func TestConfigStore_DuplicateKeyID(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Key 1", Role: "admin"},
+			{ID: "k1", Key: "spgr_sk_def", Name: "Key 2", Role: "reader"},
+		},
+	}
+	_, err := auth.NewConfigStore(cfg)
+	if err == nil {
+		t.Fatal("expected error for duplicate key ID")
+	}
+}
+
+func TestConfigStore_DuplicateKeyValue(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_same", Name: "Key 1", Role: "admin"},
+			{ID: "k2", Key: "spgr_sk_same", Name: "Key 2", Role: "reader"},
+		},
+	}
+	_, err := auth.NewConfigStore(cfg)
+	if err == nil {
+		t.Fatal("expected error for duplicate key value")
+	}
+}
+
+func TestConfigStore_UnknownRole(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Key", Role: "nonexistent"},
+		},
+	}
+	_, err := auth.NewConfigStore(cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown role")
+	}
+}
+
+func TestConfigStore_CustomRole(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "CI", Role: "ci-readonly"},
+		},
+		Roles: map[string]config.RoleConfig{
+			"ci-readonly": {Permissions: []string{"spec:read", "decision:read"}},
+		},
+	}
+	store, err := auth.NewConfigStore(cfg)
+	if err != nil {
+		t.Fatalf("NewConfigStore: %v", err)
+	}
+
+	id, err := store.ResolveAPIKey(context.Background(), "spgr_sk_abc")
+	if err != nil {
+		t.Fatalf("ResolveAPIKey: %v", err)
+	}
+	if !auth.HasPermission(id.Permissions, "spec:read") {
+		t.Error("expected spec:read permission")
+	}
+	if auth.HasPermission(id.Permissions, "spec:write") {
+		t.Error("unexpected spec:write permission")
+	}
+}
+
+func TestConfigStore_BuiltinRolePermissions(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_r", Name: "Reader", Role: "reader"},
+			{ID: "k2", Key: "spgr_sk_w", Name: "Writer", Role: "writer"},
+			{ID: "k3", Key: "spgr_sk_a", Name: "Admin", Role: "admin"},
+		},
+	}
+	store, err := auth.NewConfigStore(cfg)
+	if err != nil {
+		t.Fatalf("NewConfigStore: %v", err)
+	}
+
+	reader, _ := store.ResolveAPIKey(context.Background(), "spgr_sk_r")
+	if !auth.HasPermission(reader.Permissions, "spec:read") {
+		t.Error("reader should have spec:read")
+	}
+	if auth.HasPermission(reader.Permissions, "spec:write") {
+		t.Error("reader should not have spec:write")
+	}
+
+	writer, _ := store.ResolveAPIKey(context.Background(), "spgr_sk_w")
+	if !auth.HasPermission(writer.Permissions, "spec:write") {
+		t.Error("writer should have spec:write")
+	}
+	if auth.HasPermission(writer.Permissions, "graph:delete") {
+		t.Error("writer should not have graph:delete")
+	}
+
+	admin, _ := store.ResolveAPIKey(context.Background(), "spgr_sk_a")
+	if !auth.HasPermission(admin.Permissions, "graph:delete") {
+		t.Error("admin should have graph:delete via *:*")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/auth/ -run TestConfigStore -v`
+Expected: FAIL — `NewConfigStore` not defined
+
+- [ ] **Step 3: Write ConfigStore implementation**
+
+```go
+// internal/auth/config_store.go
+package auth
+
+import (
+	"context"
+	"crypto/subtle"
+	"fmt"
+
+	"github.com/seanb4t/specgraph/internal/config"
+)
+
+// DefaultRolePermissions defines the built-in role permission bundles.
+var DefaultRolePermissions = map[Role][]string{
+	RoleReader: {"*:read"},
+	RoleWriter: {"*:read", "*:write"},
+	RoleAdmin:  {"*:*"},
+}
+
+// ConfigStore implements IdentityStore backed by config file data.
+// It is immutable after construction.
+type ConfigStore struct {
+	identities map[string]*Identity // key value → identity
+	hasKeys    bool
+}
+
+// NewConfigStore creates an IdentityStore from the auth config.
+// Returns an error if config is invalid (duplicate IDs, duplicate key values,
+// unknown roles).
+func NewConfigStore(cfg config.AuthConfig) (*ConfigStore, error) {
+	// Build role lookup: built-in defaults + custom roles (custom overrides built-in)
+	roles := make(map[string][]string)
+	for role, perms := range DefaultRolePermissions {
+		roles[string(role)] = perms
+	}
+	for name, rc := range cfg.Roles {
+		roles[name] = rc.Permissions
+	}
+
+	identities := make(map[string]*Identity, len(cfg.APIKeys))
+	seenIDs := make(map[string]bool, len(cfg.APIKeys))
+
+	for _, ak := range cfg.APIKeys {
+		if seenIDs[ak.ID] {
+			return nil, fmt.Errorf("duplicate API key ID: %s", ak.ID)
+		}
+		seenIDs[ak.ID] = true
+
+		if _, exists := identities[ak.Key]; exists {
+			return nil, fmt.Errorf("duplicate API key value for IDs: %s", ak.ID)
+		}
+
+		perms, ok := roles[ak.Role]
+		if !ok {
+			return nil, fmt.Errorf("API key %s references unknown role: %s", ak.ID, ak.Role)
+		}
+
+		permMap := make(map[string]bool, len(perms))
+		for _, p := range perms {
+			permMap[p] = true
+		}
+
+		identities[ak.Key] = &Identity{
+			Subject:     "apikey:" + ak.ID,
+			DisplayName: ak.Name,
+			Role:        Role(ak.Role),
+			Permissions: permMap,
+			Source:      "apikey",
+		}
+	}
+
+	return &ConfigStore{
+		identities: identities,
+		hasKeys:    len(identities) > 0,
+	}, nil
+}
+
+// ResolveAPIKey resolves an API key to an identity using constant-time comparison.
+func (s *ConfigStore) ResolveAPIKey(_ context.Context, key string) (*Identity, error) {
+	// Use constant-time comparison to prevent timing side-channels.
+	for storedKey, id := range s.identities {
+		if subtle.ConstantTimeCompare([]byte(storedKey), []byte(key)) == 1 {
+			return id, nil
+		}
+	}
+	return nil, ErrUnknownKey
+}
+
+// HasKeys reports whether any API keys are configured.
+func (s *ConfigStore) HasKeys() bool {
+	return s.hasKeys
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/auth/ -run TestConfigStore -v`
+Expected: PASS (all 8 tests)
+
+- [ ] **Step 5: Commit**
+
+```text
+feat(auth): add ConfigStore with constant-time key comparison and validation
+```
+
+---
+
+## Chunk 3: Permission Table & Interceptor
+
+### Task 6: Permission Table
+
+**Files:**
+
+- Create: `internal/auth/permissions.go`
+- Create: `internal/auth/permissions_test.go`
+
+- [ ] **Step 1: Write the permission table completeness test**
+
+This test imports all generated `*Procedure` constants and asserts coverage.
+
+```go
+// internal/auth/permissions_test.go
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/seanb4t/specgraph/internal/auth"
+)
+
+// allProcedures lists every ConnectRPC procedure from generated code.
+var allProcedures = []string{
+	// SpecService
+	specgraphv1connect.SpecServiceCreateSpecProcedure,
+	specgraphv1connect.SpecServiceGetSpecProcedure,
+	specgraphv1connect.SpecServiceListSpecsProcedure,
+	specgraphv1connect.SpecServiceUpdateSpecProcedure,
+	// DecisionService
+	specgraphv1connect.DecisionServiceCreateDecisionProcedure,
+	specgraphv1connect.DecisionServiceGetDecisionProcedure,
+	specgraphv1connect.DecisionServiceListDecisionsProcedure,
+	specgraphv1connect.DecisionServiceUpdateDecisionProcedure,
+	// GraphService
+	specgraphv1connect.GraphServiceAddEdgeProcedure,
+	specgraphv1connect.GraphServiceRemoveEdgeProcedure,
+	specgraphv1connect.GraphServiceListEdgesProcedure,
+	specgraphv1connect.GraphServiceGetDependenciesProcedure,
+	specgraphv1connect.GraphServiceGetTransitiveDepsProcedure,
+	specgraphv1connect.GraphServiceGetImpactProcedure,
+	specgraphv1connect.GraphServiceGetReadyProcedure,
+	specgraphv1connect.GraphServiceGetCriticalPathProcedure,
+	// ClaimService
+	specgraphv1connect.ClaimServiceClaimSpecProcedure,
+	specgraphv1connect.ClaimServiceUnclaimSpecProcedure,
+	specgraphv1connect.ClaimServiceHeartbeatProcedure,
+	// ConstitutionService
+	specgraphv1connect.ConstitutionServiceGetConstitutionProcedure,
+	specgraphv1connect.ConstitutionServiceUpdateConstitutionProcedure,
+	specgraphv1connect.ConstitutionServiceCheckViolationProcedure,
+	specgraphv1connect.ConstitutionServiceEmitToolFilesProcedure,
+	// AuthoringService
+	specgraphv1connect.AuthoringServiceSparkProcedure,
+	specgraphv1connect.AuthoringServiceShapeProcedure,
+	specgraphv1connect.AuthoringServiceSpecifyProcedure,
+	specgraphv1connect.AuthoringServiceDecomposeProcedure,
+	specgraphv1connect.AuthoringServiceApproveProcedure,
+	specgraphv1connect.AuthoringServiceAmendProcedure,
+	specgraphv1connect.AuthoringServiceSupersedeProcedure,
+	specgraphv1connect.AuthoringServiceGetPromptsProcedure,
+	// ExecutionService
+	specgraphv1connect.ExecutionServiceGenerateBundleProcedure,
+	specgraphv1connect.ExecutionServiceGetPrimeProcedure,
+	specgraphv1connect.ExecutionServiceReportProgressProcedure,
+	specgraphv1connect.ExecutionServiceReportBlockerProcedure,
+	specgraphv1connect.ExecutionServiceReportCompletionProcedure,
+	specgraphv1connect.ExecutionServiceGetExecutionEventsProcedure,
+	// LifecycleService
+	specgraphv1connect.LifecycleServiceTransitionAmendProcedure,
+	specgraphv1connect.LifecycleServiceTransitionSupersedeProcedure,
+	specgraphv1connect.LifecycleServiceTransitionAbandonProcedure,
+	specgraphv1connect.LifecycleServiceCheckDriftProcedure,
+	specgraphv1connect.LifecycleServiceAcknowledgeDriftProcedure,
+	specgraphv1connect.LifecycleServiceLintProcedure,
+	// SyncService
+	specgraphv1connect.SyncServiceSyncBeadsProcedure,
+	specgraphv1connect.SyncServiceSyncGitHubProcedure,
+	specgraphv1connect.SyncServiceGetSyncStatusProcedure,
+	specgraphv1connect.SyncServiceInjectProcedure,
+	// ServerService (exempt)
+	specgraphv1connect.ServerServiceHealthProcedure,
+}
+
+func TestPermissionTable_Completeness(t *testing.T) {
+	for _, proc := range allProcedures {
+		if auth.IsExempt(proc) {
+			continue
+		}
+		if _, ok := auth.RPCPermission(proc); !ok {
+			t.Errorf("procedure %s is not in rpcPermissions and not exempt", proc)
+		}
+	}
+}
+
+func TestPermissionTable_NoExemptInPermissions(t *testing.T) {
+	for _, proc := range allProcedures {
+		if !auth.IsExempt(proc) {
+			continue
+		}
+		if _, ok := auth.RPCPermission(proc); ok {
+			t.Errorf("exempt procedure %s should not be in rpcPermissions", proc)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/auth/ -run TestPermissionTable -v`
+Expected: FAIL — `IsExempt`, `RPCPermission` not defined
+
+- [ ] **Step 3: Write permissions.go**
+
+```go
+// internal/auth/permissions.go
+package auth
+
+import (
+	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+)
+
+// rpcPermissions maps ConnectRPC procedure names to required permissions.
+var rpcPermissions = map[string]string{
+	// SpecService
+	specgraphv1connect.SpecServiceGetSpecProcedure:    "spec:read",
+	specgraphv1connect.SpecServiceListSpecsProcedure:   "spec:read",
+	specgraphv1connect.SpecServiceCreateSpecProcedure:  "spec:write",
+	specgraphv1connect.SpecServiceUpdateSpecProcedure:  "spec:write",
+
+	// DecisionService
+	specgraphv1connect.DecisionServiceGetDecisionProcedure:    "decision:read",
+	specgraphv1connect.DecisionServiceListDecisionsProcedure:   "decision:read",
+	specgraphv1connect.DecisionServiceCreateDecisionProcedure:  "decision:write",
+	specgraphv1connect.DecisionServiceUpdateDecisionProcedure:  "decision:write",
+
+	// GraphService
+	specgraphv1connect.GraphServiceGetDependenciesProcedure:    "graph:read",
+	specgraphv1connect.GraphServiceGetTransitiveDepsProcedure:  "graph:read",
+	specgraphv1connect.GraphServiceGetImpactProcedure:          "graph:read",
+	specgraphv1connect.GraphServiceGetReadyProcedure:           "graph:read",
+	specgraphv1connect.GraphServiceGetCriticalPathProcedure:    "graph:read",
+	specgraphv1connect.GraphServiceListEdgesProcedure:          "graph:read",
+	specgraphv1connect.GraphServiceAddEdgeProcedure:            "graph:write",
+	specgraphv1connect.GraphServiceRemoveEdgeProcedure:         "graph:delete",
+
+	// ClaimService
+	specgraphv1connect.ClaimServiceClaimSpecProcedure:   "claim:write",
+	specgraphv1connect.ClaimServiceHeartbeatProcedure:   "claim:write",
+	specgraphv1connect.ClaimServiceUnclaimSpecProcedure: "claim:write",
+
+	// ConstitutionService
+	specgraphv1connect.ConstitutionServiceGetConstitutionProcedure:    "constitution:read",
+	specgraphv1connect.ConstitutionServiceCheckViolationProcedure:     "constitution:read",
+	specgraphv1connect.ConstitutionServiceUpdateConstitutionProcedure: "constitution:write",
+	specgraphv1connect.ConstitutionServiceEmitToolFilesProcedure:      "constitution:write",
+
+	// AuthoringService
+	specgraphv1connect.AuthoringServiceGetPromptsProcedure:  "authoring:read",
+	specgraphv1connect.AuthoringServiceSparkProcedure:       "authoring:write",
+	specgraphv1connect.AuthoringServiceShapeProcedure:       "authoring:write",
+	specgraphv1connect.AuthoringServiceSpecifyProcedure:     "authoring:write",
+	specgraphv1connect.AuthoringServiceDecomposeProcedure:   "authoring:write",
+	specgraphv1connect.AuthoringServiceApproveProcedure:     "authoring:write",
+	specgraphv1connect.AuthoringServiceAmendProcedure:       "authoring:write",
+	specgraphv1connect.AuthoringServiceSupersedeProcedure:   "authoring:write",
+
+	// ExecutionService
+	specgraphv1connect.ExecutionServiceGenerateBundleProcedure:     "execution:read",
+	specgraphv1connect.ExecutionServiceGetPrimeProcedure:           "execution:read",
+	specgraphv1connect.ExecutionServiceGetExecutionEventsProcedure: "execution:read",
+	specgraphv1connect.ExecutionServiceReportProgressProcedure:     "execution:write",
+	specgraphv1connect.ExecutionServiceReportBlockerProcedure:      "execution:write",
+	specgraphv1connect.ExecutionServiceReportCompletionProcedure:   "execution:write",
+
+	// LifecycleService
+	specgraphv1connect.LifecycleServiceCheckDriftProcedure:          "lifecycle:read",
+	specgraphv1connect.LifecycleServiceLintProcedure:                "lifecycle:read",
+	specgraphv1connect.LifecycleServiceAcknowledgeDriftProcedure:    "lifecycle:write",
+	specgraphv1connect.LifecycleServiceTransitionAmendProcedure:     "lifecycle:write",
+	specgraphv1connect.LifecycleServiceTransitionSupersedeProcedure: "lifecycle:write",
+	specgraphv1connect.LifecycleServiceTransitionAbandonProcedure:   "lifecycle:write",
+
+	// SyncService
+	specgraphv1connect.SyncServiceGetSyncStatusProcedure: "sync:read",
+	specgraphv1connect.SyncServiceSyncBeadsProcedure:     "sync:write",
+	specgraphv1connect.SyncServiceSyncGitHubProcedure:    "sync:write",
+	specgraphv1connect.SyncServiceInjectProcedure:        "sync:write",
+}
+
+// exemptProcedures are RPCs that skip authentication entirely.
+var exemptProcedures = map[string]bool{
+	specgraphv1connect.ServerServiceHealthProcedure: true,
+}
+
+// RPCPermission returns the required permission for a procedure.
+func RPCPermission(procedure string) (string, bool) {
+	perm, ok := rpcPermissions[procedure]
+	return perm, ok
+}
+
+// IsExempt reports whether a procedure is exempt from authentication.
+func IsExempt(procedure string) bool {
+	return exemptProcedures[procedure]
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/auth/ -run TestPermissionTable -v`
+Expected: PASS (both tests)
+
+- [ ] **Step 5: Commit**
+
+```text
+feat(auth): add RPC permission table with completeness test
+```
+
+### Task 7: Auth Interceptor
+
+**Files:**
+
+- Create: `internal/auth/interceptor.go`
+- Create: `internal/auth/interceptor_test.go`
+
+**Important:** ConnectRPC's `AnyRequest` interface has unexported methods, so it
+cannot be faked directly. The interceptor tests use `httptest.Server` with a
+real ConnectRPC handler (the Health service is simplest) and make HTTP requests
+with appropriate Authorization headers. The interceptor is wired as a handler
+option, so it runs on real requests through the full ConnectRPC stack.
+
+- [ ] **Step 1: Write failing interceptor tests using httptest**
+
+```go
+// internal/auth/interceptor_test.go
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	specgraphv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/seanb4t/specgraph/internal/auth"
+	"github.com/seanb4t/specgraph/internal/config"
+)
+
+// stubHealthHandler returns a minimal Health handler for testing the interceptor.
+type stubHealthHandler struct {
+	specgraphv1connect.UnimplementedServerServiceHandler
+}
+
+func (h *stubHealthHandler) Health(_ context.Context, _ *connect.Request[specgraphv1.HealthRequest]) (*connect.Response[specgraphv1.HealthResponse], error) {
+	return connect.NewResponse(&specgraphv1.HealthResponse{}), nil
+}
+
+// stubSpecHandler returns unimplemented for all but captures that the handler was reached.
+type stubSpecHandler struct {
+	specgraphv1connect.UnimplementedSpecServiceHandler
+	called bool
+}
+
+func (h *stubSpecHandler) GetSpec(_ context.Context, _ *connect.Request[specgraphv1.GetSpecRequest]) (*connect.Response[specgraphv1.Spec], error) {
+	h.called = true
+	return connect.NewResponse(&specgraphv1.Spec{}), nil
+}
+
+func (h *stubSpecHandler) CreateSpec(_ context.Context, _ *connect.Request[specgraphv1.CreateSpecRequest]) (*connect.Response[specgraphv1.Spec], error) {
+	h.called = true
+	return connect.NewResponse(&specgraphv1.Spec{}), nil
+}
+
+// newTestServer creates an httptest.Server with Health and Spec services wired
+// with the given auth config. Returns the server, a SpecService client, and
+// a ServerService (Health) client.
+func newTestServer(t *testing.T, authCfg config.AuthConfig) (*httptest.Server, specgraphv1connect.SpecServiceClient, specgraphv1connect.ServerServiceClient) {
+	t.Helper()
+	store, err := auth.NewConfigStore(authCfg)
+	if err != nil {
+		t.Fatalf("NewConfigStore: %v", err)
+	}
+	interceptor := auth.NewAuthInterceptor(store)
+	opts := connect.WithInterceptors(interceptor)
+
+	mux := http.NewServeMux()
+	path, handler := specgraphv1connect.NewServerServiceHandler(&stubHealthHandler{}, opts)
+	mux.Handle(path, handler)
+	path, handler = specgraphv1connect.NewSpecServiceHandler(&stubSpecHandler{}, opts)
+	mux.Handle(path, handler)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	specClient := specgraphv1connect.NewSpecServiceClient(http.DefaultClient, srv.URL)
+	healthClient := specgraphv1connect.NewServerServiceClient(http.DefaultClient, srv.URL)
+	return srv, specClient, healthClient
+}
+
+func withBearer(token string) connect.ClientOption {
+	return connect.WithInterceptors(connect.UnaryInterceptorFunc(
+		func(next connect.UnaryFunc) connect.UnaryFunc {
+			return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+				req.Header().Set("Authorization", "Bearer "+token)
+				return next(ctx, req)
+			}
+		},
+	))
+}
+
+func newSpecClientWithAuth(url, token string) specgraphv1connect.SpecServiceClient {
+	return specgraphv1connect.NewSpecServiceClient(http.DefaultClient, url, withBearer(token))
+}
+
+func TestInterceptor_ValidAPIKey(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Admin", Role: "admin"},
+		},
+	}
+	srv, _, _ := newTestServer(t, cfg)
+	client := newSpecClientWithAuth(srv.URL, "spgr_sk_abc")
+	_, err := client.GetSpec(context.Background(), connect.NewRequest(&specgraphv1.GetSpecRequest{}))
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+}
+
+func TestInterceptor_InvalidAPIKey(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Admin", Role: "admin"},
+		},
+	}
+	srv, _, _ := newTestServer(t, cfg)
+	client := newSpecClientWithAuth(srv.URL, "wrong_key")
+	_, err := client.GetSpec(context.Background(), connect.NewRequest(&specgraphv1.GetSpecRequest{}))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Errorf("code = %v, want Unauthenticated", connect.CodeOf(err))
+	}
+}
+
+func TestInterceptor_NoToken_NoKeys(t *testing.T) {
+	_, specClient, _ := newTestServer(t, config.AuthConfig{})
+	// No auth header, no keys configured → local identity (admin)
+	_, err := specClient.GetSpec(context.Background(), connect.NewRequest(&specgraphv1.GetSpecRequest{}))
+	if err != nil {
+		t.Fatalf("expected success with local identity, got: %v", err)
+	}
+}
+
+func TestInterceptor_NoToken_WithKeys(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Admin", Role: "admin"},
+		},
+	}
+	_, specClient, _ := newTestServer(t, cfg)
+	// No auth header, but keys ARE configured → Unauthenticated
+	_, err := specClient.GetSpec(context.Background(), connect.NewRequest(&specgraphv1.GetSpecRequest{}))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Errorf("code = %v, want Unauthenticated", connect.CodeOf(err))
+	}
+}
+
+func TestInterceptor_InsufficientPermission(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_r", Name: "Reader", Role: "reader"},
+		},
+	}
+	srv, _, _ := newTestServer(t, cfg)
+	client := newSpecClientWithAuth(srv.URL, "spgr_sk_r")
+	// Reader can GetSpec (spec:read)
+	_, err := client.GetSpec(context.Background(), connect.NewRequest(&specgraphv1.GetSpecRequest{}))
+	if err != nil {
+		t.Fatalf("reader should be able to GetSpec: %v", err)
+	}
+	// Reader cannot CreateSpec (spec:write)
+	_, err = client.CreateSpec(context.Background(), connect.NewRequest(&specgraphv1.CreateSpecRequest{}))
+	if err == nil {
+		t.Fatal("expected error for reader calling CreateSpec")
+	}
+	if connect.CodeOf(err) != connect.CodePermissionDenied {
+		t.Errorf("code = %v, want PermissionDenied", connect.CodeOf(err))
+	}
+}
+
+func TestInterceptor_ExemptRPC(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Admin", Role: "admin"},
+		},
+	}
+	_, _, healthClient := newTestServer(t, cfg)
+	// Health is exempt — no auth header required even with keys configured
+	_, err := healthClient.Health(context.Background(), connect.NewRequest(&specgraphv1.HealthRequest{}))
+	if err != nil {
+		t.Fatalf("Health should be exempt: %v", err)
+	}
+}
+
+func TestInterceptor_JWTToken(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Admin", Role: "admin"},
+		},
+	}
+	srv, _, _ := newTestServer(t, cfg)
+	// JWT has 3 dot-separated segments
+	client := newSpecClientWithAuth(srv.URL, "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature")
+	_, err := client.GetSpec(context.Background(), connect.NewRequest(&specgraphv1.GetSpecRequest{}))
+	if err == nil {
+		t.Fatal("expected error for JWT token")
+	}
+	if connect.CodeOf(err) != connect.CodeUnimplemented {
+		t.Errorf("code = %v, want Unimplemented", connect.CodeOf(err))
+	}
+}
+```
+
+**Note:** The "unknown procedure" test case cannot be tested through the
+ConnectRPC client (it only calls known procedures). That scenario is covered
+by the runtime safety net + the permission table completeness test. If a
+procedure is registered but not in the permission table, the completeness
+test catches it.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/auth/ -run TestInterceptor -v`
+Expected: FAIL — `NewAuthInterceptor` not defined
+
+- [ ] **Step 3: Write interceptor implementation**
+
+```go
+// internal/auth/interceptor.go
+package auth
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os/user"
+	"strings"
+
+	"connectrpc.com/connect"
+)
+
+// NewAuthInterceptor returns a ConnectRPC unary interceptor that enforces
+// authentication and authorization on all non-exempt RPCs.
+func NewAuthInterceptor(store IdentityStore) connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			procedure := req.Spec().Procedure
+
+			// 1. Exempt RPCs pass through with no identity.
+			if IsExempt(procedure) {
+				return next(ctx, req)
+			}
+
+			// 2. Resolve identity from Authorization header.
+			id, authErr := resolveIdentity(ctx, store, req.Header())
+			if authErr != nil {
+				slog.Warn("auth: authentication failed",
+					"procedure", procedure,
+					"error", authErr.Error(),
+				)
+				return nil, authErr
+			}
+
+			// 3. Check permission for this RPC.
+			required, ok := RPCPermission(procedure)
+			if !ok {
+				slog.Error("auth: unconfigured RPC permission",
+					"procedure", procedure,
+				)
+				return nil, connect.NewError(connect.CodeInternal, nil)
+			}
+
+			if !HasPermission(id.Permissions, required) {
+				slog.Warn("auth: permission denied",
+					"subject", id.Subject,
+					"procedure", procedure,
+					"required", required,
+				)
+				return nil, connect.NewError(connect.CodePermissionDenied, nil)
+			}
+
+			// 4. Inject identity into context and proceed.
+			slog.Info("auth: authenticated",
+				"subject", id.Subject,
+				"procedure", procedure,
+			)
+			return next(WithIdentity(ctx, id), req)
+		}
+	}
+}
+
+// resolveIdentity extracts and validates the identity from request headers.
+func resolveIdentity(ctx context.Context, store IdentityStore, headers http.Header) (*Identity, error) {
+	authHeader := headers.Get("Authorization")
+
+	if authHeader == "" {
+		// No token: fall back to local identity if no keys configured.
+		if !store.HasKeys() {
+			return localIdentity(), nil
+		}
+		return nil, connect.NewError(connect.CodeUnauthenticated, nil)
+	}
+
+	// Parse "Bearer <token>"
+	token := strings.TrimPrefix(authHeader, "Bearer ")
+	if token == authHeader {
+		// No "Bearer " prefix
+		return nil, connect.NewError(connect.CodeUnauthenticated, nil)
+	}
+
+	// Try API key resolution first — keys are opaque strings that may contain dots.
+	id, err := store.ResolveAPIKey(ctx, token)
+	if err == nil {
+		return id, nil
+	}
+	// Unknown key: check if it looks like a JWT (future OIDC support).
+	if errors.Is(err, ErrUnknownKey) && strings.Count(token, ".") == 2 {
+		return nil, connect.NewError(connect.CodeUnimplemented, nil)
+	}
+	if errors.Is(err, ErrUnknownKey) {
+		return nil, connect.NewError(connect.CodeUnauthenticated, nil)
+	}
+	// Non-ErrUnknownKey failures (I/O, store outage) are internal errors.
+	return nil, connect.NewError(connect.CodeInternal, nil)
+}
+
+// localIdentity creates the implicit admin identity from the OS user.
+func localIdentity() *Identity {
+	username := "unknown"
+	if u, err := user.Current(); err == nil {
+		username = u.Username
+	}
+	return &Identity{
+		Subject:     "local:" + username,
+		DisplayName: username,
+		Role:        RoleAdmin,
+		Permissions: map[string]bool{"*:*": true},
+		Source:      "local",
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/auth/ -run TestInterceptor -v`
+Expected: PASS (all 7 tests)
+
+- [ ] **Step 5: Commit**
+
+```text
+feat(auth): add ConnectRPC auth interceptor with full flow
+```
+
+---
+
+## Chunk 4: Server Wiring
+
+### Task 8: Add HandlerOption to Register Functions
+
+**Files:**
+
+- Modify: `internal/server/server.go`
+- Modify: `internal/server/health_handler.go`
+- Modify: `internal/server/decision_handler.go`
+- Modify: `internal/server/graph_handler.go`
+- Modify: `internal/server/claim_handler.go`
+- Modify: `internal/server/constitution_handler.go`
+- Modify: `internal/server/authoring_handler.go`
+- Modify: `internal/server/execution_handler.go`
+- Modify: `internal/server/lifecycle_handler.go`
+- Modify: `internal/server/sync_handler.go`
+
+Each `Register*Service` function needs to accept `...connect.HandlerOption` and pass it to the generated `New*ServiceHandler` call.
+
+- [ ] **Step 1: Update NewMux in server.go**
+
+Change signature to accept and propagate handler options:
+
+```go
+func NewMux(scoper storage.Scoper, opts ...connect.HandlerOption) *http.ServeMux {
+	mux := http.NewServeMux()
+	specHandler := NewSpecHandler(scoper)
+	path, handler := specgraphv1connect.NewSpecServiceHandler(specHandler, opts...)
+	mux.Handle(path, handler)
+	return mux
+}
+```
+
+Add `"connectrpc.com/connect"` to imports.
+
+- [ ] **Step 2: Update RegisterHealthService**
+
+```go
+func RegisterHealthService(mux *http.ServeMux, opts ...connect.HandlerOption) {
+	path, handler := specgraphv1connect.NewServerServiceHandler(&HealthHandler{}, opts...)
+	mux.Handle(path, handler)
+}
+```
+
+- [ ] **Step 3: Update all other Register functions**
+
+Apply the same pattern to each:
+
+- `RegisterDecisionService(mux *http.ServeMux, scoper storage.Scoper, opts ...connect.HandlerOption)`
+- `RegisterGraphService(mux *http.ServeMux, scoper storage.Scoper, opts ...connect.HandlerOption)`
+- `RegisterClaimService(mux *http.ServeMux, scoper storage.Scoper, opts ...connect.HandlerOption)`
+- `RegisterConstitutionService(mux *http.ServeMux, scoper storage.Scoper, opts ...connect.HandlerOption)`
+- `RegisterAuthoringService(mux *http.ServeMux, scoper storage.Scoper, opts ...connect.HandlerOption)`
+- `RegisterExecutionService(mux *http.ServeMux, scoper storage.Scoper, opts ...connect.HandlerOption)`
+- `RegisterLifecycleService(mux *http.ServeMux, scoper storage.Scoper, dc DriftChecker, l SpecLinter, logger *slog.Logger, opts ...connect.HandlerOption)`
+- `RegisterSyncService(mux *http.ServeMux, scoper storage.Scoper, allowedOutputRoot string, opts ...connect.HandlerOption) *SyncHandler`
+
+In each, pass `opts...` to the corresponding `specgraphv1connect.New*ServiceHandler()` call.
+
+- [ ] **Step 4: Verify build**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go build ./...`
+Expected: PASS — the variadic `...connect.HandlerOption` is backward compatible (callers not passing opts still compile)
+
+- [ ] **Step 5: Run existing tests to verify no regressions**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/server/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```text
+refactor(server): accept connect.HandlerOption in all Register functions
+```
+
+### Task 9: Wire Interceptor in serve.go
+
+**Files:**
+
+- Modify: `cmd/specgraph/serve.go`
+
+- [ ] **Step 1: Create interceptor from config and pass as handler option**
+
+After `store` is created (around line 78), add:
+
+```go
+authStore, err := auth.NewConfigStore(cfg.Auth)
+if err != nil {
+	return fmt.Errorf("auth config: %w", err)
+}
+interceptor := auth.NewAuthInterceptor(authStore)
+opts := connect.WithInterceptors(interceptor)
+```
+
+Then pass `opts` to every `NewMux` and `Register*Service` call:
+
+```go
+mux := server.NewMux(store, opts)
+server.RegisterHealthService(mux, opts)
+server.RegisterDecisionService(mux, store, opts)
+server.RegisterGraphService(mux, store, opts)
+server.RegisterClaimService(mux, store, opts)
+server.RegisterConstitutionService(mux, store, opts)
+server.RegisterAuthoringService(mux, store, opts)
+server.RegisterExecutionService(mux, store, opts)
+// ...
+server.RegisterLifecycleService(mux, store, driftEngine, lintEngine, nil, opts)
+syncHandler := server.RegisterSyncService(mux, store, "", opts)
+```
+
+Add imports: `"github.com/seanb4t/specgraph/internal/auth"`, `"connectrpc.com/connect"`.
+
+- [ ] **Step 2: Verify build**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go build ./cmd/specgraph/`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```text
+feat(server): wire auth interceptor into server startup
+```
+
+### Task 10: Wire Interceptor in E2E Test Server
+
+**Files:**
+
+- Modify: `e2e/testutil/server.go`
+
+- [ ] **Step 1: Update StartServer to accept and propagate handler options**
+
+The E2E test server needs to optionally receive `connect.HandlerOption` so tests can configure auth. Update `StartServer` (or add a parameter) to pass opts through to all `Register*Service` calls, same pattern as `serve.go`.
+
+For tests that don't need auth (existing tests), pass no opts (empty variadic). For auth-specific tests, pass the interceptor.
+
+- [ ] **Step 2: Verify E2E tests still pass without auth**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test -tags e2e ./e2e/api/ -v --ginkgo.label-filter='!auth' -count=1`
+Expected: PASS (existing tests unaffected — no opts passed = no interceptor)
+
+- [ ] **Step 3: Commit**
+
+```text
+refactor(e2e): propagate handler options through test server setup
+```
+
+---
+
+## Chunk 5: E2E Auth Tests
+
+### Task 11: E2E Auth Test Scenarios
+
+**Files:**
+
+- Create: `e2e/api/auth_test.go`
+
+- [ ] **Step 1: Write E2E auth tests**
+
+Create Ginkgo test file with `//go:build e2e` tag and `auth` label:
+
+```go
+// e2e/api/auth_test.go
+//go:build e2e
+
+package api_test
+
+// Tests covering:
+// - No keys configured → all requests succeed (local identity)
+// - Keys configured → no Bearer → Unauthenticated on non-Health RPCs
+// - Keys configured → valid reader key → can GetSpec, cannot CreateSpec
+// - Keys configured → valid admin key → can CreateSpec
+// - Keys configured → custom role with specific permissions
+// - Health always responds regardless of auth config
+```
+
+Each scenario starts a fresh server with a specific auth config (using the E2E test helpers).
+
+**Key approach:** The E2E tests need separate server instances with different auth configs. Use `BeforeEach` to start a server with the config for that `Describe` block, or use table-driven Ginkgo `Entry` patterns.
+
+- [ ] **Step 2: Run E2E auth tests**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test -tags e2e ./e2e/api/ -v --ginkgo.label-filter='auth' -count=1`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```text
+test(e2e): add auth interceptor E2E test scenarios
+```
+
+### Task 12: Run Full Quality Gate
+
+- [ ] **Step 1: Run task check**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && task check`
+Expected: PASS (fmt, license, lint, build, unit tests)
+
+- [ ] **Step 2: Run task pr-prep**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && task pr-prep`
+Expected: PASS (check + integration + e2e)
+
+- [ ] **Step 3: Add license headers to new files if missing**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && task license:add`
+
+- [ ] **Step 4: Fix any lint issues**
+
+Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && task lint`
+Fix any issues found.
+
+- [ ] **Step 5: Final commit if any fixes needed**
+
+```text
+chore: fix lint and license headers for auth package
+```
+
+### Task 13: Close Beads
+
+- [ ] **Step 1: Close resolved beads**
+
+```bash
+bd close spgr-dpi spgr-ous spgr-4r8 --reason="Resolved by auth interceptor (PR #XX)"
+```
+
+- [ ] **Step 2: Update OIDC bead with progress note**
+
+```bash
+bd update spgr-0az --notes="JWT detection hook and IdentityStore interface in place. Ready for OIDC provider implementation."
+```

--- a/e2e/api/api_suite_test.go
+++ b/e2e/api/api_suite_test.go
@@ -16,10 +16,11 @@ import (
 )
 
 var (
-	serverInfo    *testutil.ServerInfo
-	cleanupServer func()
-	cleanupMG     func()
-	cliBinaryPath string
+	serverInfo      *testutil.ServerInfo
+	cleanupServer   func()
+	cleanupMG       func()
+	cliBinaryPath   string
+	memgraphBoltURI string
 )
 
 func TestAPI(t *testing.T) {
@@ -37,11 +38,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	DeferCleanup(cleanupBinary)
 
-	var boltURI string
-	boltURI, cleanupMG, err = testutil.StartMemgraph(ctx)
+	memgraphBoltURI, cleanupMG, err = testutil.StartMemgraph(ctx)
 	Expect(err).NotTo(HaveOccurred())
 
-	serverInfo, cleanupServer, err = testutil.StartServer(ctx, boltURI)
+	serverInfo, cleanupServer, err = testutil.StartServer(ctx, memgraphBoltURI)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Clear any leftover data from previous test runs.

--- a/e2e/api/auth_test.go
+++ b/e2e/api/auth_test.go
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+//go:build e2e
+
+package api_test
+
+import (
+	"context"
+	"net/http"
+
+	"connectrpc.com/connect"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/seanb4t/specgraph/internal/auth"
+	"github.com/seanb4t/specgraph/internal/config"
+	"github.com/seanb4t/specgraph/e2e/testutil"
+)
+
+// withBearer returns a client option that injects a Bearer token into requests.
+func withBearer(token string) connect.ClientOption {
+	return connect.WithInterceptors(connect.UnaryInterceptorFunc(
+		func(next connect.UnaryFunc) connect.UnaryFunc {
+			return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+				req.Header().Set("Authorization", "Bearer "+token)
+				return next(ctx, req)
+			}
+		},
+	))
+}
+
+// authProjectClient returns an HTTP client with the project header set.
+func authProjectClient() *http.Client {
+	return projectClientFor(e2eProject)
+}
+
+var _ = Describe("Auth", Label("auth"), func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	Describe("no keys configured", func() {
+		var (
+			info    *testutil.ServerInfo
+			cleanup func()
+		)
+
+		BeforeEach(func() {
+			// Start server with auth interceptor but no API keys configured.
+			store, err := auth.NewConfigStore(config.AuthConfig{})
+			Expect(err).NotTo(HaveOccurred())
+			interceptor := auth.NewAuthInterceptor(store)
+
+			boltURI := memgraphBoltURI
+			info, cleanup, err = testutil.StartServer(ctx, boltURI,
+				connect.WithInterceptors(interceptor),
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			if cleanup != nil {
+				cleanup()
+			}
+		})
+
+		It("allows unauthenticated requests via local identity fallback", func() {
+			client := specgraphv1connect.NewSpecServiceClient(authProjectClient(), info.BaseURL)
+			_, err := client.ListSpecs(ctx, connect.NewRequest(&specv1.ListSpecsRequest{}))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows health check without auth", func() {
+			client := specgraphv1connect.NewServerServiceClient(http.DefaultClient, info.BaseURL)
+			resp, err := client.Health(ctx, connect.NewRequest(&specv1.HealthRequest{}))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Msg.Status).To(Equal("ok"))
+		})
+	})
+
+	Describe("keys configured, no Bearer token", func() {
+		var (
+			info    *testutil.ServerInfo
+			cleanup func()
+		)
+
+		BeforeEach(func() {
+			authCfg := config.AuthConfig{
+				APIKeys: []config.APIKeyConfig{
+					{ID: "k1", Key: "secret-admin-key", Name: "Admin", Role: "admin"},
+				},
+			}
+			store, err := auth.NewConfigStore(authCfg)
+			Expect(err).NotTo(HaveOccurred())
+			interceptor := auth.NewAuthInterceptor(store)
+
+			boltURI := memgraphBoltURI
+			info, cleanup, err = testutil.StartServer(ctx, boltURI,
+				connect.WithInterceptors(interceptor),
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			if cleanup != nil {
+				cleanup()
+			}
+		})
+
+		It("rejects unauthenticated GetSpec with Unauthenticated", func() {
+			client := specgraphv1connect.NewSpecServiceClient(authProjectClient(), info.BaseURL)
+			_, err := client.GetSpec(ctx, connect.NewRequest(&specv1.GetSpecRequest{Slug: "nonexistent"}))
+			Expect(err).To(HaveOccurred())
+			Expect(connect.CodeOf(err)).To(Equal(connect.CodeUnauthenticated))
+		})
+
+		It("rejects unauthenticated CreateSpec with Unauthenticated", func() {
+			client := specgraphv1connect.NewSpecServiceClient(authProjectClient(), info.BaseURL)
+			_, err := client.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+				Slug: "auth-test", Intent: "test", Priority: "p2",
+			}))
+			Expect(err).To(HaveOccurred())
+			Expect(connect.CodeOf(err)).To(Equal(connect.CodeUnauthenticated))
+		})
+
+		It("rejects unauthenticated ListDecisions with Unauthenticated", func() {
+			client := specgraphv1connect.NewDecisionServiceClient(authProjectClient(), info.BaseURL)
+			_, err := client.ListDecisions(ctx, connect.NewRequest(&specv1.ListDecisionsRequest{}))
+			Expect(err).To(HaveOccurred())
+			Expect(connect.CodeOf(err)).To(Equal(connect.CodeUnauthenticated))
+		})
+
+		It("allows Health without Bearer token", func() {
+			client := specgraphv1connect.NewServerServiceClient(http.DefaultClient, info.BaseURL)
+			resp, err := client.Health(ctx, connect.NewRequest(&specv1.HealthRequest{}))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Msg.Status).To(Equal("ok"))
+		})
+	})
+
+	Describe("keys configured, valid reader key", func() {
+		const readerKey = "reader-secret-key-123"
+
+		var (
+			info    *testutil.ServerInfo
+			cleanup func()
+		)
+
+		BeforeEach(func() {
+			authCfg := config.AuthConfig{
+				APIKeys: []config.APIKeyConfig{
+					{ID: "reader1", Key: readerKey, Name: "Reader", Role: "reader"},
+				},
+			}
+			store, err := auth.NewConfigStore(authCfg)
+			Expect(err).NotTo(HaveOccurred())
+			interceptor := auth.NewAuthInterceptor(store)
+
+			boltURI := memgraphBoltURI
+			info, cleanup, err = testutil.StartServer(ctx, boltURI,
+				connect.WithInterceptors(interceptor),
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			if cleanup != nil {
+				cleanup()
+			}
+		})
+
+		It("can ListSpecs with reader key", func() {
+			client := specgraphv1connect.NewSpecServiceClient(authProjectClient(), info.BaseURL, withBearer(readerKey))
+			_, err := client.ListSpecs(ctx, connect.NewRequest(&specv1.ListSpecsRequest{}))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("cannot CreateSpec with reader key", func() {
+			client := specgraphv1connect.NewSpecServiceClient(authProjectClient(), info.BaseURL, withBearer(readerKey))
+			_, err := client.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+				Slug: "reader-attempt", Intent: "should fail", Priority: "p3",
+			}))
+			Expect(err).To(HaveOccurred())
+			Expect(connect.CodeOf(err)).To(Equal(connect.CodePermissionDenied))
+		})
+
+		It("can ListDecisions with reader key", func() {
+			client := specgraphv1connect.NewDecisionServiceClient(authProjectClient(), info.BaseURL, withBearer(readerKey))
+			_, err := client.ListDecisions(ctx, connect.NewRequest(&specv1.ListDecisionsRequest{}))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("cannot CreateDecision with reader key", func() {
+			client := specgraphv1connect.NewDecisionServiceClient(authProjectClient(), info.BaseURL, withBearer(readerKey))
+			_, err := client.CreateDecision(ctx, connect.NewRequest(&specv1.CreateDecisionRequest{
+				Slug: "reader-decision", Title: "should fail",
+			}))
+			Expect(err).To(HaveOccurred())
+			Expect(connect.CodeOf(err)).To(Equal(connect.CodePermissionDenied))
+		})
+	})
+
+	Describe("keys configured, valid admin key", func() {
+		const adminKey = "admin-secret-key-456"
+
+		var (
+			info    *testutil.ServerInfo
+			cleanup func()
+		)
+
+		BeforeEach(func() {
+			authCfg := config.AuthConfig{
+				APIKeys: []config.APIKeyConfig{
+					{ID: "admin1", Key: adminKey, Name: "Admin", Role: "admin"},
+				},
+			}
+			store, err := auth.NewConfigStore(authCfg)
+			Expect(err).NotTo(HaveOccurred())
+			interceptor := auth.NewAuthInterceptor(store)
+
+			boltURI := memgraphBoltURI
+			info, cleanup, err = testutil.StartServer(ctx, boltURI,
+				connect.WithInterceptors(interceptor),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Seed a spec for read operations.
+			client := specgraphv1connect.NewSpecServiceClient(authProjectClient(), info.BaseURL, withBearer(adminKey))
+			_, err = client.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+				Slug: "admin-test-spec", Intent: "admin seeded spec", Priority: "p1",
+			}))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			if cleanup != nil {
+				cleanup()
+			}
+		})
+
+		It("can ListSpecs", func() {
+			client := specgraphv1connect.NewSpecServiceClient(authProjectClient(), info.BaseURL, withBearer(adminKey))
+			resp, err := client.ListSpecs(ctx, connect.NewRequest(&specv1.ListSpecsRequest{}))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Msg.Specs).NotTo(BeEmpty())
+		})
+
+		It("can CreateSpec", func() {
+			client := specgraphv1connect.NewSpecServiceClient(authProjectClient(), info.BaseURL, withBearer(adminKey))
+			_, err := client.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+				Slug: "admin-create-test", Intent: "admin can create", Priority: "p2",
+			}))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("can GetSpec", func() {
+			client := specgraphv1connect.NewSpecServiceClient(authProjectClient(), info.BaseURL, withBearer(adminKey))
+			resp, err := client.GetSpec(ctx, connect.NewRequest(&specv1.GetSpecRequest{Slug: "admin-test-spec"}))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Msg.Slug).To(Equal("admin-test-spec"))
+		})
+
+		It("can CreateDecision", func() {
+			client := specgraphv1connect.NewDecisionServiceClient(authProjectClient(), info.BaseURL, withBearer(adminKey))
+			_, err := client.CreateDecision(ctx, connect.NewRequest(&specv1.CreateDecisionRequest{
+				Slug: "admin-decision", Title: "admin decision",
+			}))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("keys configured, custom role", func() {
+		const customKey = "custom-role-key-789"
+
+		var (
+			info    *testutil.ServerInfo
+			cleanup func()
+		)
+
+		BeforeEach(func() {
+			authCfg := config.AuthConfig{
+				APIKeys: []config.APIKeyConfig{
+					{ID: "custom1", Key: customKey, Name: "SpecOnly", Role: "spec-reader"},
+				},
+				Roles: map[string]config.RoleConfig{
+					"spec-reader": {Permissions: []string{"spec:read"}},
+				},
+			}
+			store, err := auth.NewConfigStore(authCfg)
+			Expect(err).NotTo(HaveOccurred())
+			interceptor := auth.NewAuthInterceptor(store)
+
+			boltURI := memgraphBoltURI
+			info, cleanup, err = testutil.StartServer(ctx, boltURI,
+				connect.WithInterceptors(interceptor),
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			if cleanup != nil {
+				cleanup()
+			}
+		})
+
+		It("can ListSpecs with spec:read permission", func() {
+			client := specgraphv1connect.NewSpecServiceClient(authProjectClient(), info.BaseURL, withBearer(customKey))
+			_, err := client.ListSpecs(ctx, connect.NewRequest(&specv1.ListSpecsRequest{}))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("cannot CreateSpec with only spec:read permission", func() {
+			client := specgraphv1connect.NewSpecServiceClient(authProjectClient(), info.BaseURL, withBearer(customKey))
+			_, err := client.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+				Slug: "custom-attempt", Intent: "should fail", Priority: "p3",
+			}))
+			Expect(err).To(HaveOccurred())
+			Expect(connect.CodeOf(err)).To(Equal(connect.CodePermissionDenied))
+		})
+
+		It("cannot ListDecisions with only spec:read permission", func() {
+			client := specgraphv1connect.NewDecisionServiceClient(authProjectClient(), info.BaseURL, withBearer(customKey))
+			_, err := client.ListDecisions(ctx, connect.NewRequest(&specv1.ListDecisionsRequest{}))
+			Expect(err).To(HaveOccurred())
+			Expect(connect.CodeOf(err)).To(Equal(connect.CodePermissionDenied))
+		})
+
+		It("cannot access graph endpoints with only spec:read permission", func() {
+			client := specgraphv1connect.NewGraphServiceClient(authProjectClient(), info.BaseURL, withBearer(customKey))
+			_, err := client.ListEdges(ctx, connect.NewRequest(&specv1.ListEdgesRequest{}))
+			Expect(err).To(HaveOccurred())
+			Expect(connect.CodeOf(err)).To(Equal(connect.CodePermissionDenied))
+		})
+	})
+
+	Describe("Health always responds", Label("auth"), func() {
+		It("responds when no auth interceptor is configured", func() {
+			// The suite-level server has no auth interceptor.
+			client := specgraphv1connect.NewServerServiceClient(http.DefaultClient, serverInfo.BaseURL)
+			resp, err := client.Health(ctx, connect.NewRequest(&specv1.HealthRequest{}))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Msg.Status).To(Equal("ok"))
+		})
+
+		It("responds when auth is configured and no token is provided", func() {
+			authCfg := config.AuthConfig{
+				APIKeys: []config.APIKeyConfig{
+					{ID: "h1", Key: "health-test-key", Name: "Test", Role: "admin"},
+				},
+			}
+			store, err := auth.NewConfigStore(authCfg)
+			Expect(err).NotTo(HaveOccurred())
+			interceptor := auth.NewAuthInterceptor(store)
+
+			boltURI := memgraphBoltURI
+			info, cleanup, err := testutil.StartServer(ctx, boltURI,
+				connect.WithInterceptors(interceptor),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			defer cleanup()
+
+			client := specgraphv1connect.NewServerServiceClient(http.DefaultClient, info.BaseURL)
+			resp, err := client.Health(ctx, connect.NewRequest(&specv1.HealthRequest{}))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Msg.Status).To(Equal("ok"))
+		})
+	})
+})

--- a/e2e/testutil/server.go
+++ b/e2e/testutil/server.go
@@ -14,6 +14,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"connectrpc.com/connect"
+
 	"github.com/seanb4t/specgraph/internal/drift"
 	"github.com/seanb4t/specgraph/internal/linter"
 	"github.com/seanb4t/specgraph/internal/server"
@@ -29,7 +31,7 @@ type ServerInfo struct {
 
 // StartServer launches a specgraph HTTP server connected to the given Memgraph instance.
 // Returns the base URL and a cleanup function that shuts down the server.
-func StartServer(ctx context.Context, boltURI string) (*ServerInfo, func(), error) {
+func StartServer(ctx context.Context, boltURI string, opts ...connect.HandlerOption) (*ServerInfo, func(), error) {
 	var store *memgraph.Store
 	var err error
 	for range 10 {
@@ -43,18 +45,18 @@ func StartServer(ctx context.Context, boltURI string) (*ServerInfo, func(), erro
 		return nil, nil, fmt.Errorf("connect to memgraph: %w", err)
 	}
 
-	mux := server.NewMux(store)
-	server.RegisterHealthService(mux)
-	server.RegisterDecisionService(mux, store)
-	server.RegisterGraphService(mux, store)
-	server.RegisterClaimService(mux, store)
-	server.RegisterConstitutionService(mux, store)
-	server.RegisterAuthoringService(mux, store)
-	server.RegisterExecutionService(mux, store)
+	mux := server.NewMux(store, opts...)
+	server.RegisterHealthService(mux, opts...)
+	server.RegisterDecisionService(mux, store, opts...)
+	server.RegisterGraphService(mux, store, opts...)
+	server.RegisterClaimService(mux, store, opts...)
+	server.RegisterConstitutionService(mux, store, opts...)
+	server.RegisterAuthoringService(mux, store, opts...)
+	server.RegisterExecutionService(mux, store, opts...)
 	driftEngine := drift.NewEngine(store, nil)
 	lintEngine := linter.NewEngine(store, nil)
-	server.RegisterLifecycleService(mux, store, driftEngine, lintEngine, nil)
-	server.RegisterSyncService(mux, store, "")
+	server.RegisterLifecycleService(mux, store, driftEngine, lintEngine, nil, opts...)
+	server.RegisterSyncService(mux, store, "", opts...)
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+// Package auth provides authentication and authorization for SpecGraph RPCs.
+package auth
+
+import "strings"
+
+// Role represents a named authorization role.
+type Role string
+
+// Built-in roles.
+const (
+	RoleAdmin  Role = "admin"
+	RoleWriter Role = "writer"
+	RoleReader Role = "reader"
+)
+
+// Identity represents an authenticated principal.
+type Identity struct {
+	Subject     string          // "local:<user>" | "apikey:<id>" | "oidc:<sub>"
+	DisplayName string          // human-friendly name
+	Role        Role            // role name (built-in or custom)
+	Permissions map[string]bool // raw entries from role definition
+	Source      string          // "local" | "apikey" | "oidc"
+}
+
+// HasPermission checks whether perms satisfies the required permission.
+// Supports wildcards: "*:*" (full), "*:read" (action), "spec:*" (service).
+func HasPermission(perms map[string]bool, required string) bool {
+	if len(perms) == 0 {
+		return false
+	}
+	if perms["*:*"] {
+		return true
+	}
+	if perms[required] {
+		return true
+	}
+	parts := strings.SplitN(required, ":", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	service, action := parts[0], parts[1]
+	if perms[service+":*"] {
+		return true
+	}
+	if perms["*:"+action] {
+		return true
+	}
+	return false
+}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/seanb4t/specgraph/internal/auth"
+)
+
+func TestHasPermission_ExactMatch(t *testing.T) {
+	perms := map[string]bool{"spec:read": true, "spec:write": true}
+	if !auth.HasPermission(perms, "spec:read") {
+		t.Fatal("expected spec:read to match")
+	}
+	if auth.HasPermission(perms, "spec:delete") {
+		t.Fatal("expected spec:delete to not match")
+	}
+}
+
+func TestHasPermission_FullWildcard(t *testing.T) {
+	perms := map[string]bool{"*:*": true}
+	if !auth.HasPermission(perms, "spec:read") {
+		t.Fatal("expected *:* to match spec:read")
+	}
+	if !auth.HasPermission(perms, "lifecycle:delete") {
+		t.Fatal("expected *:* to match lifecycle:delete")
+	}
+}
+
+func TestHasPermission_ActionWildcard(t *testing.T) {
+	perms := map[string]bool{"*:read": true}
+	if !auth.HasPermission(perms, "spec:read") {
+		t.Fatal("expected *:read to match spec:read")
+	}
+	if auth.HasPermission(perms, "spec:write") {
+		t.Fatal("expected *:read to not match spec:write")
+	}
+}
+
+func TestHasPermission_ServiceWildcard(t *testing.T) {
+	perms := map[string]bool{"spec:*": true}
+	if !auth.HasPermission(perms, "spec:read") {
+		t.Fatal("expected spec:* to match spec:read")
+	}
+	if !auth.HasPermission(perms, "spec:delete") {
+		t.Fatal("expected spec:* to match spec:delete")
+	}
+	if auth.HasPermission(perms, "decision:read") {
+		t.Fatal("expected spec:* to not match decision:read")
+	}
+}
+
+func TestHasPermission_EmptyPerms(t *testing.T) {
+	if auth.HasPermission(nil, "spec:read") {
+		t.Fatal("nil perms should deny everything")
+	}
+	if auth.HasPermission(map[string]bool{}, "spec:read") {
+		t.Fatal("empty perms should deny everything")
+	}
+}

--- a/internal/auth/config_store.go
+++ b/internal/auth/config_store.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"context"
+	"crypto/subtle"
+	"fmt"
+	"strings"
+
+	"github.com/seanb4t/specgraph/internal/config"
+)
+
+// DefaultRolePermissions defines the built-in role permission bundles.
+var DefaultRolePermissions = map[Role][]string{
+	RoleReader: {"*:read"},
+	RoleWriter: {"*:read", "*:write"},
+	RoleAdmin:  {"*:*"},
+}
+
+// ConfigStore implements IdentityStore backed by static config file entries.
+type ConfigStore struct {
+	identities map[string]*Identity
+	hasKeys    bool
+}
+
+// NewConfigStore builds a ConfigStore from the auth section of the config file.
+// It validates that all key IDs and values are unique and that referenced roles exist.
+func NewConfigStore(cfg config.AuthConfig) (*ConfigStore, error) {
+	roles := make(map[string][]string)
+	for role, perms := range DefaultRolePermissions {
+		roles[string(role)] = perms
+	}
+	for name, rc := range cfg.Roles {
+		roles[name] = rc.Permissions
+	}
+
+	identities := make(map[string]*Identity, len(cfg.APIKeys))
+	seenIDs := make(map[string]bool, len(cfg.APIKeys))
+
+	for _, ak := range cfg.APIKeys {
+		if strings.TrimSpace(ak.ID) == "" {
+			return nil, fmt.Errorf("API key ID must not be empty")
+		}
+		if strings.TrimSpace(ak.Key) == "" {
+			return nil, fmt.Errorf("API key %s must have a non-empty value", ak.ID)
+		}
+		if seenIDs[ak.ID] {
+			return nil, fmt.Errorf("duplicate API key ID: %s", ak.ID)
+		}
+		seenIDs[ak.ID] = true
+		if _, exists := identities[ak.Key]; exists {
+			return nil, fmt.Errorf("duplicate API key value for IDs: %s", ak.ID)
+		}
+		perms, ok := roles[ak.Role]
+		if !ok {
+			return nil, fmt.Errorf("API key %s references unknown role: %s", ak.ID, ak.Role)
+		}
+		permMap := make(map[string]bool, len(perms))
+		for _, p := range perms {
+			permMap[p] = true
+		}
+		identities[ak.Key] = &Identity{
+			Subject:     "apikey:" + ak.ID,
+			DisplayName: ak.Name,
+			Role:        Role(ak.Role),
+			Permissions: permMap,
+			Source:      "apikey",
+		}
+	}
+
+	return &ConfigStore{
+		identities: identities,
+		hasKeys:    len(identities) > 0,
+	}, nil
+}
+
+// ResolveAPIKey looks up the identity for the given API key using constant-time comparison.
+// Always iterates all keys to prevent timing side-channels from leaking which slot matched.
+func (s *ConfigStore) ResolveAPIKey(_ context.Context, key string) (*Identity, error) {
+	var matched *Identity
+	for storedKey, id := range s.identities {
+		if subtle.ConstantTimeCompare([]byte(storedKey), []byte(key)) == 1 {
+			matched = id
+		}
+	}
+	if matched != nil {
+		return matched, nil
+	}
+	return nil, ErrUnknownKey
+}
+
+// HasKeys reports whether any API keys are configured.
+func (s *ConfigStore) HasKeys() bool {
+	return s.hasKeys
+}

--- a/internal/auth/config_store_test.go
+++ b/internal/auth/config_store_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/seanb4t/specgraph/internal/auth"
+	"github.com/seanb4t/specgraph/internal/config"
+)
+
+func TestConfigStore_ResolveAPIKey(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Test Key", Role: "admin"},
+		},
+	}
+	store, err := auth.NewConfigStore(cfg)
+	if err != nil {
+		t.Fatalf("NewConfigStore: %v", err)
+	}
+	id, err := store.ResolveAPIKey(context.Background(), "spgr_sk_abc")
+	if err != nil {
+		t.Fatalf("ResolveAPIKey: %v", err)
+	}
+	if id.Subject != "apikey:k1" {
+		t.Errorf("subject = %q, want apikey:k1", id.Subject)
+	}
+	if id.Role != auth.RoleAdmin {
+		t.Errorf("role = %q, want admin", id.Role)
+	}
+	if id.Source != "apikey" {
+		t.Errorf("source = %q, want apikey", id.Source)
+	}
+}
+
+func TestConfigStore_UnknownKey(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Test Key", Role: "admin"},
+		},
+	}
+	store, err := auth.NewConfigStore(cfg)
+	if err != nil {
+		t.Fatalf("NewConfigStore: %v", err)
+	}
+	_, err = store.ResolveAPIKey(context.Background(), "wrong_key")
+	if !errors.Is(err, auth.ErrUnknownKey) {
+		t.Errorf("err = %v, want ErrUnknownKey", err)
+	}
+}
+
+func TestConfigStore_HasKeys(t *testing.T) {
+	empty, err := auth.NewConfigStore(config.AuthConfig{})
+	if err != nil {
+		t.Fatalf("NewConfigStore: %v", err)
+	}
+	if empty.HasKeys() {
+		t.Error("HasKeys() = true for empty config")
+	}
+	withKey, err := auth.NewConfigStore(config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Key", Role: "reader"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewConfigStore: %v", err)
+	}
+	if !withKey.HasKeys() {
+		t.Error("HasKeys() = false for config with keys")
+	}
+}
+
+func TestConfigStore_DuplicateKeyID(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Key 1", Role: "admin"},
+			{ID: "k1", Key: "spgr_sk_def", Name: "Key 2", Role: "reader"},
+		},
+	}
+	_, err := auth.NewConfigStore(cfg)
+	if err == nil {
+		t.Fatal("expected error for duplicate key ID")
+	}
+}
+
+func TestConfigStore_DuplicateKeyValue(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_same", Name: "Key 1", Role: "admin"},
+			{ID: "k2", Key: "spgr_sk_same", Name: "Key 2", Role: "reader"},
+		},
+	}
+	_, err := auth.NewConfigStore(cfg)
+	if err == nil {
+		t.Fatal("expected error for duplicate key value")
+	}
+}
+
+func TestConfigStore_UnknownRole(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Key", Role: "nonexistent"},
+		},
+	}
+	_, err := auth.NewConfigStore(cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown role")
+	}
+}
+
+func TestConfigStore_BlankID(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "", Key: "spgr_sk_abc", Name: "Key", Role: "admin"},
+		},
+	}
+	_, err := auth.NewConfigStore(cfg)
+	if err == nil {
+		t.Fatal("expected error for blank key ID")
+	}
+}
+
+func TestConfigStore_BlankKey(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "", Name: "Key", Role: "admin"},
+		},
+	}
+	_, err := auth.NewConfigStore(cfg)
+	if err == nil {
+		t.Fatal("expected error for blank key value")
+	}
+}
+
+func TestConfigStore_CustomRole(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "CI", Role: "ci-readonly"},
+		},
+		Roles: map[string]config.RoleConfig{
+			"ci-readonly": {Permissions: []string{"spec:read", "decision:read"}},
+		},
+	}
+	store, err := auth.NewConfigStore(cfg)
+	if err != nil {
+		t.Fatalf("NewConfigStore: %v", err)
+	}
+	id, err := store.ResolveAPIKey(context.Background(), "spgr_sk_abc")
+	if err != nil {
+		t.Fatalf("ResolveAPIKey: %v", err)
+	}
+	if !auth.HasPermission(id.Permissions, "spec:read") {
+		t.Error("expected spec:read permission")
+	}
+	if auth.HasPermission(id.Permissions, "spec:write") {
+		t.Error("unexpected spec:write permission")
+	}
+}
+
+func TestConfigStore_BuiltinRolePermissions(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_r", Name: "Reader", Role: "reader"},
+			{ID: "k2", Key: "spgr_sk_w", Name: "Writer", Role: "writer"},
+			{ID: "k3", Key: "spgr_sk_a", Name: "Admin", Role: "admin"},
+		},
+	}
+	store, err := auth.NewConfigStore(cfg)
+	if err != nil {
+		t.Fatalf("NewConfigStore: %v", err)
+	}
+	reader, _ := store.ResolveAPIKey(context.Background(), "spgr_sk_r")
+	if !auth.HasPermission(reader.Permissions, "spec:read") {
+		t.Error("reader should have spec:read")
+	}
+	if auth.HasPermission(reader.Permissions, "spec:write") {
+		t.Error("reader should not have spec:write")
+	}
+	writer, _ := store.ResolveAPIKey(context.Background(), "spgr_sk_w")
+	if !auth.HasPermission(writer.Permissions, "spec:write") {
+		t.Error("writer should have spec:write")
+	}
+	if auth.HasPermission(writer.Permissions, "graph:delete") {
+		t.Error("writer should not have graph:delete")
+	}
+	admin, _ := store.ResolveAPIKey(context.Background(), "spgr_sk_a")
+	if !auth.HasPermission(admin.Permissions, "graph:delete") {
+		t.Error("admin should have graph:delete via *:*")
+	}
+}

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import "context"
+
+type contextKey struct{}
+
+// WithIdentity returns a new context carrying the given identity.
+// A nil identity is treated as absent — the original context is returned unchanged.
+func WithIdentity(ctx context.Context, id *Identity) context.Context {
+	if id == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, contextKey{}, id)
+}
+
+// IdentityFromContext extracts the identity from the context.
+// Returns nil, false if no identity is present (e.g., exempt RPCs).
+func IdentityFromContext(ctx context.Context) (*Identity, bool) {
+	id, ok := ctx.Value(contextKey{}).(*Identity)
+	if !ok || id == nil {
+		return nil, false
+	}
+	return id, true
+}

--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os/user"
+	"strings"
+
+	"connectrpc.com/connect"
+)
+
+// NewAuthInterceptor returns a ConnectRPC unary interceptor that authenticates
+// requests using the provided IdentityStore. Exempt procedures (e.g., Health)
+// bypass authentication entirely.
+func NewAuthInterceptor(store IdentityStore) connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			procedure := req.Spec().Procedure
+
+			if IsExempt(procedure) {
+				return next(ctx, req)
+			}
+
+			id, authErr := resolveIdentity(ctx, store, req.Header())
+			if authErr != nil {
+				slog.Warn("auth: authentication failed",
+					"procedure", procedure,
+					"error", authErr.Error(),
+				)
+				return nil, authErr
+			}
+
+			required, ok := RPCPermission(procedure)
+			if !ok {
+				slog.Error("auth: unconfigured RPC permission",
+					"procedure", procedure,
+				)
+				return nil, connect.NewError(connect.CodeInternal, nil)
+			}
+
+			if !HasPermission(id.Permissions, required) {
+				slog.Warn("auth: permission denied",
+					"subject", id.Subject,
+					"procedure", procedure,
+					"required", required,
+				)
+				return nil, connect.NewError(connect.CodePermissionDenied, nil)
+			}
+
+			slog.Info("auth: authenticated",
+				"subject", id.Subject,
+				"procedure", procedure,
+			)
+			return next(WithIdentity(ctx, id), req)
+		}
+	}
+}
+
+func resolveIdentity(ctx context.Context, store IdentityStore, headers http.Header) (*Identity, error) {
+	authHeader := headers.Get("Authorization")
+
+	if authHeader == "" {
+		if !store.HasKeys() {
+			return localIdentity(), nil
+		}
+		return nil, connect.NewError(connect.CodeUnauthenticated, nil)
+	}
+
+	// Parse "Bearer <token>" — scheme is case-insensitive per RFC 7235.
+	scheme, token, ok := strings.Cut(authHeader, " ")
+	token = strings.TrimSpace(token)
+	if !ok || !strings.EqualFold(scheme, "Bearer") || token == "" {
+		return nil, connect.NewError(connect.CodeUnauthenticated, nil)
+	}
+
+	// Try API key resolution first — keys are opaque strings that may contain dots.
+	id, err := store.ResolveAPIKey(ctx, token)
+	if err == nil {
+		return id, nil
+	}
+	// Unknown key: check if it looks like a JWT (future OIDC support).
+	if errors.Is(err, ErrUnknownKey) && strings.Count(token, ".") == 2 {
+		return nil, connect.NewError(connect.CodeUnimplemented, nil)
+	}
+	if errors.Is(err, ErrUnknownKey) {
+		return nil, connect.NewError(connect.CodeUnauthenticated, nil)
+	}
+	// Non-ErrUnknownKey failures (I/O, store outage) are internal errors.
+	return nil, connect.NewError(connect.CodeInternal, nil)
+}
+
+func localIdentity() *Identity {
+	username := "unknown"
+	if u, err := user.Current(); err == nil {
+		username = u.Username
+	}
+	return &Identity{
+		Subject:     "local:" + username,
+		DisplayName: username,
+		Role:        RoleAdmin,
+		Permissions: map[string]bool{"*:*": true},
+		Source:      "local",
+	}
+}

--- a/internal/auth/interceptor_test.go
+++ b/internal/auth/interceptor_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	specgraphv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/seanb4t/specgraph/internal/auth"
+	"github.com/seanb4t/specgraph/internal/config"
+)
+
+type stubHealthHandler struct {
+	specgraphv1connect.UnimplementedServerServiceHandler
+}
+
+func (h *stubHealthHandler) Health(_ context.Context, _ *connect.Request[specgraphv1.HealthRequest]) (*connect.Response[specgraphv1.HealthResponse], error) {
+	return connect.NewResponse(&specgraphv1.HealthResponse{}), nil
+}
+
+type stubSpecHandler struct {
+	specgraphv1connect.UnimplementedSpecServiceHandler
+}
+
+func (h *stubSpecHandler) GetSpec(_ context.Context, _ *connect.Request[specgraphv1.GetSpecRequest]) (*connect.Response[specgraphv1.Spec], error) {
+	return connect.NewResponse(&specgraphv1.Spec{}), nil
+}
+
+func (h *stubSpecHandler) CreateSpec(_ context.Context, _ *connect.Request[specgraphv1.CreateSpecRequest]) (*connect.Response[specgraphv1.Spec], error) {
+	return connect.NewResponse(&specgraphv1.Spec{}), nil
+}
+
+func newTestServer(t *testing.T, authCfg config.AuthConfig) (*httptest.Server, specgraphv1connect.SpecServiceClient, specgraphv1connect.ServerServiceClient) {
+	t.Helper()
+	store, err := auth.NewConfigStore(authCfg)
+	if err != nil {
+		t.Fatalf("NewConfigStore: %v", err)
+	}
+	interceptor := auth.NewAuthInterceptor(store)
+	opts := connect.WithInterceptors(interceptor)
+
+	mux := http.NewServeMux()
+	path, handler := specgraphv1connect.NewServerServiceHandler(&stubHealthHandler{}, opts)
+	mux.Handle(path, handler)
+	path, handler = specgraphv1connect.NewSpecServiceHandler(&stubSpecHandler{}, opts)
+	mux.Handle(path, handler)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	specClient := specgraphv1connect.NewSpecServiceClient(http.DefaultClient, srv.URL)
+	healthClient := specgraphv1connect.NewServerServiceClient(http.DefaultClient, srv.URL)
+	return srv, specClient, healthClient
+}
+
+func withBearer(token string) connect.ClientOption {
+	return connect.WithInterceptors(connect.UnaryInterceptorFunc(
+		func(next connect.UnaryFunc) connect.UnaryFunc {
+			return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+				req.Header().Set("Authorization", "Bearer "+token)
+				return next(ctx, req)
+			}
+		},
+	))
+}
+
+func newSpecClientWithAuth(url, token string) specgraphv1connect.SpecServiceClient {
+	return specgraphv1connect.NewSpecServiceClient(http.DefaultClient, url, withBearer(token))
+}
+
+func TestInterceptor_ValidAPIKey(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Admin", Role: "admin"},
+		},
+	}
+	srv, _, _ := newTestServer(t, cfg)
+	client := newSpecClientWithAuth(srv.URL, "spgr_sk_abc")
+	_, err := client.GetSpec(context.Background(), connect.NewRequest(&specgraphv1.GetSpecRequest{}))
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+}
+
+func TestInterceptor_InvalidAPIKey(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Admin", Role: "admin"},
+		},
+	}
+	srv, _, _ := newTestServer(t, cfg)
+	client := newSpecClientWithAuth(srv.URL, "wrong_key")
+	_, err := client.GetSpec(context.Background(), connect.NewRequest(&specgraphv1.GetSpecRequest{}))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Errorf("code = %v, want Unauthenticated", connect.CodeOf(err))
+	}
+}
+
+func TestInterceptor_NoToken_NoKeys(t *testing.T) {
+	_, specClient, _ := newTestServer(t, config.AuthConfig{})
+	_, err := specClient.GetSpec(context.Background(), connect.NewRequest(&specgraphv1.GetSpecRequest{}))
+	if err != nil {
+		t.Fatalf("expected success with local identity, got: %v", err)
+	}
+}
+
+func TestInterceptor_NoToken_WithKeys(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Admin", Role: "admin"},
+		},
+	}
+	_, specClient, _ := newTestServer(t, cfg)
+	_, err := specClient.GetSpec(context.Background(), connect.NewRequest(&specgraphv1.GetSpecRequest{}))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Errorf("code = %v, want Unauthenticated", connect.CodeOf(err))
+	}
+}
+
+func TestInterceptor_InsufficientPermission(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_r", Name: "Reader", Role: "reader"},
+		},
+	}
+	srv, _, _ := newTestServer(t, cfg)
+	client := newSpecClientWithAuth(srv.URL, "spgr_sk_r")
+	// Reader can GetSpec (spec:read)
+	_, err := client.GetSpec(context.Background(), connect.NewRequest(&specgraphv1.GetSpecRequest{}))
+	if err != nil {
+		t.Fatalf("reader should be able to GetSpec: %v", err)
+	}
+	// Reader cannot CreateSpec (spec:write)
+	_, err = client.CreateSpec(context.Background(), connect.NewRequest(&specgraphv1.CreateSpecRequest{}))
+	if err == nil {
+		t.Fatal("expected error for reader calling CreateSpec")
+	}
+	if connect.CodeOf(err) != connect.CodePermissionDenied {
+		t.Errorf("code = %v, want PermissionDenied", connect.CodeOf(err))
+	}
+}
+
+func TestInterceptor_ExemptRPC(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Admin", Role: "admin"},
+		},
+	}
+	_, _, healthClient := newTestServer(t, cfg)
+	_, err := healthClient.Health(context.Background(), connect.NewRequest(&specgraphv1.HealthRequest{}))
+	if err != nil {
+		t.Fatalf("Health should be exempt: %v", err)
+	}
+}
+
+func TestInterceptor_JWTToken(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Admin", Role: "admin"},
+		},
+	}
+	srv, _, _ := newTestServer(t, cfg)
+	client := newSpecClientWithAuth(srv.URL, "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature")
+	_, err := client.GetSpec(context.Background(), connect.NewRequest(&specgraphv1.GetSpecRequest{}))
+	if err == nil {
+		t.Fatal("expected error for JWT token")
+	}
+	if connect.CodeOf(err) != connect.CodeUnimplemented {
+		t.Errorf("code = %v, want Unimplemented", connect.CodeOf(err))
+	}
+}

--- a/internal/auth/permissions.go
+++ b/internal/auth/permissions.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+)
+
+var rpcPermissions = map[string]string{
+	// SpecService
+	specgraphv1connect.SpecServiceGetSpecProcedure:    "spec:read",
+	specgraphv1connect.SpecServiceListSpecsProcedure:   "spec:read",
+	specgraphv1connect.SpecServiceCreateSpecProcedure:  "spec:write",
+	specgraphv1connect.SpecServiceUpdateSpecProcedure:  "spec:write",
+	// DecisionService
+	specgraphv1connect.DecisionServiceGetDecisionProcedure:    "decision:read",
+	specgraphv1connect.DecisionServiceListDecisionsProcedure:   "decision:read",
+	specgraphv1connect.DecisionServiceCreateDecisionProcedure:  "decision:write",
+	specgraphv1connect.DecisionServiceUpdateDecisionProcedure:  "decision:write",
+	// GraphService
+	specgraphv1connect.GraphServiceGetDependenciesProcedure:    "graph:read",
+	specgraphv1connect.GraphServiceGetTransitiveDepsProcedure:  "graph:read",
+	specgraphv1connect.GraphServiceGetImpactProcedure:          "graph:read",
+	specgraphv1connect.GraphServiceGetReadyProcedure:           "graph:read",
+	specgraphv1connect.GraphServiceGetCriticalPathProcedure:    "graph:read",
+	specgraphv1connect.GraphServiceListEdgesProcedure:          "graph:read",
+	specgraphv1connect.GraphServiceAddEdgeProcedure:            "graph:write",
+	specgraphv1connect.GraphServiceRemoveEdgeProcedure:         "graph:delete",
+	// ClaimService
+	specgraphv1connect.ClaimServiceClaimSpecProcedure:   "claim:write",
+	specgraphv1connect.ClaimServiceHeartbeatProcedure:   "claim:write",
+	specgraphv1connect.ClaimServiceUnclaimSpecProcedure: "claim:write",
+	// ConstitutionService
+	specgraphv1connect.ConstitutionServiceGetConstitutionProcedure:    "constitution:read",
+	specgraphv1connect.ConstitutionServiceCheckViolationProcedure:     "constitution:read",
+	specgraphv1connect.ConstitutionServiceUpdateConstitutionProcedure: "constitution:write",
+	specgraphv1connect.ConstitutionServiceEmitToolFilesProcedure:      "constitution:write",
+	// AuthoringService
+	specgraphv1connect.AuthoringServiceGetPromptsProcedure:  "authoring:read",
+	specgraphv1connect.AuthoringServiceSparkProcedure:       "authoring:write",
+	specgraphv1connect.AuthoringServiceShapeProcedure:       "authoring:write",
+	specgraphv1connect.AuthoringServiceSpecifyProcedure:     "authoring:write",
+	specgraphv1connect.AuthoringServiceDecomposeProcedure:   "authoring:write",
+	specgraphv1connect.AuthoringServiceApproveProcedure:     "authoring:write",
+	specgraphv1connect.AuthoringServiceAmendProcedure:       "authoring:write",
+	specgraphv1connect.AuthoringServiceSupersedeProcedure:   "authoring:write",
+	// ExecutionService
+	specgraphv1connect.ExecutionServiceGenerateBundleProcedure:     "execution:read",
+	specgraphv1connect.ExecutionServiceGetPrimeProcedure:           "execution:read",
+	specgraphv1connect.ExecutionServiceGetExecutionEventsProcedure: "execution:read",
+	specgraphv1connect.ExecutionServiceReportProgressProcedure:     "execution:write",
+	specgraphv1connect.ExecutionServiceReportBlockerProcedure:      "execution:write",
+	specgraphv1connect.ExecutionServiceReportCompletionProcedure:   "execution:write",
+	// LifecycleService
+	specgraphv1connect.LifecycleServiceCheckDriftProcedure:          "lifecycle:read",
+	specgraphv1connect.LifecycleServiceLintProcedure:                "lifecycle:read",
+	specgraphv1connect.LifecycleServiceAcknowledgeDriftProcedure:    "lifecycle:write",
+	specgraphv1connect.LifecycleServiceTransitionAmendProcedure:     "lifecycle:write",
+	specgraphv1connect.LifecycleServiceTransitionSupersedeProcedure: "lifecycle:write",
+	specgraphv1connect.LifecycleServiceTransitionAbandonProcedure:   "lifecycle:write",
+	// SyncService
+	specgraphv1connect.SyncServiceGetSyncStatusProcedure: "sync:read",
+	specgraphv1connect.SyncServiceSyncBeadsProcedure:     "sync:write",
+	specgraphv1connect.SyncServiceSyncGitHubProcedure:    "sync:write",
+	specgraphv1connect.SyncServiceInjectProcedure:        "sync:write",
+}
+
+var exemptProcedures = map[string]bool{
+	specgraphv1connect.ServerServiceHealthProcedure: true,
+}
+
+// RPCPermission returns the required permission for a procedure.
+func RPCPermission(procedure string) (string, bool) {
+	perm, ok := rpcPermissions[procedure]
+	return perm, ok
+}
+
+// IsExempt reports whether a procedure is exempt from authentication.
+func IsExempt(procedure string) bool {
+	return exemptProcedures[procedure]
+}

--- a/internal/auth/permissions_test.go
+++ b/internal/auth/permissions_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/seanb4t/specgraph/internal/auth"
+)
+
+var allProcedures = []string{
+	// SpecService
+	specgraphv1connect.SpecServiceCreateSpecProcedure,
+	specgraphv1connect.SpecServiceGetSpecProcedure,
+	specgraphv1connect.SpecServiceListSpecsProcedure,
+	specgraphv1connect.SpecServiceUpdateSpecProcedure,
+	// DecisionService
+	specgraphv1connect.DecisionServiceCreateDecisionProcedure,
+	specgraphv1connect.DecisionServiceGetDecisionProcedure,
+	specgraphv1connect.DecisionServiceListDecisionsProcedure,
+	specgraphv1connect.DecisionServiceUpdateDecisionProcedure,
+	// GraphService
+	specgraphv1connect.GraphServiceAddEdgeProcedure,
+	specgraphv1connect.GraphServiceRemoveEdgeProcedure,
+	specgraphv1connect.GraphServiceListEdgesProcedure,
+	specgraphv1connect.GraphServiceGetDependenciesProcedure,
+	specgraphv1connect.GraphServiceGetTransitiveDepsProcedure,
+	specgraphv1connect.GraphServiceGetImpactProcedure,
+	specgraphv1connect.GraphServiceGetReadyProcedure,
+	specgraphv1connect.GraphServiceGetCriticalPathProcedure,
+	// ClaimService
+	specgraphv1connect.ClaimServiceClaimSpecProcedure,
+	specgraphv1connect.ClaimServiceUnclaimSpecProcedure,
+	specgraphv1connect.ClaimServiceHeartbeatProcedure,
+	// ConstitutionService
+	specgraphv1connect.ConstitutionServiceGetConstitutionProcedure,
+	specgraphv1connect.ConstitutionServiceUpdateConstitutionProcedure,
+	specgraphv1connect.ConstitutionServiceCheckViolationProcedure,
+	specgraphv1connect.ConstitutionServiceEmitToolFilesProcedure,
+	// AuthoringService
+	specgraphv1connect.AuthoringServiceSparkProcedure,
+	specgraphv1connect.AuthoringServiceShapeProcedure,
+	specgraphv1connect.AuthoringServiceSpecifyProcedure,
+	specgraphv1connect.AuthoringServiceDecomposeProcedure,
+	specgraphv1connect.AuthoringServiceApproveProcedure,
+	specgraphv1connect.AuthoringServiceAmendProcedure,
+	specgraphv1connect.AuthoringServiceSupersedeProcedure,
+	specgraphv1connect.AuthoringServiceGetPromptsProcedure,
+	// ExecutionService
+	specgraphv1connect.ExecutionServiceGenerateBundleProcedure,
+	specgraphv1connect.ExecutionServiceGetPrimeProcedure,
+	specgraphv1connect.ExecutionServiceReportProgressProcedure,
+	specgraphv1connect.ExecutionServiceReportBlockerProcedure,
+	specgraphv1connect.ExecutionServiceReportCompletionProcedure,
+	specgraphv1connect.ExecutionServiceGetExecutionEventsProcedure,
+	// LifecycleService
+	specgraphv1connect.LifecycleServiceTransitionAmendProcedure,
+	specgraphv1connect.LifecycleServiceTransitionSupersedeProcedure,
+	specgraphv1connect.LifecycleServiceTransitionAbandonProcedure,
+	specgraphv1connect.LifecycleServiceCheckDriftProcedure,
+	specgraphv1connect.LifecycleServiceAcknowledgeDriftProcedure,
+	specgraphv1connect.LifecycleServiceLintProcedure,
+	// SyncService
+	specgraphv1connect.SyncServiceSyncBeadsProcedure,
+	specgraphv1connect.SyncServiceSyncGitHubProcedure,
+	specgraphv1connect.SyncServiceGetSyncStatusProcedure,
+	specgraphv1connect.SyncServiceInjectProcedure,
+	// ServerService (exempt)
+	specgraphv1connect.ServerServiceHealthProcedure,
+}
+
+func TestPermissionTable_Completeness(t *testing.T) {
+	for _, proc := range allProcedures {
+		if auth.IsExempt(proc) {
+			continue
+		}
+		if _, ok := auth.RPCPermission(proc); !ok {
+			t.Errorf("procedure %s is not in rpcPermissions and not exempt", proc)
+		}
+	}
+}
+
+func TestPermissionTable_NoExemptInPermissions(t *testing.T) {
+	for _, proc := range allProcedures {
+		if !auth.IsExempt(proc) {
+			continue
+		}
+		if _, ok := auth.RPCPermission(proc); ok {
+			t.Errorf("exempt procedure %s should not be in rpcPermissions", proc)
+		}
+	}
+}

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrUnknownKey is returned when an API key is not recognized.
+var ErrUnknownKey = errors.New("unknown API key")
+
+// IdentityStore resolves authentication tokens to identities.
+type IdentityStore interface {
+	// ResolveAPIKey returns the identity for the given API key.
+	// Returns ErrUnknownKey if the key is not recognized.
+	ResolveAPIKey(ctx context.Context, key string) (*Identity, error)
+
+	// HasKeys reports whether any API keys are configured.
+	// When false, unauthenticated requests fall back to the implicit local identity.
+	HasKeys() bool
+}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -15,6 +15,7 @@ import (
 type GlobalConfig struct {
 	Server ServerSection `yaml:"server"`
 	Client ClientConfig  `yaml:"client"`
+	Auth   AuthConfig    `yaml:"auth"`
 }
 
 // ServerSection configures the specgraph server daemon.
@@ -36,6 +37,25 @@ type ClientConfig struct {
 type Route struct {
 	Project string `yaml:"project"`
 	Server  string `yaml:"server"`
+}
+
+// AuthConfig configures authentication and authorization.
+type AuthConfig struct {
+	APIKeys []APIKeyConfig        `yaml:"api_keys"`
+	Roles   map[string]RoleConfig `yaml:"roles"`
+}
+
+// APIKeyConfig defines a single API key and its associated role.
+type APIKeyConfig struct {
+	ID   string `yaml:"id"`
+	Key  string `yaml:"key"`
+	Name string `yaml:"name"`
+	Role string `yaml:"role"`
+}
+
+// RoleConfig defines a custom role with explicit permissions.
+type RoleConfig struct {
+	Permissions []string `yaml:"permissions"`
 }
 
 // LoadGlobal loads the global config from path. If the file doesn't exist,

--- a/internal/server/authoring_handler.go
+++ b/internal/server/authoring_handler.go
@@ -516,12 +516,12 @@ func acceptLinkedDecisions(ctx context.Context, logger *slog.Logger, graphBacken
 }
 
 // RegisterAuthoringService registers the AuthoringService on the given mux.
-func RegisterAuthoringService(mux *http.ServeMux, scoper storage.Scoper) {
+func RegisterAuthoringService(mux *http.ServeMux, scoper storage.Scoper, opts ...connect.HandlerOption) {
 	if scoper == nil {
 		panic("RegisterAuthoringService: scoper must not be nil")
 	}
 	handler := &AuthoringHandler{scoper: scoper, logger: slog.Default()}
-	path, h := specgraphv1connect.NewAuthoringServiceHandler(handler)
+	path, h := specgraphv1connect.NewAuthoringServiceHandler(handler, opts...)
 	mux.Handle(path, h)
 }
 

--- a/internal/server/claim_handler.go
+++ b/internal/server/claim_handler.go
@@ -94,8 +94,8 @@ func (h *ClaimHandler) Heartbeat(ctx context.Context, req *connect.Request[specv
 }
 
 // RegisterClaimService registers the ClaimService on the given mux.
-func RegisterClaimService(mux *http.ServeMux, scoper storage.Scoper) {
+func RegisterClaimService(mux *http.ServeMux, scoper storage.Scoper, opts ...connect.HandlerOption) {
 	handler := &ClaimHandler{scoper: scoper}
-	path, h := specgraphv1connect.NewClaimServiceHandler(handler)
+	path, h := specgraphv1connect.NewClaimServiceHandler(handler, opts...)
 	mux.Handle(path, h)
 }

--- a/internal/server/constitution_handler.go
+++ b/internal/server/constitution_handler.go
@@ -24,9 +24,9 @@ type ConstitutionHandler struct {
 var _ specgraphv1connect.ConstitutionServiceHandler = (*ConstitutionHandler)(nil)
 
 // RegisterConstitutionService registers the ConstitutionService on the given mux.
-func RegisterConstitutionService(mux *http.ServeMux, scoper storage.Scoper) {
+func RegisterConstitutionService(mux *http.ServeMux, scoper storage.Scoper, opts ...connect.HandlerOption) {
 	handler := &ConstitutionHandler{scoper: scoper}
-	path, h := specgraphv1connect.NewConstitutionServiceHandler(handler)
+	path, h := specgraphv1connect.NewConstitutionServiceHandler(handler, opts...)
 	mux.Handle(path, h)
 }
 

--- a/internal/server/decision_handler.go
+++ b/internal/server/decision_handler.go
@@ -140,8 +140,8 @@ func (h *DecisionHandler) UpdateDecision(ctx context.Context, req *connect.Reque
 }
 
 // RegisterDecisionService registers the DecisionService on the given mux.
-func RegisterDecisionService(mux *http.ServeMux, scoper storage.Scoper) {
+func RegisterDecisionService(mux *http.ServeMux, scoper storage.Scoper, opts ...connect.HandlerOption) {
 	handler := &DecisionHandler{scoper: scoper, logger: slog.Default()}
-	path, h := specgraphv1connect.NewDecisionServiceHandler(handler)
+	path, h := specgraphv1connect.NewDecisionServiceHandler(handler, opts...)
 	mux.Handle(path, h)
 }

--- a/internal/server/execution_handler.go
+++ b/internal/server/execution_handler.go
@@ -27,9 +27,9 @@ type ExecutionHandler struct {
 var _ specgraphv1connect.ExecutionServiceHandler = (*ExecutionHandler)(nil)
 
 // RegisterExecutionService registers the ExecutionService on the given mux.
-func RegisterExecutionService(mux *http.ServeMux, scoper storage.Scoper) {
+func RegisterExecutionService(mux *http.ServeMux, scoper storage.Scoper, opts ...connect.HandlerOption) {
 	handler := &ExecutionHandler{scoper: scoper}
-	path, h := specgraphv1connect.NewExecutionServiceHandler(handler)
+	path, h := specgraphv1connect.NewExecutionServiceHandler(handler, opts...)
 	mux.Handle(path, h)
 }
 

--- a/internal/server/graph_handler.go
+++ b/internal/server/graph_handler.go
@@ -177,9 +177,9 @@ func (h *GraphHandler) GetCriticalPath(ctx context.Context, req *connect.Request
 }
 
 // RegisterGraphService registers the GraphService on the given mux.
-func RegisterGraphService(mux *http.ServeMux, scoper storage.Scoper) {
+func RegisterGraphService(mux *http.ServeMux, scoper storage.Scoper, opts ...connect.HandlerOption) {
 	handler := &GraphHandler{scoper: scoper}
-	path, h := specgraphv1connect.NewGraphServiceHandler(handler)
+	path, h := specgraphv1connect.NewGraphServiceHandler(handler, opts...)
 	mux.Handle(path, h)
 }
 

--- a/internal/server/health_handler.go
+++ b/internal/server/health_handler.go
@@ -31,7 +31,7 @@ func (h *HealthHandler) Health(_ context.Context, _ *connect.Request[specv1.Heal
 }
 
 // RegisterHealthService registers the ServerService on the given mux.
-func RegisterHealthService(mux *http.ServeMux) {
-	path, handler := specgraphv1connect.NewServerServiceHandler(&HealthHandler{})
+func RegisterHealthService(mux *http.ServeMux, opts ...connect.HandlerOption) {
+	path, handler := specgraphv1connect.NewServerServiceHandler(&HealthHandler{}, opts...)
 	mux.Handle(path, handler)
 }

--- a/internal/server/lifecycle_handler.go
+++ b/internal/server/lifecycle_handler.go
@@ -381,7 +381,7 @@ func (h *LifecycleHandler) lifecycleError(op, slug string, err error) error {
 
 // RegisterLifecycleService registers the LifecycleService on the given mux.
 // If logger is nil, slog.Default() is used.
-func RegisterLifecycleService(mux *http.ServeMux, scoper storage.Scoper, dc DriftChecker, l SpecLinter, logger *slog.Logger) {
+func RegisterLifecycleService(mux *http.ServeMux, scoper storage.Scoper, dc DriftChecker, l SpecLinter, logger *slog.Logger, opts ...connect.HandlerOption) {
 	if scoper == nil {
 		panic("RegisterLifecycleService: scoper must not be nil")
 	}
@@ -394,6 +394,6 @@ func RegisterLifecycleService(mux *http.ServeMux, scoper storage.Scoper, dc Drif
 		linter:       l,
 		logger:       logger,
 	}
-	path, h := specgraphv1connect.NewLifecycleServiceHandler(handler)
+	path, h := specgraphv1connect.NewLifecycleServiceHandler(handler, opts...)
 	mux.Handle(path, h)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,6 +7,7 @@ package server
 import (
 	"net/http"
 
+	"connectrpc.com/connect"
 	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/seanb4t/specgraph/internal/storage"
 )
@@ -14,10 +15,10 @@ import (
 // NewMux creates an http.ServeMux with the SpecService handler registered.
 // Callers register additional services (lifecycle, authoring, etc.) on the
 // returned mux via their respective Register functions.
-func NewMux(scoper storage.Scoper) *http.ServeMux {
+func NewMux(scoper storage.Scoper, opts ...connect.HandlerOption) *http.ServeMux {
 	mux := http.NewServeMux()
 	specHandler := NewSpecHandler(scoper)
-	path, handler := specgraphv1connect.NewSpecServiceHandler(specHandler)
+	path, handler := specgraphv1connect.NewSpecServiceHandler(specHandler, opts...)
 	mux.Handle(path, handler)
 	return mux
 }

--- a/internal/server/sync_handler.go
+++ b/internal/server/sync_handler.go
@@ -35,13 +35,13 @@ var _ specgraphv1connect.SyncServiceHandler = (*SyncHandler)(nil)
 // the handler so callers can register adapters via RegisterAdapter.
 // allowedOutputRoot restricts Inject output_dir to paths within this root;
 // pass "" for unrestricted mode (not recommended for production).
-func RegisterSyncService(mux *http.ServeMux, scoper storage.Scoper, allowedOutputRoot string) *SyncHandler {
+func RegisterSyncService(mux *http.ServeMux, scoper storage.Scoper, allowedOutputRoot string, opts ...connect.HandlerOption) *SyncHandler {
 	handler := &SyncHandler{
 		scoper:            scoper,
 		adapters:          map[storage.SyncAdapterType]syncpkg.Adapter{},
 		allowedOutputRoot: allowedOutputRoot,
 	}
-	path, h := specgraphv1connect.NewSyncServiceHandler(handler)
+	path, h := specgraphv1connect.NewSyncServiceHandler(handler, opts...)
 	mux.Handle(path, h)
 	return handler
 }


### PR DESCRIPTION
## Summary

- Add ConnectRPC unary interceptor for API key authentication with fine-grained `service:action` permissions
- Implicit local identity fallback (OS user as admin) when no API keys configured — zero-config local dev
- JWT/OIDC-ready: detects JWT-shaped tokens, rejects with `Unimplemented` until OIDC support added
- Wildcard permission resolution (`*:*`, `*:read`, `spec:*`) with roles as convenience bundles
- Default-deny: unknown RPCs without permission mappings are rejected at runtime and caught by completeness test

### New package: `internal/auth/`

| File | Purpose |
|------|---------|
| `auth.go` | Identity type, Role constants, HasPermission with wildcards |
| `context.go` | WithIdentity / IdentityFromContext |
| `store.go` | IdentityStore interface, ErrUnknownKey |
| `config_store.go` | Config-file backed store with constant-time key comparison |
| `permissions.go` | RPC→permission table (43 procedures), exempt set |
| `interceptor.go` | NewAuthInterceptor — the ConnectRPC unary interceptor |

### Server wiring

- All `Register*Service` functions accept `...connect.HandlerOption` (backward compatible)
- Interceptor created from `GlobalConfig.Auth` in `serve.go`
- E2E test server propagates handler options

### Config

```yaml
auth:
  api_keys:
    - id: "key-1"
      key: "spgr_sk_abc123..."
      name: "CI Pipeline"
      role: writer
  roles:
    ci-readonly:
      permissions: ["spec:read", "decision:read"]
```

### Epic: spgr-5wb (Authentication & Authorization)

Resolves: spgr-dpi (P1), spgr-ous (P2), spgr-4r8 (P2)
Advances: spgr-0az (OIDC — JWT detection hook in place)

## Test plan

- [x] 18 unit tests (HasPermission wildcards, ConfigStore validation, interceptor flow)
- [x] Permission table completeness test (all 43 RPCs mapped)
- [x] 20 E2E auth tests (no-auth fallback, unauthenticated rejection, reader/writer/admin, custom roles, Health exemption)
- [x] 136 total API E2E tests pass (existing + new auth tests)
- [x] `task check` passes (fmt, license, lint, build, unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in authentication & role-based authorization (admin, writer, reader, custom) with API-key support, local fallback admin, and RPC-level permission checks; health checks remain exempt.
  * Auth interceptor can be wired into server handlers so enforcement applies across all services.

* **Documentation**
  * Added comprehensive Auth Interceptor design and configuration guidance.

* **Tests**
  * Extensive unit and end-to-end auth test suites covering keys, roles, permissions, exemptions, and E2E flows.

* **Chores**
  * Added auth config model and updated server registration to accept and forward handler options for interceptor wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->