### PR TITLE
Update architecture docs and refine authoring/lifecycle stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Start the server and begin working with specs:
 
 ```bash
 specgraph serve             # starts the API and manages Memgraph via Docker Compose
-specgraph spec create auth-login --title "User login flow"
+specgraph spec create auth-login --intent "User login flow"
 specgraph constitution show # view project ground truth
 ```
 
@@ -88,14 +88,32 @@ See the [deployment guide](https://seanb4t.github.io/specgraph/deployment/) for 
 
 | Command | Description |
 |---------|-------------|
-| `specgraph init` | Initialize project config and optionally scan for constitution |
-| `specgraph serve` | Start the ConnectRPC API server |
+| **Specs** | |
 | `specgraph spec create/list/show/update` | Manage specs |
 | `specgraph decision create/list/show` | Manage decisions |
-| `specgraph constitution show/check/emit` | View and validate project constitution |
-| `specgraph claim/unclaim` | Claim or release specs for work |
+| **Authoring** | |
+| `specgraph spark/shape/specify/decompose/approve` | Drive specs through the authoring funnel |
+| **Lifecycle** | |
+| `specgraph amend/supersede/abandon` | Transition specs through lifecycle states |
+| `specgraph drift` | Check for spec drift; `drift ack` to acknowledge |
+| `specgraph lint` | Run the spec linter |
+| **Graph** | |
 | `specgraph edge add/remove/list` | Manage graph edges between specs |
-| `specgraph deps` | Show dependency tree for a spec |
+| `specgraph deps/impact/ready/critical-path` | Query the dependency graph |
+| **Execution** | |
+| `specgraph claim/unclaim` | Claim or release specs for work |
+| `specgraph bundle/prime` | Generate execution bundles and prime context |
+| `specgraph report-progress/report-blocker/report-completion` | Report execution status |
+| **Constitution** | |
+| `specgraph constitution show/import/check/emit` | View, import, validate, and emit constitution |
+| **Sync & Injection** | |
+| `specgraph sync` | Sync specs to Beads or GitHub |
+| `specgraph inject` | Inject spec context into tool files (CLAUDE.md, .cursor/rules, AGENTS.md) |
+| **Infrastructure** | |
+| `specgraph init` | Initialize project config and optionally scan for constitution |
+| `specgraph serve` | Start the ConnectRPC API server |
+| `specgraph health` | Check server health |
+| `specgraph up/down` | Start or stop the database container |
 
 ## Contributing
 
@@ -123,7 +141,7 @@ This runs protobuf code generation (`buf generate`) then builds the binary.
 ### Run tests
 
 ```bash
-task test          # all tests
+task test          # unit tests (excludes integration and e2e)
 task test:short    # skip integration tests
 task test:e2e      # end-to-end smoke tests
 ```
@@ -138,7 +156,7 @@ task dev                    # development mode with hot reload
 
 ### Code generation
 
-Protobuf sources live in `proto/`. Generated code goes to `gen/` (gitignored). Regenerate after changing `.proto` files:
+Protobuf sources live in `proto/`. Generated code goes to `gen/` (committed for Go module compatibility). Regenerate after changing `.proto` files:
 
 ```bash
 task proto

--- a/internal/authoring/prompts.go
+++ b/internal/authoring/prompts.go
@@ -34,7 +34,7 @@ var promptRegistry = map[Stage][]Prompt{
 		{Name: "invariants", Template: "State the invariants that must hold before, during, and after execution."},
 	},
 	StageDecompose: {
-		{Name: "strategy", Template: "Choose a decomposition strategy: vertical slices, horizontal layers, or risk-first."},
+		{Name: "strategy", Template: "Choose a decomposition strategy: vertical slices, horizontal layers, or single unit."},
 		{Name: "slices", Template: "Break the spec into ordered, independently-deliverable slices."},
 	},
 }

--- a/plugin/specgraph/skills/specgraph/decompose/SKILL.md
+++ b/plugin/specgraph/skills/specgraph/decompose/SKILL.md
@@ -45,7 +45,7 @@ RECOMMEND a decomposition strategy based on the spec's shape:
 |----------|-------------------|-------------|
 | **Vertical slice** | User-facing features | Each slice delivers end-to-end value |
 | **Horizontal layer** | Infrastructure work | Split by architecture tier (storage → API → UI) |
-| **Risk-first** | Significant technical risk | Front-load the hardest unknowns |
+| **Single unit** | Small, self-contained work | Deliver the spec as-is without decomposition |
 
 Explain why you recommend one and ask the user to confirm.
 

--- a/site/docs/architecture.md
+++ b/site/docs/architecture.md
@@ -32,7 +32,7 @@ there is no embedded or library mode.
 │  ├─ Beads (spec→bead issue)                         │
 │  ├─ GitHub Issues                                   │
 │  ├─ Linear                                          │
-│  └─ Tool Injection (CLAUDE.md, .cursorrules)        │
+│  └─ Tool Injection (CLAUDE.md, .cursor/rules)        │
 └─────────────────────────────────────────────────────┘
 ```
 
@@ -48,10 +48,13 @@ a single domain concern:
 | **SpecService** | CRUD for specs — create, get, list, update. The primary resource in the graph. |
 | **DecisionService** | CRUD for decisions. ADRs are first-class graph nodes with bidirectional edges to the specs they affect. |
 | **ConstitutionService** | Constitution management — layer merging, validation, and queries across the User → Org → Project → Domain hierarchy. |
-| **AuthoringService** | The authoring funnel RPCs: Spark, Shape, Specify, Decompose, Approve. Drives specs from rough idea to execution-ready. |
+| **AuthoringService** | The authoring funnel RPCs: Spark, Shape, Specify, Decompose, Approve, Amend, Supersede. Drives specs from rough idea to execution-ready. |
 | **ClaimService** | Claim and unclaim specs for execution. Manages leases so multiple agents don't collide on the same work. |
 | **GraphService** | Dependency queries, impact analysis, critical-path computation, and ready-spec detection. |
-| **HealthService** | Server health checks. |
+| **LifecycleService** | Spec lifecycle transitions (amend, supersede, abandon), drift detection, and spec linting. |
+| **ExecutionService** | Execution bundles, prime context, and agent progress/blocker/completion reporting. |
+| **SyncService** | Sync specs to external systems (Beads, GitHub) and inject context into tool files. |
+| **ServerService** | Server health checks. |
 
 All services use protobuf message types on the wire and generate both `.pb.go`
 and `.connect.go` files from the proto definitions.
@@ -94,9 +97,10 @@ are typed edges:
 (:Spec) -[:DEPENDS_ON]->  (:Spec)
 (:Spec) -[:BLOCKS]->      (:Spec)
 (:Spec) -[:COMPOSES]->    (:Spec)
-(:Spec) -[:GOVERNED_BY]-> (:Constitution)
+(:Spec) -[:RELATES_TO]->  (:Spec)
 (:Spec) -[:DECIDED_IN]->  (:Decision)
-(:Spec) -[:CLAIMED_BY]->  (:Agent)
+(:Decision) -[:INFORMS]-> (:Spec)
+(:Spec) -[:SUPERSEDES]->  (:Spec)
 ```
 
 These edges are first-class — they carry metadata, support traversal queries,
@@ -118,20 +122,29 @@ human-readable JSON for debugging.
 
 ```text
 specgraph/
-├── proto/specgraph/v1/     # Protobuf service definitions
-├── gen/                    # Generated code (gitignored)
+├── proto/specgraph/v1/     # Protobuf service definitions (source of truth)
+├── gen/                    # Generated Go code (committed for module compat)
 ├── internal/
-│   ├── server/             # ConnectRPC handlers
+│   ├── server/             # ConnectRPC handlers + proto↔domain converters
 │   ├── storage/            # Backend interface + implementations
-│   │   └── memgraph/       # Memgraph implementation
-│   ├── authoring/          # Domain logic (stages, postures, passes)
-│   └── config/             # Server configuration
+│   │   └── memgraph/       # Memgraph implementation (Cypher, testcontainers)
+│   ├── authoring/          # Authoring funnel (stages, postures, passes)
+│   ├── config/             # YAML-based server configuration
+│   ├── drift/              # Drift detection engine
+│   ├── driftscope/         # Drift scope analysis
+│   ├── linter/             # Spec linter (schema, edges, cycles)
+│   ├── inject/             # Tool injection (CLAUDE.md, .cursor/rules, AGENTS.md)
+│   ├── sync/               # Sync adapters (Beads, GitHub)
+│   ├── emitter/            # Event/output emitters
+│   ├── docker/             # Docker Compose templates for DB containers
+│   └── service/            # systemd/launchd integration
 ├── cmd/specgraph/          # CLI entry point
-├── docker/                 # Docker Compose for dev
+├── e2e/                    # End-to-end tests (Ginkgo/Gomega)
+├── plugin/                 # Claude Code skills and hooks
 └── Taskfile.yml            # Build automation
 ```
 
 Build automation is via [Taskfile.dev](https://taskfile.dev). Run `task --list`
 for the full catalog. The key commands are `task build`, `task test`,
 `task proto`, `task lint`, and `task fmt`. Generated code in `gen/` is
-gitignored — run `task proto` after clone to regenerate it.
+committed — regenerate with `task proto` after changing `.proto` files.

--- a/site/docs/concepts/authoring.md
+++ b/site/docs/concepts/authoring.md
@@ -24,7 +24,7 @@ just enough to start a conversation.
 |-------|-------------|
 | `seed` | The idea itself, in the author's own words. |
 | `signal` | Why now — what triggered this idea (a bug report, a security audit, a customer request). |
-| `scope_sniff` | Initial size estimate: `small`, `medium`, or `large`. |
+| `scope_sniff` | Initial size estimate: `tiny`, `small`, `medium`, `large`, or `epic`. |
 | `kill_test` | What would make this idea not worth pursuing. If the kill test is true, stop here. |
 
 **Example:**

--- a/site/docs/concepts/example-spec.md
+++ b/site/docs/concepts/example-spec.md
@@ -214,8 +214,8 @@ Error (401): token family revoked (reuse detected)
     Decompose breaks the spec into independently deliverable slices. Each slice
     is small enough to implement, test, and review in isolation. The **strategy**
     determines how you cut: vertical slices deliver end-to-end value in each
-    piece, horizontal layers split by architecture tier, and risk-first
-    front-loads the hardest unknowns.
+    piece, horizontal layers split by architecture tier, or single unit
+    delivers the spec as-is when it's small enough.
 
 !!! tip "Graph edges from Depends On"
     The **Depends On** column creates `DEPENDS_ON` graph edges between slices.

--- a/site/docs/concepts/specs.md
+++ b/site/docs/concepts/specs.md
@@ -67,7 +67,10 @@ they are queryable, traversable relationships:
 | `depends_on` | This spec requires another to be done first |
 | `blocks` | This spec prevents another from starting |
 | `composes` | This spec was decomposed from a parent spec |
-| `references` | Links to decisions, ADRs, incidents, or other artifacts |
+| `relates_to` | Informational link between specs or other artifacts |
+| `decided_in` | This spec made a design decision (spec → decision) |
+| `informs` | A decision informs this spec (decision → spec) |
+| `supersedes` | This spec replaces another spec |
 
 ```text
 ┌──────────────────┐
@@ -91,8 +94,9 @@ they are queryable, traversable relationships:
 Edges carry semantics. A `depends_on` edge tells the scheduler not to release a
 spec until its dependency is complete. A `blocks` edge surfaces bottlenecks. A
 `composes` edge traces how a large spec was broken into deliverable slices. A
-`references` edge connects specs to the [decisions](decisions.md) that informed
-them.
+`decided_in` edge connects specs to the [decisions](decisions.md) they produced,
+while `informs` connects decisions back to the specs they affect. A `supersedes`
+edge tracks when one spec replaces another.
 
 ---
 
@@ -122,7 +126,7 @@ The full spec schema is organized into five categories:
 | Category | Fields |
 |---|---|
 | **Identity** | `id`, `slug`, `version`, `created_at`, `updated_at` |
-| **Intent** | `intent`, `stage` (spark / shape / specify / decompose / approved / in_progress / done), `priority` (p0-p3), `complexity` |
+| **Intent** | `intent`, `stage` (spark / shape / specify / decompose / approved / in_progress / review / done / amended / superseded / abandoned), `priority` (p0-p3), `complexity` |
 | **Edges** | `depends_on`, `blocks`, `composes`, `references` |
 | **Authoring Outputs** | `spark_output`, `shape_output`, `specify_output`, `decompose_output` |
 | **Verification** | `verify` (acceptance criteria), `invariants` (conditions that must hold before and after execution) |

--- a/site/docs/ecosystem.md
+++ b/site/docs/ecosystem.md
@@ -65,8 +65,8 @@ eventual-consistency lag between design and execution.
 
 ## Sync Adapters
 
-!!! note "Status: Planned"
-    Sync adapters are designed for Slice 6. None are implemented yet.
+!!! info "Status: In Progress"
+    Beads and GitHub adapters are implemented. Linear is planned.
 
 SpecGraph can push specs to external trackers for visibility and coordination
 with teams that do not use SpecGraph directly.
@@ -76,12 +76,12 @@ with teams that do not use SpecGraph directly.
   sync as task checklists. Full interface contracts and constitution references
   stay in SpecGraph — GitHub gets the summary, SpecGraph keeps the detail.
 
-- **Linear** — Bidirectional or push-only sync. The same fields as GitHub sync
-  to Linear issues and projects. Push-only mode is useful when Linear is the
-  PM-facing view but SpecGraph remains the authoring system.
+- **Linear** (Planned) — Bidirectional or push-only sync. The same fields as
+  GitHub sync to Linear issues and projects. Push-only mode is useful when
+  Linear is the PM-facing view but SpecGraph remains the authoring system.
 
 - **Tool Injection** — Emit the constitution and per-spec context into
-  coding-agent context files: `CLAUDE.md`, `.cursorrules`, `AGENTS.md`. The
+  coding-agent context files: `CLAUDE.md`, `.cursor/rules`, `AGENTS.md`. The
   command `specgraph inject <slug>` writes a spec's interface contracts,
   constraints, and relevant constitution layers into the current working
   directory so that any coding agent picks them up automatically.

--- a/site/docs/roadmap.md
+++ b/site/docs/roadmap.md
@@ -13,10 +13,10 @@ The core system: spec schema, storage, authoring, and execution primitives.
 | 1 | Core proto schema, ConnectRPC server, Memgraph backend, CLI basics | Done |
 | 2 | Constitution creation/storage/validation, emitters | Done |
 | 3 | Full authoring funnel (Spark → Approve), AI postures, analytical passes, safety net, CLI commands | Done |
-| 4 | Execution bundles, prime endpoint, agent callbacks, claim leasing | Planned |
-| 5 | Spec lifecycle (amend/supersede/abandon), drift detection, spec linter | Planned |
-| 6 | Sync adapters (Beads, GitHub Issues, Linear), tool injection (CLAUDE.md, .cursorrules) | Planned |
-| 7 | Claude Code plugin (skills, hooks, MCP integration) | Planned |
+| 4 | Execution bundles, prime endpoint, agent callbacks, claim leasing | Done |
+| 5 | Spec lifecycle (amend/supersede/abandon), drift detection, spec linter | Done |
+| 6 | Sync adapters (Beads, GitHub Issues, Linear), tool injection (CLAUDE.md, .cursor/rules) | In Progress |
+| 7 | Claude Code plugin (skills, hooks, MCP integration) | In Progress |
 
 After Phase 1, you have a complete spec-driven development system: author specs with AI assistance, store them in a graph, query dependencies, claim work, and sync to your issue tracker.
 


### PR DESCRIPTION
## Summary
This PR updates documentation to reflect the current state of the system and refines the authoring funnel and spec lifecycle stages. It includes corrections to file paths, service definitions, graph schema, CLI commands, and decomposition strategies.

## Key Changes

**Documentation & Architecture:**
- Fixed `.cursorrules` → `.cursor/rules` path references across docs and architecture diagrams
- Updated service definitions in architecture.md to reflect actual implementation:
  - Added `LifecycleService`, `ExecutionService`, `SyncService` to service table
  - Renamed `HealthService` → `ServerService`
  - Updated `AuthoringService` description to include `Amend` and `Supersede` stages
- Reorganized graph schema edges:
  - Replaced `GOVERNED_BY` with `RELATES_TO` for general spec-to-spec links
  - Added `INFORMS` edge (decision → spec) alongside existing `DECIDED_IN` (spec → decision)
  - Added `SUPERSEDES` edge for spec replacement tracking
  - Removed `CLAIMED_BY` edge

**File Structure & Build:**
- Updated `specgraph/` directory structure documentation to reflect actual layout:
  - Added new packages: `drift/`, `driftscope/`, `linter/`, `inject/`, `sync/`, `emitter/`, `docker/`, `service/`
  - Clarified that generated code in `gen/` is now committed (not gitignored) for Go module compatibility
- Updated build automation notes to reflect committed generated code

**CLI & Commands:**
- Reorganized README CLI command table by functional category (Specs, Authoring, Lifecycle, Graph, Execution, Constitution, Sync & Injection, Infrastructure)
- Updated example command: `--title` → `--intent` flag
- Added new commands: `amend`, `supersede`, `abandon`, `drift`, `lint`, `bundle`, `prime`, `report-*`, `sync`, `inject`, `health`, `up/down`
- Clarified test command descriptions

**Authoring & Lifecycle:**
- Updated spec stage enum to include: `amended`, `superseded`, `abandoned`, `review` (in addition to existing stages)
- Updated `scope_sniff` field values: `tiny`, `small`, `medium`, `large`, `epic` (was: `small`, `medium`, `large`)
- Changed decomposition strategies in prompts and skill docs:
  - Replaced `risk-first` with `single unit` strategy
  - Updated strategy descriptions and recommendation table

**Ecosystem & Roadmap:**
- Updated roadmap to reflect current progress:
  - Slices 4-5 marked as "Done"
  - Slice 6 marked as "In Progress" (Beads and GitHub adapters implemented, Linear planned)
  - Slice 7 marked as "In Progress"
- Updated sync adapter status notes and tool injection file references

## Implementation Details
- All changes are documentation and configuration updates
- No breaking changes to core logic; updates reflect actual system state
- Graph schema changes align with decision/spec relationship modeling improvements
- Decomposition strategy simplification removes risk-first in favor of explicit single-unit option

https://claude.ai/code/session_01SbfwwWRpzgfVPvwx6fMdXE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Reorganized CLI commands into functional categories: Specs, Authoring, Lifecycle, Graph, Execution, Constitution, Sync & Injection, and Infrastructure
* Updated spec-graph model with new relationship types: relates_to, decided_in, informs, and supersedes
* Expanded scope estimates to include tiny and epic sizes
* Added new lifecycle stages: amended, superseded, abandoned, and review
* Updated sync adapter implementation status (Beads and GitHub now implemented; Linear planned)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->