### PR TITLE
chore: move module path to specgraph/specgraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In docker mode (the default), `serve` automatically starts and stops the Memgrap
 | **Team / shared server** | `remote` | Point CLI at a shared SpecGraph instance via config |
 | **Production / BYO infra** | `external` | Connect to your own Memgraph or Postgres |
 
-See the [deployment guide](https://seanb4t.github.io/specgraph/deployment/) for team and production configurations.
+See the [deployment guide](https://specgraph.io/deployment/) for team and production configurations.
 
 ### CLI overview
 

--- a/cmd/specgraph/approve.go
+++ b/cmd/specgraph/approve.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/bundle.go
+++ b/cmd/specgraph/bundle.go
@@ -9,8 +9,8 @@ import (
 	"os"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/claim.go
+++ b/cmd/specgraph/claim.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/types/known/durationpb"
 )

--- a/cmd/specgraph/client.go
+++ b/cmd/specgraph/client.go
@@ -9,9 +9,9 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/config"
-	"github.com/seanb4t/specgraph/internal/xdg"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/xdg"
 )
 
 // projectTransport injects the X-Specgraph-Project header on every request.

--- a/cmd/specgraph/constitution.go
+++ b/cmd/specgraph/constitution.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/config"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/constitution_test.go
+++ b/cmd/specgraph/constitution_test.go
@@ -6,8 +6,8 @@ package main
 import (
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/config"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cmd/specgraph/decision.go
+++ b/cmd/specgraph/decision.go
@@ -9,8 +9,8 @@ import (
 	"text/tabwriter"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/decompose.go
+++ b/cmd/specgraph/decompose.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/down.go
+++ b/cmd/specgraph/down.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/seanb4t/specgraph/internal/config"
-	"github.com/seanb4t/specgraph/internal/docker"
-	"github.com/seanb4t/specgraph/internal/service"
-	"github.com/seanb4t/specgraph/internal/xdg"
+	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/docker"
+	"github.com/specgraph/specgraph/internal/service"
+	"github.com/specgraph/specgraph/internal/xdg"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/edge.go
+++ b/cmd/specgraph/edge.go
@@ -9,8 +9,8 @@ import (
 	"text/tabwriter"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/graph.go
+++ b/cmd/specgraph/graph.go
@@ -9,7 +9,7 @@ import (
 	"text/tabwriter"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/health.go
+++ b/cmd/specgraph/health.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/init.go
+++ b/cmd/specgraph/init.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/seanb4t/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/init_test.go
+++ b/cmd/specgraph/init_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/specgraph/inject.go
+++ b/cmd/specgraph/inject.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/lifecycle.go
+++ b/cmd/specgraph/lifecycle.go
@@ -9,8 +9,8 @@ import (
 	"os"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/lifecycle_test.go
+++ b/cmd/specgraph/lifecycle_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/driftscope"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/driftscope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/specgraph/prime.go
+++ b/cmd/specgraph/prime.go
@@ -9,9 +9,9 @@ import (
 	"text/tabwriter"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/config"
-	"github.com/seanb4t/specgraph/internal/xdg"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/xdg"
 	"github.com/spf13/cobra"
 )
 
@@ -49,8 +49,8 @@ func runPrime(cmd *cobra.Command, args []string) error {
 	serverURL := cfg.ResolveServer(project.Slug, project.Server)
 
 	// 5. Print orientation header.
-	fmt.Fprintf(cmd.OutOrStdout(), "Project: %s\n", project.Slug)   //nolint:errcheck // stdout write
-	fmt.Fprintf(cmd.OutOrStdout(), "Server:  %s\n", serverURL)     //nolint:errcheck // stdout write
+	fmt.Fprintf(cmd.OutOrStdout(), "Project: %s\n", project.Slug) //nolint:errcheck // stdout write
+	fmt.Fprintf(cmd.OutOrStdout(), "Server:  %s\n", serverURL)    //nolint:errcheck // stdout write
 
 	// 6. List non-terminal specs.
 	client, err := specClient()

--- a/cmd/specgraph/progress.go
+++ b/cmd/specgraph/progress.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/report.go
+++ b/cmd/specgraph/report.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -14,15 +14,15 @@ import (
 
 	"connectrpc.com/connect"
 
-	"github.com/seanb4t/specgraph/internal/auth"
-	"github.com/seanb4t/specgraph/internal/config"
-	"github.com/seanb4t/specgraph/internal/docker"
-	"github.com/seanb4t/specgraph/internal/drift"
-	"github.com/seanb4t/specgraph/internal/linter"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage/memgraph"
-	syncpkg "github.com/seanb4t/specgraph/internal/sync"
-	"github.com/seanb4t/specgraph/internal/xdg"
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/docker"
+	"github.com/specgraph/specgraph/internal/drift"
+	"github.com/specgraph/specgraph/internal/linter"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage/memgraph"
+	syncpkg "github.com/specgraph/specgraph/internal/sync"
+	"github.com/specgraph/specgraph/internal/xdg"
 	"github.com/spf13/cobra"
 )
 
@@ -135,4 +135,3 @@ func runServe(_ *cobra.Command, _ []string) error {
 
 	return nil
 }
-

--- a/cmd/specgraph/shape.go
+++ b/cmd/specgraph/shape.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/spark.go
+++ b/cmd/specgraph/spark.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/spec.go
+++ b/cmd/specgraph/spec.go
@@ -10,8 +10,8 @@ import (
 	"text/tabwriter"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
 )

--- a/cmd/specgraph/specify.go
+++ b/cmd/specgraph/specify.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/sync.go
+++ b/cmd/specgraph/sync.go
@@ -10,8 +10,8 @@ import (
 	"text/tabwriter"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/up.go
+++ b/cmd/specgraph/up.go
@@ -13,12 +13,12 @@ import (
 	"time"
 
 	connect "connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/config"
-	"github.com/seanb4t/specgraph/internal/docker"
-	"github.com/seanb4t/specgraph/internal/service"
-	"github.com/seanb4t/specgraph/internal/xdg"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/docker"
+	"github.com/specgraph/specgraph/internal/service"
+	"github.com/specgraph/specgraph/internal/xdg"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/specgraph/util.go
+++ b/cmd/specgraph/util.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )

--- a/cmd/specgraph/util_test.go
+++ b/cmd/specgraph/util_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/docker/docker-compose.memgraph.yaml
+++ b/docker/docker-compose.memgraph.yaml
@@ -1,6 +1,6 @@
 services:
   specgraph:
-    image: ghcr.io/seanb4t/specgraph:latest
+    image: ghcr.io/specgraph/specgraph:latest
     ports:
       - "${SPECGRAPH_PORT:-9090}:9090"
     depends_on:

--- a/docs/plans/2026-02-28-slice-2-constitution-plan.md
+++ b/docs/plans/2026-02-28-slice-2-constitution-plan.md
@@ -57,7 +57,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 import "google/protobuf/timestamp.proto";
 
@@ -235,7 +235,7 @@ import (
 	"context"
 	"errors"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 var ErrConstitutionNotFound = errors.New("constitution not found")
@@ -290,9 +290,9 @@ import (
 	"context"
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/storage"
-	"github.com/seanb4t/specgraph/internal/storage/memgraph"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage/memgraph"
 	"github.com/stretchr/testify/require"
 )
 
@@ -448,8 +448,8 @@ import (
 	"time"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/storage"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -744,10 +744,10 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -886,9 +886,9 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // ConstitutionHandler implements the ConstitutionService.
@@ -1050,8 +1050,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/scanner"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/scanner"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1160,7 +1160,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 // Scan performs a Tier 0 scan of the given directory, detecting languages,
@@ -1356,8 +1356,8 @@ package emitter_test
 import (
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/emitter"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/emitter"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1461,7 +1461,7 @@ import (
 	"fmt"
 	"strings"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 // Emit generates a tool-specific file from the given constitution.
@@ -1621,7 +1621,7 @@ Replace the placeholder `emitConstitution` function in `internal/server/constitu
 // In constitution_handler.go, replace the emitConstitution function and
 // the placeholder format functions with:
 
-import "github.com/seanb4t/specgraph/internal/emitter"
+import "github.com/specgraph/specgraph/internal/emitter"
 
 // In the EmitToolFiles method, replace the call to emitConstitution with:
 content, filename, err := emitter.Emit(constitution, req.Msg.Format)
@@ -1669,8 +1669,8 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/spf13/cobra"
 )
 

--- a/docs/plans/2026-02-28-slice-3-authoring-funnel-plan.md
+++ b/docs/plans/2026-02-28-slice-3-authoring-funnel-plan.md
@@ -69,7 +69,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 import "google/protobuf/timestamp.proto";
 
@@ -362,7 +362,7 @@ package authoring_test
 import (
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/authoring"
+	"github.com/specgraph/specgraph/internal/authoring"
 	"github.com/stretchr/testify/require"
 )
 
@@ -510,8 +510,8 @@ package authoring_test
 import (
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/authoring"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/authoring"
 	"github.com/stretchr/testify/require"
 )
 
@@ -556,7 +556,7 @@ Expected: FAIL
 
 package authoring
 
-import specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+import specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 
 const (
 	driveThreshold   = 20
@@ -626,7 +626,7 @@ package authoring_test
 import (
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/authoring"
+	"github.com/specgraph/specgraph/internal/authoring"
 	"github.com/stretchr/testify/require"
 )
 
@@ -664,7 +664,7 @@ Expected: FAIL
 
 package authoring
 
-import specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+import specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 
 // Prompt holds a named template for a stage.
 type Prompt struct {
@@ -752,8 +752,8 @@ package authoring_test
 import (
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/authoring"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/authoring"
 	"github.com/stretchr/testify/require"
 )
 
@@ -811,7 +811,7 @@ package authoring
 import (
 	"strings"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 // SafetyInput is the data fed into the safety net.
@@ -919,8 +919,8 @@ package authoring_test
 import (
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/authoring"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/authoring"
 	"github.com/stretchr/testify/require"
 )
 
@@ -971,7 +971,7 @@ Expected: FAIL
 
 package authoring
 
-import specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+import specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 
 type passConfig struct {
 	pass      string
@@ -1075,7 +1075,7 @@ import (
 	"context"
 	"errors"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 var ErrInvalidStageTransition = errors.New("invalid stage transition")
@@ -1113,9 +1113,9 @@ import (
 	"context"
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/storage"
-	"github.com/seanb4t/specgraph/internal/storage/memgraph"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage/memgraph"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1251,10 +1251,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/seanb4t/specgraph/internal/authoring"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/authoring"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 func (s *Store) TransitionStage(ctx context.Context, slug string, from, to string) error {
@@ -1457,10 +1457,10 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/authoring"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/authoring"
+	"github.com/specgraph/specgraph/internal/storage"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -1626,9 +1626,9 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/server"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1696,8 +1696,8 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/spf13/cobra"
 )
 
@@ -1763,7 +1763,7 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -1813,7 +1813,7 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -1863,7 +1863,7 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -1917,7 +1917,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -1989,7 +1989,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/scanner"
+	"github.com/specgraph/specgraph/internal/scanner"
 	"github.com/stretchr/testify/require"
 )
 
@@ -2140,7 +2140,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/scanner"
+	"github.com/specgraph/specgraph/internal/scanner"
 	"github.com/stretchr/testify/require"
 )
 

--- a/docs/plans/2026-02-28-slice-4-execution-bundles-plan.md
+++ b/docs/plans/2026-02-28-slice-4-execution-bundles-plan.md
@@ -59,7 +59,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 import "google/protobuf/timestamp.proto";
 import "specgraph/v1/spec.proto";
@@ -217,7 +217,7 @@ import (
 	"context"
 	"errors"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 // ErrSpecNotApproved is returned when a bundle is requested for a spec not in an executable stage.
@@ -302,8 +302,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/seanb4t/specgraph/internal/storage"
-	"github.com/seanb4t/specgraph/internal/storage/memgraph"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage/memgraph"
 	"github.com/stretchr/testify/require"
 )
 
@@ -516,8 +516,8 @@ import (
 	"time"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/storage"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -864,10 +864,10 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -1089,9 +1089,9 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // ExecutionHandler implements the ExecutionService.
@@ -1460,8 +1460,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1630,8 +1630,8 @@ import (
 	"os"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/spf13/cobra"
 )
 
@@ -1743,7 +1743,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/spf13/cobra"
 )
 

--- a/docs/plans/2026-02-28-slice-5-spec-lifecycle-plan.md
+++ b/docs/plans/2026-02-28-slice-5-spec-lifecycle-plan.md
@@ -97,7 +97,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 import "specgraph/v1/spec.proto";
 
@@ -321,7 +321,7 @@ import (
 	"context"
 	"errors"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 // ErrSpecNotDone is returned when amend is called on a spec that is not in done stage.
@@ -400,8 +400,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage"
-	"github.com/seanb4t/specgraph/internal/storage/memgraph"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage/memgraph"
 	"github.com/stretchr/testify/require"
 )
 
@@ -653,8 +653,8 @@ import (
 	"time"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/storage"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -1308,7 +1308,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 //go:embed ../../spec.schema.json
@@ -1435,8 +1435,8 @@ package linter_test
 import (
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/linter"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/linter"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1563,8 +1563,8 @@ import (
 	"context"
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/linter"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/linter"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1742,7 +1742,7 @@ import (
 	"context"
 	"fmt"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 // LintBackend is the subset of storage needed by the linter.
@@ -1922,8 +1922,8 @@ import (
 	"testing"
 	"time"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/drift"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/drift"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -2131,7 +2131,7 @@ import (
 	"context"
 	"fmt"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 // DriftBackend is the subset of storage needed by the drift engine.
@@ -2302,10 +2302,10 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -2529,9 +2529,9 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // LifecycleHandler implements the LifecycleService.
@@ -2705,8 +2705,8 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/spf13/cobra"
 )
 

--- a/docs/plans/2026-02-28-slice-6-sync-integration-plan.md
+++ b/docs/plans/2026-02-28-slice-6-sync-integration-plan.md
@@ -64,7 +64,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 import "google/protobuf/timestamp.proto";
 
@@ -209,7 +209,7 @@ import (
 	"context"
 	"errors"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 // ErrSyncMappingNotFound is returned when a sync mapping does not exist.
@@ -273,9 +273,9 @@ import (
 	"context"
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/storage"
-	"github.com/seanb4t/specgraph/internal/storage/memgraph"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage/memgraph"
 	"github.com/stretchr/testify/require"
 )
 
@@ -496,8 +496,8 @@ import (
 	"time"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/storage"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -784,7 +784,7 @@ import (
 	"context"
 	"errors"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 // ErrAdapterNotAvailable is returned when the adapter's CLI tool is not installed.
@@ -835,8 +835,8 @@ import (
 	"fmt"
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/sync"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/sync"
 	"github.com/stretchr/testify/require"
 )
 
@@ -939,7 +939,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 // BeadsAdapter syncs specs with the Beads issue tracker via the bd CLI.
@@ -1041,8 +1041,8 @@ import (
 	"fmt"
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/sync"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/sync"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1125,7 +1125,7 @@ import (
 	"strconv"
 	"strings"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 // GitHubAdapter syncs specs with GitHub Issues via the gh CLI.
@@ -1257,8 +1257,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/inject"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/inject"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1379,7 +1379,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 // Inject writes an execution bundle for the given spec and constitution into
@@ -1557,10 +1557,10 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1766,11 +1766,11 @@ import (
 	"os"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/inject"
-	"github.com/seanb4t/specgraph/internal/storage"
-	syncpkg "github.com/seanb4t/specgraph/internal/sync"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/inject"
+	"github.com/specgraph/specgraph/internal/storage"
+	syncpkg "github.com/specgraph/specgraph/internal/sync"
 )
 
 // SpecGetter retrieves specs for sync operations.
@@ -1989,8 +1989,8 @@ import (
 	"text/tabwriter"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/spf13/cobra"
 )
 
@@ -2190,8 +2190,8 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/spf13/cobra"
 )
 
@@ -2296,7 +2296,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/sync"
+	"github.com/specgraph/specgraph/internal/sync"
 	"github.com/stretchr/testify/require"
 )
 

--- a/docs/plans/2026-02-28-slice-7-claude-code-plugin-plan.md
+++ b/docs/plans/2026-02-28-slice-7-claude-code-plugin-plan.md
@@ -64,7 +64,7 @@ cmd/specgraph/
   "name": "specgraph",
   "version": "0.1.0",
   "description": "SpecGraph: spec-driven development workflow — author, query, and execute specs from Claude Code",
-  "homepage": "https://github.com/seanb4t/specgraph",
+  "homepage": "https://github.com/specgraph/specgraph",
   "license": "MIT",
   "requires": {
     "cli": ["specgraph"]
@@ -1206,8 +1206,8 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/spf13/cobra"
 )
 

--- a/docs/plans/2026-02-28-vertical-slice-plan.md
+++ b/docs/plans/2026-02-28-vertical-slice-plan.md
@@ -65,7 +65,7 @@ specgraph/
 
 ```bash
 cd /Volumes/Code/github.com/seanb4t/beads/specgraph
-go mod init github.com/seanb4t/specgraph
+go mod init github.com/specgraph/specgraph
 ```
 
 **Step 2: Create buf configuration**
@@ -161,7 +161,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 import "google/protobuf/timestamp.proto";
 
@@ -249,7 +249,7 @@ package storage
 import (
 	"context"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 // Backend is the interface that all storage backends must implement.
@@ -312,7 +312,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/seanb4t/specgraph/internal/storage/memgraph"
+	"github.com/specgraph/specgraph/internal/storage/memgraph"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -457,7 +457,7 @@ import (
 	"time"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -654,10 +654,10 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // mockBackend is a test double for the storage interface.
@@ -782,9 +782,9 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 type SpecHandler struct {
@@ -839,8 +839,8 @@ package server
 import (
 	"net/http"
 
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // NewMux creates an HTTP mux with all ConnectRPC services registered.
@@ -893,7 +893,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/config"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -1320,10 +1320,10 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/seanb4t/specgraph/internal/config"
-	"github.com/seanb4t/specgraph/internal/docker"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage/memgraph"
+	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/docker"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage/memgraph"
 	"github.com/spf13/cobra"
 )
 
@@ -1410,9 +1410,9 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/config"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/docs/plans/2026-03-03-slice-3.5-scanner-cleanup-plan.md
+++ b/docs/plans/2026-03-03-slice-3.5-scanner-cleanup-plan.md
@@ -72,7 +72,7 @@ Removes: scanner.go, tier1.go, tier2.go, walk.go, and all tests."
 Remove from imports:
 
 ```go
-"github.com/seanb4t/specgraph/internal/scanner"
+"github.com/specgraph/specgraph/internal/scanner"
 ```
 
 Remove the `initScan` variable declaration (line 35).

--- a/docs/plans/2026-03-05-e2e-test-system-plan.md
+++ b/docs/plans/2026-03-05-e2e-test-system-plan.md
@@ -101,8 +101,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage/memgraph"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage/memgraph"
 )
 
 // ServerInfo holds the running server's details.
@@ -268,7 +268,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/seanb4t/specgraph/e2e/testutil"
+	"github.com/specgraph/specgraph/e2e/testutil"
 )
 
 var (
@@ -321,8 +321,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"net/http"
 )
 
@@ -374,8 +374,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 var _ = Describe("spec lifecycle", Ordered, func() {

--- a/docs/plans/2026-03-06-storage-domain-types-plan.md
+++ b/docs/plans/2026-03-06-storage-domain-types-plan.md
@@ -30,7 +30,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -203,8 +203,8 @@ import (
 	"testing"
 	"time"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -290,8 +290,8 @@ Expected: FAIL — converter functions don't exist
 package server
 
 import (
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/storage"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/docs/plans/2026-03-07-domain-types-and-slice4-plan.md
+++ b/docs/plans/2026-03-07-domain-types-and-slice4-plan.md
@@ -938,7 +938,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 import "google/protobuf/timestamp.proto";
 import "specgraph/v1/spec.proto";

--- a/docs/plans/2026-03-07-slice-5-spec-lifecycle-revised-plan.md
+++ b/docs/plans/2026-03-07-slice-5-spec-lifecycle-revised-plan.md
@@ -511,7 +511,7 @@ package linter
 import (
 	"fmt"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // ValidateSchema validates a spec against the spec schema rules.

--- a/docs/plans/2026-03-16-slice-7-global-daemon-and-plugin-design.md
+++ b/docs/plans/2026-03-16-slice-7-global-daemon-and-plugin-design.md
@@ -451,7 +451,7 @@ Output is injected into the session context, giving the AI:
   "name": "specgraph",
   "version": "0.1.0",
   "description": "SpecGraph: spec-driven development — author, query, and execute specs",
-  "homepage": "https://github.com/seanb4t/specgraph",
+  "homepage": "https://github.com/specgraph/specgraph",
   "license": "MIT",
   "skills": [
     { "name": "specgraph", "path": "skills/specgraph/SKILL.md" },

--- a/docs/plans/2026-03-16-slice-7-global-daemon-and-plugin-plan.md
+++ b/docs/plans/2026-03-16-slice-7-global-daemon-and-plugin-plan.md
@@ -32,7 +32,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/xdg"
+	"github.com/specgraph/specgraph/internal/xdg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -170,7 +170,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -395,7 +395,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -678,7 +678,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -778,7 +778,7 @@ import (
 	"fmt"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 func (s *Store) EnsureProject(ctx context.Context, slug string) (*storage.Project, error) {
@@ -1195,7 +1195,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/service"
+	"github.com/specgraph/specgraph/internal/service"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/docs/plans/2026-03-17-full-pipeline-e2e-plan.md
+++ b/docs/plans/2026-03-17-full-pipeline-e2e-plan.md
@@ -75,8 +75,8 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 var _ = Describe("Full pipeline", Ordered, func() {
@@ -329,8 +329,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 var _ = Describe("Project isolation", Ordered, func() {

--- a/docs/plans/2026-03-18-auth-interceptor-plan.md
+++ b/docs/plans/2026-03-18-auth-interceptor-plan.md
@@ -72,7 +72,7 @@ package auth_test
 import (
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/auth"
 )
 
 func TestHasPermission_ExactMatch(t *testing.T) {
@@ -130,7 +130,7 @@ func TestHasPermission_EmptyPerms(t *testing.T) {
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/auth/ -run TestHasPermission -v`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && go test ./internal/auth/ -run TestHasPermission -v`
 Expected: FAIL — package does not exist yet
 
 - [ ] **Step 3: Write Identity type, Role constants, and HasPermission**
@@ -188,7 +188,7 @@ func HasPermission(perms map[string]bool, required string) bool {
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/auth/ -run TestHasPermission -v`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && go test ./internal/auth/ -run TestHasPermission -v`
 Expected: PASS (all 5 tests)
 
 - [ ] **Step 5: Commit**
@@ -319,7 +319,7 @@ type RoleConfig struct {
 
 - [ ] **Step 2: Verify build**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go build ./...`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && go build ./...`
 Expected: PASS
 
 - [ ] **Step 3: Commit**
@@ -346,8 +346,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/auth"
-	"github.com/seanb4t/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/config"
 )
 
 func TestConfigStore_ResolveAPIKey(t *testing.T) {
@@ -517,7 +517,7 @@ func TestConfigStore_BuiltinRolePermissions(t *testing.T) {
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/auth/ -run TestConfigStore -v`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && go test ./internal/auth/ -run TestConfigStore -v`
 Expected: FAIL — `NewConfigStore` not defined
 
 - [ ] **Step 3: Write ConfigStore implementation**
@@ -531,7 +531,7 @@ import (
 	"crypto/subtle"
 	"fmt"
 
-	"github.com/seanb4t/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/config"
 )
 
 // DefaultRolePermissions defines the built-in role permission bundles.
@@ -618,7 +618,7 @@ func (s *ConfigStore) HasKeys() bool {
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/auth/ -run TestConfigStore -v`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && go test ./internal/auth/ -run TestConfigStore -v`
 Expected: PASS (all 8 tests)
 
 - [ ] **Step 5: Commit**
@@ -649,8 +649,8 @@ package auth_test
 import (
 	"testing"
 
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/auth"
 )
 
 // allProcedures lists every ConnectRPC procedure from generated code.
@@ -740,7 +740,7 @@ func TestPermissionTable_NoExemptInPermissions(t *testing.T) {
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/auth/ -run TestPermissionTable -v`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && go test ./internal/auth/ -run TestPermissionTable -v`
 Expected: FAIL — `IsExempt`, `RPCPermission` not defined
 
 - [ ] **Step 3: Write permissions.go**
@@ -750,7 +750,7 @@ Expected: FAIL — `IsExempt`, `RPCPermission` not defined
 package auth
 
 import (
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 // rpcPermissions maps ConnectRPC procedure names to required permissions.
@@ -840,7 +840,7 @@ func IsExempt(procedure string) bool {
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/auth/ -run TestPermissionTable -v`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && go test ./internal/auth/ -run TestPermissionTable -v`
 Expected: PASS (both tests)
 
 - [ ] **Step 5: Commit**
@@ -876,10 +876,10 @@ import (
 
 	"connectrpc.com/connect"
 
-	specgraphv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/auth"
-	"github.com/seanb4t/specgraph/internal/config"
+	specgraphv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/config"
 )
 
 // stubHealthHandler returns a minimal Health handler for testing the interceptor.
@@ -1069,7 +1069,7 @@ test catches it.
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/auth/ -run TestInterceptor -v`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && go test ./internal/auth/ -run TestInterceptor -v`
 Expected: FAIL — `NewAuthInterceptor` not defined
 
 - [ ] **Step 3: Write interceptor implementation**
@@ -1192,7 +1192,7 @@ func localIdentity() *Identity {
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/auth/ -run TestInterceptor -v`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && go test ./internal/auth/ -run TestInterceptor -v`
 Expected: PASS (all 7 tests)
 
 - [ ] **Step 5: Commit**
@@ -1264,12 +1264,12 @@ In each, pass `opts...` to the corresponding `specgraphv1connect.New*ServiceHand
 
 - [ ] **Step 4: Verify build**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go build ./...`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && go build ./...`
 Expected: PASS — the variadic `...connect.HandlerOption` is backward compatible (callers not passing opts still compile)
 
 - [ ] **Step 5: Run existing tests to verify no regressions**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test ./internal/server/ -v`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && go test ./internal/server/ -v`
 Expected: PASS
 
 - [ ] **Step 6: Commit**
@@ -1313,11 +1313,11 @@ server.RegisterLifecycleService(mux, store, driftEngine, lintEngine, nil, opts)
 syncHandler := server.RegisterSyncService(mux, store, "", opts)
 ```
 
-Add imports: `"github.com/seanb4t/specgraph/internal/auth"`, `"connectrpc.com/connect"`.
+Add imports: `"github.com/specgraph/specgraph/internal/auth"`, `"connectrpc.com/connect"`.
 
 - [ ] **Step 2: Verify build**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go build ./cmd/specgraph/`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && go build ./cmd/specgraph/`
 Expected: PASS
 
 - [ ] **Step 3: Commit**
@@ -1340,7 +1340,7 @@ For tests that don't need auth (existing tests), pass no opts (empty variadic). 
 
 - [ ] **Step 2: Verify E2E tests still pass without auth**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test -tags e2e ./e2e/api/ -v --ginkgo.label-filter='!auth' -count=1`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && go test -tags e2e ./e2e/api/ -v --ginkgo.label-filter='!auth' -count=1`
 Expected: PASS (existing tests unaffected — no opts passed = no interceptor)
 
 - [ ] **Step 3: Commit**
@@ -1384,7 +1384,7 @@ Each scenario starts a fresh server with a specific auth config (using the E2E t
 
 - [ ] **Step 2: Run E2E auth tests**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && go test -tags e2e ./e2e/api/ -v --ginkgo.label-filter='auth' -count=1`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && go test -tags e2e ./e2e/api/ -v --ginkgo.label-filter='auth' -count=1`
 Expected: PASS
 
 - [ ] **Step 3: Commit**
@@ -1397,21 +1397,21 @@ test(e2e): add auth interceptor E2E test scenarios
 
 - [ ] **Step 1: Run task check**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && task check`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && task check`
 Expected: PASS (fmt, license, lint, build, unit tests)
 
 - [ ] **Step 2: Run task pr-prep**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && task pr-prep`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && task pr-prep`
 Expected: PASS (check + integration + e2e)
 
 - [ ] **Step 3: Add license headers to new files if missing**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && task license:add`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && task license:add`
 
 - [ ] **Step 4: Fix any lint issues**
 
-Run: `cd /Volumes/Code/github.com/seanb4t/specgraph && task lint`
+Run: `cd /Volumes/Code/github.com/specgraph/specgraph && task lint`
 Fix any issues found.
 
 - [ ] **Step 5: Final commit if any fixes needed**

--- a/docs/superpowers/plans/2026-03-18-changelog-graph-nodes.md
+++ b/docs/superpowers/plans/2026-03-18-changelog-graph-nodes.md
@@ -104,7 +104,7 @@ package storage_test
 import (
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -516,7 +516,7 @@ package memgraph_test
 import (
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -562,7 +562,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // changeLogEntryJSON is the JSON serialization format for field changes.

--- a/docs/superpowers/plans/2026-03-18-content-hash.md
+++ b/docs/superpowers/plans/2026-03-18-content-hash.md
@@ -225,7 +225,7 @@ package contenthash_test
 import (
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage/contenthash"
+	"github.com/specgraph/specgraph/internal/storage/contenthash"
 	"github.com/stretchr/testify/require"
 )
 

--- a/docs/superpowers/plans/2026-03-20-repo-org-move.md
+++ b/docs/superpowers/plans/2026-03-20-repo-org-move.md
@@ -1,0 +1,296 @@
+# Repository Organization Move Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update all references from `github.com/specgraph/specgraph` to `github.com/specgraph/specgraph` after the GitHub repo transfer.
+
+**Architecture:** Bulk find-replace across Go imports, proto go_package options, site config, and documentation. Regenerate proto-generated code. No logic changes.
+
+**Tech Stack:** Go, protobuf (buf), jj
+
+**Spec:** `docs/superpowers/specs/2026-03-20-repo-org-move-design.md`
+
+**Prerequisites:** Sean must transfer the repo via GitHub Settings → Transfer to `specgraph` org BEFORE executing this plan. After transfer, update local remote:
+
+```bash
+jj git remote set-url origin git@github.com:specgraph/specgraph.git
+jj git fetch
+```
+
+---
+
+## Chunk 1: Module Path and Source Code
+
+### Task 1: Update go.mod
+
+**Files:**
+
+- Modify: `go.mod`
+
+- [ ] **Step 1: Update module declaration**
+
+```text
+- module github.com/specgraph/specgraph
++ module github.com/specgraph/specgraph
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+jj commit -m "chore: update go.mod module path to specgraph org"
+```
+
+### Task 2: Update All Go Import Paths
+
+**Files:**
+
+- Modify: All `.go` files (~165 files) excluding `gen/` (regenerated in Task 4)
+
+- [ ] **Step 1: Bulk find-replace Go imports**
+
+```bash
+find . -name '*.go' -not -path './gen/*' -not -path './.jj/*' -exec \
+  sed -i '' 's|github.com/specgraph/specgraph|github.com/specgraph/specgraph|g' {} +
+```
+
+- [ ] **Step 2: Verify no remaining old references in Go source**
+
+```bash
+grep -r "seanb4t/specgraph" --include="*.go" --exclude-dir=gen --exclude-dir=.jj | head -5
+```
+
+Expected: No output
+
+- [ ] **Step 3: Verify build (will fail on gen/ mismatch — expected)**
+
+```bash
+go build ./cmd/specgraph/...
+```
+
+Expected: May fail because `gen/` still has old paths. That's OK — Task 4 fixes it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "chore: update Go import paths to specgraph org"
+```
+
+### Task 3: Update Proto go_package Options
+
+**Files:**
+
+- Modify: All `.proto` files in `proto/specgraph/v1/` (10 files)
+
+- [ ] **Step 1: Bulk find-replace proto go_package**
+
+```bash
+find proto -name '*.proto' -exec \
+  sed -i '' 's|github.com/specgraph/specgraph|github.com/specgraph/specgraph|g' {} +
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -r "seanb4t" proto/
+```
+
+Expected: No output
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj commit -m "chore: update proto go_package paths to specgraph org"
+```
+
+### Task 4: Regenerate Proto Code
+
+**Files:**
+
+- Regenerate: All files in `gen/`
+
+- [ ] **Step 1: Clean and regenerate**
+
+```bash
+rm -rf gen/
+task proto
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+go build ./...
+```
+
+Expected: PASS — all imports and generated code now use the new path.
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj commit -m "chore: regenerate proto code with new module path"
+```
+
+---
+
+## Chunk 2: Configuration and Documentation
+
+### Task 5: Update Site Configuration
+
+**Files:**
+
+- Modify: `site/zensical.toml`
+
+- [ ] **Step 1: Update site_url and repo URL**
+
+Change `site_url` from `https://specgraph.io/` to `https://specgraph.io/` (or `https://specgraph.github.io/specgraph/` as interim).
+
+Change repo `url` from `https://github.com/specgraph/specgraph` to `https://github.com/specgraph/specgraph`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+jj commit -m "chore: update site config URLs for specgraph org"
+```
+
+### Task 6: Update Plugin Manifest
+
+**Files:**
+
+- Modify: `plugin/specgraph/plugin.json`
+
+- [ ] **Step 1: Update any repo references**
+
+```bash
+sed -i '' 's|seanb4t/specgraph|specgraph/specgraph|g' plugin/specgraph/plugin.json
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+jj commit -m "chore: update plugin.json for specgraph org"
+```
+
+### Task 7: Update Docker Compose References
+
+**Files:**
+
+- Modify: `docker/docker-compose.memgraph.yaml` (if it references GHCR)
+- Modify: `internal/docker/compose.go` (if it references GHCR)
+
+- [ ] **Step 1: Check and update GHCR image references**
+
+```bash
+grep -r "seanb4t" docker/ internal/docker/
+```
+
+Update any `ghcr.io/seanb4t/specgraph` → `ghcr.io/specgraph/specgraph`.
+
+- [ ] **Step 2: Commit (if changes made)**
+
+```bash
+jj commit -m "chore: update Docker image references for specgraph org"
+```
+
+### Task 8: Update README and CLAUDE.md
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Bulk replace in markdown docs**
+
+```bash
+sed -i '' 's|seanb4t/specgraph|specgraph/specgraph|g' README.md CLAUDE.md
+sed -i '' 's|specgraph.io|specgraph.io|g' README.md CLAUDE.md
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep "seanb4t" README.md CLAUDE.md
+```
+
+Expected: No output
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj commit -m "docs: update README and CLAUDE.md for specgraph org"
+```
+
+### Task 9: Update Historical Docs (plans, specs)
+
+**Files:**
+
+- Modify: All files in `docs/plans/` and `docs/superpowers/` referencing `seanb4t`
+
+- [ ] **Step 1: Bulk replace in docs**
+
+```bash
+find docs -name '*.md' -exec \
+  sed -i '' 's|github.com/specgraph/specgraph|github.com/specgraph/specgraph|g' {} +
+find docs -name '*.md' -exec \
+  sed -i '' 's|specgraph.io|specgraph.io|g' {} +
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+jj commit -m "docs: update historical plan/spec references for specgraph org"
+```
+
+---
+
+## Chunk 3: Verification
+
+### Task 10: Full Verification
+
+- [ ] **Step 1: Verify no remaining seanb4t references in source**
+
+```bash
+grep -r "seanb4t" --include="*.go" --include="*.proto" --include="*.mod" \
+  --include="*.yaml" --include="*.yml" --include="*.json" --include="*.toml" \
+  --exclude-dir=.jj | head -10
+```
+
+Expected: No output (docs may still have historical references — that's OK).
+
+- [ ] **Step 2: Run task pr-prep**
+
+```bash
+task pr-prep
+```
+
+Expected: All checks pass (fmt, lint, build, unit tests, integration, e2e).
+
+- [ ] **Step 3: Fix any remaining issues**
+
+If `pr-prep` fails, investigate and fix. Common issues:
+
+- Missed import path in a test file
+- Generated code stale (re-run `task proto`)
+- YAML formatting (run `yamlfmt`)
+
+- [ ] **Step 4: Final commit if fixups needed**
+
+```bash
+jj commit -m "fix: address remaining org-move issues"
+```
+
+### Task 11: Post-Merge Housekeeping
+
+After PR is merged:
+
+- [ ] **Step 1: Verify Go module proxy**
+
+```bash
+go list -m github.com/specgraph/specgraph@latest
+```
+
+- [ ] **Step 2: Update beads external-ref URLs**
+
+Bulk update any beads pointing to the old repo URL.
+
+- [ ] **Step 3: Update local directory name (optional)**
+
+If desired, rename the local clone directory to match the new org.

--- a/docs/superpowers/specs/2026-03-20-repo-org-move-design.md
+++ b/docs/superpowers/specs/2026-03-20-repo-org-move-design.md
@@ -1,0 +1,140 @@
+# Repository Organization Move
+
+**Status:** Approved
+**Date:** 2026-03-20
+**Bead:** spgr-4ha
+
+## Problem
+
+The repository lives at `github.com/specgraph/specgraph` under a personal account. Before publishing a Go module or a 0.1.0 release, the repo should move to the `specgraph` GitHub organization so the module path is stable and professional.
+
+## Decision
+
+Transfer the repo to `github.com/specgraph/specgraph`. The Go module path becomes `github.com/specgraph/specgraph`. The project site domain is `specgraph.io` (Cloudflare Pages deployment is out of scope for this spec).
+
+## Two-Phase Process
+
+### Phase 1: GitHub Transfer (manual)
+
+Sean transfers the repo via GitHub Settings → Danger Zone → Transfer. This:
+
+- Moves the repo to `github.com/specgraph/specgraph`
+- Creates a redirect from `github.com/specgraph/specgraph`
+- Preserves all git history, PRs, issues, and settings
+- Requires org owner permissions
+
+### Phase 2: Code Changes (automated PR)
+
+A single PR updates all references from `github.com/specgraph/specgraph` to `github.com/specgraph/specgraph`.
+
+## What Changes
+
+### go.mod
+
+```text
+- module github.com/specgraph/specgraph
++ module github.com/specgraph/specgraph
+```
+
+### Go Import Paths (~165 files)
+
+Every `.go` file with `"github.com/specgraph/specgraph/..."` imports. Bulk find-replace:
+
+```text
+github.com/specgraph/specgraph → github.com/specgraph/specgraph
+```
+
+### Proto go_package Options (10 files)
+
+Each `.proto` file in `proto/specgraph/v1/`:
+
+```text
+- option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
++ option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
+```
+
+The proto package name `specgraph.v1` does not change.
+
+After updating, regenerate all `gen/` files with `task proto`. Do NOT manually edit files in `gen/` — they are fully regenerated.
+
+### buf.yaml / buf.gen.yaml
+
+No changes needed — these files use relative paths (`path: proto`, `out: gen`) and do not reference the module path.
+
+### CI Workflows
+
+No `seanb4t` references exist in `.github/workflows/*.yml`. No changes needed.
+
+### Site Configuration
+
+Update `site/zensical.toml`:
+
+- `site_url`: change from `https://specgraph.io/` to `https://specgraph.io/` (or `https://specgraph.github.io/specgraph/` as interim until custom domain is configured)
+- `url`: change from `https://github.com/specgraph/specgraph` to `https://github.com/specgraph/specgraph`
+
+**Note:** After transfer, GitHub Pages serves from `specgraph.github.io/specgraph` until the `specgraph.io` custom domain is configured on Cloudflare Pages. The site deploy workflow (`site.yml`) may need updating when the hosting moves — that is out of scope for this spec.
+
+### Docker Compose
+
+Update `internal/docker/compose.go` templates if they reference `ghcr.io/seanb4t/specgraph`. Check any Docker Compose YAML files for GHCR image references.
+
+### plugin.json
+
+The Claude Code plugin manifest at `plugin/specgraph/plugin.json` may reference the repo URL. Update if present.
+
+### CLAUDE.md and Documentation
+
+Update any `github.com/specgraph/specgraph` or `specgraph.io` URLs in:
+
+- `CLAUDE.md`
+- `README.md` (includes GitHub Pages URL)
+- `docs/` files (plans, specs, ADRs)
+- `site/` docs
+
+### License Headers
+
+The SPDX headers say `Copyright 2026 Sean Brandt` with no repo path — no change needed.
+
+## What Does NOT Change
+
+- Proto package name (`specgraph.v1`)
+- Directory structure
+- Git history
+- Any code logic or behavior
+- Beads database content (external-ref URLs updated separately as housekeeping)
+
+## Post-Transfer Housekeeping
+
+After the transfer and code PR merge:
+
+1. **Update local git remote:**
+
+   ```bash
+   jj git remote set-url origin git@github.com:specgraph/specgraph.git
+   ```
+
+2. **Verify Go module proxy:**
+
+   ```bash
+   go list -m github.com/specgraph/specgraph@latest
+   ```
+
+   Note: The old module path (`github.com/specgraph/specgraph`) has no published tags on `proxy.golang.org`, so there is no cached old-path entry to worry about. If a tag had been published, the old path would remain permanently in the proxy (immutable). This is why we move before any release.
+
+3. **Update beads external-ref URLs** (bulk search-replace in beads DB if needed).
+
+4. **Update any local `.claude/` project paths** that reference the old repo location on disk (if the local directory is renamed).
+
+## Testing
+
+The PR must pass `task pr-prep` (fmt, lint, build, unit tests, integration tests, e2e). Since this is purely a rename with no logic changes, test failures indicate a missed reference.
+
+## Alternatives Considered
+
+### github.com/specgraph/core
+
+Rejected — this repo is the entire project, not a "core" subset. `specgraph/specgraph` follows the standard primary-repo pattern.
+
+### Prepare code changes before transfer
+
+Rejected — GitHub redirects make the brief inconsistency harmless, and the coordination complexity isn't worth it.

--- a/e2e/agent/agent_suite_test.go
+++ b/e2e/agent/agent_suite_test.go
@@ -19,7 +19,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/seanb4t/specgraph/e2e/testutil"
+	"github.com/specgraph/specgraph/e2e/testutil"
 )
 
 var (

--- a/e2e/agent/pipeline_test.go
+++ b/e2e/agent/pipeline_test.go
@@ -17,7 +17,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/seanb4t/specgraph/e2e/testutil"
+	"github.com/specgraph/specgraph/e2e/testutil"
 )
 
 // appendPath returns a copy of os.Environ() with dir prepended to PATH.

--- a/e2e/api/api_suite_test.go
+++ b/e2e/api/api_suite_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/seanb4t/specgraph/e2e/testutil"
+	"github.com/specgraph/specgraph/e2e/testutil"
 )
 
 var (

--- a/e2e/api/auth_test.go
+++ b/e2e/api/auth_test.go
@@ -13,11 +13,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/auth"
-	"github.com/seanb4t/specgraph/internal/config"
-	"github.com/seanb4t/specgraph/e2e/testutil"
+	"github.com/specgraph/specgraph/e2e/testutil"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/config"
 )
 
 // withBearer returns a client option that injects a Bearer token into requests.

--- a/e2e/api/authoring_test.go
+++ b/e2e/api/authoring_test.go
@@ -12,8 +12,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 var _ = Describe("Authoring funnel", Ordered, func() {

--- a/e2e/api/claim_test.go
+++ b/e2e/api/claim_test.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 var _ = Describe("Claim protocol", Ordered, func() {

--- a/e2e/api/constitution_pipeline_test.go
+++ b/e2e/api/constitution_pipeline_test.go
@@ -13,8 +13,8 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 var _ = Describe("Constitution pipeline", Ordered, func() {

--- a/e2e/api/constitution_test.go
+++ b/e2e/api/constitution_test.go
@@ -12,8 +12,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 var _ = Describe("Constitution", Ordered, func() {

--- a/e2e/api/decision_test.go
+++ b/e2e/api/decision_test.go
@@ -12,8 +12,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 var _ = Describe("Decision", Ordered, func() {

--- a/e2e/api/edge_test.go
+++ b/e2e/api/edge_test.go
@@ -12,8 +12,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 var _ = Describe("graph edges", Ordered, func() {

--- a/e2e/api/errors_test.go
+++ b/e2e/api/errors_test.go
@@ -15,8 +15,8 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 var _ = Describe("error handling", func() {

--- a/e2e/api/graph_test.go
+++ b/e2e/api/graph_test.go
@@ -12,8 +12,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 var _ = Describe("graph queries", Ordered, func() {

--- a/e2e/api/health_test.go
+++ b/e2e/api/health_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 )
 
 var _ = Describe("Health", func() {

--- a/e2e/api/helpers_test.go
+++ b/e2e/api/helpers_test.go
@@ -8,7 +8,7 @@ package api_test
 import (
 	"net/http"
 
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 // e2eProject is the project slug used by the E2E test server (set in testutil.StartServer).

--- a/e2e/api/init_test.go
+++ b/e2e/api/init_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/seanb4t/specgraph/e2e/testutil"
+	"github.com/specgraph/specgraph/e2e/testutil"
 )
 
 var _ = Describe("init command", func() {

--- a/e2e/api/isolation_test.go
+++ b/e2e/api/isolation_test.go
@@ -12,8 +12,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 var _ = Describe("Project isolation", Ordered, func() {

--- a/e2e/api/lifecycle_pipeline_test.go
+++ b/e2e/api/lifecycle_pipeline_test.go
@@ -13,8 +13,8 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 var _ = Describe("Lifecycle Pipeline", Ordered, func() {

--- a/e2e/api/lifecycle_test.go
+++ b/e2e/api/lifecycle_test.go
@@ -14,8 +14,8 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 // timestampSkew is the minimum sleep to guarantee Memgraph datetime ordering.

--- a/e2e/api/pipeline_test.go
+++ b/e2e/api/pipeline_test.go
@@ -13,8 +13,8 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 var _ = Describe("Full pipeline", Ordered, func() {

--- a/e2e/api/spec_test.go
+++ b/e2e/api/spec_test.go
@@ -13,8 +13,8 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 var _ = Describe("Spec lifecycle", Ordered, func() {

--- a/e2e/cli/cli_suite_test.go
+++ b/e2e/cli/cli_suite_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/seanb4t/specgraph/e2e/testutil"
+	"github.com/specgraph/specgraph/e2e/testutil"
 )
 
 var (

--- a/e2e/docker/docker_suite_test.go
+++ b/e2e/docker/docker_suite_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/seanb4t/specgraph/e2e/testutil"
+	"github.com/specgraph/specgraph/e2e/testutil"
 )
 
 var binaryPath string

--- a/e2e/testutil/server.go
+++ b/e2e/testutil/server.go
@@ -16,10 +16,10 @@ import (
 
 	"connectrpc.com/connect"
 
-	"github.com/seanb4t/specgraph/internal/drift"
-	"github.com/seanb4t/specgraph/internal/linter"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage/memgraph"
+	"github.com/specgraph/specgraph/internal/drift"
+	"github.com/specgraph/specgraph/internal/linter"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage/memgraph"
 )
 
 // ServerInfo holds the running server's details.

--- a/gen/specgraph/v1/authoring.pb.go
+++ b/gen/specgraph/v1/authoring.pb.go
@@ -2714,7 +2714,7 @@ const file_specgraph_v1_authoring_proto_rawDesc = "" +
 	"\x05Amend\x12\x1a.specgraph.v1.AmendRequest\x1a\x1b.specgraph.v1.AmendResponse\x12L\n" +
 	"\tSupersede\x12\x1e.specgraph.v1.SupersedeRequest\x1a\x1f.specgraph.v1.SupersedeResponse\x12O\n" +
 	"\n" +
-	"GetPrompts\x12\x1f.specgraph.v1.GetPromptsRequest\x1a .specgraph.v1.GetPromptsResponseB;Z9github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
+	"GetPrompts\x12\x1f.specgraph.v1.GetPromptsRequest\x1a .specgraph.v1.GetPromptsResponseB=Z;github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
 
 var (
 	file_specgraph_v1_authoring_proto_rawDescOnce sync.Once

--- a/gen/specgraph/v1/claim.pb.go
+++ b/gen/specgraph/v1/claim.pb.go
@@ -328,7 +328,7 @@ const file_specgraph_v1_claim_proto_rawDesc = "" +
 	"\fClaimService\x12@\n" +
 	"\tClaimSpec\x12\x1e.specgraph.v1.ClaimSpecRequest\x1a\x13.specgraph.v1.Claim\x12R\n" +
 	"\vUnclaimSpec\x12 .specgraph.v1.UnclaimSpecRequest\x1a!.specgraph.v1.UnclaimSpecResponse\x12@\n" +
-	"\tHeartbeat\x12\x1e.specgraph.v1.HeartbeatRequest\x1a\x13.specgraph.v1.ClaimB;Z9github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
+	"\tHeartbeat\x12\x1e.specgraph.v1.HeartbeatRequest\x1a\x13.specgraph.v1.ClaimB=Z;github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
 
 var (
 	file_specgraph_v1_claim_proto_rawDescOnce sync.Once

--- a/gen/specgraph/v1/constitution.pb.go
+++ b/gen/specgraph/v1/constitution.pb.go
@@ -1537,7 +1537,7 @@ const file_specgraph_v1_constitution_proto_rawDesc = "" +
 	"\x0fGetConstitution\x12$.specgraph.v1.GetConstitutionRequest\x1a%.specgraph.v1.GetConstitutionResponse\x12g\n" +
 	"\x12UpdateConstitution\x12'.specgraph.v1.UpdateConstitutionRequest\x1a(.specgraph.v1.UpdateConstitutionResponse\x12[\n" +
 	"\x0eCheckViolation\x12#.specgraph.v1.CheckViolationRequest\x1a$.specgraph.v1.CheckViolationResponse\x12X\n" +
-	"\rEmitToolFiles\x12\".specgraph.v1.EmitToolFilesRequest\x1a#.specgraph.v1.EmitToolFilesResponseB;Z9github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
+	"\rEmitToolFiles\x12\".specgraph.v1.EmitToolFilesRequest\x1a#.specgraph.v1.EmitToolFilesResponseB=Z;github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
 
 var (
 	file_specgraph_v1_constitution_proto_rawDescOnce sync.Once

--- a/gen/specgraph/v1/decision.pb.go
+++ b/gen/specgraph/v1/decision.pb.go
@@ -542,7 +542,7 @@ const file_specgraph_v1_decision_proto_rawDesc = "" +
 	"\x0eCreateDecision\x12#.specgraph.v1.CreateDecisionRequest\x1a\x16.specgraph.v1.Decision\x12G\n" +
 	"\vGetDecision\x12 .specgraph.v1.GetDecisionRequest\x1a\x16.specgraph.v1.Decision\x12X\n" +
 	"\rListDecisions\x12\".specgraph.v1.ListDecisionsRequest\x1a#.specgraph.v1.ListDecisionsResponse\x12M\n" +
-	"\x0eUpdateDecision\x12#.specgraph.v1.UpdateDecisionRequest\x1a\x16.specgraph.v1.DecisionB;Z9github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
+	"\x0eUpdateDecision\x12#.specgraph.v1.UpdateDecisionRequest\x1a\x16.specgraph.v1.DecisionB=Z;github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
 
 var (
 	file_specgraph_v1_decision_proto_rawDescOnce sync.Once

--- a/gen/specgraph/v1/execution.pb.go
+++ b/gen/specgraph/v1/execution.pb.go
@@ -975,7 +975,7 @@ const file_specgraph_v1_execution_proto_rawDesc = "" +
 	"\x0eReportProgress\x12#.specgraph.v1.ReportProgressRequest\x1a$.specgraph.v1.ReportProgressResponse\x12X\n" +
 	"\rReportBlocker\x12\".specgraph.v1.ReportBlockerRequest\x1a#.specgraph.v1.ReportBlockerResponse\x12a\n" +
 	"\x10ReportCompletion\x12%.specgraph.v1.ReportCompletionRequest\x1a&.specgraph.v1.ReportCompletionResponse\x12g\n" +
-	"\x12GetExecutionEvents\x12'.specgraph.v1.GetExecutionEventsRequest\x1a(.specgraph.v1.GetExecutionEventsResponseB;Z9github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
+	"\x12GetExecutionEvents\x12'.specgraph.v1.GetExecutionEventsRequest\x1a(.specgraph.v1.GetExecutionEventsResponseB=Z;github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
 
 var (
 	file_specgraph_v1_execution_proto_rawDescOnce sync.Once

--- a/gen/specgraph/v1/graph.pb.go
+++ b/gen/specgraph/v1/graph.pb.go
@@ -965,7 +965,7 @@ const file_specgraph_v1_graph_proto_rawDesc = "" +
 	"\x11GetTransitiveDeps\x12&.specgraph.v1.GetTransitiveDepsRequest\x1a'.specgraph.v1.GetTransitiveDepsResponse\x12L\n" +
 	"\tGetImpact\x12\x1e.specgraph.v1.GetImpactRequest\x1a\x1f.specgraph.v1.GetImpactResponse\x12I\n" +
 	"\bGetReady\x12\x1d.specgraph.v1.GetReadyRequest\x1a\x1e.specgraph.v1.GetReadyResponse\x12^\n" +
-	"\x0fGetCriticalPath\x12$.specgraph.v1.GetCriticalPathRequest\x1a%.specgraph.v1.GetCriticalPathResponseB;Z9github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
+	"\x0fGetCriticalPath\x12$.specgraph.v1.GetCriticalPathRequest\x1a%.specgraph.v1.GetCriticalPathResponseB=Z;github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
 
 var (
 	file_specgraph_v1_graph_proto_rawDescOnce sync.Once

--- a/gen/specgraph/v1/lifecycle.pb.go
+++ b/gen/specgraph/v1/lifecycle.pb.go
@@ -1254,7 +1254,7 @@ const file_specgraph_v1_lifecycle_proto_rawDesc = "" +
 	"\n" +
 	"CheckDrift\x12\x1f.specgraph.v1.DriftCheckRequest\x1a .specgraph.v1.DriftCheckResponse\x12a\n" +
 	"\x10AcknowledgeDrift\x12%.specgraph.v1.DriftAcknowledgeRequest\x1a&.specgraph.v1.DriftAcknowledgeResponse\x12=\n" +
-	"\x04Lint\x12\x19.specgraph.v1.LintRequest\x1a\x1a.specgraph.v1.LintResponseB;Z9github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
+	"\x04Lint\x12\x19.specgraph.v1.LintRequest\x1a\x1a.specgraph.v1.LintResponseB=Z;github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
 
 var (
 	file_specgraph_v1_lifecycle_proto_rawDescOnce sync.Once

--- a/gen/specgraph/v1/server.pb.go
+++ b/gen/specgraph/v1/server.pb.go
@@ -133,7 +133,7 @@ const file_specgraph_v1_server_proto_rawDesc = "" +
 	"\vserver_time\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"serverTime2T\n" +
 	"\rServerService\x12C\n" +
-	"\x06Health\x12\x1b.specgraph.v1.HealthRequest\x1a\x1c.specgraph.v1.HealthResponseB;Z9github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
+	"\x06Health\x12\x1b.specgraph.v1.HealthRequest\x1a\x1c.specgraph.v1.HealthResponseB=Z;github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
 
 var (
 	file_specgraph_v1_server_proto_rawDescOnce sync.Once

--- a/gen/specgraph/v1/spec.pb.go
+++ b/gen/specgraph/v1/spec.pb.go
@@ -652,7 +652,7 @@ const file_specgraph_v1_spec_proto_rawDesc = "" +
 	"\aGetSpec\x12\x1c.specgraph.v1.GetSpecRequest\x1a\x12.specgraph.v1.Spec\x12L\n" +
 	"\tListSpecs\x12\x1e.specgraph.v1.ListSpecsRequest\x1a\x1f.specgraph.v1.ListSpecsResponse\x12A\n" +
 	"\n" +
-	"UpdateSpec\x12\x1f.specgraph.v1.UpdateSpecRequest\x1a\x12.specgraph.v1.SpecB;Z9github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
+	"UpdateSpec\x12\x1f.specgraph.v1.UpdateSpecRequest\x1a\x12.specgraph.v1.SpecB=Z;github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
 
 var (
 	file_specgraph_v1_spec_proto_rawDescOnce sync.Once

--- a/gen/specgraph/v1/specgraphv1connect/authoring.connect.go
+++ b/gen/specgraph/v1/specgraphv1connect/authoring.connect.go
@@ -11,7 +11,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	v1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	http "net/http"
 	strings "strings"
 )

--- a/gen/specgraph/v1/specgraphv1connect/claim.connect.go
+++ b/gen/specgraph/v1/specgraphv1connect/claim.connect.go
@@ -11,7 +11,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	v1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	http "net/http"
 	strings "strings"
 )

--- a/gen/specgraph/v1/specgraphv1connect/constitution.connect.go
+++ b/gen/specgraph/v1/specgraphv1connect/constitution.connect.go
@@ -11,7 +11,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	v1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	http "net/http"
 	strings "strings"
 )

--- a/gen/specgraph/v1/specgraphv1connect/decision.connect.go
+++ b/gen/specgraph/v1/specgraphv1connect/decision.connect.go
@@ -11,7 +11,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	v1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	http "net/http"
 	strings "strings"
 )

--- a/gen/specgraph/v1/specgraphv1connect/execution.connect.go
+++ b/gen/specgraph/v1/specgraphv1connect/execution.connect.go
@@ -11,7 +11,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	v1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	http "net/http"
 	strings "strings"
 )

--- a/gen/specgraph/v1/specgraphv1connect/graph.connect.go
+++ b/gen/specgraph/v1/specgraphv1connect/graph.connect.go
@@ -11,7 +11,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	v1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	http "net/http"
 	strings "strings"
 )

--- a/gen/specgraph/v1/specgraphv1connect/lifecycle.connect.go
+++ b/gen/specgraph/v1/specgraphv1connect/lifecycle.connect.go
@@ -11,7 +11,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	v1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	http "net/http"
 	strings "strings"
 )

--- a/gen/specgraph/v1/specgraphv1connect/server.connect.go
+++ b/gen/specgraph/v1/specgraphv1connect/server.connect.go
@@ -11,7 +11,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	v1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	http "net/http"
 	strings "strings"
 )

--- a/gen/specgraph/v1/specgraphv1connect/spec.connect.go
+++ b/gen/specgraph/v1/specgraphv1connect/spec.connect.go
@@ -11,7 +11,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	v1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	http "net/http"
 	strings "strings"
 )

--- a/gen/specgraph/v1/specgraphv1connect/sync.connect.go
+++ b/gen/specgraph/v1/specgraphv1connect/sync.connect.go
@@ -11,7 +11,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+	v1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	http "net/http"
 	strings "strings"
 )

--- a/gen/specgraph/v1/sync.pb.go
+++ b/gen/specgraph/v1/sync.pb.go
@@ -862,7 +862,7 @@ const file_specgraph_v1_sync_proto_rawDesc = "" +
 	"\n" +
 	"SyncGitHub\x12\x1f.specgraph.v1.SyncGitHubRequest\x1a\x1a.specgraph.v1.SyncResponse\x12R\n" +
 	"\rGetSyncStatus\x12\x1f.specgraph.v1.SyncStatusRequest\x1a .specgraph.v1.SyncStatusResponse\x12C\n" +
-	"\x06Inject\x12\x1b.specgraph.v1.InjectRequest\x1a\x1c.specgraph.v1.InjectResponseB;Z9github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
+	"\x06Inject\x12\x1b.specgraph.v1.InjectRequest\x1a\x1c.specgraph.v1.InjectResponseB=Z;github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
 
 var (
 	file_specgraph_v1_sync_proto_rawDescOnce sync.Once

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/seanb4t/specgraph
+module github.com/specgraph/specgraph
 
 go 1.25.0
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -6,7 +6,7 @@ package auth_test
 import (
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/auth"
 )
 
 func TestHasPermission_ExactMatch(t *testing.T) {

--- a/internal/auth/config_store.go
+++ b/internal/auth/config_store.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/seanb4t/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/config"
 )
 
 // DefaultRolePermissions defines the built-in role permission bundles.

--- a/internal/auth/config_store_test.go
+++ b/internal/auth/config_store_test.go
@@ -8,8 +8,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/auth"
-	"github.com/seanb4t/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/config"
 )
 
 func TestConfigStore_ResolveAPIKey(t *testing.T) {

--- a/internal/auth/interceptor_test.go
+++ b/internal/auth/interceptor_test.go
@@ -11,10 +11,10 @@ import (
 
 	"connectrpc.com/connect"
 
-	specgraphv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/auth"
-	"github.com/seanb4t/specgraph/internal/config"
+	specgraphv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/config"
 )
 
 type stubHealthHandler struct {

--- a/internal/auth/permissions.go
+++ b/internal/auth/permissions.go
@@ -4,29 +4,29 @@
 package auth
 
 import (
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 )
 
 var rpcPermissions = map[string]string{
 	// SpecService
 	specgraphv1connect.SpecServiceGetSpecProcedure:    "spec:read",
-	specgraphv1connect.SpecServiceListSpecsProcedure:   "spec:read",
-	specgraphv1connect.SpecServiceCreateSpecProcedure:  "spec:write",
-	specgraphv1connect.SpecServiceUpdateSpecProcedure:  "spec:write",
+	specgraphv1connect.SpecServiceListSpecsProcedure:  "spec:read",
+	specgraphv1connect.SpecServiceCreateSpecProcedure: "spec:write",
+	specgraphv1connect.SpecServiceUpdateSpecProcedure: "spec:write",
 	// DecisionService
 	specgraphv1connect.DecisionServiceGetDecisionProcedure:    "decision:read",
-	specgraphv1connect.DecisionServiceListDecisionsProcedure:   "decision:read",
-	specgraphv1connect.DecisionServiceCreateDecisionProcedure:  "decision:write",
-	specgraphv1connect.DecisionServiceUpdateDecisionProcedure:  "decision:write",
+	specgraphv1connect.DecisionServiceListDecisionsProcedure:  "decision:read",
+	specgraphv1connect.DecisionServiceCreateDecisionProcedure: "decision:write",
+	specgraphv1connect.DecisionServiceUpdateDecisionProcedure: "decision:write",
 	// GraphService
-	specgraphv1connect.GraphServiceGetDependenciesProcedure:    "graph:read",
-	specgraphv1connect.GraphServiceGetTransitiveDepsProcedure:  "graph:read",
-	specgraphv1connect.GraphServiceGetImpactProcedure:          "graph:read",
-	specgraphv1connect.GraphServiceGetReadyProcedure:           "graph:read",
-	specgraphv1connect.GraphServiceGetCriticalPathProcedure:    "graph:read",
-	specgraphv1connect.GraphServiceListEdgesProcedure:          "graph:read",
-	specgraphv1connect.GraphServiceAddEdgeProcedure:            "graph:write",
-	specgraphv1connect.GraphServiceRemoveEdgeProcedure:         "graph:delete",
+	specgraphv1connect.GraphServiceGetDependenciesProcedure:   "graph:read",
+	specgraphv1connect.GraphServiceGetTransitiveDepsProcedure: "graph:read",
+	specgraphv1connect.GraphServiceGetImpactProcedure:         "graph:read",
+	specgraphv1connect.GraphServiceGetReadyProcedure:          "graph:read",
+	specgraphv1connect.GraphServiceGetCriticalPathProcedure:   "graph:read",
+	specgraphv1connect.GraphServiceListEdgesProcedure:         "graph:read",
+	specgraphv1connect.GraphServiceAddEdgeProcedure:           "graph:write",
+	specgraphv1connect.GraphServiceRemoveEdgeProcedure:        "graph:delete",
 	// ClaimService
 	specgraphv1connect.ClaimServiceClaimSpecProcedure:   "claim:write",
 	specgraphv1connect.ClaimServiceHeartbeatProcedure:   "claim:write",
@@ -37,14 +37,14 @@ var rpcPermissions = map[string]string{
 	specgraphv1connect.ConstitutionServiceUpdateConstitutionProcedure: "constitution:write",
 	specgraphv1connect.ConstitutionServiceEmitToolFilesProcedure:      "constitution:write",
 	// AuthoringService
-	specgraphv1connect.AuthoringServiceGetPromptsProcedure:  "authoring:read",
-	specgraphv1connect.AuthoringServiceSparkProcedure:       "authoring:write",
-	specgraphv1connect.AuthoringServiceShapeProcedure:       "authoring:write",
-	specgraphv1connect.AuthoringServiceSpecifyProcedure:     "authoring:write",
-	specgraphv1connect.AuthoringServiceDecomposeProcedure:   "authoring:write",
-	specgraphv1connect.AuthoringServiceApproveProcedure:     "authoring:write",
-	specgraphv1connect.AuthoringServiceAmendProcedure:       "authoring:write",
-	specgraphv1connect.AuthoringServiceSupersedeProcedure:   "authoring:write",
+	specgraphv1connect.AuthoringServiceGetPromptsProcedure: "authoring:read",
+	specgraphv1connect.AuthoringServiceSparkProcedure:      "authoring:write",
+	specgraphv1connect.AuthoringServiceShapeProcedure:      "authoring:write",
+	specgraphv1connect.AuthoringServiceSpecifyProcedure:    "authoring:write",
+	specgraphv1connect.AuthoringServiceDecomposeProcedure:  "authoring:write",
+	specgraphv1connect.AuthoringServiceApproveProcedure:    "authoring:write",
+	specgraphv1connect.AuthoringServiceAmendProcedure:      "authoring:write",
+	specgraphv1connect.AuthoringServiceSupersedeProcedure:  "authoring:write",
 	// ExecutionService
 	specgraphv1connect.ExecutionServiceGenerateBundleProcedure:     "execution:read",
 	specgraphv1connect.ExecutionServiceGetPrimeProcedure:           "execution:read",

--- a/internal/auth/permissions_test.go
+++ b/internal/auth/permissions_test.go
@@ -6,8 +6,8 @@ package auth_test
 import (
 	"testing"
 
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/auth"
 )
 
 var allProcedures = []string{

--- a/internal/authoring/passes_test.go
+++ b/internal/authoring/passes_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/seanb4t/specgraph/internal/authoring"
+	"github.com/specgraph/specgraph/internal/authoring"
 )
 
 func TestPassesForStage(t *testing.T) {

--- a/internal/authoring/posture.go
+++ b/internal/authoring/posture.go
@@ -6,7 +6,7 @@
 // specified, decomposed, and approved spec nodes.
 package authoring
 
-import specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+import specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 
 // Posture represents the collaboration posture between the AI and the human.
 type Posture int

--- a/internal/authoring/posture_test.go
+++ b/internal/authoring/posture_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/seanb4t/specgraph/internal/authoring"
+	"github.com/specgraph/specgraph/internal/authoring"
 )
 
 func TestDetectPosture(t *testing.T) {

--- a/internal/authoring/prompts.go
+++ b/internal/authoring/prompts.go
@@ -3,7 +3,7 @@
 
 package authoring
 
-import specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
+import specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 
 // Prompt is a named template used during a funnel stage.
 type Prompt struct {

--- a/internal/authoring/prompts_test.go
+++ b/internal/authoring/prompts_test.go
@@ -6,8 +6,8 @@ package authoring_test
 import (
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/authoring"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/authoring"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/authoring/safety.go
+++ b/internal/authoring/safety.go
@@ -9,8 +9,8 @@ import (
 	"sort"
 	"strings"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/storage"
 	"golang.org/x/text/unicode/norm"
 )
 

--- a/internal/authoring/safety_test.go
+++ b/internal/authoring/safety_test.go
@@ -6,8 +6,8 @@ package authoring_test
 import (
 	"testing"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/authoring"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/authoring"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/authoring/stages.go
+++ b/internal/authoring/stages.go
@@ -6,7 +6,7 @@ package authoring
 import (
 	"fmt"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // Stage is a typed authoring funnel stage name.

--- a/internal/authoring/stages_test.go
+++ b/internal/authoring/stages_test.go
@@ -6,7 +6,7 @@ package authoring_test
 import (
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/authoring"
+	"github.com/specgraph/specgraph/internal/authoring"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -88,7 +88,7 @@ func TestLoadGlobal_ReadOnlyParentDir(t *testing.T) {
 	}
 	parent := t.TempDir()
 	// Make parent read-only so creating config.yaml inside it fails.
-	require.NoError(t, os.Chmod(parent, 0o555)) //nolint:gosec // intentional for test
+	require.NoError(t, os.Chmod(parent, 0o555))       //nolint:gosec // intentional for test
 	t.Cleanup(func() { _ = os.Chmod(parent, 0o750) }) //nolint:gosec // restore perms for cleanup
 
 	path := filepath.Join(parent, "subdir", "config.yaml")

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/drift/drift.go
+++ b/internal/drift/drift.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/seanb4t/specgraph/internal/driftscope"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/driftscope"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // Backend is the subset of storage needed by the drift engine.

--- a/internal/drift/drift_test.go
+++ b/internal/drift/drift_test.go
@@ -8,8 +8,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/drift"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/drift"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/emitter/emitter.go
+++ b/internal/emitter/emitter.go
@@ -10,7 +10,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // Emit generates a tool-specific file from the given constitution.

--- a/internal/emitter/emitter_test.go
+++ b/internal/emitter/emitter_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/emitter"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/emitter"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/inject/inject.go
+++ b/internal/inject/inject.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // atomicWriteFile writes data to path atomically via a temp file + rename.

--- a/internal/inject/inject_test.go
+++ b/internal/inject/inject_test.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/inject"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/inject"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 func testSpec() *storage.Spec {

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // Backend is the subset of storage needed by the linter.

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/linter"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/linter"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/linter/schema.go
+++ b/internal/linter/schema.go
@@ -6,7 +6,7 @@ package linter
 import (
 	"fmt"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // ValidateSchema validates a spec against the spec schema rules.

--- a/internal/linter/schema_test.go
+++ b/internal/linter/schema_test.go
@@ -6,8 +6,8 @@ package linter_test
 import (
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/linter"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/linter"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/server/authoring_handler.go
+++ b/internal/server/authoring_handler.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/authoring"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/authoring"
+	"github.com/specgraph/specgraph/internal/storage"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/internal/server/authoring_handler_test.go
+++ b/internal/server/authoring_handler_test.go
@@ -13,10 +13,10 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/server/claim_handler.go
+++ b/internal/server/claim_handler.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 const (

--- a/internal/server/claim_handler_test.go
+++ b/internal/server/claim_handler_test.go
@@ -13,10 +13,10 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/durationpb"
 )

--- a/internal/server/constitution_handler.go
+++ b/internal/server/constitution_handler.go
@@ -10,10 +10,10 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/emitter"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/emitter"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // ConstitutionHandler implements the ConnectRPC ConstitutionService.

--- a/internal/server/constitution_handler_test.go
+++ b/internal/server/constitution_handler_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/server/convert.go
+++ b/internal/server/convert.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"time"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/storage"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/internal/server/convert_test.go
+++ b/internal/server/convert_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/internal/driftscope"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/driftscope"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/server/decision_handler.go
+++ b/internal/server/decision_handler.go
@@ -10,9 +10,9 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // DecisionHandler implements the ConnectRPC DecisionService.

--- a/internal/server/decision_handler_test.go
+++ b/internal/server/decision_handler_test.go
@@ -14,10 +14,10 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/server/execution_handler.go
+++ b/internal/server/execution_handler.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/storage"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/server/execution_handler_test.go
+++ b/internal/server/execution_handler_test.go
@@ -14,10 +14,10 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -6,7 +6,7 @@ package server
 import (
 	"context"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // ScopeStore is a test export of the unexported scopeStore function.

--- a/internal/server/graph_handler.go
+++ b/internal/server/graph_handler.go
@@ -9,9 +9,9 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // GraphHandler implements the ConnectRPC GraphService.

--- a/internal/server/graph_handler_test.go
+++ b/internal/server/graph_handler_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/server/health_handler.go
+++ b/internal/server/health_handler.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/internal/server/health_handler_test.go
+++ b/internal/server/health_handler_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/server"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/server/lifecycle_handler.go
+++ b/internal/server/lifecycle_handler.go
@@ -11,9 +11,9 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // DriftChecker runs drift detection for specs.

--- a/internal/server/lifecycle_handler_test.go
+++ b/internal/server/lifecycle_handler_test.go
@@ -13,10 +13,10 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/server/project.go
+++ b/internal/server/project.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 
 	"connectrpc.com/connect"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // validProjectSlug matches kebab-case identifiers: alphanumeric + hyphens,

--- a/internal/server/project_test.go
+++ b/internal/server/project_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 
 	"connectrpc.com/connect"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // NewMux creates an http.ServeMux with the SpecService handler registered.

--- a/internal/server/spec_handler.go
+++ b/internal/server/spec_handler.go
@@ -10,9 +10,9 @@ import (
 	"unicode/utf8"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 const (

--- a/internal/server/spec_handler_test.go
+++ b/internal/server/spec_handler_test.go
@@ -14,10 +14,10 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/server/sweeper_test.go
+++ b/internal/server/sweeper_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/seanb4t/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/server"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/server/sync_handler.go
+++ b/internal/server/sync_handler.go
@@ -14,11 +14,11 @@ import (
 	"sync"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/inject"
-	"github.com/seanb4t/specgraph/internal/storage"
-	syncpkg "github.com/seanb4t/specgraph/internal/sync"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/inject"
+	"github.com/specgraph/specgraph/internal/storage"
+	syncpkg "github.com/specgraph/specgraph/internal/sync"
 )
 
 // SyncHandler implements the ConnectRPC SyncService.

--- a/internal/server/sync_handler_test.go
+++ b/internal/server/sync_handler_test.go
@@ -14,11 +14,11 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	specv1 "github.com/seanb4t/specgraph/gen/specgraph/v1"
-	"github.com/seanb4t/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
-	syncpkg "github.com/seanb4t/specgraph/internal/sync"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
+	syncpkg "github.com/specgraph/specgraph/internal/sync"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/server/test_scoper_test.go
+++ b/internal/server/test_scoper_test.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/seanb4t/specgraph/internal/server"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 const testProject = "test-project"

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/service"
+	"github.com/specgraph/specgraph/internal/service"
 )
 
 func TestGenerate(t *testing.T) {

--- a/internal/storage/contenthash/contenthash.go
+++ b/internal/storage/contenthash/contenthash.go
@@ -53,7 +53,7 @@ func Decision(title, status, decision, rationale string) string {
 // murmur3.Hash128 is an interface — do NOT use a pointer to it.
 func writeField(h murmur3.Hash128, key, value string) {
 	var buf [4]byte
-	binary.BigEndian.PutUint32(buf[:], uint32(len(key)))  //nolint:gosec // key length will never overflow uint32
+	binary.BigEndian.PutUint32(buf[:], uint32(len(key))) //nolint:gosec // key length will never overflow uint32
 	_, _ = h.Write(buf[:])
 	_, _ = h.Write([]byte(key))
 	binary.BigEndian.PutUint32(buf[:], uint32(len(value))) //nolint:gosec // value length will never overflow uint32

--- a/internal/storage/contenthash/contenthash_test.go
+++ b/internal/storage/contenthash/contenthash_test.go
@@ -6,7 +6,7 @@ package contenthash_test
 import (
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage/contenthash"
+	"github.com/specgraph/specgraph/internal/storage/contenthash"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/storage/fieldchange_test.go
+++ b/internal/storage/fieldchange_test.go
@@ -6,7 +6,7 @@ package storage_test
 import (
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/storage/lifecycle_test.go
+++ b/internal/storage/lifecycle_test.go
@@ -6,7 +6,7 @@ package storage_test
 import (
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/storage/memgraph/authoring.go
+++ b/internal/storage/memgraph/authoring.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/seanb4t/specgraph/internal/authoring"
-	"github.com/seanb4t/specgraph/internal/storage"
-	"github.com/seanb4t/specgraph/internal/storage/contenthash"
+	"github.com/specgraph/specgraph/internal/authoring"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage/contenthash"
 )
 
 const (

--- a/internal/storage/memgraph/authoring_test.go
+++ b/internal/storage/memgraph/authoring_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/seanb4t/specgraph/internal/authoring"
-	"github.com/seanb4t/specgraph/internal/storage"
-	"github.com/seanb4t/specgraph/internal/storage/memgraph"
+	"github.com/specgraph/specgraph/internal/authoring"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage/memgraph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/storage/memgraph/changelog.go
+++ b/internal/storage/memgraph/changelog.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // Compile-time interface assertion.
@@ -117,13 +117,13 @@ func (s *Store) createChangeLog(ctx context.Context, slug string, entry *storage
 		"expected_version": int64(entry.Version),
 		"id":               entry.ID,
 		"version":          int64(entry.Version),
-		"stage":        string(entry.Stage),
-		"content_hash": entry.ContentHash,
-		"checkpoint":   entry.Checkpoint,
-		"summary":      entry.Summary,
-		"reason":       entry.Reason,
-		"changes_json": changesJSON,
-		"date":         dateStr,
+		"stage":            string(entry.Stage),
+		"content_hash":     entry.ContentHash,
+		"checkpoint":       entry.Checkpoint,
+		"summary":          entry.Summary,
+		"reason":           entry.Reason,
+		"changes_json":     changesJSON,
+		"date":             dateStr,
 	})
 
 	records, err := s.executeQuery(ctx, query, params)

--- a/internal/storage/memgraph/changelog_test.go
+++ b/internal/storage/memgraph/changelog_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/storage/memgraph/changelog_unit_test.go
+++ b/internal/storage/memgraph/changelog_unit_test.go
@@ -6,7 +6,7 @@ package memgraph
 import (
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/storage/memgraph/claim.go
+++ b/internal/storage/memgraph/claim.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 const defaultLeaseDuration = 15 * time.Minute

--- a/internal/storage/memgraph/constitution.go
+++ b/internal/storage/memgraph/constitution.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )

--- a/internal/storage/memgraph/constitution_test.go
+++ b/internal/storage/memgraph/constitution_test.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/storage/memgraph/decision.go
+++ b/internal/storage/memgraph/decision.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/seanb4t/specgraph/internal/storage"
-	"github.com/seanb4t/specgraph/internal/storage/contenthash"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage/contenthash"
 )
 
 // CreateDecision stores a new decision node in Memgraph.

--- a/internal/storage/memgraph/decision_test.go
+++ b/internal/storage/memgraph/decision_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/storage/memgraph/execution.go
+++ b/internal/storage/memgraph/execution.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // GenerateBundle assembles a bundle from the spec and its linked decisions.

--- a/internal/storage/memgraph/execution_test.go
+++ b/internal/storage/memgraph/execution_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/storage/memgraph/graph.go
+++ b/internal/storage/memgraph/graph.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )

--- a/internal/storage/memgraph/graph_test.go
+++ b/internal/storage/memgraph/graph_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/storage/memgraph/lifecycle.go
+++ b/internal/storage/memgraph/lifecycle.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // terminalStages maps stages from which no further lifecycle transitions

--- a/internal/storage/memgraph/lifecycle_test.go
+++ b/internal/storage/memgraph/lifecycle_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/seanb4t/specgraph/internal/drift"
-	"github.com/seanb4t/specgraph/internal/storage"
-	"github.com/seanb4t/specgraph/internal/storage/memgraph"
+	"github.com/specgraph/specgraph/internal/drift"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage/memgraph"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/storage/memgraph/lifecycle_unit_test.go
+++ b/internal/storage/memgraph/lifecycle_unit_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -71,4 +71,3 @@ func TestSortableRFC3339Nano_LexicographicOrdering(t *testing.T) {
 	assert.Less(t, oldFormatEarlier, laterStr,
 		"old RFC3339 format should still sort before newer sortableRFC3339Nano")
 }
-

--- a/internal/storage/memgraph/memgraph.go
+++ b/internal/storage/memgraph/memgraph.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/oklog/ulid/v2"
 
-	"github.com/seanb4t/specgraph/internal/storage"
-	"github.com/seanb4t/specgraph/internal/storage/contenthash"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage/contenthash"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
@@ -700,20 +700,20 @@ func recordToSpecOffset(rec *neo4j.Record, offset int) (*storage.Spec, error) {
 	}
 
 	return &storage.Spec{
-		ID:          id,
-		Slug:        slug,
-		Intent:      intent,
-		Stage:       storage.SpecStage(stage),
-		Priority:    storage.SpecPriority(priority),
-		Complexity:  complexity,
-		Version:     safeInt32(version),
-		CreatedAt:   createdAt,
-		UpdatedAt:   updatedAt,
-		Lifecycle:   lifecycle,
+		ID:           id,
+		Slug:         slug,
+		Intent:       intent,
+		Stage:        storage.SpecStage(stage),
+		Priority:     storage.SpecPriority(priority),
+		Complexity:   complexity,
+		Version:      safeInt32(version),
+		CreatedAt:    createdAt,
+		UpdatedAt:    updatedAt,
+		Lifecycle:    lifecycle,
 		SupersededBy: supersededBy,
-		Supersedes:  supersedes,
-		Notes:       notes,
-		ContentHash: contentHash,
+		Supersedes:   supersedes,
+		Notes:        notes,
+		ContentHash:  contentHash,
 	}, nil
 }
 

--- a/internal/storage/memgraph/memgraph_test.go
+++ b/internal/storage/memgraph/memgraph_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/seanb4t/specgraph/internal/storage"
-	"github.com/seanb4t/specgraph/internal/storage/memgraph"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage/memgraph"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"

--- a/internal/storage/memgraph/project.go
+++ b/internal/storage/memgraph/project.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // EnsureProject implements storage.ProjectBackend.

--- a/internal/storage/memgraph/project_test.go
+++ b/internal/storage/memgraph/project_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/storage/memgraph/sync.go
+++ b/internal/storage/memgraph/sync.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // CreateSyncMapping implements storage.SyncBackend.

--- a/internal/storage/memgraph/sync_test.go
+++ b/internal/storage/memgraph/sync_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/storage/memgraph/tx.go
+++ b/internal/storage/memgraph/tx.go
@@ -40,7 +40,7 @@ import (
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // txKey is the context key used to thread a managed transaction through storage calls.

--- a/internal/storage/memgraph/tx_changelog_test.go
+++ b/internal/storage/memgraph/tx_changelog_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/storage/spec_domain.go
+++ b/internal/storage/spec_domain.go
@@ -134,19 +134,18 @@ func (l SpecLifecycle) IsValid() bool {
 // Spec is the storage-layer domain type for specifications.
 // Handlers convert between this type and the proto Spec message.
 type Spec struct {
-	ID                   string
-	Slug                 string
-	Intent               string
-	Stage                SpecStage
-	Priority             SpecPriority
-	Complexity           string
-	Version              int32
-	CreatedAt            time.Time
-	UpdatedAt            time.Time
-	Lifecycle            SpecLifecycle  // "task" (default) or "living"
-	SupersededBy         string         // slug of replacement spec
-	Supersedes           string         // slug of spec this replaced
-	Notes                string         // free-text notes (conversation summaries, context)
-	ContentHash          string         // Murmur3-128 hash of substantive fields
+	ID           string
+	Slug         string
+	Intent       string
+	Stage        SpecStage
+	Priority     SpecPriority
+	Complexity   string
+	Version      int32
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	Lifecycle    SpecLifecycle // "task" (default) or "living"
+	SupersededBy string        // slug of replacement spec
+	Supersedes   string        // slug of spec this replaced
+	Notes        string        // free-text notes (conversation summaries, context)
+	ContentHash  string        // Murmur3-128 hash of substantive fields
 }
-

--- a/internal/storage/spec_domain_test.go
+++ b/internal/storage/spec_domain_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/sync/adapter.go
+++ b/internal/sync/adapter.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // Sentinel errors for sync adapters.

--- a/internal/sync/beads.go
+++ b/internal/sync/beads.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // beadsIDPattern matches valid bead IDs (alphanumeric with hyphens, dots, underscores).

--- a/internal/sync/beads_test.go
+++ b/internal/sync/beads_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // mockRunner implements CommandRunner for testing.

--- a/internal/sync/exec_test.go
+++ b/internal/sync/exec_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/seanb4t/specgraph/internal/sync"
+	"github.com/specgraph/specgraph/internal/sync"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/sync/github.go
+++ b/internal/sync/github.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // GitHubAdapter syncs specs to GitHub Issues via the gh CLI.

--- a/internal/sync/github_test.go
+++ b/internal/sync/github_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 func TestGitHubAdapter_Name(t *testing.T) {

--- a/internal/xdg/xdg_test.go
+++ b/internal/xdg/xdg_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/seanb4t/specgraph/internal/xdg"
+	"github.com/specgraph/specgraph/internal/xdg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/plugin/specgraph/plugin.json
+++ b/plugin/specgraph/plugin.json
@@ -2,7 +2,7 @@
   "name": "specgraph",
   "version": "0.1.0",
   "description": "SpecGraph: spec-driven development — author, query, and execute specs",
-  "homepage": "https://github.com/seanb4t/specgraph",
+  "homepage": "https://github.com/specgraph/specgraph",
   "license": "MIT",
   "skills": [
     { "name": "specgraph", "path": "skills/specgraph/SKILL.md" },

--- a/proto/specgraph/v1/authoring.proto
+++ b/proto/specgraph/v1/authoring.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 import "google/protobuf/timestamp.proto";
 

--- a/proto/specgraph/v1/claim.proto
+++ b/proto/specgraph/v1/claim.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";

--- a/proto/specgraph/v1/constitution.proto
+++ b/proto/specgraph/v1/constitution.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 import "google/protobuf/timestamp.proto";
 

--- a/proto/specgraph/v1/decision.proto
+++ b/proto/specgraph/v1/decision.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 import "google/protobuf/timestamp.proto";
 

--- a/proto/specgraph/v1/execution.proto
+++ b/proto/specgraph/v1/execution.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 import "google/protobuf/timestamp.proto";
 import "specgraph/v1/spec.proto";

--- a/proto/specgraph/v1/graph.proto
+++ b/proto/specgraph/v1/graph.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 // --- Edge Types ---
 

--- a/proto/specgraph/v1/lifecycle.proto
+++ b/proto/specgraph/v1/lifecycle.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 import "specgraph/v1/spec.proto";
 

--- a/proto/specgraph/v1/server.proto
+++ b/proto/specgraph/v1/server.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 import "google/protobuf/timestamp.proto";
 

--- a/proto/specgraph/v1/spec.proto
+++ b/proto/specgraph/v1/spec.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 import "google/protobuf/timestamp.proto";
 

--- a/proto/specgraph/v1/sync.proto
+++ b/proto/specgraph/v1/sync.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
 
 package specgraph.v1;
 
-option go_package = "github.com/seanb4t/specgraph/gen/specgraph/v1;specgraphv1";
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
 
 import "google/protobuf/timestamp.proto";
 

--- a/site/zensical.toml
+++ b/site/zensical.toml
@@ -1,6 +1,6 @@
 [project]
 site_name = "SpecGraph"
-site_url = "https://seanb4t.github.io/specgraph/"
+site_url = "https://specgraph.io/"
 site_description = "Live Spec-Driven Development Framework"
 site_author = "Sean Brandt"
 copyright = "© 2026 Sean Brandt • MIT"
@@ -34,5 +34,5 @@ search.suggest = true
 content.code.copy = true
 
 [project.repo]
-url = "https://github.com/seanb4t/specgraph"
+url = "https://github.com/specgraph/specgraph"
 name = "GitHub"


### PR DESCRIPTION
## Summary

- Update Go module path from `github.com/seanb4t/specgraph` to `github.com/specgraph/specgraph`
- Update all Go imports (~165 files), proto `go_package` options (10 files), regenerate `gen/`
- Update site config, plugin.json, Docker compose, README, CLAUDE.md, and historical docs
- Zero logic changes — pure rename

## Test plan

- [x] `task pr-prep` passes (fmt, lint, build, unit, integration, e2e/api, e2e/cli, e2e/docker)
- [x] `grep -r "seanb4t"` returns zero hits in source files
- [x] `go build ./...` passes with new module path

Closes spgr-4ha

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>