### PR TITLE
perf: share single memgraph container across integration tests

### DIFF
--- a/internal/storage/memgraph/authoring_test.go
+++ b/internal/storage/memgraph/authoring_test.go
@@ -18,12 +18,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newTestStore creates a fresh Memgraph-backed store for a single test,
-// registering cleanup of the container and store connection.
+// newTestStore creates a Memgraph-backed store for a single test,
+// registering cleanup of the store connection.
 func newTestStore(t *testing.T, opts ...memgraph.Option) (*memgraph.Store, context.Context) {
 	t.Helper()
-	boltURI, cleanup := setupMemgraph(t)
-	t.Cleanup(cleanup)
+	clearDatabase(t)
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI, opts...)
 	require.NoError(t, err)
@@ -36,11 +35,8 @@ func newTestStore(t *testing.T, opts ...memgraph.Option) (*memgraph.Store, conte
 }
 
 func TestAuthoring(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	t.Cleanup(cleanup)
-
 	t.Run("TransitionStage", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -66,7 +62,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("TransitionStage_WrongStage", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -81,7 +77,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("StoreSparkOutput", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -101,7 +97,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("StoreDecomposeOutput", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -124,7 +120,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("AmendSpec", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -144,7 +140,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("AmendSpec_AlreadyApproved", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -162,7 +158,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("AmendSpec_InvalidTransition", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -178,7 +174,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("AmendSpec_NotFound", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -190,7 +186,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("AmendSpec_EmptyReason", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -209,7 +205,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("SupersedeSpec", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -230,7 +226,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("SupersedeSpec_NotFound", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -249,7 +245,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("StoreDecomposeOutput_Idempotent", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -282,7 +278,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("StoreDecomposeOutput_MissingParent", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -299,7 +295,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("StoreDecomposeOutput_DuplicateSliceID", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -320,7 +316,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("StoreDecomposeOutput_UnknownDependency", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -341,7 +337,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("TransitionStage_BackwardViaAmend", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -365,7 +361,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("TransitionStage_ApprovedGuard", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -386,7 +382,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("TransitionStage_SupersededGuard", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -408,7 +404,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("StoreShapeOutput_CreatesDecisionNodes", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -448,7 +444,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("StoreShapeOutput_IdempotentDecisions", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -480,7 +476,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("StoreSafetyFlags", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -534,7 +530,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("StoreSafetyFlags_SpecNotFound", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -547,7 +543,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("StoreSparkOutput_UpdatesContentHash", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -568,7 +564,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("TransitionStage_UpdatesContentHash", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -590,7 +586,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("AmendSpec_UpdatesContentHash", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -619,7 +615,7 @@ func TestAuthoring(t *testing.T) {
 	})
 
 	t.Run("StoreRedTeamFindings_DoesNotUpdateContentHash", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)

--- a/internal/storage/memgraph/changelog_test.go
+++ b/internal/storage/memgraph/changelog_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestCreateSpec_CreatesChangeLogEntry(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -40,8 +39,7 @@ func TestCreateSpec_CreatesChangeLogEntry(t *testing.T) {
 }
 
 func TestUpdateSpec_CreatesChangeLogEntry(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -69,8 +67,7 @@ func TestUpdateSpec_CreatesChangeLogEntry(t *testing.T) {
 }
 
 func TestTransitionStage_CreatesCheckpointChangeLog(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -98,8 +95,7 @@ func TestTransitionStage_CreatesCheckpointChangeLog(t *testing.T) {
 }
 
 func TestStoreSparkOutput_CreatesChangeLog(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -131,8 +127,7 @@ func TestStoreSparkOutput_CreatesChangeLog(t *testing.T) {
 }
 
 func TestStoreShapeOutput_CreatesChangeLog(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -166,8 +161,7 @@ func TestStoreShapeOutput_CreatesChangeLog(t *testing.T) {
 }
 
 func TestStoreSpecifyOutput_CreatesChangeLog(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -192,8 +186,7 @@ func TestStoreSpecifyOutput_CreatesChangeLog(t *testing.T) {
 }
 
 func TestStoreDecomposeOutput_CreatesChangeLog(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -221,8 +214,7 @@ func TestStoreDecomposeOutput_CreatesChangeLog(t *testing.T) {
 }
 
 func TestLifecycleAmendSpec_CreatesCheckpointChangeLog(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -249,8 +241,7 @@ func TestLifecycleAmendSpec_CreatesCheckpointChangeLog(t *testing.T) {
 }
 
 func TestLifecycleAbandonSpec_CreatesCheckpointChangeLog(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -275,8 +266,7 @@ func TestLifecycleAbandonSpec_CreatesCheckpointChangeLog(t *testing.T) {
 }
 
 func TestLifecycleSupersedeSpec_CreatesCheckpointChangeLogs(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -308,8 +298,7 @@ func TestLifecycleSupersedeSpec_CreatesCheckpointChangeLogs(t *testing.T) {
 }
 
 func TestListChanges_CheckpointsOnly(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -333,8 +322,7 @@ func TestListChanges_CheckpointsOnly(t *testing.T) {
 }
 
 func TestListChanges_SinceVersion(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -355,8 +343,7 @@ func TestListChanges_SinceVersion(t *testing.T) {
 }
 
 func TestListChanges_Limit(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -379,8 +366,7 @@ func TestListChanges_Limit(t *testing.T) {
 }
 
 func TestListChanges_SpecNotFound(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -393,8 +379,7 @@ func TestListChanges_SpecNotFound(t *testing.T) {
 }
 
 func TestUpdateSpec_NoChangeLogOnNoOp(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)

--- a/internal/storage/memgraph/claim_test.go
+++ b/internal/storage/memgraph/claim_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestClaimAndUnclaim(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -48,8 +47,7 @@ func TestClaimAndUnclaim(t *testing.T) {
 }
 
 func TestHeartbeat(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)

--- a/internal/storage/memgraph/constitution_test.go
+++ b/internal/storage/memgraph/constitution_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestConstitution_GetNotFound(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -29,8 +28,7 @@ func TestConstitution_GetNotFound(t *testing.T) {
 }
 
 func TestConstitution_UpdateAndGet(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -107,8 +105,7 @@ func TestConstitution_UpdateAndGet(t *testing.T) {
 }
 
 func TestConstitution_MinimalRoundTrip(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -139,8 +136,7 @@ func TestConstitution_MinimalRoundTrip(t *testing.T) {
 }
 
 func TestConstitution_CheckViolation(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)

--- a/internal/storage/memgraph/decision_test.go
+++ b/internal/storage/memgraph/decision_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestCreateAndGetDecision(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -40,8 +39,7 @@ func TestCreateAndGetDecision(t *testing.T) {
 }
 
 func TestListDecisions(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -63,8 +61,7 @@ func TestListDecisions(t *testing.T) {
 }
 
 func TestUpdateDecision(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -85,8 +82,7 @@ func TestUpdateDecision(t *testing.T) {
 }
 
 func TestCreateDecision_SetsContentHash(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -111,8 +107,7 @@ func TestCreateDecision_SetsContentHash(t *testing.T) {
 }
 
 func TestGetDecision_NotFound(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)

--- a/internal/storage/memgraph/execution_test.go
+++ b/internal/storage/memgraph/execution_test.go
@@ -19,11 +19,8 @@ import (
 func ptr(s string) *string { return &s }
 
 func TestExecution(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
-
 	t.Run("GenerateBundle_SpecNotFound", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -35,7 +32,7 @@ func TestExecution(t *testing.T) {
 	})
 
 	t.Run("GenerateBundle_NotApproved", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -50,7 +47,7 @@ func TestExecution(t *testing.T) {
 	})
 
 	t.Run("GenerateBundle_Success", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -81,7 +78,7 @@ func TestExecution(t *testing.T) {
 	})
 
 	t.Run("RecordProgress_NoClaim", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -99,7 +96,7 @@ func TestExecution(t *testing.T) {
 	})
 
 	t.Run("FullLifecycle", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -159,7 +156,7 @@ func TestExecution(t *testing.T) {
 		// duplicate edge here is a best-effort reproduction. The DISTINCT
 		// is defensive — if this test passes without it, the protection
 		// is still warranted for the E2E scenario.
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -201,7 +198,7 @@ func TestExecution(t *testing.T) {
 	})
 
 	t.Run("GetPrimeData", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -236,7 +233,7 @@ func TestExecution(t *testing.T) {
 	})
 
 	t.Run("GetPrimeData_NoConstitution", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -254,7 +251,7 @@ func TestExecution(t *testing.T) {
 	})
 
 	t.Run("ReleaseExpiredClaims", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)

--- a/internal/storage/memgraph/graph_test.go
+++ b/internal/storage/memgraph/graph_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestAddAndListEdges(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -46,8 +45,7 @@ func TestAddAndListEdges(t *testing.T) {
 }
 
 func TestGetDependencies(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -69,8 +67,7 @@ func TestGetDependencies(t *testing.T) {
 }
 
 func TestDiamondDependencies(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -104,8 +101,7 @@ func TestDiamondDependencies(t *testing.T) {
 }
 
 func TestBlocksEdgeDirection(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -143,8 +139,7 @@ func TestBlocksEdgeDirection(t *testing.T) {
 }
 
 func TestGetReady(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)

--- a/internal/storage/memgraph/lifecycle_test.go
+++ b/internal/storage/memgraph/lifecycle_test.go
@@ -38,11 +38,8 @@ func newTestClock() (now func() time.Time, advance func(time.Duration)) {
 }
 
 func TestLifecycle(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	t.Cleanup(cleanup)
-
 	t.Run("AmendSpec_HappyPath", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -68,7 +65,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AmendSpec_NotDone", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -82,7 +79,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AmendSpec_LifecycleNotFound", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -93,7 +90,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("SupersedeSpec_HappyPath", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -112,7 +109,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("SupersedeSpec_SupersedesEdgePersists", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -135,7 +132,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("SupersedeSpec_OldNotFound", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -149,7 +146,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("SupersedeSpec_NewNotFound", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -163,7 +160,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("SupersedeSpec_TerminalState", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -184,7 +181,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("SupersedeSpec_SameSlug", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -199,7 +196,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AbandonSpec_HappyPath", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -216,7 +213,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AbandonSpec_ConcurrentModification", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -253,7 +250,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AbandonSpec_Terminal", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -271,7 +268,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("CheckDrift_DependencyDrift", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		clock, advance := newTestClock()
 		store, err := newStore(ctx, boltURI, memgraph.WithClock(clock))
@@ -314,7 +311,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AbandonSpec_NotFound", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -325,7 +322,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AmendSpec_Terminal", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -344,7 +341,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AcknowledgeDrift", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -380,7 +377,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AcknowledgeDrift_IneligibleStage", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -396,7 +393,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AmendSpec_ConcurrentModification", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -437,7 +434,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("CheckDrift_AllSpecs_Integration", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		clock, advance := newTestClock()
 		store, err := newStore(ctx, boltURI, memgraph.WithClock(clock))
@@ -492,7 +489,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AcknowledgeDrift_PerUpstream_UpdatesEdgeHash", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -553,7 +550,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AcknowledgeDrift_AllUpstreams_UpdatesAllEdges", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -608,7 +605,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AmendedSpec_CanBeAbandoned", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -632,7 +629,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AmendedSpec_CanBeSuperseded", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -662,7 +659,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AmendSpec_ReEntryExcludedStages", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -682,7 +679,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("SupersedeSpec_ConcurrentModificationOnNewSpec", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -738,7 +735,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("SupersedeSpec_NewSpecConcurrentlyAbandoned", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -766,7 +763,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("SupersedeSpec_NewSpecNotFound", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -786,7 +783,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("CheckDrift_AmendedSpecDrift", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		clock, advance := newTestClock()
 		store, err := newStore(ctx, boltURI, memgraph.WithClock(clock))
@@ -833,7 +830,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("BatchGetSpecs", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -870,7 +867,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AcknowledgeDrift_AmendedStage", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -892,7 +889,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AcknowledgeDrift_NotFound", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -904,7 +901,7 @@ func TestLifecycle(t *testing.T) {
 	})
 
 	t.Run("AcknowledgeDrift_ConcurrentAckAndCheck", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)

--- a/internal/storage/memgraph/memgraph_test.go
+++ b/internal/storage/memgraph/memgraph_test.go
@@ -8,9 +8,11 @@ package memgraph_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/specgraph/specgraph/internal/storage/memgraph"
 	"github.com/stretchr/testify/require"
@@ -18,8 +20,10 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-func setupMemgraph(t *testing.T) (string, func()) {
-	t.Helper()
+// boltURI is set once by TestMain and shared across all tests.
+var boltURI string
+
+func TestMain(m *testing.M) {
 	ctx := context.Background()
 
 	req := testcontainers.ContainerRequest{
@@ -37,27 +41,65 @@ func setupMemgraph(t *testing.T) (string, func()) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	require.NoError(t, err)
-
-	host, err := container.Host(ctx)
-	require.NoError(t, err)
-
-	port, err := container.MappedPort(ctx, "7687")
-	require.NoError(t, err)
-
-	boltURI := fmt.Sprintf("bolt://%s:%s", host, port.Port())
-
-	cleanup := func() {
-		_ = container.Terminate(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start memgraph container: %v\n", err)
+		os.Exit(1)
 	}
 
-	return boltURI, cleanup
+	host, err := container.Host(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get container host: %v\n", err)
+		_ = container.Terminate(ctx)
+		os.Exit(1)
+	}
+
+	port, err := container.MappedPort(ctx, "7687")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get mapped port: %v\n", err)
+		_ = container.Terminate(ctx)
+		os.Exit(1)
+	}
+
+	boltURI = fmt.Sprintf("bolt://%s:%s", host, port.Port())
+
+	code := m.Run()
+
+	_ = container.Terminate(ctx)
+	os.Exit(code)
 }
 
-// newStore creates a Store with retry logic to handle the brief window between
-// the container wait strategy completing and the bolt protocol being fully ready.
-// Prepends WithProject("test") so callers don't need to specify a project.
-// Callers can override with their own WithProject (last option wins).
+// clearDatabase removes all nodes and edges from the shared Memgraph container.
+// Call at the start of each test to ensure isolation. Uses a retry loop and
+// neo4j.ExecuteQuery with EagerResultTransformer to avoid CI flakes from
+// transient Bolt connection issues.
+func clearDatabase(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+
+	var lastErr error
+	for range 10 {
+		driver, err := neo4j.NewDriverWithContext(boltURI, neo4j.NoAuth())
+		if err != nil {
+			lastErr = err
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		_, err = neo4j.ExecuteQuery(ctx, driver,
+			"MATCH (n) DETACH DELETE n", nil,
+			neo4j.EagerResultTransformer)
+		closeErr := driver.Close(ctx)
+		if err != nil {
+			lastErr = err
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		require.NoError(t, closeErr)
+		return
+	}
+	require.NoError(t, lastErr, "clearDatabase: retry exhausted")
+}
+
+// newStore creates a Store with retry logic. Uses the shared boltURI.
 func newStore(ctx context.Context, boltURI string, opts ...memgraph.Option) (*memgraph.Store, error) {
 	opts = append([]memgraph.Option{memgraph.WithProject("test")}, opts...)
 	var (
@@ -75,8 +117,7 @@ func newStore(ctx context.Context, boltURI string, opts ...memgraph.Option) (*me
 }
 
 func TestCreateAndGetSpec(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -111,8 +152,7 @@ func TestCreateAndGetSpec(t *testing.T) {
 }
 
 func TestListSpecs(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -138,8 +178,7 @@ func TestListSpecs(t *testing.T) {
 }
 
 func TestUpdateSpec(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -176,8 +215,7 @@ func TestUpdateSpec(t *testing.T) {
 }
 
 func TestCreateSpec_SetsContentHash(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -202,8 +240,7 @@ func TestCreateSpec_SetsContentHash(t *testing.T) {
 }
 
 func TestGetSpec_NotFound(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)

--- a/internal/storage/memgraph/project_test.go
+++ b/internal/storage/memgraph/project_test.go
@@ -15,9 +15,8 @@ import (
 )
 
 func TestEnsureProject_CreatesNew(t *testing.T) {
+	clearDatabase(t)
 	ctx := context.Background()
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
 	store, err := newStore(ctx, boltURI)
 	require.NoError(t, err)
 	defer store.Close(ctx)
@@ -29,9 +28,8 @@ func TestEnsureProject_CreatesNew(t *testing.T) {
 }
 
 func TestEnsureProject_Idempotent(t *testing.T) {
+	clearDatabase(t)
 	ctx := context.Background()
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
 	store, err := newStore(ctx, boltURI)
 	require.NoError(t, err)
 	defer store.Close(ctx)
@@ -44,9 +42,8 @@ func TestEnsureProject_Idempotent(t *testing.T) {
 }
 
 func TestGetProject_NotFound(t *testing.T) {
+	clearDatabase(t)
 	ctx := context.Background()
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
 	store, err := newStore(ctx, boltURI)
 	require.NoError(t, err)
 	defer store.Close(ctx)
@@ -56,9 +53,8 @@ func TestGetProject_NotFound(t *testing.T) {
 }
 
 func TestUpdateProject_SyncAdapters(t *testing.T) {
+	clearDatabase(t)
 	ctx := context.Background()
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
 	store, err := newStore(ctx, boltURI)
 	require.NoError(t, err)
 	defer store.Close(ctx)
@@ -72,9 +68,8 @@ func TestUpdateProject_SyncAdapters(t *testing.T) {
 }
 
 func TestListProjects(t *testing.T) {
+	clearDatabase(t)
 	ctx := context.Background()
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
 	store, err := newStore(ctx, boltURI)
 	require.NoError(t, err)
 	defer store.Close(ctx)

--- a/internal/storage/memgraph/sync_test.go
+++ b/internal/storage/memgraph/sync_test.go
@@ -14,27 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// clearGraph removes all nodes and relationships from the Memgraph instance.
-func clearGraph(t *testing.T, boltURI string) {
-	t.Helper()
-	driver, err := neo4j.NewDriverWithContext(boltURI, neo4j.NoAuth())
-	require.NoError(t, err)
-	ctx := context.Background()
-	defer driver.Close(ctx)
-	session := driver.NewSession(ctx, neo4j.SessionConfig{})
-	defer session.Close(ctx)
-	_, err = session.Run(ctx, "MATCH (n) DETACH DELETE n", nil)
-	require.NoError(t, err)
-}
-
-// TestSync runs all sync integration tests against a single shared Memgraph
-// container to avoid the per-test container startup overhead (~6s each).
+// TestSync runs all sync integration tests against the shared Memgraph
+// container, clearing the database between subtests for isolation.
 func TestSync(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
-
 	t.Run("CreateMapping", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -55,7 +39,7 @@ func TestSync(t *testing.T) {
 	})
 
 	t.Run("CreateMappingDuplicate", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -72,7 +56,7 @@ func TestSync(t *testing.T) {
 	})
 
 	t.Run("CreateMappingSpecNotFound", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -83,7 +67,7 @@ func TestSync(t *testing.T) {
 	})
 
 	t.Run("UpdateState", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -107,7 +91,7 @@ func TestSync(t *testing.T) {
 	})
 
 	t.Run("UpdateStateNotFound", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -118,7 +102,7 @@ func TestSync(t *testing.T) {
 	})
 
 	t.Run("GetMapping", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -139,7 +123,7 @@ func TestSync(t *testing.T) {
 	})
 
 	t.Run("ListMappings", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -176,7 +160,7 @@ func TestSync(t *testing.T) {
 	})
 
 	t.Run("DeleteMapping", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)
@@ -200,7 +184,7 @@ func TestSync(t *testing.T) {
 	})
 
 	t.Run("DeleteMappingCleansUpExternalRef", func(t *testing.T) {
-		clearGraph(t, boltURI)
+		clearDatabase(t)
 		ctx := context.Background()
 		store, err := newStore(ctx, boltURI)
 		require.NoError(t, err)

--- a/internal/storage/memgraph/tx_changelog_test.go
+++ b/internal/storage/memgraph/tx_changelog_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestCreateSpec_AtomicWithChangeLog(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -38,8 +37,7 @@ func TestCreateSpec_AtomicWithChangeLog(t *testing.T) {
 }
 
 func TestLifecycleAmendSpec_AtomicWithChangeLog(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)

--- a/internal/storage/memgraph/tx_test.go
+++ b/internal/storage/memgraph/tx_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestRunInTransaction_Commit(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)
@@ -43,8 +42,7 @@ func TestRunInTransaction_Commit(t *testing.T) {
 }
 
 func TestRunInTransaction_Rollback(t *testing.T) {
-	boltURI, cleanup := setupMemgraph(t)
-	defer cleanup()
+	clearDatabase(t)
 
 	ctx := context.Background()
 	store, err := newStore(ctx, boltURI)


### PR DESCRIPTION
## Summary

- Replace per-test `setupMemgraph()` with a single `TestMain` that starts one Memgraph container for the entire `internal/storage/memgraph/` test package
- Add `clearDatabase(t)` helper that wipes all nodes/edges between tests via `MATCH (n) DETACH DELETE n`
- Remove ~50 container startup/teardown cycles

**Result:** 60 integration tests run in **8 seconds** (down from ~280 seconds) — **34x speedup**

## Test plan

- [x] All 60 integration tests pass (`go test -tags integration ./internal/storage/memgraph/`)
- [x] `task check` passes (fmt, lint, build, unit tests)
- [ ] CI e2e job passes

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Switched integration tests to a single shared database instance with explicit per-test state resets, removing per-test container start/stop.
  * This improves test run performance, isolation between cases, and overall stability of the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->