### PR TITLE
ci: use PAT for release-please to trigger CI on release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Summary

- Change release-please token from `GITHUB_TOKEN` to `RELEASE_PLEASE_TOKEN` (a PAT)
- **Root cause:** `GITHUB_TOKEN` pushes don't trigger further workflow runs (GitHub's infinite loop prevention). Release-please pushes to `release-please--branches--main`, but the CI workflow never runs because the push was made with `GITHUB_TOKEN`.
- **Fix:** A PAT with workflow permission triggers CI normally.

## Setup required

Add a fine-grained PAT as repository secret `RELEASE_PLEASE_TOKEN` with permissions:
- Contents: Read and write
- Pull requests: Read and write  
- Workflows: Read and write

## Test plan

- [ ] After merging, push to main triggers release-please with new token
- [ ] Release PR gets CI checks associated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal release automation configuration.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->