### PR TITLE
fix: coordinate release-please and goreleaser — draft release handoff

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -68,6 +68,9 @@ docker_manifests:
     image_templates:
       - "ghcr.io/specgraph/specgraph:{{ .Version }}-amd64"
       - "ghcr.io/specgraph/specgraph:{{ .Version }}-arm64"
+release:
+  mode: keep-existing
+  draft: false
 changelog:
   use: github
   groups:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "draft": true,
   "packages": {
     ".": {
       "release-type": "go",


### PR DESCRIPTION
## Summary

Fixes the `422 Cannot upload assets to an immutable release` error that caused v0.1.0 and v0.1.1 to release without binaries or homebrew formula.

**Root cause:** Release-please creates a published (immutable) GitHub release. Goreleaser then tries to upload assets to it and gets rejected.

**Fix:** 
- `release-please-config.json`: `"draft": true` — release-please creates a draft release
- `.goreleaser.yaml`: `release.mode: keep-existing` + `release.draft: false` — goreleaser finds the draft, uploads assets, and publishes it

**Note:** Docker images for v0.1.1 already pushed successfully (multi-arch amd64/arm64). Only the binary upload and homebrew tap failed.

## After merging

Delete the v0.1.1 release and tag, then let release-please recreate the release PR. Or bump to v0.1.2.

## Test plan

- [ ] Next release: release-please creates draft → goreleaser uploads + publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>