### PR TITLE
fix: simple release flow — release-please creates release, goreleaser uploads assets

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -68,6 +68,9 @@ docker_manifests:
     image_templates:
       - "ghcr.io/specgraph/specgraph:{{ .Version }}-amd64"
       - "ghcr.io/specgraph/specgraph:{{ .Version }}-arm64"
+release:
+  mode: keep-existing
+  draft: false
 changelog:
   use: github
   groups:


### PR DESCRIPTION
## Summary

Simplifies the release pipeline:

1. **Release-please** creates a normal (non-draft) GitHub release + pushes the git tag
2. **Tag push** triggers the goreleaser workflow
3. **Goreleaser** with `mode: keep-existing` uploads binaries, Docker images, and homebrew formula to the existing release

Changes:
- Remove `"draft": true` from `release-please-config.json`
- Revert goreleaser trigger to `push: tags: ["v*"]`
- Keep `release.mode: keep-existing` in `.goreleaser.yaml` (prevents 422 "immutable release" error)

## After merging

Delete the v0.1.2 draft release, then let release-please recreate it as a normal release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>