### PR TITLE
fix: remove draft:true from release-please config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ name: Release Please
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 permissions:
   contents: write
   pull-requests: write

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,4 @@
 {
-  "draft": true,
   "packages": {
     ".": {
       "release-type": "go",


### PR DESCRIPTION
## Summary

- Remove `"draft": true` from `release-please-config.json` — it survived the #524 merge due to conflict resolution
- Add `workflow_dispatch` trigger to release-please workflow for manual runs

With this fix, release-please creates a normal (published) release with a tag push, which triggers goreleaser to upload assets via `mode: keep-existing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)