### PR TITLE
fix: let goreleaser own GitHub releases, release-please only tags

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -68,9 +68,6 @@ docker_manifests:
     image_templates:
       - "ghcr.io/specgraph/specgraph:{{ .Version }}-amd64"
       - "ghcr.io/specgraph/specgraph:{{ .Version }}-arm64"
-release:
-  mode: keep-existing
-  draft: false
 changelog:
   use: github
   groups:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "skip-github-release": true,
   "packages": {
     ".": {
       "release-type": "go",


### PR DESCRIPTION
## Summary

Clear ownership split between the two tools:

- **Release-please:** `skip-github-release: true` — creates the version PR, bumps manifest, pushes the git tag. Does NOT create a GitHub release.
- **Goreleaser:** triggered by tag push, creates the GitHub release with binaries, Docker images, and homebrew formula. No conflict because no pre-existing release.

Previous attempts failed because both tools tried to own the GitHub release, causing 422 "immutable release" errors on asset upload.

## Test plan

- [ ] Next release: tag push triggers goreleaser, release created with all assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted release process automation configuration to modify GitHub release creation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->