### PR TITLE
fix: push git tag to remote before goreleaser changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.release-please.outputs.sha }}
-      - name: Create git tag
+      - name: Create and push git tag
         run: |
           git tag "$TAG" "$SHA"
+          git push origin "$TAG"
         env:
           TAG: ${{ needs.release-please.outputs.tag_name }}
           SHA: ${{ needs.release-please.outputs.sha }}


### PR DESCRIPTION
## Summary

Goreleaser's `changelog.use: github` calls the GitHub API to compare tags (`v0.1.3...v0.1.4`). Draft releases don't push tags, so the tag only existed locally — GitHub returned 404 on the compare.

Fix: `git push origin "$TAG"` after creating the local tag, before goreleaser runs.

Includes `Release-As: 0.1.5` to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)