### PR TITLE
fix: pin cosign-installer to v4.1.0 (no floating v4 tag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           TAG: ${{ needs.release-please.outputs.tag_name }}
           SHA: ${{ needs.release-please.outputs.sha }}
-      - uses: sigstore/cosign-installer@v4
+      - uses: sigstore/cosign-installer@v4.1.0
       - uses: anchore/sbom-action/download-syft@v0
       - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
sigstore/cosign-installer doesn't publish floating major version tags like most actions. `v4` doesn't exist — only `v4.0.0` and `v4.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)