### PR TITLE
chore: add Claude Code plugin symlink for specgraph skills

### DIFF
--- a/.claude/plugins/specgraph
+++ b/.claude/plugins/specgraph
@@ -1,0 +1,1 @@
+../../plugin/specgraph

--- a/plugin/specgraph/README.md
+++ b/plugin/specgraph/README.md
@@ -4,14 +4,9 @@ Skills for the SpecGraph authoring funnel and graph queries.
 
 ## Install
 
-**Inside the specgraph repo:** Auto-discovered by Claude Code.
+**Inside the specgraph repo:** The plugin symlink is committed — skills are available automatically.
 
-**For other projects:**
-
-```bash
-mkdir -p .claude/plugins
-ln -s /path/to/specgraph/plugin/specgraph .claude/plugins/specgraph
-```
+**For other projects:** Install via Claude Code plugin marketplace or repo add (coming soon).
 
 ## Skills
 


### PR DESCRIPTION
## Summary
- Add `.claude/plugins/specgraph` symlink pointing to `plugin/specgraph/` so the SpecGraph skills are available in Claude Code when working in this repo
- Fix plugin README: remove incorrect "auto-discovered" claim, document the symlink setup

## Test plan
- [x] Symlink resolves correctly: `ls -la .claude/plugins/specgraph`
- [ ] Claude Code picks up skills: `/specgraph-list` works in a new session

🤖 Generated with [Claude Code](https://claude.com/claude-code)