### PR TITLE
fix: resolve absolute binary path and quote slugs in tool commands

### DIFF
--- a/cmd/specgraph/up.go
+++ b/cmd/specgraph/up.go
@@ -67,6 +67,10 @@ func runUp(_ *cobra.Command, _ []string) error {
 		if err != nil {
 			return fmt.Errorf("resolve binary path: %w", err)
 		}
+		binaryPath, err = filepath.Abs(binaryPath)
+		if err != nil {
+			return fmt.Errorf("resolve absolute binary path: %w", err)
+		}
 		destDir, err := serviceDestDir()
 		if err != nil {
 			return fmt.Errorf("service dest dir: %w", err)

--- a/internal/server/analytical_pass_handler.go
+++ b/internal/server/analytical_pass_handler.go
@@ -196,9 +196,9 @@ func (h *AnalyticalPassHandler) ListFindings(ctx context.Context, req *connect.R
 // passToolManifest returns the tool references for an analytical pass.
 func passToolManifest(slug string) []*specv1.ToolReference {
 	return []*specv1.ToolReference{
-		{Name: "show_spec", Command: fmt.Sprintf("specgraph show %s --json", slug), Description: "Read the spec's full content including all stage outputs"},
+		{Name: "show_spec", Command: fmt.Sprintf("specgraph show %q --json", slug), Description: "Read the spec's full content including all stage outputs"},
 		{Name: "show_constitution", Command: "specgraph constitution show --json", Description: "Read the full project constitution"},
-		{Name: "list_deps", Command: fmt.Sprintf("specgraph edges %s --type DEPENDS_ON --json", slug), Description: "List specs this one depends on"},
+		{Name: "list_deps", Command: fmt.Sprintf("specgraph edges %q --type DEPENDS_ON --json", slug), Description: "List specs this one depends on"},
 		{Name: "show_dep", Command: "specgraph show {slug} --json", Description: "Read a specific dependency's full content (replace {slug} with the dependency slug)"},
 	}
 }


### PR DESCRIPTION
## Summary

- **specgraph up**: Resolve `os.Executable()` to absolute path via `filepath.Abs` before writing LaunchAgent plist — fixes launchctl rejection of relative paths (e.g., `./specgraph`)
- **passToolManifest**: Use `%q` to shell-quote slug in CLI command strings returned to analytical pass agents — defense-in-depth against shell injection

## Changes

| File | Change |
|------|--------|
| `cmd/specgraph/up.go` | Add `filepath.Abs` after `os.Executable()` |
| `internal/server/analytical_pass_handler.go` | `%s` → `%q` for slug in tool command strings |

## Test plan

- [x] `task check` passes
- [x] Slug regex already blocks shell metacharacters — `%q` is defense-in-depth
- [x] `generate()` already validates `filepath.IsAbs` — `filepath.Abs` ensures we always pass

Closes: spgr-kzl, spgr-bp7.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced service mode with improved error handling for executable path resolution to provide clearer error messages when the system cannot determine the proper file path
  * Fixed slug argument formatting in analytical pass tool commands to ensure correct command generation and proper execution of related tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->