### PR TITLE
refactor: split AnalyticalFinding into input/output types

### DIFF
--- a/internal/server/analytical_pass_handler.go
+++ b/internal/server/analytical_pass_handler.go
@@ -98,7 +98,7 @@ func (h *AnalyticalPassHandler) StoreFindings(ctx context.Context, req *connect.
 	if len(msg.Findings) > maxFindingsPerRequest {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("too many findings: %d exceeds maximum of %d", len(msg.Findings), maxFindingsPerRequest))
 	}
-	domain := make([]storage.AnalyticalFinding, len(msg.Findings))
+	domain := make([]storage.AnalyticalFindingInput, len(msg.Findings))
 	for i, f := range msg.Findings {
 		if f == nil {
 			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("finding[%d]: must not be null", i))
@@ -113,8 +113,7 @@ func (h *AnalyticalPassHandler) StoreFindings(ctx context.Context, req *connect.
 		if convErr != nil {
 			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("finding[%d]: %w", i, convErr))
 		}
-		domain[i] = storage.AnalyticalFinding{
-			PassType:   pt,
+		domain[i] = storage.AnalyticalFindingInput{
 			Severity:   sev,
 			Summary:    f.Summary,
 			Detail:     f.Detail,

--- a/internal/server/analytical_pass_handler_test.go
+++ b/internal/server/analytical_pass_handler_test.go
@@ -66,7 +66,7 @@ func (b *analyticalPassTestBackend) GetSpec(_ context.Context, slug string) (*st
 	return spec, nil
 }
 
-func (b *analyticalPassTestBackend) StoreFindings(_ context.Context, slug string, passType storage.PassType, findings []storage.AnalyticalFinding) ([]string, error) {
+func (b *analyticalPassTestBackend) StoreFindings(_ context.Context, slug string, passType storage.PassType, findings []storage.AnalyticalFindingInput) ([]string, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if _, ok := b.specs[slug]; !ok {

--- a/internal/server/test_scoper_test.go
+++ b/internal/server/test_scoper_test.go
@@ -174,7 +174,7 @@ func (stubBackend) AmendSpec(context.Context, string, string, storage.AuthoringS
 
 // --- FindingsBackend ---
 
-func (stubBackend) StoreFindings(context.Context, string, storage.PassType, []storage.AnalyticalFinding) ([]string, error) {
+func (stubBackend) StoreFindings(context.Context, string, storage.PassType, []storage.AnalyticalFindingInput) ([]string, error) {
 	return nil, errNotImplemented
 }
 

--- a/internal/storage/findings.go
+++ b/internal/storage/findings.go
@@ -30,7 +30,17 @@ func ValidPassType(pt PassType) bool {
 	return false
 }
 
-// AnalyticalFinding records a finding produced by an analytical pass.
+// AnalyticalFindingInput contains the fields required to create a finding.
+// PassType is derived from the method-level parameter, not per-finding.
+type AnalyticalFindingInput struct {
+	Severity   FindingSeverity
+	Summary    string
+	Detail     string
+	Constraint string
+	Resolution string
+}
+
+// AnalyticalFinding records a finding produced by an analytical pass (read-side).
 type AnalyticalFinding struct {
 	ID         string
 	PassType   PassType
@@ -47,7 +57,7 @@ type AnalyticalFinding struct {
 type FindingsWriter interface {
 	// StoreFindings replaces all findings for the given (slug, passType) pair
 	// and returns the IDs assigned to the persisted findings.
-	StoreFindings(ctx context.Context, slug string, passType PassType, findings []AnalyticalFinding) ([]string, error)
+	StoreFindings(ctx context.Context, slug string, passType PassType, findings []AnalyticalFindingInput) ([]string, error)
 }
 
 // FindingsReader retrieves analytical pass findings.

--- a/internal/storage/memgraph/findings.go
+++ b/internal/storage/memgraph/findings.go
@@ -16,7 +16,7 @@ var _ storage.FindingsBackend = (*Store)(nil)
 // StoreFindings persists analytical pass findings for a spec.
 // Existing findings for the given (slug, passType) are atomically replaced
 // via RunInTransaction: delete-then-create ensures no stale findings remain.
-func (s *Store) StoreFindings(ctx context.Context, slug string, passType storage.PassType, findings []storage.AnalyticalFinding) ([]string, error) {
+func (s *Store) StoreFindings(ctx context.Context, slug string, passType storage.PassType, findings []storage.AnalyticalFindingInput) ([]string, error) {
 	var ids []string
 	err := s.RunInTransaction(ctx, func(txCtx context.Context) error {
 		// Verify spec exists and capture its version.

--- a/internal/storage/memgraph/findings_test.go
+++ b/internal/storage/memgraph/findings_test.go
@@ -18,9 +18,8 @@ func TestStoreFindings_CreatesNodesAndEdges(t *testing.T) {
 	_, err := store.CreateSpec(ctx, "findings-create", "Test findings creation", "p1", "medium")
 	require.NoError(t, err)
 
-	findings := []storage.AnalyticalFinding{
+	findings := []storage.AnalyticalFindingInput{
 		{
-			PassType:   storage.PassTypeConstitutionCheck,
 			Severity:   storage.SeverityWarning,
 			Summary:    "Missing constraint coverage",
 			Detail:     "The spec does not address constraint X",
@@ -28,7 +27,6 @@ func TestStoreFindings_CreatesNodesAndEdges(t *testing.T) {
 			Resolution: "Add a section covering constraint X",
 		},
 		{
-			PassType:   storage.PassTypeConstitutionCheck,
 			Severity:   storage.SeverityCritical,
 			Summary:    "Violates naming convention",
 			Detail:     "Slug uses underscores instead of hyphens",
@@ -75,14 +73,12 @@ func TestStoreFindings_ReplacesExistingFindings(t *testing.T) {
 	_, err := store.CreateSpec(ctx, "findings-replace", "Test findings replacement", "p1", "medium")
 	require.NoError(t, err)
 
-	initial := []storage.AnalyticalFinding{
+	initial := []storage.AnalyticalFindingInput{
 		{
-			PassType: storage.PassTypeRedTeam,
 			Severity: storage.SeverityWarning,
 			Summary:  "Old finding A",
 		},
 		{
-			PassType: storage.PassTypeRedTeam,
 			Severity: storage.SeverityNote,
 			Summary:  "Old finding B",
 		},
@@ -92,9 +88,8 @@ func TestStoreFindings_ReplacesExistingFindings(t *testing.T) {
 	require.NoError(t, err)
 
 	// Replace with a single new finding.
-	replacement := []storage.AnalyticalFinding{
+	replacement := []storage.AnalyticalFindingInput{
 		{
-			PassType: storage.PassTypeRedTeam,
 			Severity: storage.SeverityCritical,
 			Summary:  "New finding C",
 		},
@@ -116,9 +111,8 @@ func TestStoreFindings_DifferentPassTypesAreIndependent(t *testing.T) {
 	_, err := store.CreateSpec(ctx, "findings-types", "Test pass type independence", "p1", "medium")
 	require.NoError(t, err)
 
-	constFindings := []storage.AnalyticalFinding{
+	constFindings := []storage.AnalyticalFindingInput{
 		{
-			PassType: storage.PassTypeConstitutionCheck,
 			Severity: storage.SeverityWarning,
 			Summary:  "Constitution finding",
 		},
@@ -126,14 +120,12 @@ func TestStoreFindings_DifferentPassTypesAreIndependent(t *testing.T) {
 	_, err = store.StoreFindings(ctx, "findings-types", storage.PassTypeConstitutionCheck, constFindings)
 	require.NoError(t, err)
 
-	redTeamFindings := []storage.AnalyticalFinding{
+	redTeamFindings := []storage.AnalyticalFindingInput{
 		{
-			PassType: storage.PassTypeRedTeam,
 			Severity: storage.SeverityCritical,
 			Summary:  "Red team finding 1",
 		},
 		{
-			PassType: storage.PassTypeRedTeam,
 			Severity: storage.SeverityNote,
 			Summary:  "Red team finding 2",
 		},
@@ -165,9 +157,8 @@ func TestStoreFindings_RecordsSpecVersion(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int32(1), spec.Version)
 
-	findings := []storage.AnalyticalFinding{
+	findings := []storage.AnalyticalFindingInput{
 		{
-			PassType: storage.PassTypeConstitutionCheck,
 			Severity: storage.SeverityNote,
 			Summary:  "Version check finding",
 		},
@@ -185,9 +176,8 @@ func TestStoreFindings_RecordsSpecVersion(t *testing.T) {
 func TestStoreFindings_SpecNotFound(t *testing.T) {
 	store, ctx := newTestStore(t)
 
-	findings := []storage.AnalyticalFinding{
+	findings := []storage.AnalyticalFindingInput{
 		{
-			PassType: storage.PassTypeRedTeam,
 			Severity: storage.SeverityWarning,
 			Summary:  "Should fail",
 		},
@@ -221,14 +211,12 @@ func TestStoreFindings_EmptySliceDeletesExisting(t *testing.T) {
 	require.NoError(t, err)
 
 	// Store initial findings.
-	initial := []storage.AnalyticalFinding{
+	initial := []storage.AnalyticalFindingInput{
 		{
-			PassType: storage.PassTypeConstitutionCheck,
 			Severity: storage.SeverityWarning,
 			Summary:  "Will be deleted",
 		},
 		{
-			PassType: storage.PassTypeConstitutionCheck,
 			Severity: storage.SeverityCritical,
 			Summary:  "Also deleted",
 		},


### PR DESCRIPTION
## Summary

- Add `AnalyticalFindingInput` struct for the write path — contains only `Severity`, `Summary`, `Detail`, `Constraint`, `Resolution`
- `AnalyticalFinding` (with `ID`, `PassType`, `Version`, `CreatedAt`) is now read-only, returned by `ListFindings`
- `StoreFindings` accepts `[]AnalyticalFindingInput` — `PassType` is derived solely from the method-level parameter
- Mirrors the existing proto split: `AnalyticalFindingInput` (write) vs `AnalyticalFinding` (read)

## Motivation

The dual-purpose `AnalyticalFinding` struct created an unenforceable invariant: callers could set `PassType` on individual findings differently from the method-level `passType` parameter. While the implementation already used the method-level param, the struct was semantically ambiguous.

## Changes

| File | Change |
|------|--------|
| `internal/storage/findings.go` | Add `AnalyticalFindingInput`, change `FindingsWriter.StoreFindings` signature |
| `internal/storage/memgraph/findings.go` | Update implementation signature |
| `internal/server/analytical_pass_handler.go` | Map to `AnalyticalFindingInput` (remove `PassType` from domain mapping) |
| `internal/server/analytical_pass_handler_test.go` | Update test backend |
| `internal/server/test_scoper_test.go` | Update stub backend |
| `internal/storage/memgraph/findings_test.go` | Use `AnalyticalFindingInput` in all test fixtures |

## Test plan

- [x] `task check` passes (lint, build, unit tests)
- [x] `go vet ./...` passes (interface compliance verified)

Closes: spgr-bp7.17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored the internal data model for analytical findings to better separate input data from stored data representations. Updated the storage interface and related implementations to use the streamlined input structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->