### PR TITLE
fix: add explicit step gating to shape skill

### DIFF
--- a/plugin/specgraph/skills/specgraph-shape/SKILL.md
+++ b/plugin/specgraph/skills/specgraph-shape/SKILL.md
@@ -142,6 +142,10 @@ Surface findings naturally when they arrive — don't block the conversation
 waiting for results. Example: "I checked the graph — there's already a spec for X
 that touches the same files. Want to factor that in?"
 
+**Important:** Background agent completions are NOT user input. When a background
+agent returns, fold its results into the current discussion but do NOT treat the
+notification as user approval of the current step.
+
 ---
 
 ## Execution
@@ -175,6 +179,22 @@ criteria, risks) are always completed.
 
 During the conversation, run background research as described in the Domain
 section. Surface findings when relevant — don't wait until the end.
+
+#### Step Gating (CRITICAL)
+
+Each elicitation step MUST be explicitly approved by the user before advancing to
+the next. Background agent notifications (e.g., codebase scan results) are NOT
+user approval — they are supplementary context to weave into the current step.
+
+- After presenting scope in/out: WAIT for user to confirm, adjust, or discuss.
+- After presenting approaches: WAIT for user to choose or discuss.
+- After presenting decisions: WAIT for user to confirm or revise.
+- After presenting success criteria: WAIT for user to confirm or adjust.
+- After presenting risks: WAIT for user to confirm or add.
+
+Use `AskUserQuestion` when presenting each step for approval. If a background
+agent returns results while waiting, incorporate the findings into the current
+step's presentation but do NOT advance to the next step.
 
 ### Persistence
 


### PR DESCRIPTION
## Summary

- Add **Step Gating** section to shape skill requiring explicit user confirmation before advancing between elicitation steps (scope, approaches, decisions, success criteria, risks)
- Add warning in Background Research section that agent notifications must not be treated as user approval
- Fixes the bug where background codebase scan results were misinterpreted as scope approval, causing auto-advance

## Root Cause

Claude Code processes background agent completions as conversation turns. The skill had no instruction distinguishing "user responded" from "background agent completed," so the model would advance through steps without user input.

## Changes

| File | Change |
|------|--------|
| `plugin/specgraph/skills/specgraph-shape/SKILL.md` | Add Step Gating section + background agent warning |

## Test plan

- [x] `task check` passes
- [ ] Manual: run `/specgraph-shape` with a spec, verify scope step waits for user approval even when background scan returns

Closes: spgr-0vx

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that background agent notifications do not constitute user input or implicit approvals.
  * Introduced explicit step-gating requirement: users must approve each of the five elicitation steps (scope, approaches, decisions, success criteria, risks) before advancing.
  * Specified that background research findings are integrated into the current step without auto-advancing to the next step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->