### PR TITLE
feat: restructure SpecifyOutput with InterfaceSection, VerifyCriterion, FileTouch

### DIFF
--- a/docs/superpowers/plans/2026-03-22-structured-specify-output.md
+++ b/docs/superpowers/plans/2026-03-22-structured-specify-output.md
@@ -1,0 +1,577 @@
+# Structured SpecifyOutput Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace flat string fields in SpecifyOutput with structured sub-messages for multi-surface APIs and categorized criteria.
+
+**Architecture:** Add InterfaceSection, VerifyCriterion, FileTouch proto messages. Update domain types, handler validation, proto-to-domain converters, safety scanner, tests, and skill format references. Clean break at 0.2.0-dev.
+
+**Tech Stack:** Protobuf, Go, ConnectRPC, Ginkgo/Gomega (e2e), testify (unit)
+
+**Spec:** `docs/superpowers/specs/2026-03-22-structured-specify-output-design.md`
+
+---
+
+## Chunk 1: Proto and Generated Code
+
+### Task 1: Update proto with new messages and restructured SpecifyOutput
+
+**Files:**
+
+- Modify: `proto/specgraph/v1/authoring.proto:142-152`
+
+- [ ] **Step 1: Replace SpecifyOutput and add new messages**
+
+Insert the three new messages before SpecifyOutput, then replace SpecifyOutput.
+Add them after the `Approach` message (line 140) and before `DecomposeOutput`:
+
+```protobuf
+// InterfaceSection defines one API surface in the specify stage contract.
+message InterfaceSection {
+  // Surface name, e.g. "WebhookService proto", "EventBus Go interface".
+  string name = 1;
+  // Free-form contract content (proto definitions, method signatures, etc.).
+  string body = 2;
+}
+
+// VerifyCriterion defines one testable acceptance criterion with a category.
+message VerifyCriterion {
+  // Category grouping, e.g. "emission", "CRUD", "e2e".
+  string category = 1;
+  // The criterion description.
+  string description = 2;
+}
+
+// FileTouch identifies a file expected to be created or modified by this spec.
+message FileTouch {
+  // File or package path relative to repo root.
+  string path = 1;
+  // What changes and why.
+  string purpose = 2;
+  // Type of change: "new", "modify", "delete".
+  string change_type = 3;
+}
+
+// SpecifyOutput captures the precise contract and verification criteria for a spec.
+// WIRE-BREAK: Fields 1, 2, 4 change type from string/repeated-string to
+// repeated-message. Intentional at 0.2.0-dev (no production data). Field
+// numbers reused because semantic intent is preserved.
+message SpecifyOutput {
+  // Interface contracts, one per API surface.
+  repeated InterfaceSection interfaces = 1;
+  // Categorized conditions that must hold for correctness.
+  repeated VerifyCriterion verify_criteria = 2;
+  // Invariants that must never be violated across any implementation state.
+  repeated string invariants = 3;
+  // Files, packages, or components expected to be modified.
+  repeated FileTouch touches = 4;
+}
+```
+
+- [ ] **Step 2: Regenerate Go code**
+
+Run: `task proto`
+
+- [ ] **Step 3: Verify generated code compiles**
+
+Run: `go build ./gen/...`
+Expected: Build succeeds (handler code will NOT compile yet — that's Task 2)
+
+- [ ] **Step 4: Commit**
+
+```text
+feat(proto): restructure SpecifyOutput with InterfaceSection, VerifyCriterion, FileTouch
+```
+
+---
+
+## Chunk 2: Domain Types and Handler
+
+### Task 2: Update domain types
+
+**Files:**
+
+- Modify: `internal/storage/authoring.go:63-69`
+
+- [ ] **Step 1: Replace SpecifyOutput domain type and add sub-types**
+
+Replace the existing `SpecifyOutput` struct with:
+
+```go
+// InterfaceSection defines one API surface in the specify stage contract.
+type InterfaceSection struct {
+	Name string `json:"name"`
+	Body string `json:"body"`
+}
+
+// VerifyCriterion defines one testable acceptance criterion with a category.
+type VerifyCriterion struct {
+	Category    string `json:"category"`
+	Description string `json:"description"`
+}
+
+// FileTouch identifies a file expected to be created or modified by this spec.
+type FileTouch struct {
+	Path       string `json:"path"`
+	Purpose    string `json:"purpose"`
+	ChangeType string `json:"change_type"`
+}
+
+// SpecifyOutput captures the precise contract and verification criteria.
+type SpecifyOutput struct {
+	Interfaces     []InterfaceSection `json:"interfaces,omitempty"`
+	VerifyCriteria []VerifyCriterion  `json:"verify_criteria,omitempty"`
+	Invariants     []string           `json:"invariants,omitempty"`
+	Touches        []FileTouch        `json:"touches,omitempty"`
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```text
+refactor(storage): replace flat SpecifyOutput with structured sub-types
+```
+
+### Task 3: Update handler validation and converter
+
+**Files:**
+
+- Modify: `internal/server/authoring_handler.go:190-216` (validation + safety scanner)
+- Modify: `internal/server/authoring_handler.go:615-622` (specifyOutputToDomain)
+
+- [ ] **Step 1: Replace validation block (lines 190-211)**
+
+Replace the old `interface_contract` length check and item iteration with:
+
+```go
+	if len(msg.Output.GetInterfaces()) > maxElements {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("interfaces exceeds maximum of %d elements", maxElements))
+	}
+	for i, iface := range msg.Output.GetInterfaces() {
+		if iface.GetName() == "" {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("interfaces[%d]: name is required", i))
+		}
+		if len(iface.GetBody()) > maxFieldLen {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("interfaces[%d]: body exceeds maximum length of %d characters", i, maxFieldLen))
+		}
+	}
+	if len(msg.Output.GetVerifyCriteria()) > maxElements {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("verify_criteria exceeds maximum of %d elements", maxElements))
+	}
+	for i, vc := range msg.Output.GetVerifyCriteria() {
+		if vc.GetDescription() == "" {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("verify_criteria[%d]: description is required", i))
+		}
+		if len(vc.GetDescription()) > maxFieldLen {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("verify_criteria[%d]: description exceeds maximum length of %d characters", i, maxFieldLen))
+		}
+	}
+	if len(msg.Output.GetInvariants()) > maxElements {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invariants exceeds maximum of %d elements", maxElements))
+	}
+	for _, item := range msg.Output.GetInvariants() {
+		if len(item) > maxFieldLen {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invariants item exceeds maximum length of %d characters", maxFieldLen))
+		}
+	}
+	if len(msg.Output.GetTouches()) > maxElements {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("touches exceeds maximum of %d elements", maxElements))
+	}
+	for i, ft := range msg.Output.GetTouches() {
+		if ft.GetPath() == "" {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("touches[%d]: path is required", i))
+		}
+		if len(ft.GetPurpose()) > maxFieldLen {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("touches[%d]: purpose exceeds maximum length of %d characters", i, maxFieldLen))
+		}
+	}
+```
+
+- [ ] **Step 2: Update safety scanner text derivation (line ~213-214)**
+
+Replace:
+
+```go
+safetyInput := &authoring.SafetyInput{
+    Text:       msg.Output.GetInterfaceContract(),
+    Invariants: msg.Output.GetInvariants(),
+}
+```
+
+With:
+
+```go
+var contractText strings.Builder
+for _, iface := range msg.Output.GetInterfaces() {
+    if contractText.Len() > 0 {
+        contractText.WriteString("\n\n")
+    }
+    contractText.WriteString(iface.GetName() + ":\n" + iface.GetBody())
+}
+safetyInput := &authoring.SafetyInput{
+    Text:       contractText.String(),
+    Invariants: msg.Output.GetInvariants(),
+}
+```
+
+Ensure `"strings"` is imported (it likely already is).
+
+- [ ] **Step 3: Replace specifyOutputToDomain (line ~615)**
+
+Note: `make([]T, len(source))` produces a non-nil empty slice when source is
+empty, which marshals to `[]` in JSON (not `null`). This is the correct
+behavior for Memgraph JSON storage. Do NOT use `append` patterns that
+produce `nil` slices.
+
+```go
+func specifyOutputToDomain(p *specv1.SpecifyOutput) *storage.SpecifyOutput {
+	interfaces := make([]storage.InterfaceSection, len(p.GetInterfaces()))
+	for i, iface := range p.GetInterfaces() {
+		interfaces[i] = storage.InterfaceSection{
+			Name: iface.GetName(),
+			Body: iface.GetBody(),
+		}
+	}
+	criteria := make([]storage.VerifyCriterion, len(p.GetVerifyCriteria()))
+	for i, vc := range p.GetVerifyCriteria() {
+		criteria[i] = storage.VerifyCriterion{
+			Category:    vc.GetCategory(),
+			Description: vc.GetDescription(),
+		}
+	}
+	touches := make([]storage.FileTouch, len(p.GetTouches()))
+	for i, ft := range p.GetTouches() {
+		touches[i] = storage.FileTouch{
+			Path:       ft.GetPath(),
+			Purpose:    ft.GetPurpose(),
+			ChangeType: ft.GetChangeType(),
+		}
+	}
+	return &storage.SpecifyOutput{
+		Interfaces:     interfaces,
+		VerifyCriteria: criteria,
+		Invariants:     p.GetInvariants(),
+		Touches:        touches,
+	}
+}
+```
+
+- [ ] **Step 4: Verify contenthash is unaffected**
+
+Run: `grep -n 'specify_output\|SpecifyOutput' internal/storage/contenthash/*.go`
+Expected: No matches. `contenthash.Spec()` accepts `authoringOutputs map[string]string`
+(serialized JSON), so the struct shape change is transparent. No hash code changes needed.
+
+- [ ] **Step 5: Rename prompt registry entry**
+
+In `internal/authoring/prompts.go:32`, change:
+
+```go
+{Name: "interface_contract", Template: "Define the public interface: inputs, outputs, error cases."},
+```
+
+To:
+
+```go
+{Name: "interfaces", Template: "Define the public interfaces: inputs, outputs, error cases for each API surface."},
+```
+
+- [ ] **Step 6: Verify build compiles**
+
+Run: `go build ./...`
+
+- [ ] **Step 7: Commit**
+
+```text
+feat(server): update specify handler for structured SpecifyOutput
+```
+
+---
+
+## Chunk 3: Unit Tests
+
+### Task 4: Update handler unit tests
+
+**Files:**
+
+- Modify: `internal/server/authoring_handler_test.go`
+
+- [ ] **Step 1: Update all SpecifyOutput fixtures**
+
+Replace every `&specv1.SpecifyOutput{InterfaceContract: "..."}` with the new
+structured form. For example, line 306-307:
+
+```go
+Output: &specv1.SpecifyOutput{
+    Interfaces: []*specv1.InterfaceSection{
+        {Name: "API", Body: "POST /api/login"},
+    },
+},
+```
+
+And line 314:
+
+```go
+require.Len(t, resp.Msg.Output.Interfaces, 1)
+require.Equal(t, "POST /api/login", resp.Msg.Output.Interfaces[0].Body)
+```
+
+Apply the same pattern to all test fixtures that use `SpecifyOutput`:
+
+- Line 377: empty output `&specv1.SpecifyOutput{}` — can stay as-is
+- Line 540: `InterfaceContract: "POST /api/login"` — update
+- Line 901-902: `InterfaceContract: "interface contract"` — update
+
+- [ ] **Step 2: Update prompt name assertion (line ~839)**
+
+Change:
+
+```go
+require.True(t, names["interface_contract"])
+```
+
+To:
+
+```go
+require.True(t, names["interfaces"])
+```
+
+**Note:** This depends on Task 3 Step 5 (prompt rename). Both are in the same
+commit, so they must be applied together.
+
+- [ ] **Step 3: Add negative-path validation tests**
+
+Add new test cases for the per-element validation rules introduced in Task 3.
+Follow the existing pattern using `newAuthoringClient` (see
+`TestAuthoringHandler_Specify_EmptySlug` at line 373 for the setup pattern).
+
+The handler validates output fields (lines 190-211) BEFORE any store call,
+so no spec seeding is needed — `&fakeAuthoringBackend{}` zero-value is
+sufficient:
+
+```go
+func TestAuthoringHandler_Specify_InterfacesMissingName(t *testing.T) {
+	client := newAuthoringClient(t, &fakeAuthoringBackend{}, &fakeBackend{})
+	_, err := client.Specify(context.Background(), connect.NewRequest(&specv1.SpecifyRequest{
+		Slug: "test-spec",
+		Output: &specv1.SpecifyOutput{
+			Interfaces: []*specv1.InterfaceSection{
+				{Name: "", Body: "some body"},
+			},
+		},
+	}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestAuthoringHandler_Specify_VerifyCriteriaMissingDescription(t *testing.T) {
+	client := newAuthoringClient(t, &fakeAuthoringBackend{}, &fakeBackend{})
+	_, err := client.Specify(context.Background(), connect.NewRequest(&specv1.SpecifyRequest{
+		Slug: "test-spec",
+		Output: &specv1.SpecifyOutput{
+			VerifyCriteria: []*specv1.VerifyCriterion{
+				{Category: "test", Description: ""},
+			},
+		},
+	}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestAuthoringHandler_Specify_TouchesMissingPath(t *testing.T) {
+	client := newAuthoringClient(t, &fakeAuthoringBackend{}, &fakeBackend{})
+	_, err := client.Specify(context.Background(), connect.NewRequest(&specv1.SpecifyRequest{
+		Slug: "test-spec",
+		Output: &specv1.SpecifyOutput{
+			Touches: []*specv1.FileTouch{
+				{Path: "", Purpose: "something"},
+			},
+		},
+	}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+```
+
+- [ ] **Step 4: Add safety scanner multi-interface test**
+
+Add a test verifying multi-interface output is accepted and returned
+correctly. Mirrors the existing `TestAuthoringHandler_Specify_HappyPath`
+pattern — bare `&fakeAuthoringBackend{}` with no seeding (the handler does
+not verify spec existence via the authoring backend):
+
+```go
+func TestAuthoringHandler_Specify_MultipleInterfaces(t *testing.T) {
+	client := newAuthoringClient(t, &fakeAuthoringBackend{}, &fakeBackend{})
+	resp, err := client.Specify(context.Background(), connect.NewRequest(&specv1.SpecifyRequest{
+		Slug: "multi-iface",
+		Output: &specv1.SpecifyOutput{
+			Interfaces: []*specv1.InterfaceSection{
+				{Name: "ProtoService", Body: "service Webhook { rpc Send(...) }"},
+				{Name: "GoInterface", Body: "type EventBus interface { Publish(event) }"},
+			},
+		},
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Output.Interfaces, 2)
+}
+```
+
+- [ ] **Step 5: Run unit tests**
+
+Run: `go test ./internal/server/ -run TestAuthoring -v -count=1`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```text
+test(server): update and add authoring handler tests for structured SpecifyOutput
+```
+
+---
+
+## Chunk 4: E2E Tests and Fixtures
+
+### Task 5: Update e2e API test fixtures
+
+**Files:**
+
+- Modify: `e2e/api/authoring_test.go:89-99`
+- Modify: `e2e/api/pipeline_test.go:132-142`
+- Modify: `e2e/api/lifecycle_pipeline_test.go:89-99`
+- Modify: `e2e/api/errors_test.go:113-114`
+- Verify: `e2e/cli/pipeline_test.go` (no edit needed — reads fixture file)
+
+- [ ] **Step 1: Update each file's SpecifyOutput fixture**
+
+Pattern — replace:
+
+```go
+Output: &specv1.SpecifyOutput{
+    InterfaceContract: "POST /api/v1/things",
+```
+
+With:
+
+```go
+Output: &specv1.SpecifyOutput{
+    Interfaces: []*specv1.InterfaceSection{
+        {Name: "API", Body: "POST /api/v1/things"},
+    },
+```
+
+For assertions, match the original semantics:
+
+**authoring_test.go, pipeline_test.go** (emptiness check):
+
+```go
+// Before:
+Expect(resp.Msg.Output.InterfaceContract).NotTo(BeEmpty())
+// After:
+Expect(resp.Msg.Output.Interfaces).NotTo(BeEmpty())
+```
+
+**lifecycle_pipeline_test.go** (value equality — MUST preserve `Equal`):
+
+```go
+// Before:
+Expect(resp.Msg.Output.InterfaceContract).To(Equal("POST /api/v1/amended"))
+// After:
+Expect(resp.Msg.Output.Interfaces[0].Body).To(Equal("POST /api/v1/amended"))
+```
+
+**errors_test.go** (negative test — input fixture only, no output assertion):
+This test verifies a failed stage transition, so `resp` is nil and there is
+no output assertion. Only update the input fixture `InterfaceContract` →
+`Interfaces`. Do NOT add output assertions.
+
+Apply to all four files.
+
+**Note:** `e2e/cli/pipeline_test.go` reads `e2e/cli/testdata/specify-output.json`
+by path — no Go edit needed, the fixture update in Step 2 is sufficient.
+
+- [ ] **Step 2: Update CLI test fixture**
+
+Replace `e2e/cli/testdata/specify-output.json` with:
+
+```json
+{
+  "interfaces": [
+    {"name": "API", "body": "POST /api/v1/cli-pipeline"}
+  ],
+  "verifyCriteria": [
+    {"category": "happy-path", "description": "returns 200 on valid input"},
+    {"category": "validation", "description": "returns 400 on missing slug"}
+  ],
+  "invariants": [
+    "spec state is consistent after each stage transition"
+  ],
+  "touches": [
+    {"path": "internal/authoring/funnel.go", "purpose": "funnel logic", "changeType": "modify"},
+    {"path": "internal/server/authoring_handler.go", "purpose": "handler updates", "changeType": "modify"}
+  ]
+}
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `go build ./...`
+
+- [ ] **Step 4: Commit**
+
+```text
+test(e2e): update specify output fixtures for structured messages
+```
+
+---
+
+## Chunk 5: Skill References and Documentation
+
+### Task 6: Update skill format reference
+
+**Files:**
+
+- Modify: `plugin/specgraph/skills/specgraph-specify/references/specify-output-format.md`
+
+- [ ] **Step 1: Replace the format reference**
+
+Replace the entire file with the new schema showing `interfaces` (name+body),
+`verifyCriteria` (category+description), `invariants` (strings), and `touches`
+(path+purpose+changeType). See the design spec for the exact schema.
+
+- [ ] **Step 2: Update SKILL.md persistence section**
+
+In `plugin/specgraph/skills/specgraph-specify/SKILL.md`, update the JSON
+example in the Persistence section (~line 188-219) to use the new schema shape.
+
+- [ ] **Step 3: Update example spec**
+
+In `site/docs/concepts/example-spec.md`, update the Specify section (~line
+145-175) to show multiple interface sections and categorized criteria.
+
+- [ ] **Step 4: Commit**
+
+```text
+docs: update specify output format references and example spec
+```
+
+---
+
+## Chunk 6: Quality Gates
+
+### Task 7: Run full quality gates
+
+- [ ] **Step 1: Run task check**
+
+Run: `task check`
+Expected: All lint, build, and unit tests pass
+
+- [ ] **Step 2: Run task pr-prep (if Docker available)**
+
+Run: `task pr-prep`
+Expected: Integration + e2e tests pass
+
+- [ ] **Step 3: Create branch and PR**
+
+```text
+feat: restructure SpecifyOutput with InterfaceSection, VerifyCriterion, FileTouch
+
+Closes: spgr-dp9, spgr-6vl
+```

--- a/docs/superpowers/specs/2026-03-22-structured-specify-output-design.md
+++ b/docs/superpowers/specs/2026-03-22-structured-specify-output-design.md
@@ -1,0 +1,217 @@
+# Structured SpecifyOutput
+
+**Date:** 2026-03-22
+**Closes:** spgr-dp9, spgr-6vl
+
+## Problem
+
+`SpecifyOutput` uses flat types: `interface_contract` is a single string,
+`verify_criteria` and `invariants` are `repeated string`, `touches` is
+`repeated string`. The specify skill produces rich structured content
+(multiple API surfaces, categorized criteria, file paths with purpose and
+change type) that flattens into plain strings when persisted. Downstream
+consumers (execution bundles, analytical passes, graph queries) cannot
+navigate the content programmatically.
+
+Discovered during the demo walkthrough where the specify stage produced
+excellent structured output that could not survive the proto roundtrip.
+
+## Approach
+
+Replace flat fields with structured sub-messages that are free-form enough
+for skill flexibility but defined enough for programmatic navigation.
+`invariants` stays `repeated string` since invariants are naturally single
+statements.
+
+This is a clean break — no migration of existing data. Acceptable at
+0.2.0-dev with no production data.
+
+## Proto Changes
+
+Three new messages and a restructured `SpecifyOutput`:
+
+```protobuf
+message InterfaceSection {
+  string name = 1;        // surface name, e.g. "WebhookService proto"
+  string body = 2;        // free-form contract content
+}
+
+message VerifyCriterion {
+  string category = 1;    // e.g. "emission", "CRUD", "e2e"
+  string description = 2; // the criterion itself
+}
+
+message FileTouch {
+  string path = 1;        // file/package path
+  string purpose = 2;     // what changes and why
+  string change_type = 3; // "new", "modify", "delete"
+}
+
+// WIRE-BREAK: Fields 1, 2, 4 change type from string/repeated-string to
+// repeated-message. This is intentional at 0.2.0-dev (no production data).
+// Field numbers are reused rather than reserved because the semantic intent
+// of each field is preserved — only the structure changes.
+message SpecifyOutput {
+  repeated InterfaceSection interfaces = 1;
+  repeated VerifyCriterion verify_criteria = 2;
+  repeated string invariants = 3;
+  repeated FileTouch touches = 4;
+}
+```
+
+### Design Decisions
+
+- **`invariants` stays `repeated string`:** Invariants are naturally single
+  statements ("A spec may have at most one active lease"). No added structure
+  needed.
+- **Field numbers reused with WIRE-BREAK note:** Clean break at 0.2.0-dev.
+  Field numbers 1, 2, 4 change type but preserve semantic intent. Documented
+  with a WIRE-BREAK comment in the proto (same pattern as `ShapeOutput`
+  `decisions` field 9).
+- **`change_type` is a string, not an enum:** Keeps it free-form for skill
+  flexibility. Known values: "new", "modify", "delete". The handler does NOT
+  validate `change_type` against a fixed set — this is intentionally different
+  from `DecompositionStrategy` which uses a typed string with validation.
+  Rationale: file changes are descriptive metadata, not behavioral selectors.
+- **`InterfaceSection.body` is free-form text:** Skills can put proto
+  definitions, Go interfaces, HTTP endpoint tables, or any format. The `name`
+  field provides programmatic navigation.
+
+## Domain Type Changes
+
+`internal/storage/authoring.go`:
+
+```go
+type InterfaceSection struct {
+    Name string `json:"name"`
+    Body string `json:"body"`
+}
+
+type VerifyCriterion struct {
+    Category    string `json:"category"`
+    Description string `json:"description"`
+}
+
+type FileTouch struct {
+    Path       string `json:"path"`
+    Purpose    string `json:"purpose"`
+    ChangeType string `json:"change_type"`
+}
+
+type SpecifyOutput struct {
+    Interfaces     []InterfaceSection `json:"interfaces,omitempty"`
+    VerifyCriteria []VerifyCriterion  `json:"verify_criteria,omitempty"`
+    Invariants     []string           `json:"invariants,omitempty"`
+    Touches        []FileTouch        `json:"touches,omitempty"`
+}
+```
+
+## Handler Changes
+
+### Safety Scanner (`safetyInput`)
+
+`authoring_handler.go` constructs `safetyInput` for the specify stage with:
+
+```go
+Text:       msg.Output.GetInterfaceContract(),
+Invariants: msg.Output.GetInvariants(),
+```
+
+After the change, `GetInterfaceContract()` no longer exists. The safety
+scanner text must be derived by concatenating all `interfaces[].body` fields:
+
+```go
+var contractText strings.Builder
+for _, iface := range msg.Output.GetInterfaces() {
+    if contractText.Len() > 0 {
+        contractText.WriteString("\n\n")
+    }
+    contractText.WriteString(iface.GetName() + ":\n" + iface.GetBody())
+}
+// safetyInput.Text = contractText.String()
+```
+
+### Validation
+
+Replace the single `interface_contract` length check with per-element
+validation for the new structured fields:
+
+| Field | Validation |
+|-------|------------|
+| `interfaces` | Max count check (same pattern as other repeated fields). Per-element: `name` required, `body` length <= `maxFieldLen` |
+| `verify_criteria` | Per-element: `description` required, `description` length <= `maxFieldLen` |
+| `touches` | Max count check. Per-element: `path` required, `purpose` length <= `maxFieldLen` |
+| `invariants` | Unchanged (already `repeated string` with per-item check) |
+
+### Prompt Registry
+
+`internal/authoring/prompts.go` has a prompt named `"interface_contract"`
+for the specify stage. Rename to `"interfaces"` to match the new field name.
+Update the corresponding test assertion in `authoring_handler_test.go`.
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `proto/specgraph/v1/authoring.proto` | New messages + restructured `SpecifyOutput` with WIRE-BREAK comment |
+| `gen/specgraph/v1/` | Regenerate with `task proto` |
+| `internal/storage/authoring.go` | New domain types, replace `SpecifyOutput` |
+| `internal/server/authoring_handler.go` | Update validation, proto-to-domain conversion, safety scanner text derivation |
+| `internal/server/authoring_handler_test.go` | Update test fixtures, prompt name assertion |
+| `internal/authoring/prompts.go` | Rename `"interface_contract"` prompt to `"interfaces"` |
+| `internal/storage/contenthash/` | Update if specify fields are in hash computation |
+| `e2e/api/authoring_test.go` | Update `SpecifyOutput` test fixtures |
+| `e2e/api/pipeline_test.go` | Update `SpecifyOutput` test fixtures |
+| `e2e/api/lifecycle_pipeline_test.go` | Update `SpecifyOutput` test fixtures |
+| `e2e/api/errors_test.go` | Update `SpecifyOutput` test fixtures |
+| `e2e/cli/testdata/specify-output.json` | Update JSON to new shape |
+| `e2e/cli/pipeline_test.go` | Verify CLI test uses updated fixture |
+| `plugin/specgraph/skills/specgraph-specify/SKILL.md` | Update JSON schema in persistence section |
+| `plugin/specgraph/skills/specgraph-specify/references/specify-output-format.md` | Update format reference |
+| `site/docs/concepts/example-spec.md` | Update example spec (canonical example on public site) |
+
+## Example
+
+A realistic SpecifyOutput using the new structured fields:
+
+```json
+{
+  "interfaces": [
+    {
+      "name": "WebhookService proto",
+      "body": "service WebhookService {\n  rpc Send(SendRequest) returns (SendResponse);\n}"
+    },
+    {
+      "name": "EventBus Go interface",
+      "body": "type EventBus interface {\n  Publish(ctx context.Context, event Event) error\n}"
+    }
+  ],
+  "verifyCriteria": [
+    { "category": "behavior", "description": "Send with valid payload returns 200 and delivery ID" },
+    { "category": "security", "description": "Send without auth token returns 401" },
+    { "category": "retry", "description": "Failed delivery retries up to 3 times with backoff" }
+  ],
+  "invariants": [
+    "Each event is delivered at least once",
+    "Delivery order within a topic is preserved"
+  ],
+  "touches": [
+    { "path": "internal/server/webhook_handler.go", "purpose": "new handler", "change_type": "new" },
+    { "path": "internal/storage/event.go", "purpose": "event domain types", "change_type": "new" },
+    { "path": "proto/specgraph/v1/webhook.proto", "purpose": "service definition", "change_type": "new" }
+  ]
+}
+```
+
+## Migration
+
+None. Clean break at 0.2.0-dev. Existing specify_output JSON in Memgraph
+will not parse into the new struct. Specs that have already been specified
+would need to be re-specified.
+
+## Content Hash Impact
+
+Check whether `contenthash.Spec()` includes specify output fields. If so,
+the hash computation needs to accept the new types. Since the output is
+stored as JSON in Memgraph, the hash may already operate on the serialized
+JSON string (in which case the shape change is transparent).

--- a/e2e/api/authoring_test.go
+++ b/e2e/api/authoring_test.go
@@ -87,16 +87,22 @@ var _ = Describe("Authoring funnel", Ordered, func() {
 		resp, err := authoringClient.Specify(ctx, connect.NewRequest(&specv1.SpecifyRequest{
 			Slug: authoringSlug,
 			Output: &specv1.SpecifyOutput{
-				InterfaceContract: "POST /api/v1/things",
-				VerifyCriteria:    []string{"returns 200"},
-				Invariants:        []string{"data is valid"},
-				Touches:           []string{"internal/server/handler.go"},
+				Interfaces: []*specv1.InterfaceSection{
+					{Name: "API", Body: "POST /api/v1/things"},
+				},
+				VerifyCriteria: []*specv1.VerifyCriterion{
+					{Category: "happy-path", Description: "returns 200"},
+				},
+				Invariants: []string{"data is valid"},
+				Touches: []*specv1.FileTouch{
+					{Path: "internal/server/handler.go", Purpose: "handler updates", ChangeType: "modify"},
+				},
 			},
 			Posture: specv1.Posture_POSTURE_DRIVE,
 		}))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.Msg.Output).NotTo(BeNil())
-		Expect(resp.Msg.Output.InterfaceContract).NotTo(BeEmpty())
+		Expect(resp.Msg.Output.Interfaces).NotTo(BeEmpty())
 	})
 
 	It("decomposes a specified spec", func() {

--- a/e2e/api/errors_test.go
+++ b/e2e/api/errors_test.go
@@ -111,8 +111,12 @@ var _ = Describe("error handling", func() {
 		_, err = authoringClient.Specify(ctx, connect.NewRequest(&specv1.SpecifyRequest{
 			Slug: "err-bad-transition",
 			Output: &specv1.SpecifyOutput{
-				InterfaceContract: "POST /api",
-				VerifyCriteria:    []string{"returns 200"},
+				Interfaces: []*specv1.InterfaceSection{
+					{Name: "API", Body: "POST /api"},
+				},
+				VerifyCriteria: []*specv1.VerifyCriterion{
+					{Category: "happy-path", Description: "returns 200"},
+				},
 			},
 			Posture: specv1.Posture_POSTURE_DRIVE,
 		}))

--- a/e2e/api/lifecycle_pipeline_test.go
+++ b/e2e/api/lifecycle_pipeline_test.go
@@ -87,16 +87,22 @@ var _ = Describe("Lifecycle Pipeline", Ordered, func() {
 		resp, err := authoringClient.Specify(ctx, connect.NewRequest(&specv1.SpecifyRequest{
 			Slug: pipelineSlug,
 			Output: &specv1.SpecifyOutput{
-				InterfaceContract: "POST /api/v1/amended",
-				VerifyCriteria:    []string{"returns 200"},
-				Invariants:        []string{"data consistent"},
-				Touches:           []string{"internal/amended/handler.go"},
+				Interfaces: []*specv1.InterfaceSection{
+					{Name: "API", Body: "POST /api/v1/amended"},
+				},
+				VerifyCriteria: []*specv1.VerifyCriterion{
+					{Category: "happy-path", Description: "returns 200"},
+				},
+				Invariants: []string{"data consistent"},
+				Touches: []*specv1.FileTouch{
+					{Path: "internal/amended/handler.go", Purpose: "handler updates", ChangeType: "modify"},
+				},
 			},
 			Posture: specv1.Posture_POSTURE_DRIVE,
 		}))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.Msg.Output).NotTo(BeNil())
-		Expect(resp.Msg.Output.InterfaceContract).To(Equal("POST /api/v1/amended"))
+		Expect(resp.Msg.Output.Interfaces[0].Body).To(Equal("POST /api/v1/amended"))
 	})
 
 	It("re-traverses funnel: decompose", func() {

--- a/e2e/api/pipeline_test.go
+++ b/e2e/api/pipeline_test.go
@@ -130,16 +130,22 @@ var _ = Describe("Full pipeline", Ordered, func() {
 		resp, err := authoringClient.Specify(ctx, connect.NewRequest(&specv1.SpecifyRequest{
 			Slug: pipelineSlug,
 			Output: &specv1.SpecifyOutput{
-				InterfaceContract: "POST /api/v1/pipeline",
-				VerifyCriteria:    []string{"returns 200"},
-				Invariants:        []string{"data is consistent"},
-				Touches:           []string{"internal/pipeline/handler.go"},
+				Interfaces: []*specv1.InterfaceSection{
+					{Name: "API", Body: "POST /api/v1/pipeline"},
+				},
+				VerifyCriteria: []*specv1.VerifyCriterion{
+					{Category: "happy-path", Description: "returns 200"},
+				},
+				Invariants: []string{"data is consistent"},
+				Touches: []*specv1.FileTouch{
+					{Path: "internal/pipeline/handler.go", Purpose: "handler updates", ChangeType: "modify"},
+				},
 			},
 			Posture: specv1.Posture_POSTURE_DRIVE,
 		}))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.Msg.Output).NotTo(BeNil())
-		Expect(resp.Msg.Output.InterfaceContract).NotTo(BeEmpty())
+		Expect(resp.Msg.Output.Interfaces).NotTo(BeEmpty())
 	})
 
 	It("decomposes the spec", func() {

--- a/e2e/cli/testdata/specify-output.json
+++ b/e2e/cli/testdata/specify-output.json
@@ -1,14 +1,16 @@
 {
-  "interfaceContract": "POST /api/v1/cli-pipeline",
+  "interfaces": [
+    { "name": "API", "body": "POST /api/v1/cli-pipeline" }
+  ],
   "verifyCriteria": [
-    "returns 200 on valid input",
-    "returns 400 on missing slug"
+    { "category": "happy-path", "description": "returns 200 on valid input" },
+    { "category": "validation", "description": "returns 400 on missing slug" }
   ],
   "invariants": [
     "spec state is consistent after each stage transition"
   ],
   "touches": [
-    "internal/authoring/funnel.go",
-    "internal/server/authoring_handler.go"
+    { "path": "internal/authoring/funnel.go", "purpose": "funnel logic", "changeType": "modify" },
+    { "path": "internal/server/authoring_handler.go", "purpose": "handler updates", "changeType": "modify" }
   ]
 }

--- a/gen/specgraph/v1/authoring.pb.go
+++ b/gen/specgraph/v1/authoring.pb.go
@@ -706,24 +706,201 @@ func (x *Approach) GetTradeoffs() []string {
 	return nil
 }
 
+// InterfaceSection defines one API surface in the specify stage contract.
+type InterfaceSection struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Surface name, e.g. "WebhookService proto", "EventBus Go interface".
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Free-form contract content (proto definitions, method signatures, etc.).
+	Body          string `protobuf:"bytes,2,opt,name=body,proto3" json:"body,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InterfaceSection) Reset() {
+	*x = InterfaceSection{}
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InterfaceSection) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InterfaceSection) ProtoMessage() {}
+
+func (x *InterfaceSection) ProtoReflect() protoreflect.Message {
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InterfaceSection.ProtoReflect.Descriptor instead.
+func (*InterfaceSection) Descriptor() ([]byte, []int) {
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *InterfaceSection) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *InterfaceSection) GetBody() string {
+	if x != nil {
+		return x.Body
+	}
+	return ""
+}
+
+// VerifyCriterion defines one testable acceptance criterion with a category.
+type VerifyCriterion struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Category grouping, e.g. "emission", "CRUD", "e2e".
+	Category string `protobuf:"bytes,1,opt,name=category,proto3" json:"category,omitempty"`
+	// The criterion description.
+	Description   string `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *VerifyCriterion) Reset() {
+	*x = VerifyCriterion{}
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VerifyCriterion) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VerifyCriterion) ProtoMessage() {}
+
+func (x *VerifyCriterion) ProtoReflect() protoreflect.Message {
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VerifyCriterion.ProtoReflect.Descriptor instead.
+func (*VerifyCriterion) Descriptor() ([]byte, []int) {
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *VerifyCriterion) GetCategory() string {
+	if x != nil {
+		return x.Category
+	}
+	return ""
+}
+
+func (x *VerifyCriterion) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+// FileTouch identifies a file expected to be created or modified by this spec.
+type FileTouch struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// File or package path relative to repo root.
+	Path string `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	// What changes and why.
+	Purpose string `protobuf:"bytes,2,opt,name=purpose,proto3" json:"purpose,omitempty"`
+	// Type of change: "new", "modify", "delete".
+	ChangeType    string `protobuf:"bytes,3,opt,name=change_type,json=changeType,proto3" json:"change_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FileTouch) Reset() {
+	*x = FileTouch{}
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FileTouch) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FileTouch) ProtoMessage() {}
+
+func (x *FileTouch) ProtoReflect() protoreflect.Message {
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FileTouch.ProtoReflect.Descriptor instead.
+func (*FileTouch) Descriptor() ([]byte, []int) {
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *FileTouch) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *FileTouch) GetPurpose() string {
+	if x != nil {
+		return x.Purpose
+	}
+	return ""
+}
+
+func (x *FileTouch) GetChangeType() string {
+	if x != nil {
+		return x.ChangeType
+	}
+	return ""
+}
+
 // SpecifyOutput captures the precise contract and verification criteria for a spec.
+// WIRE-BREAK: Fields 1, 2, 4 change type from string/repeated-string to
+// repeated-message. Intentional at 0.2.0-dev (no production data). Field
+// numbers reused because semantic intent is preserved.
 type SpecifyOutput struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Formal interface contract (API shape, data model, or behaviour spec).
-	InterfaceContract string `protobuf:"bytes,1,opt,name=interface_contract,json=interfaceContract,proto3" json:"interface_contract,omitempty"`
-	// Conditions that must hold for an implementation to be considered correct.
-	VerifyCriteria []string `protobuf:"bytes,2,rep,name=verify_criteria,json=verifyCriteria,proto3" json:"verify_criteria,omitempty"`
+	// Interface contracts, one per API surface.
+	Interfaces []*InterfaceSection `protobuf:"bytes,1,rep,name=interfaces,proto3" json:"interfaces,omitempty"`
+	// Categorized conditions that must hold for correctness.
+	VerifyCriteria []*VerifyCriterion `protobuf:"bytes,2,rep,name=verify_criteria,json=verifyCriteria,proto3" json:"verify_criteria,omitempty"`
 	// Invariants that must never be violated across any implementation state.
 	Invariants []string `protobuf:"bytes,3,rep,name=invariants,proto3" json:"invariants,omitempty"`
-	// Files, packages, or components expected to be modified by this spec.
-	Touches       []string `protobuf:"bytes,4,rep,name=touches,proto3" json:"touches,omitempty"`
+	// Files, packages, or components expected to be created or modified.
+	Touches       []*FileTouch `protobuf:"bytes,4,rep,name=touches,proto3" json:"touches,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SpecifyOutput) Reset() {
 	*x = SpecifyOutput{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[4]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -735,7 +912,7 @@ func (x *SpecifyOutput) String() string {
 func (*SpecifyOutput) ProtoMessage() {}
 
 func (x *SpecifyOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[4]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -748,17 +925,17 @@ func (x *SpecifyOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpecifyOutput.ProtoReflect.Descriptor instead.
 func (*SpecifyOutput) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{4}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{7}
 }
 
-func (x *SpecifyOutput) GetInterfaceContract() string {
+func (x *SpecifyOutput) GetInterfaces() []*InterfaceSection {
 	if x != nil {
-		return x.InterfaceContract
+		return x.Interfaces
 	}
-	return ""
+	return nil
 }
 
-func (x *SpecifyOutput) GetVerifyCriteria() []string {
+func (x *SpecifyOutput) GetVerifyCriteria() []*VerifyCriterion {
 	if x != nil {
 		return x.VerifyCriteria
 	}
@@ -772,7 +949,7 @@ func (x *SpecifyOutput) GetInvariants() []string {
 	return nil
 }
 
-func (x *SpecifyOutput) GetTouches() []string {
+func (x *SpecifyOutput) GetTouches() []*FileTouch {
 	if x != nil {
 		return x.Touches
 	}
@@ -792,7 +969,7 @@ type DecomposeOutput struct {
 
 func (x *DecomposeOutput) Reset() {
 	*x = DecomposeOutput{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[5]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -804,7 +981,7 @@ func (x *DecomposeOutput) String() string {
 func (*DecomposeOutput) ProtoMessage() {}
 
 func (x *DecomposeOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[5]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -817,7 +994,7 @@ func (x *DecomposeOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DecomposeOutput.ProtoReflect.Descriptor instead.
 func (*DecomposeOutput) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{5}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *DecomposeOutput) GetStrategy() DecompositionStrategy {
@@ -853,7 +1030,7 @@ type DecompositionSlice struct {
 
 func (x *DecompositionSlice) Reset() {
 	*x = DecompositionSlice{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[6]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -865,7 +1042,7 @@ func (x *DecompositionSlice) String() string {
 func (*DecompositionSlice) ProtoMessage() {}
 
 func (x *DecompositionSlice) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[6]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -878,7 +1055,7 @@ func (x *DecompositionSlice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DecompositionSlice.ProtoReflect.Descriptor instead.
 func (*DecompositionSlice) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{6}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *DecompositionSlice) GetId() string {
@@ -931,7 +1108,7 @@ type SafetyFlag struct {
 
 func (x *SafetyFlag) Reset() {
 	*x = SafetyFlag{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[7]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -943,7 +1120,7 @@ func (x *SafetyFlag) String() string {
 func (*SafetyFlag) ProtoMessage() {}
 
 func (x *SafetyFlag) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[7]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -956,7 +1133,7 @@ func (x *SafetyFlag) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SafetyFlag.ProtoReflect.Descriptor instead.
 func (*SafetyFlag) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{7}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *SafetyFlag) GetCategory() SafetyCategory {
@@ -995,7 +1172,7 @@ type PromptTemplate struct {
 
 func (x *PromptTemplate) Reset() {
 	*x = PromptTemplate{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[8]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1007,7 +1184,7 @@ func (x *PromptTemplate) String() string {
 func (*PromptTemplate) ProtoMessage() {}
 
 func (x *PromptTemplate) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[8]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1020,7 +1197,7 @@ func (x *PromptTemplate) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromptTemplate.ProtoReflect.Descriptor instead.
 func (*PromptTemplate) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{8}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *PromptTemplate) GetStage() AuthoringStage {
@@ -1062,7 +1239,7 @@ type SparkRequest struct {
 
 func (x *SparkRequest) Reset() {
 	*x = SparkRequest{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[9]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1074,7 +1251,7 @@ func (x *SparkRequest) String() string {
 func (*SparkRequest) ProtoMessage() {}
 
 func (x *SparkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[9]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1087,7 +1264,7 @@ func (x *SparkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SparkRequest.ProtoReflect.Descriptor instead.
 func (*SparkRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{9}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *SparkRequest) GetSlug() string {
@@ -1126,7 +1303,7 @@ type SparkResponse struct {
 
 func (x *SparkResponse) Reset() {
 	*x = SparkResponse{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[10]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1138,7 +1315,7 @@ func (x *SparkResponse) String() string {
 func (*SparkResponse) ProtoMessage() {}
 
 func (x *SparkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[10]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1151,7 +1328,7 @@ func (x *SparkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SparkResponse.ProtoReflect.Descriptor instead.
 func (*SparkResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{10}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *SparkResponse) GetOutput() *SparkOutput {
@@ -1190,7 +1367,7 @@ type ShapeRequest struct {
 
 func (x *ShapeRequest) Reset() {
 	*x = ShapeRequest{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[11]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1202,7 +1379,7 @@ func (x *ShapeRequest) String() string {
 func (*ShapeRequest) ProtoMessage() {}
 
 func (x *ShapeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[11]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1215,7 +1392,7 @@ func (x *ShapeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShapeRequest.ProtoReflect.Descriptor instead.
 func (*ShapeRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{11}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ShapeRequest) GetSlug() string {
@@ -1254,7 +1431,7 @@ type ShapeResponse struct {
 
 func (x *ShapeResponse) Reset() {
 	*x = ShapeResponse{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[12]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1266,7 +1443,7 @@ func (x *ShapeResponse) String() string {
 func (*ShapeResponse) ProtoMessage() {}
 
 func (x *ShapeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[12]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1279,7 +1456,7 @@ func (x *ShapeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShapeResponse.ProtoReflect.Descriptor instead.
 func (*ShapeResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{12}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ShapeResponse) GetOutput() *ShapeOutput {
@@ -1318,7 +1495,7 @@ type SpecifyRequest struct {
 
 func (x *SpecifyRequest) Reset() {
 	*x = SpecifyRequest{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[13]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1330,7 +1507,7 @@ func (x *SpecifyRequest) String() string {
 func (*SpecifyRequest) ProtoMessage() {}
 
 func (x *SpecifyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[13]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1343,7 +1520,7 @@ func (x *SpecifyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpecifyRequest.ProtoReflect.Descriptor instead.
 func (*SpecifyRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{13}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *SpecifyRequest) GetSlug() string {
@@ -1382,7 +1559,7 @@ type SpecifyResponse struct {
 
 func (x *SpecifyResponse) Reset() {
 	*x = SpecifyResponse{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[14]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1394,7 +1571,7 @@ func (x *SpecifyResponse) String() string {
 func (*SpecifyResponse) ProtoMessage() {}
 
 func (x *SpecifyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[14]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1407,7 +1584,7 @@ func (x *SpecifyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpecifyResponse.ProtoReflect.Descriptor instead.
 func (*SpecifyResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{14}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *SpecifyResponse) GetOutput() *SpecifyOutput {
@@ -1446,7 +1623,7 @@ type DecomposeRequest struct {
 
 func (x *DecomposeRequest) Reset() {
 	*x = DecomposeRequest{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[15]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1458,7 +1635,7 @@ func (x *DecomposeRequest) String() string {
 func (*DecomposeRequest) ProtoMessage() {}
 
 func (x *DecomposeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[15]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1471,7 +1648,7 @@ func (x *DecomposeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DecomposeRequest.ProtoReflect.Descriptor instead.
 func (*DecomposeRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{15}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *DecomposeRequest) GetSlug() string {
@@ -1512,7 +1689,7 @@ type DecomposeResponse struct {
 
 func (x *DecomposeResponse) Reset() {
 	*x = DecomposeResponse{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[16]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1524,7 +1701,7 @@ func (x *DecomposeResponse) String() string {
 func (*DecomposeResponse) ProtoMessage() {}
 
 func (x *DecomposeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[16]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1537,7 +1714,7 @@ func (x *DecomposeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DecomposeResponse.ProtoReflect.Descriptor instead.
 func (*DecomposeResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{16}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *DecomposeResponse) GetOutput() *DecomposeOutput {
@@ -1579,7 +1756,7 @@ type ApproveRequest struct {
 
 func (x *ApproveRequest) Reset() {
 	*x = ApproveRequest{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[17]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1591,7 +1768,7 @@ func (x *ApproveRequest) String() string {
 func (*ApproveRequest) ProtoMessage() {}
 
 func (x *ApproveRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[17]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1604,7 +1781,7 @@ func (x *ApproveRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApproveRequest.ProtoReflect.Descriptor instead.
 func (*ApproveRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{17}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ApproveRequest) GetSlug() string {
@@ -1629,7 +1806,7 @@ type ApproveResponse struct {
 
 func (x *ApproveResponse) Reset() {
 	*x = ApproveResponse{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[18]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1641,7 +1818,7 @@ func (x *ApproveResponse) String() string {
 func (*ApproveResponse) ProtoMessage() {}
 
 func (x *ApproveResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[18]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1654,7 +1831,7 @@ func (x *ApproveResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApproveResponse.ProtoReflect.Descriptor instead.
 func (*ApproveResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{18}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ApproveResponse) GetSlug() string {
@@ -1694,7 +1871,7 @@ type AmendRequest struct {
 
 func (x *AmendRequest) Reset() {
 	*x = AmendRequest{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[19]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1706,7 +1883,7 @@ func (x *AmendRequest) String() string {
 func (*AmendRequest) ProtoMessage() {}
 
 func (x *AmendRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[19]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1719,7 +1896,7 @@ func (x *AmendRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AmendRequest.ProtoReflect.Descriptor instead.
 func (*AmendRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{19}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *AmendRequest) GetSlug() string {
@@ -1758,7 +1935,7 @@ type AmendResponse struct {
 
 func (x *AmendResponse) Reset() {
 	*x = AmendResponse{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[20]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1770,7 +1947,7 @@ func (x *AmendResponse) String() string {
 func (*AmendResponse) ProtoMessage() {}
 
 func (x *AmendResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[20]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1783,7 +1960,7 @@ func (x *AmendResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AmendResponse.ProtoReflect.Descriptor instead.
 func (*AmendResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{20}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *AmendResponse) GetSlug() string {
@@ -1822,7 +1999,7 @@ type SupersedeRequest struct {
 
 func (x *SupersedeRequest) Reset() {
 	*x = SupersedeRequest{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[21]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1834,7 +2011,7 @@ func (x *SupersedeRequest) String() string {
 func (*SupersedeRequest) ProtoMessage() {}
 
 func (x *SupersedeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[21]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1847,7 +2024,7 @@ func (x *SupersedeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SupersedeRequest.ProtoReflect.Descriptor instead.
 func (*SupersedeRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{21}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *SupersedeRequest) GetSlug() string {
@@ -1884,7 +2061,7 @@ type SupersedeResponse struct {
 
 func (x *SupersedeResponse) Reset() {
 	*x = SupersedeResponse{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[22]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1896,7 +2073,7 @@ func (x *SupersedeResponse) String() string {
 func (*SupersedeResponse) ProtoMessage() {}
 
 func (x *SupersedeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[22]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1909,7 +2086,7 @@ func (x *SupersedeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SupersedeResponse.ProtoReflect.Descriptor instead.
 func (*SupersedeResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{22}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *SupersedeResponse) GetSlug() string {
@@ -1938,7 +2115,7 @@ type GetPromptsRequest struct {
 
 func (x *GetPromptsRequest) Reset() {
 	*x = GetPromptsRequest{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[23]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1950,7 +2127,7 @@ func (x *GetPromptsRequest) String() string {
 func (*GetPromptsRequest) ProtoMessage() {}
 
 func (x *GetPromptsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[23]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1963,7 +2140,7 @@ func (x *GetPromptsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPromptsRequest.ProtoReflect.Descriptor instead.
 func (*GetPromptsRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{23}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetPromptsRequest) GetStage() AuthoringStage {
@@ -1984,7 +2161,7 @@ type GetPromptsResponse struct {
 
 func (x *GetPromptsResponse) Reset() {
 	*x = GetPromptsResponse{}
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[24]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1996,7 +2173,7 @@ func (x *GetPromptsResponse) String() string {
 func (*GetPromptsResponse) ProtoMessage() {}
 
 func (x *GetPromptsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_authoring_proto_msgTypes[24]
+	mi := &file_specgraph_v1_authoring_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2009,7 +2186,7 @@ func (x *GetPromptsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPromptsResponse.ProtoReflect.Descriptor instead.
 func (*GetPromptsResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{24}
+	return file_specgraph_v1_authoring_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetPromptsResponse) GetPrompts() []*PromptTemplate {
@@ -2051,14 +2228,27 @@ const file_specgraph_v1_authoring_proto_rawDesc = "" +
 	"\bApproach\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\x1c\n" +
-	"\ttradeoffs\x18\x03 \x03(\tR\ttradeoffs\"\xa1\x01\n" +
-	"\rSpecifyOutput\x12-\n" +
-	"\x12interface_contract\x18\x01 \x01(\tR\x11interfaceContract\x12'\n" +
-	"\x0fverify_criteria\x18\x02 \x03(\tR\x0everifyCriteria\x12\x1e\n" +
+	"\ttradeoffs\x18\x03 \x03(\tR\ttradeoffs\":\n" +
+	"\x10InterfaceSection\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
+	"\x04body\x18\x02 \x01(\tR\x04body\"O\n" +
+	"\x0fVerifyCriterion\x12\x1a\n" +
+	"\bcategory\x18\x01 \x01(\tR\bcategory\x12 \n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\"Z\n" +
+	"\tFileTouch\x12\x12\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x12\x18\n" +
+	"\apurpose\x18\x02 \x01(\tR\apurpose\x12\x1f\n" +
+	"\vchange_type\x18\x03 \x01(\tR\n" +
+	"changeType\"\xea\x01\n" +
+	"\rSpecifyOutput\x12>\n" +
+	"\n" +
+	"interfaces\x18\x01 \x03(\v2\x1e.specgraph.v1.InterfaceSectionR\n" +
+	"interfaces\x12F\n" +
+	"\x0fverify_criteria\x18\x02 \x03(\v2\x1d.specgraph.v1.VerifyCriterionR\x0everifyCriteria\x12\x1e\n" +
 	"\n" +
 	"invariants\x18\x03 \x03(\tR\n" +
-	"invariants\x12\x18\n" +
-	"\atouches\x18\x04 \x03(\tR\atouches\"\x8c\x01\n" +
+	"invariants\x121\n" +
+	"\atouches\x18\x04 \x03(\v2\x17.specgraph.v1.FileTouchR\atouches\"\x8c\x01\n" +
 	"\x0fDecomposeOutput\x12?\n" +
 	"\bstrategy\x18\x01 \x01(\x0e2#.specgraph.v1.DecompositionStrategyR\bstrategy\x128\n" +
 	"\x06slices\x18\x02 \x03(\v2 .specgraph.v1.DecompositionSliceR\x06slices\"\x8d\x01\n" +
@@ -2196,7 +2386,7 @@ func file_specgraph_v1_authoring_proto_rawDescGZIP() []byte {
 }
 
 var file_specgraph_v1_authoring_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_specgraph_v1_authoring_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_specgraph_v1_authoring_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
 var file_specgraph_v1_authoring_proto_goTypes = []any{
 	(AuthoringStage)(0),           // 0: specgraph.v1.AuthoringStage
 	(Posture)(0),                  // 1: specgraph.v1.Posture
@@ -2208,85 +2398,91 @@ var file_specgraph_v1_authoring_proto_goTypes = []any{
 	(*DecisionInput)(nil),         // 7: specgraph.v1.DecisionInput
 	(*ShapeOutput)(nil),           // 8: specgraph.v1.ShapeOutput
 	(*Approach)(nil),              // 9: specgraph.v1.Approach
-	(*SpecifyOutput)(nil),         // 10: specgraph.v1.SpecifyOutput
-	(*DecomposeOutput)(nil),       // 11: specgraph.v1.DecomposeOutput
-	(*DecompositionSlice)(nil),    // 12: specgraph.v1.DecompositionSlice
-	(*SafetyFlag)(nil),            // 13: specgraph.v1.SafetyFlag
-	(*PromptTemplate)(nil),        // 14: specgraph.v1.PromptTemplate
-	(*SparkRequest)(nil),          // 15: specgraph.v1.SparkRequest
-	(*SparkResponse)(nil),         // 16: specgraph.v1.SparkResponse
-	(*ShapeRequest)(nil),          // 17: specgraph.v1.ShapeRequest
-	(*ShapeResponse)(nil),         // 18: specgraph.v1.ShapeResponse
-	(*SpecifyRequest)(nil),        // 19: specgraph.v1.SpecifyRequest
-	(*SpecifyResponse)(nil),       // 20: specgraph.v1.SpecifyResponse
-	(*DecomposeRequest)(nil),      // 21: specgraph.v1.DecomposeRequest
-	(*DecomposeResponse)(nil),     // 22: specgraph.v1.DecomposeResponse
-	(*ApproveRequest)(nil),        // 23: specgraph.v1.ApproveRequest
-	(*ApproveResponse)(nil),       // 24: specgraph.v1.ApproveResponse
-	(*AmendRequest)(nil),          // 25: specgraph.v1.AmendRequest
-	(*AmendResponse)(nil),         // 26: specgraph.v1.AmendResponse
-	(*SupersedeRequest)(nil),      // 27: specgraph.v1.SupersedeRequest
-	(*SupersedeResponse)(nil),     // 28: specgraph.v1.SupersedeResponse
-	(*GetPromptsRequest)(nil),     // 29: specgraph.v1.GetPromptsRequest
-	(*GetPromptsResponse)(nil),    // 30: specgraph.v1.GetPromptsResponse
-	(*timestamppb.Timestamp)(nil), // 31: google.protobuf.Timestamp
+	(*InterfaceSection)(nil),      // 10: specgraph.v1.InterfaceSection
+	(*VerifyCriterion)(nil),       // 11: specgraph.v1.VerifyCriterion
+	(*FileTouch)(nil),             // 12: specgraph.v1.FileTouch
+	(*SpecifyOutput)(nil),         // 13: specgraph.v1.SpecifyOutput
+	(*DecomposeOutput)(nil),       // 14: specgraph.v1.DecomposeOutput
+	(*DecompositionSlice)(nil),    // 15: specgraph.v1.DecompositionSlice
+	(*SafetyFlag)(nil),            // 16: specgraph.v1.SafetyFlag
+	(*PromptTemplate)(nil),        // 17: specgraph.v1.PromptTemplate
+	(*SparkRequest)(nil),          // 18: specgraph.v1.SparkRequest
+	(*SparkResponse)(nil),         // 19: specgraph.v1.SparkResponse
+	(*ShapeRequest)(nil),          // 20: specgraph.v1.ShapeRequest
+	(*ShapeResponse)(nil),         // 21: specgraph.v1.ShapeResponse
+	(*SpecifyRequest)(nil),        // 22: specgraph.v1.SpecifyRequest
+	(*SpecifyResponse)(nil),       // 23: specgraph.v1.SpecifyResponse
+	(*DecomposeRequest)(nil),      // 24: specgraph.v1.DecomposeRequest
+	(*DecomposeResponse)(nil),     // 25: specgraph.v1.DecomposeResponse
+	(*ApproveRequest)(nil),        // 26: specgraph.v1.ApproveRequest
+	(*ApproveResponse)(nil),       // 27: specgraph.v1.ApproveResponse
+	(*AmendRequest)(nil),          // 28: specgraph.v1.AmendRequest
+	(*AmendResponse)(nil),         // 29: specgraph.v1.AmendResponse
+	(*SupersedeRequest)(nil),      // 30: specgraph.v1.SupersedeRequest
+	(*SupersedeResponse)(nil),     // 31: specgraph.v1.SupersedeResponse
+	(*GetPromptsRequest)(nil),     // 32: specgraph.v1.GetPromptsRequest
+	(*GetPromptsResponse)(nil),    // 33: specgraph.v1.GetPromptsResponse
+	(*timestamppb.Timestamp)(nil), // 34: google.protobuf.Timestamp
 }
 var file_specgraph_v1_authoring_proto_depIdxs = []int32{
 	5,  // 0: specgraph.v1.SparkOutput.scope_sniff:type_name -> specgraph.v1.ScopeSniff
 	9,  // 1: specgraph.v1.ShapeOutput.approaches:type_name -> specgraph.v1.Approach
 	7,  // 2: specgraph.v1.ShapeOutput.decisions:type_name -> specgraph.v1.DecisionInput
-	3,  // 3: specgraph.v1.DecomposeOutput.strategy:type_name -> specgraph.v1.DecompositionStrategy
-	12, // 4: specgraph.v1.DecomposeOutput.slices:type_name -> specgraph.v1.DecompositionSlice
-	4,  // 5: specgraph.v1.SafetyFlag.category:type_name -> specgraph.v1.SafetyCategory
-	2,  // 6: specgraph.v1.SafetyFlag.severity:type_name -> specgraph.v1.FindingSeverity
-	0,  // 7: specgraph.v1.PromptTemplate.stage:type_name -> specgraph.v1.AuthoringStage
-	6,  // 8: specgraph.v1.SparkRequest.output:type_name -> specgraph.v1.SparkOutput
-	1,  // 9: specgraph.v1.SparkRequest.posture:type_name -> specgraph.v1.Posture
-	6,  // 10: specgraph.v1.SparkResponse.output:type_name -> specgraph.v1.SparkOutput
-	13, // 11: specgraph.v1.SparkResponse.safety_flags:type_name -> specgraph.v1.SafetyFlag
-	14, // 12: specgraph.v1.SparkResponse.next_prompts:type_name -> specgraph.v1.PromptTemplate
-	8,  // 13: specgraph.v1.ShapeRequest.output:type_name -> specgraph.v1.ShapeOutput
-	1,  // 14: specgraph.v1.ShapeRequest.posture:type_name -> specgraph.v1.Posture
-	8,  // 15: specgraph.v1.ShapeResponse.output:type_name -> specgraph.v1.ShapeOutput
-	13, // 16: specgraph.v1.ShapeResponse.safety_flags:type_name -> specgraph.v1.SafetyFlag
-	14, // 17: specgraph.v1.ShapeResponse.next_prompts:type_name -> specgraph.v1.PromptTemplate
-	10, // 18: specgraph.v1.SpecifyRequest.output:type_name -> specgraph.v1.SpecifyOutput
-	1,  // 19: specgraph.v1.SpecifyRequest.posture:type_name -> specgraph.v1.Posture
-	10, // 20: specgraph.v1.SpecifyResponse.output:type_name -> specgraph.v1.SpecifyOutput
-	13, // 21: specgraph.v1.SpecifyResponse.safety_flags:type_name -> specgraph.v1.SafetyFlag
-	14, // 22: specgraph.v1.SpecifyResponse.next_prompts:type_name -> specgraph.v1.PromptTemplate
-	11, // 23: specgraph.v1.DecomposeRequest.output:type_name -> specgraph.v1.DecomposeOutput
-	1,  // 24: specgraph.v1.DecomposeRequest.posture:type_name -> specgraph.v1.Posture
-	11, // 25: specgraph.v1.DecomposeResponse.output:type_name -> specgraph.v1.DecomposeOutput
-	13, // 26: specgraph.v1.DecomposeResponse.safety_flags:type_name -> specgraph.v1.SafetyFlag
-	14, // 27: specgraph.v1.DecomposeResponse.next_prompts:type_name -> specgraph.v1.PromptTemplate
-	0,  // 28: specgraph.v1.ApproveResponse.stage:type_name -> specgraph.v1.AuthoringStage
-	31, // 29: specgraph.v1.ApproveResponse.approved_at:type_name -> google.protobuf.Timestamp
-	0,  // 30: specgraph.v1.AmendRequest.target_stage:type_name -> specgraph.v1.AuthoringStage
-	0,  // 31: specgraph.v1.AmendResponse.stage:type_name -> specgraph.v1.AuthoringStage
-	0,  // 32: specgraph.v1.GetPromptsRequest.stage:type_name -> specgraph.v1.AuthoringStage
-	14, // 33: specgraph.v1.GetPromptsResponse.prompts:type_name -> specgraph.v1.PromptTemplate
-	15, // 34: specgraph.v1.AuthoringService.Spark:input_type -> specgraph.v1.SparkRequest
-	17, // 35: specgraph.v1.AuthoringService.Shape:input_type -> specgraph.v1.ShapeRequest
-	19, // 36: specgraph.v1.AuthoringService.Specify:input_type -> specgraph.v1.SpecifyRequest
-	21, // 37: specgraph.v1.AuthoringService.Decompose:input_type -> specgraph.v1.DecomposeRequest
-	23, // 38: specgraph.v1.AuthoringService.Approve:input_type -> specgraph.v1.ApproveRequest
-	25, // 39: specgraph.v1.AuthoringService.Amend:input_type -> specgraph.v1.AmendRequest
-	27, // 40: specgraph.v1.AuthoringService.Supersede:input_type -> specgraph.v1.SupersedeRequest
-	29, // 41: specgraph.v1.AuthoringService.GetPrompts:input_type -> specgraph.v1.GetPromptsRequest
-	16, // 42: specgraph.v1.AuthoringService.Spark:output_type -> specgraph.v1.SparkResponse
-	18, // 43: specgraph.v1.AuthoringService.Shape:output_type -> specgraph.v1.ShapeResponse
-	20, // 44: specgraph.v1.AuthoringService.Specify:output_type -> specgraph.v1.SpecifyResponse
-	22, // 45: specgraph.v1.AuthoringService.Decompose:output_type -> specgraph.v1.DecomposeResponse
-	24, // 46: specgraph.v1.AuthoringService.Approve:output_type -> specgraph.v1.ApproveResponse
-	26, // 47: specgraph.v1.AuthoringService.Amend:output_type -> specgraph.v1.AmendResponse
-	28, // 48: specgraph.v1.AuthoringService.Supersede:output_type -> specgraph.v1.SupersedeResponse
-	30, // 49: specgraph.v1.AuthoringService.GetPrompts:output_type -> specgraph.v1.GetPromptsResponse
-	42, // [42:50] is the sub-list for method output_type
-	34, // [34:42] is the sub-list for method input_type
-	34, // [34:34] is the sub-list for extension type_name
-	34, // [34:34] is the sub-list for extension extendee
-	0,  // [0:34] is the sub-list for field type_name
+	10, // 3: specgraph.v1.SpecifyOutput.interfaces:type_name -> specgraph.v1.InterfaceSection
+	11, // 4: specgraph.v1.SpecifyOutput.verify_criteria:type_name -> specgraph.v1.VerifyCriterion
+	12, // 5: specgraph.v1.SpecifyOutput.touches:type_name -> specgraph.v1.FileTouch
+	3,  // 6: specgraph.v1.DecomposeOutput.strategy:type_name -> specgraph.v1.DecompositionStrategy
+	15, // 7: specgraph.v1.DecomposeOutput.slices:type_name -> specgraph.v1.DecompositionSlice
+	4,  // 8: specgraph.v1.SafetyFlag.category:type_name -> specgraph.v1.SafetyCategory
+	2,  // 9: specgraph.v1.SafetyFlag.severity:type_name -> specgraph.v1.FindingSeverity
+	0,  // 10: specgraph.v1.PromptTemplate.stage:type_name -> specgraph.v1.AuthoringStage
+	6,  // 11: specgraph.v1.SparkRequest.output:type_name -> specgraph.v1.SparkOutput
+	1,  // 12: specgraph.v1.SparkRequest.posture:type_name -> specgraph.v1.Posture
+	6,  // 13: specgraph.v1.SparkResponse.output:type_name -> specgraph.v1.SparkOutput
+	16, // 14: specgraph.v1.SparkResponse.safety_flags:type_name -> specgraph.v1.SafetyFlag
+	17, // 15: specgraph.v1.SparkResponse.next_prompts:type_name -> specgraph.v1.PromptTemplate
+	8,  // 16: specgraph.v1.ShapeRequest.output:type_name -> specgraph.v1.ShapeOutput
+	1,  // 17: specgraph.v1.ShapeRequest.posture:type_name -> specgraph.v1.Posture
+	8,  // 18: specgraph.v1.ShapeResponse.output:type_name -> specgraph.v1.ShapeOutput
+	16, // 19: specgraph.v1.ShapeResponse.safety_flags:type_name -> specgraph.v1.SafetyFlag
+	17, // 20: specgraph.v1.ShapeResponse.next_prompts:type_name -> specgraph.v1.PromptTemplate
+	13, // 21: specgraph.v1.SpecifyRequest.output:type_name -> specgraph.v1.SpecifyOutput
+	1,  // 22: specgraph.v1.SpecifyRequest.posture:type_name -> specgraph.v1.Posture
+	13, // 23: specgraph.v1.SpecifyResponse.output:type_name -> specgraph.v1.SpecifyOutput
+	16, // 24: specgraph.v1.SpecifyResponse.safety_flags:type_name -> specgraph.v1.SafetyFlag
+	17, // 25: specgraph.v1.SpecifyResponse.next_prompts:type_name -> specgraph.v1.PromptTemplate
+	14, // 26: specgraph.v1.DecomposeRequest.output:type_name -> specgraph.v1.DecomposeOutput
+	1,  // 27: specgraph.v1.DecomposeRequest.posture:type_name -> specgraph.v1.Posture
+	14, // 28: specgraph.v1.DecomposeResponse.output:type_name -> specgraph.v1.DecomposeOutput
+	16, // 29: specgraph.v1.DecomposeResponse.safety_flags:type_name -> specgraph.v1.SafetyFlag
+	17, // 30: specgraph.v1.DecomposeResponse.next_prompts:type_name -> specgraph.v1.PromptTemplate
+	0,  // 31: specgraph.v1.ApproveResponse.stage:type_name -> specgraph.v1.AuthoringStage
+	34, // 32: specgraph.v1.ApproveResponse.approved_at:type_name -> google.protobuf.Timestamp
+	0,  // 33: specgraph.v1.AmendRequest.target_stage:type_name -> specgraph.v1.AuthoringStage
+	0,  // 34: specgraph.v1.AmendResponse.stage:type_name -> specgraph.v1.AuthoringStage
+	0,  // 35: specgraph.v1.GetPromptsRequest.stage:type_name -> specgraph.v1.AuthoringStage
+	17, // 36: specgraph.v1.GetPromptsResponse.prompts:type_name -> specgraph.v1.PromptTemplate
+	18, // 37: specgraph.v1.AuthoringService.Spark:input_type -> specgraph.v1.SparkRequest
+	20, // 38: specgraph.v1.AuthoringService.Shape:input_type -> specgraph.v1.ShapeRequest
+	22, // 39: specgraph.v1.AuthoringService.Specify:input_type -> specgraph.v1.SpecifyRequest
+	24, // 40: specgraph.v1.AuthoringService.Decompose:input_type -> specgraph.v1.DecomposeRequest
+	26, // 41: specgraph.v1.AuthoringService.Approve:input_type -> specgraph.v1.ApproveRequest
+	28, // 42: specgraph.v1.AuthoringService.Amend:input_type -> specgraph.v1.AmendRequest
+	30, // 43: specgraph.v1.AuthoringService.Supersede:input_type -> specgraph.v1.SupersedeRequest
+	32, // 44: specgraph.v1.AuthoringService.GetPrompts:input_type -> specgraph.v1.GetPromptsRequest
+	19, // 45: specgraph.v1.AuthoringService.Spark:output_type -> specgraph.v1.SparkResponse
+	21, // 46: specgraph.v1.AuthoringService.Shape:output_type -> specgraph.v1.ShapeResponse
+	23, // 47: specgraph.v1.AuthoringService.Specify:output_type -> specgraph.v1.SpecifyResponse
+	25, // 48: specgraph.v1.AuthoringService.Decompose:output_type -> specgraph.v1.DecomposeResponse
+	27, // 49: specgraph.v1.AuthoringService.Approve:output_type -> specgraph.v1.ApproveResponse
+	29, // 50: specgraph.v1.AuthoringService.Amend:output_type -> specgraph.v1.AmendResponse
+	31, // 51: specgraph.v1.AuthoringService.Supersede:output_type -> specgraph.v1.SupersedeResponse
+	33, // 52: specgraph.v1.AuthoringService.GetPrompts:output_type -> specgraph.v1.GetPromptsResponse
+	45, // [45:53] is the sub-list for method output_type
+	37, // [37:45] is the sub-list for method input_type
+	37, // [37:37] is the sub-list for extension type_name
+	37, // [37:37] is the sub-list for extension extendee
+	0,  // [0:37] is the sub-list for field type_name
 }
 
 func init() { file_specgraph_v1_authoring_proto_init() }
@@ -2300,7 +2496,7 @@ func file_specgraph_v1_authoring_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_specgraph_v1_authoring_proto_rawDesc), len(file_specgraph_v1_authoring_proto_rawDesc)),
 			NumEnums:      6,
-			NumMessages:   25,
+			NumMessages:   28,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/authoring/prompts.go
+++ b/internal/authoring/prompts.go
@@ -29,7 +29,7 @@ var promptRegistry = map[Stage][]Prompt{
 		{Name: "define_success", Template: "What does success look like? Define measurable acceptance criteria."},
 	},
 	StageSpecify: {
-		{Name: "interface_contract", Template: "Define the public interface: inputs, outputs, error cases."},
+		{Name: "interfaces", Template: "Define the public interfaces: inputs, outputs, error cases for each API surface."},
 		{Name: "verify_criteria", Template: "Write verification criteria that a reviewer can check mechanically."},
 		{Name: "invariants", Template: "State the invariants that must hold before, during, and after execution."},
 	},

--- a/internal/server/authoring_handler.go
+++ b/internal/server/authoring_handler.go
@@ -187,31 +187,69 @@ func (h *AuthoringHandler) Specify(ctx context.Context, req *connect.Request[spe
 	if msg.Output == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("output is required"))
 	}
-	if len(msg.Output.GetInterfaceContract()) > maxFieldLen {
-		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("interface_contract exceeds maximum length of %d characters", maxFieldLen))
+	if len(msg.Output.GetInterfaces()) > maxElements {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("interfaces exceeds maximum of %d elements", maxElements))
+	}
+	for i, iface := range msg.Output.GetInterfaces() {
+		if iface.GetName() == "" {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("interfaces[%d]: name is required", i))
+		}
+		if len(iface.GetName()) > maxFieldLen {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("interfaces[%d]: name exceeds maximum length of %d characters", i, maxFieldLen))
+		}
+		if len(iface.GetBody()) > maxFieldLen {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("interfaces[%d]: body exceeds maximum length of %d characters", i, maxFieldLen))
+		}
 	}
 	if len(msg.Output.GetVerifyCriteria()) > maxElements {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("verify_criteria exceeds maximum of %d elements", maxElements))
 	}
+	for i, vc := range msg.Output.GetVerifyCriteria() {
+		if len(vc.GetCategory()) > maxFieldLen {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("verify_criteria[%d]: category exceeds maximum length of %d characters", i, maxFieldLen))
+		}
+		if vc.GetDescription() == "" {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("verify_criteria[%d]: description is required", i))
+		}
+		if len(vc.GetDescription()) > maxFieldLen {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("verify_criteria[%d]: description exceeds maximum length of %d characters", i, maxFieldLen))
+		}
+	}
 	if len(msg.Output.GetInvariants()) > maxElements {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invariants exceeds maximum of %d elements", maxElements))
-	}
-	if len(msg.Output.GetTouches()) > maxElements {
-		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("touches exceeds maximum of %d elements", maxElements))
-	}
-	for _, item := range msg.Output.GetVerifyCriteria() {
-		if len(item) > maxFieldLen {
-			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("verify_criteria item exceeds maximum length of %d characters", maxFieldLen))
-		}
 	}
 	for _, item := range msg.Output.GetInvariants() {
 		if len(item) > maxFieldLen {
 			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invariants item exceeds maximum length of %d characters", maxFieldLen))
 		}
 	}
+	if len(msg.Output.GetTouches()) > maxElements {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("touches exceeds maximum of %d elements", maxElements))
+	}
+	for i, ft := range msg.Output.GetTouches() {
+		if ft.GetPath() == "" {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("touches[%d]: path is required", i))
+		}
+		if len(ft.GetPath()) > maxFieldLen {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("touches[%d]: path exceeds maximum length of %d characters", i, maxFieldLen))
+		}
+		if len(ft.GetPurpose()) > maxFieldLen {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("touches[%d]: purpose exceeds maximum length of %d characters", i, maxFieldLen))
+		}
+		if len(ft.GetChangeType()) > maxFieldLen {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("touches[%d]: change_type exceeds maximum length of %d characters", i, maxFieldLen))
+		}
+	}
 	specifyDomain := specifyOutputToDomain(msg.Output)
+	var contractText strings.Builder
+	for _, iface := range msg.Output.GetInterfaces() {
+		if contractText.Len() > 0 {
+			contractText.WriteString("\n\n")
+		}
+		contractText.WriteString(iface.GetName() + ":\n" + iface.GetBody())
+	}
 	safetyInput := &authoring.SafetyInput{
-		Text:       msg.Output.GetInterfaceContract(),
+		Text:       contractText.String(),
 		Invariants: msg.Output.GetInvariants(),
 	}
 	var safetyFlags []authoring.SafetyFlagResult
@@ -613,11 +651,33 @@ func shapeOutputToDomain(p *specv1.ShapeOutput) (*storage.ShapeOutput, error) {
 }
 
 func specifyOutputToDomain(p *specv1.SpecifyOutput) *storage.SpecifyOutput {
+	interfaces := make([]storage.InterfaceSection, len(p.GetInterfaces()))
+	for i, iface := range p.GetInterfaces() {
+		interfaces[i] = storage.InterfaceSection{
+			Name: iface.GetName(),
+			Body: iface.GetBody(),
+		}
+	}
+	criteria := make([]storage.VerifyCriterion, len(p.GetVerifyCriteria()))
+	for i, vc := range p.GetVerifyCriteria() {
+		criteria[i] = storage.VerifyCriterion{
+			Category:    vc.GetCategory(),
+			Description: vc.GetDescription(),
+		}
+	}
+	touches := make([]storage.FileTouch, len(p.GetTouches()))
+	for i, ft := range p.GetTouches() {
+		touches[i] = storage.FileTouch{
+			Path:       ft.GetPath(),
+			Purpose:    ft.GetPurpose(),
+			ChangeType: ft.GetChangeType(),
+		}
+	}
 	return &storage.SpecifyOutput{
-		InterfaceContract: p.GetInterfaceContract(),
-		VerifyCriteria:    p.GetVerifyCriteria(),
-		Invariants:        p.GetInvariants(),
-		Touches:           p.GetTouches(),
+		Interfaces:     interfaces,
+		VerifyCriteria: criteria,
+		Invariants:     p.GetInvariants(),
+		Touches:        touches,
 	}
 }
 

--- a/internal/server/authoring_handler_test.go
+++ b/internal/server/authoring_handler_test.go
@@ -304,14 +304,19 @@ func TestAuthoringHandler_Specify_HappyPath(t *testing.T) {
 	resp, err := client.Specify(context.Background(), connect.NewRequest(&specv1.SpecifyRequest{
 		Slug: "my-spec",
 		Output: &specv1.SpecifyOutput{
-			InterfaceContract: "POST /api/login",
-			VerifyCriteria:    []string{"returns 200 on valid credentials"},
-			Invariants:        []string{"session token is opaque"},
+			Interfaces: []*specv1.InterfaceSection{
+				{Name: "API", Body: "POST /api/login"},
+			},
+			VerifyCriteria: []*specv1.VerifyCriterion{
+				{Category: "functional", Description: "returns 200 on valid credentials"},
+			},
+			Invariants: []string{"session token is opaque"},
 		},
 	}))
 	require.NoError(t, err)
 	require.NotNil(t, resp.Msg.Output)
-	require.Equal(t, "POST /api/login", resp.Msg.Output.InterfaceContract)
+	require.Len(t, resp.Msg.Output.Interfaces, 1)
+	require.Equal(t, "POST /api/login", resp.Msg.Output.Interfaces[0].Body)
 	require.NotEmpty(t, resp.Msg.NextPrompts, "should include next-stage prompts")
 }
 
@@ -536,8 +541,12 @@ func TestAuthoringHandler_Specify_StoreOutputError(t *testing.T) {
 	authoringStore := &fakeAuthoringBackend{storeSpecifyOutputErr: errors.New("store failed")}
 	client := newAuthoringClient(t, authoringStore, &fakeBackend{})
 	_, err := client.Specify(context.Background(), connect.NewRequest(&specv1.SpecifyRequest{
-		Slug:   "my-spec",
-		Output: &specv1.SpecifyOutput{InterfaceContract: "POST /api/login"},
+		Slug: "my-spec",
+		Output: &specv1.SpecifyOutput{
+			Interfaces: []*specv1.InterfaceSection{
+				{Name: "API", Body: "POST /api/login"},
+			},
+		},
 	}))
 	require.Error(t, err)
 	var connErr *connect.Error
@@ -836,7 +845,7 @@ func TestAuthoringHandler_GetPrompts_SpecifyStage(t *testing.T) {
 		names[p.Name] = true
 		require.Equal(t, specv1.AuthoringStage_AUTHORING_STAGE_SPECIFY, p.Stage)
 	}
-	require.True(t, names["interface_contract"])
+	require.True(t, names["interfaces"])
 	require.True(t, names["invariants"])
 }
 
@@ -899,9 +908,13 @@ func TestAuthoringHandler_Specify_StoreSafetyFlagsError(t *testing.T) {
 	_, err := client.Specify(context.Background(), connect.NewRequest(&specv1.SpecifyRequest{
 		Slug: "safety-err-specify",
 		Output: &specv1.SpecifyOutput{
-			InterfaceContract: "interface contract",
-			VerifyCriteria:    []string{"check 1"},
-			Invariants:        []string{"inv 1"},
+			Interfaces: []*specv1.InterfaceSection{
+				{Name: "API", Body: "interface contract"},
+			},
+			VerifyCriteria: []*specv1.VerifyCriterion{
+				{Category: "functional", Description: "check 1"},
+			},
+			Invariants: []string{"inv 1"},
 		},
 	}))
 	if err != nil {
@@ -1204,4 +1217,58 @@ func TestAuthoringHandler_Amend_UnknownStageFromStorage(t *testing.T) {
 	require.ErrorAs(t, err, &connErr)
 	require.Equal(t, connect.CodeInternal, connErr.Code())
 	require.Contains(t, connErr.Message(), "unknown stage")
+}
+
+func TestAuthoringHandler_Specify_InterfacesMissingName(t *testing.T) {
+	client := newAuthoringClient(t, &fakeAuthoringBackend{}, &fakeBackend{})
+	_, err := client.Specify(context.Background(), connect.NewRequest(&specv1.SpecifyRequest{
+		Slug: "test-spec",
+		Output: &specv1.SpecifyOutput{
+			Interfaces: []*specv1.InterfaceSection{
+				{Name: "", Body: "some body"},
+			},
+		},
+	}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestAuthoringHandler_Specify_VerifyCriteriaMissingDescription(t *testing.T) {
+	client := newAuthoringClient(t, &fakeAuthoringBackend{}, &fakeBackend{})
+	_, err := client.Specify(context.Background(), connect.NewRequest(&specv1.SpecifyRequest{
+		Slug: "test-spec",
+		Output: &specv1.SpecifyOutput{
+			VerifyCriteria: []*specv1.VerifyCriterion{
+				{Category: "test", Description: ""},
+			},
+		},
+	}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestAuthoringHandler_Specify_TouchesMissingPath(t *testing.T) {
+	client := newAuthoringClient(t, &fakeAuthoringBackend{}, &fakeBackend{})
+	_, err := client.Specify(context.Background(), connect.NewRequest(&specv1.SpecifyRequest{
+		Slug: "test-spec",
+		Output: &specv1.SpecifyOutput{
+			Touches: []*specv1.FileTouch{
+				{Path: "", Purpose: "something"},
+			},
+		},
+	}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestAuthoringHandler_Specify_MultipleInterfaces(t *testing.T) {
+	client := newAuthoringClient(t, &fakeAuthoringBackend{}, &fakeBackend{})
+	resp, err := client.Specify(context.Background(), connect.NewRequest(&specv1.SpecifyRequest{
+		Slug: "multi-iface",
+		Output: &specv1.SpecifyOutput{
+			Interfaces: []*specv1.InterfaceSection{
+				{Name: "ProtoService", Body: "service Webhook { rpc Send(...) }"},
+				{Name: "GoInterface", Body: "type EventBus interface { Publish(event) }"},
+			},
+		},
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Output.Interfaces, 2)
 }

--- a/internal/storage/authoring.go
+++ b/internal/storage/authoring.go
@@ -60,12 +60,31 @@ type ShapeOutput struct {
 	Decisions      []DecisionInput `json:"decisions,omitempty"`
 }
 
+// InterfaceSection defines one API surface in the specify stage contract.
+type InterfaceSection struct {
+	Name string `json:"name"`
+	Body string `json:"body"`
+}
+
+// VerifyCriterion defines one testable acceptance criterion with a category.
+type VerifyCriterion struct {
+	Category    string `json:"category"`
+	Description string `json:"description"`
+}
+
+// FileTouch identifies a file expected to be created or modified by this spec.
+type FileTouch struct {
+	Path       string `json:"path"`
+	Purpose    string `json:"purpose"`
+	ChangeType string `json:"change_type"`
+}
+
 // SpecifyOutput captures the precise contract and verification criteria.
 type SpecifyOutput struct {
-	InterfaceContract string   `json:"interface_contract,omitempty"`
-	VerifyCriteria    []string `json:"verify_criteria,omitempty"`
-	Invariants        []string `json:"invariants,omitempty"`
-	Touches           []string `json:"touches,omitempty"`
+	Interfaces     []InterfaceSection `json:"interfaces,omitempty"`
+	VerifyCriteria []VerifyCriterion  `json:"verify_criteria,omitempty"`
+	Invariants     []string           `json:"invariants,omitempty"`
+	Touches        []FileTouch        `json:"touches,omitempty"`
 }
 
 // DecompositionStrategy identifies how a spec is broken into slices.

--- a/internal/storage/memgraph/changelog_test.go
+++ b/internal/storage/memgraph/changelog_test.go
@@ -172,7 +172,7 @@ func TestStoreSpecifyOutput_CreatesChangeLog(t *testing.T) {
 	require.NoError(t, err)
 
 	err = store.StoreSpecifyOutput(ctx, "test-specify-cl", &storage.SpecifyOutput{
-		VerifyCriteria: []string{"must be fast"},
+		VerifyCriteria: []storage.VerifyCriterion{{Category: "performance", Description: "must be fast"}},
 	})
 	require.NoError(t, err)
 

--- a/plugin/specgraph/skills/specgraph-specify/SKILL.md
+++ b/plugin/specgraph/skills/specgraph-specify/SKILL.md
@@ -186,35 +186,26 @@ When the specify conversation is complete:
 
    ```json
    {
-     "interface_contract": {
-       "endpoints": [
-         {
-           "method": "POST",
-           "path": "/api/v1/specs/{slug}/claim",
-           "input": { "agent_id": "string", "ttl_seconds": "int" },
-           "output": { "lease_id": "string", "expires_at": "timestamp" },
-           "errors": [
-             { "code": 404, "condition": "Spec not found" },
-             { "code": 409, "condition": "Already claimed by another agent" },
-             { "code": 422, "condition": "Invalid TTL value" }
-           ]
-         }
-       ]
-     },
-     "verify_criteria": [
-       "POST /claim with valid agent_id returns 200 and a lease_id",
-       "POST /claim on already-claimed spec returns 409",
-       "Lease expires after TTL seconds and spec becomes claimable again"
+     "interfaces": [
+       {
+         "name": "ClaimService proto",
+         "body": "POST /api/v1/specs/{slug}/claim\n  Input: { agent_id: string, ttl_seconds: int }\n  Output: { lease_id: string, expires_at: timestamp }\n  Errors:\n    404 - Spec not found\n    409 - Already claimed\n    422 - Invalid TTL"
+       }
+     ],
+     "verifyCriteria": [
+       {"category": "happy-path", "description": "POST /claim with valid agent_id returns 200 and a lease_id"},
+       {"category": "conflict", "description": "POST /claim on already-claimed spec returns 409"},
+       {"category": "expiry", "description": "Lease expires after TTL seconds and spec becomes claimable again"}
      ],
      "invariants": [
        "A spec may have at most one active lease at any time",
        "Lease expiry is monotonically increasing (no backdating)"
      ],
      "touches": [
-       "internal/server/claim_handler.go (new)",
-       "internal/storage/lease.go (new)",
-       "internal/storage/memgraph/lease_queries.go (new)",
-       "internal/server/claim_handler_test.go (new)"
+       {"path": "internal/server/claim_handler.go", "purpose": "new claim handler", "changeType": "new"},
+       {"path": "internal/storage/lease.go", "purpose": "lease domain types", "changeType": "new"},
+       {"path": "internal/storage/memgraph/lease_queries.go", "purpose": "Cypher queries for leases", "changeType": "new"},
+       {"path": "internal/server/claim_handler_test.go", "purpose": "handler tests", "changeType": "new"}
      ]
    }
    ```

--- a/plugin/specgraph/skills/specgraph-specify/references/specify-output-format.md
+++ b/plugin/specgraph/skills/specgraph-specify/references/specify-output-format.md
@@ -3,31 +3,49 @@
 The `specgraph specify <slug> --json-file <path>` command expects proto3 JSON
 (camelCase field names). Write this to a temp file and pass the path.
 
-**Important:** Use only ASCII characters. No em dashes, curly quotes, or
-Unicode punctuation — the proto JSON parser rejects them.
+**Important:** The file must be valid JSON. Unicode characters are allowed
+inside string values, but JSON delimiters must be ASCII -- do not use smart
+quotes (\u201c\u201d) as string delimiters. Use standard ASCII `"` (U+0022).
 
 ## Schema
 
-```json
+````json
 {
-  "interfaceContract": "The interface contract as a string (API shape, method signatures, etc.)",
+  "interfaces": [
+    {
+      "name": "Surface name (e.g. WebhookService proto)",
+      "body": "Free-form contract content"
+    }
+  ],
   "verifyCriteria": [
-    "Testable acceptance criterion as string"
+    {
+      "category": "Category grouping (e.g. emission, CRUD, e2e)",
+      "description": "Testable acceptance criterion"
+    }
   ],
   "invariants": [
     "Invariant that must hold as string"
   ],
   "touches": [
-    "path/to/file/this/spec/will/modify.go"
+    {
+      "path": "path/to/file.go",
+      "purpose": "What changes and why",
+      "changeType": "new | modify | delete"
+    }
   ]
 }
-```
+````
 
 ## Field Notes
 
-- `interfaceContract`: Free text describing the public API surface.
-- `verifyCriteria`: Each item should be independently testable.
+- `interfaces`: One entry per API surface. `name` identifies the surface,
+  `body` is free-form (proto definitions, Go interfaces, HTTP specs, etc.).
+- `verifyCriteria`: Each item should be independently testable. `category`
+  groups related criteria.
 - `invariants`: Properties that must always hold after implementation.
-- `touches`: File paths that will be created or modified.
+- `touches`: Files that will be created or modified. `changeType` is
+  descriptive ("new", "modify", "delete") but not validated.
 
-**Note:** `complexity` is a Spec-level field (set at spark time, default "medium"), not part of SpecifyOutput. Use `specgraph update <slug> --complexity high` to change it.
+**Note:** `complexity` is a Spec-level field (set at spark time, default
+"medium"), not part of SpecifyOutput. Use
+`specgraph update <slug> --complexity high` to change it.

--- a/proto/specgraph/v1/authoring.proto
+++ b/proto/specgraph/v1/authoring.proto
@@ -139,16 +139,45 @@ message Approach {
   repeated string tradeoffs = 3;
 }
 
+// InterfaceSection defines one API surface in the specify stage contract.
+message InterfaceSection {
+  // Surface name, e.g. "WebhookService proto", "EventBus Go interface".
+  string name = 1;
+  // Free-form contract content (proto definitions, method signatures, etc.).
+  string body = 2;
+}
+
+// VerifyCriterion defines one testable acceptance criterion with a category.
+message VerifyCriterion {
+  // Category grouping, e.g. "emission", "CRUD", "e2e".
+  string category = 1;
+  // The criterion description.
+  string description = 2;
+}
+
+// FileTouch identifies a file expected to be created or modified by this spec.
+message FileTouch {
+  // File or package path relative to repo root.
+  string path = 1;
+  // What changes and why.
+  string purpose = 2;
+  // Type of change: "new", "modify", "delete".
+  string change_type = 3;
+}
+
 // SpecifyOutput captures the precise contract and verification criteria for a spec.
+// WIRE-BREAK: Fields 1, 2, 4 change type from string/repeated-string to
+// repeated-message. Intentional at 0.2.0-dev (no production data). Field
+// numbers reused because semantic intent is preserved.
 message SpecifyOutput {
-  // Formal interface contract (API shape, data model, or behaviour spec).
-  string interface_contract = 1;
-  // Conditions that must hold for an implementation to be considered correct.
-  repeated string verify_criteria = 2;
+  // Interface contracts, one per API surface.
+  repeated InterfaceSection interfaces = 1;
+  // Categorized conditions that must hold for correctness.
+  repeated VerifyCriterion verify_criteria = 2;
   // Invariants that must never be violated across any implementation state.
   repeated string invariants = 3;
-  // Files, packages, or components expected to be modified by this spec.
-  repeated string touches = 4;
+  // Files, packages, or components expected to be created or modified.
+  repeated FileTouch touches = 4;
 }
 
 // DecomposeOutput captures the decomposition strategy and resulting slices for a spec.

--- a/site/docs/concepts/example-spec.md
+++ b/site/docs/concepts/example-spec.md
@@ -150,15 +150,13 @@ mobile clients without sacrificing reuse detection.
     this contract after approval require a new spec version.
 
 ```text
+#### Token Endpoint
 POST /oauth/token
   grant_type=refresh_token
   refresh_token=<old_token>
 
 Response (200):
-  access_token: <new_access_token>
-  refresh_token: <new_refresh_token>
-  expires_in: 3600
-  token_type: bearer
+  access_token, refresh_token, expires_in, token_type
 
 Error (401): old token past grace period
 Error (401): token family revoked (reuse detected)
@@ -171,12 +169,12 @@ Error (401): token family revoked (reuse detected)
     When the implementing agent reports completion, these are what get checked.
     If they all pass, the spec is done.
 
-- `POST /oauth/token` with valid refresh token returns new token pair and 200
-- Old refresh token accepted during grace period (30s), rejected after
-- Concurrent rotation requests (same old token, < 1s apart) both succeed — both get valid new tokens in the same lineage
-- Using a rotated-out token after grace period triggers family revocation
-- After family revocation, all tokens in the lineage return 401
-- Token endpoint latency p99 < 50ms with rotation enabled (benchmark against baseline)
+- `[rotation]` `POST /oauth/token` with valid refresh token returns new token pair and 200
+- `[rotation]` Old refresh token accepted during grace period (30s), rejected after
+- `[rotation]` Concurrent rotation requests (same old token, < 1s apart) both succeed -- both get valid new tokens in the same lineage
+- `[security]` Using a rotated-out token after grace period triggers family revocation
+- `[security]` After family revocation, all tokens in the lineage return 401
+- `[expiry]` Token endpoint latency p99 < 50ms with rotation enabled (benchmark against baseline)
 
 ### Invariants
 


### PR DESCRIPTION
## Summary

Replace flat string fields in `SpecifyOutput` with structured sub-messages, enabling multi-surface API contracts and categorized criteria.

- **`interface_contract`** (string) -> **`interfaces`** (repeated `InterfaceSection` with name + body)
- **`verify_criteria`** (repeated string) -> **`verify_criteria`** (repeated `VerifyCriterion` with category + description)
- **`invariants`** unchanged (repeated string)
- **`touches`** (repeated string) -> **`touches`** (repeated `FileTouch` with path + purpose + change_type)

## Motivation

The specify skill produces rich structured content (multiple API surfaces, categorized test criteria, files with purposes) that flattened into plain strings when persisted. Downstream consumers couldn't navigate the content programmatically. This mirrors the existing proto split pattern (e.g., `Approach`, `DecompositionSlice`).

WIRE-BREAK at 0.2.0-dev: field numbers reused with incompatible types (no production data to migrate).

## Changes

| Area | Files |
|------|-------|
| Proto | `authoring.proto` — 3 new messages + restructured `SpecifyOutput` |
| Domain | `storage/authoring.go` — matching Go types |
| Handler | `authoring_handler.go` — validation, safety scanner, proto-to-domain converter |
| Prompt | `prompts.go` — rename `interface_contract` -> `interfaces` |
| Unit tests | `authoring_handler_test.go` — fixtures + 4 new tests (validation + multi-interface) |
| E2E tests | 4 API test files + CLI JSON fixture |
| Docs | Specify skill format reference, SKILL.md, example-spec.md |
| Design | Spec + implementation plan |

## Test plan

- [x] `task check` passes (lint, build, unit tests)
- [x] 4 new negative-path tests: missing interface name, missing criterion description, missing touch path, multi-interface acceptance
- [ ] `task pr-prep` (integration + e2e — requires CI)

Closes: spgr-dp9, spgr-6vl

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Specify output restructured: interfaces become named body blocks; verify criteria now include category + description; touches include path, purpose, and change type. JSON/schema updated.

* **Documentation**
  * Specs, format reference, examples, and site docs updated to the new structured schema.

* **Tests**
  * E2E, handler, CLI fixtures and unit tests updated; added per-item validation and negative tests; updated persistence/example fixtures.

* **Chores**
  * Prompt key renamed to "interfaces"; safety-scan input now synthesized from interface bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->