### PR TITLE
feat: add duplicate slug check to spark skill

### DIFF
--- a/plugin/specgraph/skills/specgraph-spark/SKILL.md
+++ b/plugin/specgraph/skills/specgraph-spark/SKILL.md
@@ -77,6 +77,30 @@ specgraph constitution show
 Summarize to user: "Your project constitution has N principles and M
 constraints. Key ones for this spec: [relevant subset]."
 
+### Duplicate Check
+
+Before creating a new spec, check for existing specs with the same or similar
+slugs. This prevents accidental duplicates and catches near-misses.
+
+```bash
+specgraph list --json
+```
+
+1. **Exact match:** If a spec with the proposed slug already exists, do NOT
+   create a new one. Instead, present the existing spec and ask:
+   - "A spec with slug `<slug>` already exists at stage `<stage>`. Resume it,
+     or pick a different slug?"
+
+2. **Substring/prefix match:** If any existing slug contains the proposed slug
+   as a substring (or vice versa), surface the matches:
+   - "I found similar specs: `<match-1>` (stage), `<match-2>` (stage). Is your
+     idea related to one of these, or is it a new spec?"
+
+3. **No matches:** Proceed normally.
+
+Use `AskUserQuestion` to present matches with options: "Resume existing",
+"Create new spec anyway", or "Pick a different slug."
+
 ### Slug Handling
 
 - If `$ARGUMENTS` contains a slug, load existing spec:
@@ -86,6 +110,7 @@ specgraph show <slug>
 ```
 
 - If `$ARGUMENTS` is a description, generate a slug or ask the user for one.
+  Run the **Duplicate Check** above before creating.
 
 ### Resumption
 


### PR DESCRIPTION
## Summary

Add a Duplicate Check section to the spark skill that runs `specgraph list --json` before creating a new spec, catching:

- **Exact match** — presents existing spec with option to resume or pick a different slug
- **Substring/prefix match** — surfaces similar specs (e.g., `webhook-notifications` vs `webhook-stage-notifications`) with option to resume, create anyway, or rename

Uses `AskUserQuestion` for structured user input.

## Changes

| File | Change |
|------|--------|
| `plugin/specgraph/skills/specgraph-spark/SKILL.md` | Add Duplicate Check section, update Slug Handling to reference it |

## Context

Layers on top of PR #615 (code-level `slug_key` uniqueness constraint). The code enforces uniqueness at the storage layer; this skill-level check provides a better UX by catching duplicates and near-misses before the user fills out the elicitation probes. Fuzzy/semantic matching is deferred to spgr-1nk (vector search).

## Test plan

- [x] `task check` passes
- [ ] Manual: run `/specgraph-spark` with an existing slug, verify duplicate check fires

Closes: spgr-2an

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added duplicate detection to the Spark skill workflow: before creating a new spec, the system now checks for exact matches and similar slug names against existing specs
  * Users are presented with options to resume an existing spec, create the new spec anyway, or select a different slug

<!-- end of auto-generated comment: release notes by coderabbit.ai -->