### PR TITLE
refactor(proto): wrap bare-entity RPC returns in Response messages

### DIFF
--- a/cmd/specgraph/bundle.go
+++ b/cmd/specgraph/bundle.go
@@ -48,7 +48,7 @@ func runBundle(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("generate bundle: %w", err)
 	}
-	yaml := resp.Msg.GetBundleYaml()
+	yaml := resp.Msg.GetBundle().GetBundleYaml()
 	if bundleOutput != "" {
 		if err := os.WriteFile(bundleOutput, []byte(yaml), 0o600); err != nil {
 			return fmt.Errorf("write bundle: %w", err)

--- a/cmd/specgraph/claim.go
+++ b/cmd/specgraph/claim.go
@@ -58,8 +58,8 @@ func runClaim(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("claim spec: %w", err)
 	}
 	fmt.Printf("Claimed: %s by %s (expires %s)\n",
-		resp.Msg.SpecSlug, resp.Msg.Agent,
-		resp.Msg.LeaseExpires.AsTime().Format(time.RFC3339))
+		resp.Msg.GetClaim().GetSpecSlug(), resp.Msg.GetClaim().GetAgent(),
+		resp.Msg.GetClaim().GetLeaseExpires().AsTime().Format(time.RFC3339))
 	return nil
 }
 

--- a/cmd/specgraph/decision.go
+++ b/cmd/specgraph/decision.go
@@ -54,7 +54,7 @@ func runDecisionCreate(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("create decision: %w", err)
 	}
-	fmt.Printf("Created: %s (%s)\n", resp.Msg.Slug, resp.Msg.Id)
+	fmt.Printf("Created: %s (%s)\n", resp.Msg.GetDecision().GetSlug(), resp.Msg.GetDecision().GetId())
 	return nil
 }
 
@@ -141,7 +141,7 @@ func runDecisionShow(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("get decision: %w", err)
 	}
-	d := resp.Msg
+	d := resp.Msg.GetDecision()
 	fmt.Printf("ID:           %s\n", d.Id)
 	fmt.Printf("Slug:         %s\n", d.Slug)
 	fmt.Printf("Title:        %s\n", d.Title)

--- a/cmd/specgraph/edge.go
+++ b/cmd/specgraph/edge.go
@@ -62,7 +62,7 @@ func runEdgeAdd(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("add edge: %w", err)
 	}
-	fmt.Printf("Added %s edge: %s → %s\n", edgeAddType, resp.Msg.FromId, resp.Msg.ToId)
+	fmt.Printf("Added %s edge: %s → %s\n", edgeAddType, resp.Msg.GetEdge().GetFromId(), resp.Msg.GetEdge().GetToId())
 	return nil
 }
 

--- a/cmd/specgraph/spec.go
+++ b/cmd/specgraph/spec.go
@@ -47,7 +47,7 @@ func runCreate(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("create spec: %w", err)
 	}
-	fmt.Printf("Created: %s (%s)\n", resp.Msg.Slug, resp.Msg.Id)
+	fmt.Printf("Created: %s (%s)\n", resp.Msg.GetSpec().GetSlug(), resp.Msg.GetSpec().GetId())
 	return nil
 }
 
@@ -94,7 +94,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("update spec: %w", err)
 	}
-	fmt.Printf("Updated: %s (version %d)\n", resp.Msg.Slug, resp.Msg.Version)
+	fmt.Printf("Updated: %s (version %d)\n", resp.Msg.GetSpec().GetSlug(), resp.Msg.GetSpec().GetVersion())
 	return nil
 }
 
@@ -207,7 +207,7 @@ func runShow(_ *cobra.Command, args []string) error {
 		return nil
 	}
 
-	s := resp.Msg
+	s := resp.Msg.GetSpec()
 	fmt.Printf("ID:         %s\n", s.Id)
 	fmt.Printf("Slug:       %s\n", s.Slug)
 	fmt.Printf("Intent:     %s\n", s.Intent)

--- a/e2e/api/auth_test.go
+++ b/e2e/api/auth_test.go
@@ -268,7 +268,7 @@ var _ = Describe("Auth", Label("auth"), func() {
 			client := specgraphv1connect.NewSpecServiceClient(authProjectClient(), info.BaseURL, withBearer(adminKey))
 			resp, err := client.GetSpec(ctx, connect.NewRequest(&specv1.GetSpecRequest{Slug: testSlug}))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.Msg.Slug).To(Equal(testSlug))
+			Expect(resp.Msg.GetSpec().GetSlug()).To(Equal(testSlug))
 		})
 
 		It("can CreateDecision", func() {

--- a/e2e/api/authoring_test.go
+++ b/e2e/api/authoring_test.go
@@ -78,9 +78,9 @@ var _ = Describe("Authoring funnel", Ordered, func() {
 			Slug: "e2e-decision-1",
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.Msg.Title).To(Equal("Use approach 1"))
-		Expect(resp.Msg.Decision).To(Equal("We chose approach 1"))
-		Expect(resp.Msg.Status).To(Equal(specv1.DecisionStatus_DECISION_STATUS_PROPOSED))
+		Expect(resp.Msg.GetDecision().GetTitle()).To(Equal("Use approach 1"))
+		Expect(resp.Msg.GetDecision().GetDecision()).To(Equal("We chose approach 1"))
+		Expect(resp.Msg.GetDecision().GetStatus()).To(Equal(specv1.DecisionStatus_DECISION_STATUS_PROPOSED))
 	})
 
 	It("specifies a shaped spec", func() {

--- a/e2e/api/claim_test.go
+++ b/e2e/api/claim_test.go
@@ -43,8 +43,8 @@ var _ = Describe("Claim protocol", Ordered, func() {
 			Intent: "Test the claim protocol end-to-end",
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(createResp.Msg.Slug).To(Equal(claimSlug))
-		Expect(createResp.Msg.Stage).To(Equal("spark"))
+		Expect(createResp.Msg.GetSpec().GetSlug()).To(Equal(claimSlug))
+		Expect(createResp.Msg.GetSpec().GetStage()).To(Equal("spark"))
 
 		// Advance stage to approved via UpdateSpec.
 		updateResp, err := specClient.UpdateSpec(ctx, connect.NewRequest(&specv1.UpdateSpecRequest{
@@ -52,7 +52,7 @@ var _ = Describe("Claim protocol", Ordered, func() {
 			Stage: proto.String("approved"),
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(updateResp.Msg.Stage).To(Equal("approved"))
+		Expect(updateResp.Msg.GetSpec().GetStage()).To(Equal("approved"))
 	})
 
 	It("claims the approved spec", func() {
@@ -62,10 +62,10 @@ var _ = Describe("Claim protocol", Ordered, func() {
 			LeaseDuration: durationpb.New(60_000_000_000), // 1 minute
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.Msg.SpecSlug).To(Equal(claimSlug))
-		Expect(resp.Msg.Agent).To(Equal(claimAgent))
-		Expect(resp.Msg.ClaimedAt).NotTo(BeNil())
-		Expect(resp.Msg.LeaseExpires).NotTo(BeNil())
+		Expect(resp.Msg.GetClaim().GetSpecSlug()).To(Equal(claimSlug))
+		Expect(resp.Msg.GetClaim().GetAgent()).To(Equal(claimAgent))
+		Expect(resp.Msg.GetClaim().GetClaimedAt()).NotTo(BeNil())
+		Expect(resp.Msg.GetClaim().GetLeaseExpires()).NotTo(BeNil())
 	})
 
 	It("rejects a double-claim by a different agent", func() {
@@ -95,7 +95,7 @@ var _ = Describe("Claim protocol", Ordered, func() {
 			Agent:    "e2e-agent-2",
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.Msg.Agent).To(Equal("e2e-agent-2"))
+		Expect(resp.Msg.GetClaim().GetAgent()).To(Equal("e2e-agent-2"))
 
 		// Clean up: unclaim so other tests are unaffected.
 		_, err = claimClient.UnclaimSpec(ctx, connect.NewRequest(&specv1.UnclaimSpecRequest{

--- a/e2e/api/constitution_pipeline_test.go
+++ b/e2e/api/constitution_pipeline_test.go
@@ -149,14 +149,14 @@ var _ = Describe("Constitution pipeline", Ordered, func() {
 			Stage: proto.String("approved"),
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(updateResp.Msg.Stage).To(Equal("approved"))
+		Expect(updateResp.Msg.GetSpec().GetStage()).To(Equal("approved"))
 
 		claimResp, err := claimClient.ClaimSpec(ctx, connect.NewRequest(&specv1.ClaimSpecRequest{
 			SpecSlug: specSlug,
 			Agent:    "pipeline-agent",
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(claimResp.Msg.SpecSlug).To(Equal(specSlug))
+		Expect(claimResp.Msg.GetClaim().GetSpecSlug()).To(Equal(specSlug))
 	})
 
 	It("generates an execution bundle with prime callback", func() {
@@ -167,14 +167,14 @@ var _ = Describe("Constitution pipeline", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		bundle := resp.Msg
-		Expect(bundle.Spec).NotTo(BeNil())
-		Expect(bundle.Spec.Slug).To(Equal(specSlug))
-		Expect(bundle.Version).To(BeNumerically(">=", 1))
+		Expect(bundle.GetBundle().GetSpec()).NotTo(BeNil())
+		Expect(bundle.GetBundle().GetSpec().GetSlug()).To(Equal(specSlug))
+		Expect(bundle.GetBundle().GetVersion()).To(BeNumerically(">=", 1))
 		// Bundle carries callback URLs — agents call Prime to get constitution.
 		// Constitution is NOT embedded in the Bundle proto by design: agents
 		// fetch it via the Prime callback so they always get the latest version.
-		Expect(bundle.Callbacks).NotTo(BeNil())
-		Expect(bundle.Callbacks.Prime).To(ContainSubstring("/prime"))
+		Expect(bundle.GetBundle().GetCallbacks()).NotTo(BeNil())
+		Expect(bundle.GetBundle().GetCallbacks().GetPrime()).To(ContainSubstring("/prime"))
 	})
 
 	It("verifies constitution is accessible via GetPrime", func() {

--- a/e2e/api/decision_test.go
+++ b/e2e/api/decision_test.go
@@ -36,14 +36,14 @@ var _ = Describe("Decision", Ordered, func() {
 		}))
 		Expect(err).NotTo(HaveOccurred())
 
-		d := resp.Msg
-		Expect(d.Slug).To(Equal("use-memgraph"))
-		Expect(d.Title).To(Equal("Use Memgraph for graph storage"))
-		Expect(d.Decision).To(Equal("We will use Memgraph as the primary graph database."))
-		Expect(d.Rationale).To(Equal("Memgraph offers low-latency Cypher queries and good container support."))
-		Expect(d.Status).To(Equal(specv1.DecisionStatus_DECISION_STATUS_PROPOSED))
-		Expect(d.Id).NotTo(BeEmpty())
-		Expect(d.CreatedAt).NotTo(BeNil())
+		d := resp.Msg.GetDecision()
+		Expect(d.GetSlug()).To(Equal("use-memgraph"))
+		Expect(d.GetTitle()).To(Equal("Use Memgraph for graph storage"))
+		Expect(d.GetDecision()).To(Equal("We will use Memgraph as the primary graph database."))
+		Expect(d.GetRationale()).To(Equal("Memgraph offers low-latency Cypher queries and good container support."))
+		Expect(d.GetStatus()).To(Equal(specv1.DecisionStatus_DECISION_STATUS_PROPOSED))
+		Expect(d.GetId()).NotTo(BeEmpty())
+		Expect(d.GetCreatedAt()).NotTo(BeNil())
 	})
 
 	It("lists decisions", func() {
@@ -53,7 +53,7 @@ var _ = Describe("Decision", Ordered, func() {
 
 		slugs := make([]string, len(resp.Msg.Decisions))
 		for i, d := range resp.Msg.Decisions {
-			slugs[i] = d.Slug
+			slugs[i] = d.GetSlug()
 		}
 		Expect(slugs).To(ContainElement("use-memgraph"))
 	})
@@ -64,12 +64,12 @@ var _ = Describe("Decision", Ordered, func() {
 		}))
 		Expect(err).NotTo(HaveOccurred())
 
-		d := resp.Msg
-		Expect(d.Slug).To(Equal("use-memgraph"))
-		Expect(d.Title).To(Equal("Use Memgraph for graph storage"))
-		Expect(d.Decision).To(Equal("We will use Memgraph as the primary graph database."))
-		Expect(d.Rationale).To(Equal("Memgraph offers low-latency Cypher queries and good container support."))
-		Expect(d.Status).To(Equal(specv1.DecisionStatus_DECISION_STATUS_PROPOSED))
-		Expect(d.Id).NotTo(BeEmpty())
+		d := resp.Msg.GetDecision()
+		Expect(d.GetSlug()).To(Equal("use-memgraph"))
+		Expect(d.GetTitle()).To(Equal("Use Memgraph for graph storage"))
+		Expect(d.GetDecision()).To(Equal("We will use Memgraph as the primary graph database."))
+		Expect(d.GetRationale()).To(Equal("Memgraph offers low-latency Cypher queries and good container support."))
+		Expect(d.GetStatus()).To(Equal(specv1.DecisionStatus_DECISION_STATUS_PROPOSED))
+		Expect(d.GetId()).NotTo(BeEmpty())
 	})
 })

--- a/e2e/api/edge_test.go
+++ b/e2e/api/edge_test.go
@@ -47,10 +47,10 @@ var _ = Describe("graph edges", Ordered, func() {
 		}))
 		Expect(err).NotTo(HaveOccurred())
 
-		edge := resp.Msg
-		Expect(edge.FromId).NotTo(BeEmpty())
-		Expect(edge.ToId).NotTo(BeEmpty())
-		Expect(edge.EdgeType).To(Equal(specv1.EdgeType_EDGE_TYPE_DEPENDS_ON))
+		edge := resp.Msg.GetEdge()
+		Expect(edge.GetFromId()).NotTo(BeEmpty())
+		Expect(edge.GetToId()).NotTo(BeEmpty())
+		Expect(edge.GetEdgeType()).To(Equal(specv1.EdgeType_EDGE_TYPE_DEPENDS_ON))
 	})
 
 	It("adds a COMPOSES edge", func() {
@@ -61,10 +61,10 @@ var _ = Describe("graph edges", Ordered, func() {
 		}))
 		Expect(err).NotTo(HaveOccurred())
 
-		edge := resp.Msg
-		Expect(edge.FromId).NotTo(BeEmpty())
-		Expect(edge.ToId).NotTo(BeEmpty())
-		Expect(edge.EdgeType).To(Equal(specv1.EdgeType_EDGE_TYPE_COMPOSES))
+		edge := resp.Msg.GetEdge()
+		Expect(edge.GetFromId()).NotTo(BeEmpty())
+		Expect(edge.GetToId()).NotTo(BeEmpty())
+		Expect(edge.GetEdgeType()).To(Equal(specv1.EdgeType_EDGE_TYPE_COMPOSES))
 	})
 
 	It("lists edges for a spec", func() {

--- a/e2e/api/isolation_test.go
+++ b/e2e/api/isolation_test.go
@@ -41,8 +41,8 @@ var _ = Describe("Project isolation", Ordered, func() {
 			Intent: "Alpha intent for isolation test",
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.Msg.Slug).To(Equal("iso-shared-name"))
-		Expect(resp.Msg.Intent).To(Equal("Alpha intent for isolation test"))
+		Expect(resp.Msg.GetSpec().GetSlug()).To(Equal("iso-shared-name"))
+		Expect(resp.Msg.GetSpec().GetIntent()).To(Equal("Alpha intent for isolation test"))
 	})
 
 	It("creates a spec with same slug in project-beta", func() {
@@ -51,8 +51,8 @@ var _ = Describe("Project isolation", Ordered, func() {
 			Intent: "Beta intent for isolation test",
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.Msg.Slug).To(Equal("iso-shared-name"))
-		Expect(resp.Msg.Intent).To(Equal("Beta intent for isolation test"))
+		Expect(resp.Msg.GetSpec().GetSlug()).To(Equal("iso-shared-name"))
+		Expect(resp.Msg.GetSpec().GetIntent()).To(Equal("Beta intent for isolation test"))
 	})
 
 	It("creates a unique spec in each project for exclusion testing", func() {
@@ -74,7 +74,7 @@ var _ = Describe("Project isolation", Ordered, func() {
 			Slug: "iso-shared-name",
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.Msg.Intent).To(Equal("Alpha intent for isolation test"))
+		Expect(resp.Msg.GetSpec().GetIntent()).To(Equal("Alpha intent for isolation test"))
 	})
 
 	It("returns beta intent for project-beta", func() {
@@ -82,7 +82,7 @@ var _ = Describe("Project isolation", Ordered, func() {
 			Slug: "iso-shared-name",
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.Msg.Intent).To(Equal("Beta intent for isolation test"))
+		Expect(resp.Msg.GetSpec().GetIntent()).To(Equal("Beta intent for isolation test"))
 	})
 
 	It("lists specs only for the requesting project", func() {

--- a/e2e/api/lifecycle_pipeline_test.go
+++ b/e2e/api/lifecycle_pipeline_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Lifecycle Pipeline", Ordered, func() {
 			Stage: proto.String("approved"),
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.Msg.Stage).To(Equal("approved"))
+		Expect(resp.Msg.GetSpec().GetStage()).To(Equal("approved"))
 	})
 
 	It("advances to done", func() {
@@ -60,7 +60,7 @@ var _ = Describe("Lifecycle Pipeline", Ordered, func() {
 			Stage: proto.String("done"),
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.Msg.Stage).To(Equal("done"))
+		Expect(resp.Msg.GetSpec().GetStage()).To(Equal("done"))
 	})
 
 	It("amends with re-entry to shape stage", func() {
@@ -135,7 +135,7 @@ var _ = Describe("Lifecycle Pipeline", Ordered, func() {
 			Stage: proto.String("done"),
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.Msg.Stage).To(Equal("done"))
+		Expect(resp.Msg.GetSpec().GetStage()).To(Equal("done"))
 	})
 
 	It("creates a replacement spec", func() {
@@ -205,7 +205,7 @@ var _ = Describe("Lifecycle Pipeline", Ordered, func() {
 			Slug: replacementSlug,
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		versionBefore := getResp.Msg.GetVersion()
+		versionBefore := getResp.Msg.GetSpec().GetVersion()
 
 		resp, err := lifecycleClient.TransitionAbandon(ctx, connect.NewRequest(&specv1.TransitionAbandonRequest{
 			Slug:   replacementSlug,

--- a/e2e/api/lifecycle_test.go
+++ b/e2e/api/lifecycle_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Lifecycle", Ordered, func() {
 				Stage: proto.String("done"),
 			}))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.Msg.Stage).To(Equal("done"))
+			Expect(resp.Msg.GetSpec().GetStage()).To(Equal("done"))
 		})
 
 		It("amends the done spec back into authoring with re-entry stage", func() {
@@ -89,7 +89,7 @@ var _ = Describe("Lifecycle", Ordered, func() {
 				Stage: proto.String("done"),
 			}))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.Msg.Stage).To(Equal("done"))
+			Expect(resp.Msg.GetSpec().GetStage()).To(Equal("done"))
 		})
 
 		It("amends the done spec to amended stage when no re-entry stage specified", func() {

--- a/e2e/api/pipeline_test.go
+++ b/e2e/api/pipeline_test.go
@@ -121,9 +121,9 @@ var _ = Describe("Full pipeline", Ordered, func() {
 			Slug: "pipeline-decision-1",
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.Msg.Title).To(Equal("Use direct approach"))
-		Expect(resp.Msg.Decision).To(Equal("We chose the direct approach"))
-		Expect(resp.Msg.Status).To(Equal(specv1.DecisionStatus_DECISION_STATUS_PROPOSED))
+		Expect(resp.Msg.GetDecision().GetTitle()).To(Equal("Use direct approach"))
+		Expect(resp.Msg.GetDecision().GetDecision()).To(Equal("We chose the direct approach"))
+		Expect(resp.Msg.GetDecision().GetStatus()).To(Equal(specv1.DecisionStatus_DECISION_STATUS_PROPOSED))
 	})
 
 	It("specifies the spec", func() {
@@ -190,10 +190,10 @@ var _ = Describe("Full pipeline", Ordered, func() {
 			LeaseDuration: durationpb.New(60_000_000_000), // 1 minute
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.Msg.SpecSlug).To(Equal(pipelineSlug))
-		Expect(resp.Msg.Agent).To(Equal(pipelineAgent))
-		Expect(resp.Msg.ClaimedAt).NotTo(BeNil())
-		Expect(resp.Msg.LeaseExpires).NotTo(BeNil())
+		Expect(resp.Msg.GetClaim().GetSpecSlug()).To(Equal(pipelineSlug))
+		Expect(resp.Msg.GetClaim().GetAgent()).To(Equal(pipelineAgent))
+		Expect(resp.Msg.GetClaim().GetClaimedAt()).NotTo(BeNil())
+		Expect(resp.Msg.GetClaim().GetLeaseExpires()).NotTo(BeNil())
 	})
 
 	It("generates an execution bundle", func() {
@@ -202,9 +202,9 @@ var _ = Describe("Full pipeline", Ordered, func() {
 			Endpoint: serverInfo.BaseURL,
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.Msg.Spec).NotTo(BeNil())
-		Expect(resp.Msg.Spec.Slug).To(Equal(pipelineSlug))
-		Expect(resp.Msg.Version).To(BeNumerically(">=", int32(1)))
+		Expect(resp.Msg.GetBundle().GetSpec()).NotTo(BeNil())
+		Expect(resp.Msg.GetBundle().GetSpec().GetSlug()).To(Equal(pipelineSlug))
+		Expect(resp.Msg.GetBundle().GetVersion()).To(BeNumerically(">=", int32(1)))
 	})
 
 	It("returns prime data for the spec", func() {
@@ -262,7 +262,7 @@ var _ = Describe("Full pipeline", Ordered, func() {
 			Slug: pipelineSlug,
 		}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.Msg.Stage).To(Equal("done"))
+		Expect(resp.Msg.GetSpec().GetStage()).To(Equal("done"))
 	})
 
 	It("verifies execution events are recorded", func() {

--- a/e2e/api/spec_test.go
+++ b/e2e/api/spec_test.go
@@ -36,14 +36,14 @@ var _ = Describe("Spec lifecycle", Ordered, func() {
 		}))
 		Expect(err).NotTo(HaveOccurred())
 
-		spec := resp.Msg
-		Expect(spec.Slug).To(Equal("oauth-refresh-rotation"))
-		Expect(spec.Intent).To(Equal("Rotate OAuth refresh tokens on each use to limit replay window"))
-		Expect(spec.Priority).To(Equal("p1"))
-		Expect(spec.Stage).To(Equal("spark"))
-		Expect(spec.Id).NotTo(BeEmpty())
-		Expect(spec.Version).To(BeNumerically(">=", 1))
-		Expect(spec.CreatedAt).NotTo(BeNil())
+		spec := resp.Msg.GetSpec()
+		Expect(spec.GetSlug()).To(Equal("oauth-refresh-rotation"))
+		Expect(spec.GetIntent()).To(Equal("Rotate OAuth refresh tokens on each use to limit replay window"))
+		Expect(spec.GetPriority()).To(Equal("p1"))
+		Expect(spec.GetStage()).To(Equal("spark"))
+		Expect(spec.GetId()).NotTo(BeEmpty())
+		Expect(spec.GetVersion()).To(BeNumerically(">=", 1))
+		Expect(spec.GetCreatedAt()).NotTo(BeNil())
 	})
 
 	It("lists specs and the created spec appears", func() {
@@ -63,11 +63,11 @@ var _ = Describe("Spec lifecycle", Ordered, func() {
 		}))
 		Expect(err).NotTo(HaveOccurred())
 
-		spec := resp.Msg
-		Expect(spec.Slug).To(Equal("oauth-refresh-rotation"))
-		Expect(spec.Intent).To(Equal("Rotate OAuth refresh tokens on each use to limit replay window"))
-		Expect(spec.Priority).To(Equal("p1"))
-		Expect(spec.Stage).To(Equal("spark"))
+		spec := resp.Msg.GetSpec()
+		Expect(spec.GetSlug()).To(Equal("oauth-refresh-rotation"))
+		Expect(spec.GetIntent()).To(Equal("Rotate OAuth refresh tokens on each use to limit replay window"))
+		Expect(spec.GetPriority()).To(Equal("p1"))
+		Expect(spec.GetStage()).To(Equal("spark"))
 	})
 
 	It("updates spec fields", func() {
@@ -78,11 +78,11 @@ var _ = Describe("Spec lifecycle", Ordered, func() {
 		}))
 		Expect(err).NotTo(HaveOccurred())
 
-		spec := resp.Msg
-		Expect(spec.Slug).To(Equal("oauth-refresh-rotation"))
-		Expect(spec.Intent).To(Equal("Rotate OAuth refresh tokens on each use to prevent replay attacks"))
-		Expect(spec.Priority).To(Equal("p0"))
+		spec := resp.Msg.GetSpec()
+		Expect(spec.GetSlug()).To(Equal("oauth-refresh-rotation"))
+		Expect(spec.GetIntent()).To(Equal("Rotate OAuth refresh tokens on each use to prevent replay attacks"))
+		Expect(spec.GetPriority()).To(Equal("p0"))
 		// Stage should remain unchanged
-		Expect(spec.Stage).To(Equal("spark"))
+		Expect(spec.GetStage()).To(Equal("spark"))
 	})
 })

--- a/gen/specgraph/v1/claim.pb.go
+++ b/gen/specgraph/v1/claim.pb.go
@@ -302,6 +302,94 @@ func (x *HeartbeatRequest) GetExtendBy() *durationpb.Duration {
 	return nil
 }
 
+type ClaimSpecResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Claim         *Claim                 `protobuf:"bytes,1,opt,name=claim,proto3" json:"claim,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClaimSpecResponse) Reset() {
+	*x = ClaimSpecResponse{}
+	mi := &file_specgraph_v1_claim_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClaimSpecResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClaimSpecResponse) ProtoMessage() {}
+
+func (x *ClaimSpecResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_specgraph_v1_claim_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClaimSpecResponse.ProtoReflect.Descriptor instead.
+func (*ClaimSpecResponse) Descriptor() ([]byte, []int) {
+	return file_specgraph_v1_claim_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *ClaimSpecResponse) GetClaim() *Claim {
+	if x != nil {
+		return x.Claim
+	}
+	return nil
+}
+
+type HeartbeatResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Claim         *Claim                 `protobuf:"bytes,1,opt,name=claim,proto3" json:"claim,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HeartbeatResponse) Reset() {
+	*x = HeartbeatResponse{}
+	mi := &file_specgraph_v1_claim_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HeartbeatResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HeartbeatResponse) ProtoMessage() {}
+
+func (x *HeartbeatResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_specgraph_v1_claim_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HeartbeatResponse.ProtoReflect.Descriptor instead.
+func (*HeartbeatResponse) Descriptor() ([]byte, []int) {
+	return file_specgraph_v1_claim_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *HeartbeatResponse) GetClaim() *Claim {
+	if x != nil {
+		return x.Claim
+	}
+	return nil
+}
+
 var File_specgraph_v1_claim_proto protoreflect.FileDescriptor
 
 const file_specgraph_v1_claim_proto_rawDesc = "" +
@@ -324,11 +412,15 @@ const file_specgraph_v1_claim_proto_rawDesc = "" +
 	"\x10HeartbeatRequest\x12\x1b\n" +
 	"\tspec_slug\x18\x01 \x01(\tR\bspecSlug\x12\x14\n" +
 	"\x05agent\x18\x02 \x01(\tR\x05agent\x126\n" +
-	"\textend_by\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\bextendBy2\xe6\x01\n" +
-	"\fClaimService\x12@\n" +
-	"\tClaimSpec\x12\x1e.specgraph.v1.ClaimSpecRequest\x1a\x13.specgraph.v1.Claim\x12R\n" +
-	"\vUnclaimSpec\x12 .specgraph.v1.UnclaimSpecRequest\x1a!.specgraph.v1.UnclaimSpecResponse\x12@\n" +
-	"\tHeartbeat\x12\x1e.specgraph.v1.HeartbeatRequest\x1a\x13.specgraph.v1.ClaimB=Z;github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
+	"\textend_by\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\bextendBy\">\n" +
+	"\x11ClaimSpecResponse\x12)\n" +
+	"\x05claim\x18\x01 \x01(\v2\x13.specgraph.v1.ClaimR\x05claim\">\n" +
+	"\x11HeartbeatResponse\x12)\n" +
+	"\x05claim\x18\x01 \x01(\v2\x13.specgraph.v1.ClaimR\x05claim2\xfe\x01\n" +
+	"\fClaimService\x12L\n" +
+	"\tClaimSpec\x12\x1e.specgraph.v1.ClaimSpecRequest\x1a\x1f.specgraph.v1.ClaimSpecResponse\x12R\n" +
+	"\vUnclaimSpec\x12 .specgraph.v1.UnclaimSpecRequest\x1a!.specgraph.v1.UnclaimSpecResponse\x12L\n" +
+	"\tHeartbeat\x12\x1e.specgraph.v1.HeartbeatRequest\x1a\x1f.specgraph.v1.HeartbeatResponseB=Z;github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
 
 var (
 	file_specgraph_v1_claim_proto_rawDescOnce sync.Once
@@ -342,32 +434,36 @@ func file_specgraph_v1_claim_proto_rawDescGZIP() []byte {
 	return file_specgraph_v1_claim_proto_rawDescData
 }
 
-var file_specgraph_v1_claim_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_specgraph_v1_claim_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_specgraph_v1_claim_proto_goTypes = []any{
 	(*Claim)(nil),                 // 0: specgraph.v1.Claim
 	(*ClaimSpecRequest)(nil),      // 1: specgraph.v1.ClaimSpecRequest
 	(*UnclaimSpecRequest)(nil),    // 2: specgraph.v1.UnclaimSpecRequest
 	(*UnclaimSpecResponse)(nil),   // 3: specgraph.v1.UnclaimSpecResponse
 	(*HeartbeatRequest)(nil),      // 4: specgraph.v1.HeartbeatRequest
-	(*timestamppb.Timestamp)(nil), // 5: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),   // 6: google.protobuf.Duration
+	(*ClaimSpecResponse)(nil),     // 5: specgraph.v1.ClaimSpecResponse
+	(*HeartbeatResponse)(nil),     // 6: specgraph.v1.HeartbeatResponse
+	(*timestamppb.Timestamp)(nil), // 7: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),   // 8: google.protobuf.Duration
 }
 var file_specgraph_v1_claim_proto_depIdxs = []int32{
-	5, // 0: specgraph.v1.Claim.claimed_at:type_name -> google.protobuf.Timestamp
-	5, // 1: specgraph.v1.Claim.lease_expires:type_name -> google.protobuf.Timestamp
-	6, // 2: specgraph.v1.ClaimSpecRequest.lease_duration:type_name -> google.protobuf.Duration
-	6, // 3: specgraph.v1.HeartbeatRequest.extend_by:type_name -> google.protobuf.Duration
-	1, // 4: specgraph.v1.ClaimService.ClaimSpec:input_type -> specgraph.v1.ClaimSpecRequest
-	2, // 5: specgraph.v1.ClaimService.UnclaimSpec:input_type -> specgraph.v1.UnclaimSpecRequest
-	4, // 6: specgraph.v1.ClaimService.Heartbeat:input_type -> specgraph.v1.HeartbeatRequest
-	0, // 7: specgraph.v1.ClaimService.ClaimSpec:output_type -> specgraph.v1.Claim
-	3, // 8: specgraph.v1.ClaimService.UnclaimSpec:output_type -> specgraph.v1.UnclaimSpecResponse
-	0, // 9: specgraph.v1.ClaimService.Heartbeat:output_type -> specgraph.v1.Claim
-	7, // [7:10] is the sub-list for method output_type
-	4, // [4:7] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	7, // 0: specgraph.v1.Claim.claimed_at:type_name -> google.protobuf.Timestamp
+	7, // 1: specgraph.v1.Claim.lease_expires:type_name -> google.protobuf.Timestamp
+	8, // 2: specgraph.v1.ClaimSpecRequest.lease_duration:type_name -> google.protobuf.Duration
+	8, // 3: specgraph.v1.HeartbeatRequest.extend_by:type_name -> google.protobuf.Duration
+	0, // 4: specgraph.v1.ClaimSpecResponse.claim:type_name -> specgraph.v1.Claim
+	0, // 5: specgraph.v1.HeartbeatResponse.claim:type_name -> specgraph.v1.Claim
+	1, // 6: specgraph.v1.ClaimService.ClaimSpec:input_type -> specgraph.v1.ClaimSpecRequest
+	2, // 7: specgraph.v1.ClaimService.UnclaimSpec:input_type -> specgraph.v1.UnclaimSpecRequest
+	4, // 8: specgraph.v1.ClaimService.Heartbeat:input_type -> specgraph.v1.HeartbeatRequest
+	5, // 9: specgraph.v1.ClaimService.ClaimSpec:output_type -> specgraph.v1.ClaimSpecResponse
+	3, // 10: specgraph.v1.ClaimService.UnclaimSpec:output_type -> specgraph.v1.UnclaimSpecResponse
+	6, // 11: specgraph.v1.ClaimService.Heartbeat:output_type -> specgraph.v1.HeartbeatResponse
+	9, // [9:12] is the sub-list for method output_type
+	6, // [6:9] is the sub-list for method input_type
+	6, // [6:6] is the sub-list for extension type_name
+	6, // [6:6] is the sub-list for extension extendee
+	0, // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_specgraph_v1_claim_proto_init() }
@@ -381,7 +477,7 @@ func file_specgraph_v1_claim_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_specgraph_v1_claim_proto_rawDesc), len(file_specgraph_v1_claim_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/specgraph/v1/decision.pb.go
+++ b/gen/specgraph/v1/decision.pb.go
@@ -488,6 +488,138 @@ func (x *UpdateDecisionRequest) GetSupersededBy() string {
 	return ""
 }
 
+type CreateDecisionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Decision      *Decision              `protobuf:"bytes,1,opt,name=decision,proto3" json:"decision,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateDecisionResponse) Reset() {
+	*x = CreateDecisionResponse{}
+	mi := &file_specgraph_v1_decision_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateDecisionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateDecisionResponse) ProtoMessage() {}
+
+func (x *CreateDecisionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_specgraph_v1_decision_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateDecisionResponse.ProtoReflect.Descriptor instead.
+func (*CreateDecisionResponse) Descriptor() ([]byte, []int) {
+	return file_specgraph_v1_decision_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *CreateDecisionResponse) GetDecision() *Decision {
+	if x != nil {
+		return x.Decision
+	}
+	return nil
+}
+
+type GetDecisionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Decision      *Decision              `protobuf:"bytes,1,opt,name=decision,proto3" json:"decision,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetDecisionResponse) Reset() {
+	*x = GetDecisionResponse{}
+	mi := &file_specgraph_v1_decision_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetDecisionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetDecisionResponse) ProtoMessage() {}
+
+func (x *GetDecisionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_specgraph_v1_decision_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetDecisionResponse.ProtoReflect.Descriptor instead.
+func (*GetDecisionResponse) Descriptor() ([]byte, []int) {
+	return file_specgraph_v1_decision_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *GetDecisionResponse) GetDecision() *Decision {
+	if x != nil {
+		return x.Decision
+	}
+	return nil
+}
+
+type UpdateDecisionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Decision      *Decision              `protobuf:"bytes,1,opt,name=decision,proto3" json:"decision,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateDecisionResponse) Reset() {
+	*x = UpdateDecisionResponse{}
+	mi := &file_specgraph_v1_decision_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateDecisionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateDecisionResponse) ProtoMessage() {}
+
+func (x *UpdateDecisionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_specgraph_v1_decision_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateDecisionResponse.ProtoReflect.Descriptor instead.
+func (*UpdateDecisionResponse) Descriptor() ([]byte, []int) {
+	return file_specgraph_v1_decision_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *UpdateDecisionResponse) GetDecision() *Decision {
+	if x != nil {
+		return x.Decision
+	}
+	return nil
+}
+
 var File_specgraph_v1_decision_proto protoreflect.FileDescriptor
 
 const file_specgraph_v1_decision_proto_rawDesc = "" +
@@ -531,18 +663,24 @@ const file_specgraph_v1_decision_proto_rawDesc = "" +
 	"\t_decisionB\f\n" +
 	"\n" +
 	"_rationaleB\x10\n" +
-	"\x0e_superseded_by*\xad\x01\n" +
+	"\x0e_superseded_by\"L\n" +
+	"\x16CreateDecisionResponse\x122\n" +
+	"\bdecision\x18\x01 \x01(\v2\x16.specgraph.v1.DecisionR\bdecision\"I\n" +
+	"\x13GetDecisionResponse\x122\n" +
+	"\bdecision\x18\x01 \x01(\v2\x16.specgraph.v1.DecisionR\bdecision\"L\n" +
+	"\x16UpdateDecisionResponse\x122\n" +
+	"\bdecision\x18\x01 \x01(\v2\x16.specgraph.v1.DecisionR\bdecision*\xad\x01\n" +
 	"\x0eDecisionStatus\x12\x1f\n" +
 	"\x1bDECISION_STATUS_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18DECISION_STATUS_PROPOSED\x10\x01\x12\x1c\n" +
 	"\x18DECISION_STATUS_ACCEPTED\x10\x02\x12\x1e\n" +
 	"\x1aDECISION_STATUS_DEPRECATED\x10\x03\x12\x1e\n" +
-	"\x1aDECISION_STATUS_SUPERSEDED\x10\x042\xd2\x02\n" +
-	"\x0fDecisionService\x12M\n" +
-	"\x0eCreateDecision\x12#.specgraph.v1.CreateDecisionRequest\x1a\x16.specgraph.v1.Decision\x12G\n" +
-	"\vGetDecision\x12 .specgraph.v1.GetDecisionRequest\x1a\x16.specgraph.v1.Decision\x12X\n" +
-	"\rListDecisions\x12\".specgraph.v1.ListDecisionsRequest\x1a#.specgraph.v1.ListDecisionsResponse\x12M\n" +
-	"\x0eUpdateDecision\x12#.specgraph.v1.UpdateDecisionRequest\x1a\x16.specgraph.v1.DecisionB=Z;github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
+	"\x1aDECISION_STATUS_SUPERSEDED\x10\x042\xf9\x02\n" +
+	"\x0fDecisionService\x12[\n" +
+	"\x0eCreateDecision\x12#.specgraph.v1.CreateDecisionRequest\x1a$.specgraph.v1.CreateDecisionResponse\x12R\n" +
+	"\vGetDecision\x12 .specgraph.v1.GetDecisionRequest\x1a!.specgraph.v1.GetDecisionResponse\x12X\n" +
+	"\rListDecisions\x12\".specgraph.v1.ListDecisionsRequest\x1a#.specgraph.v1.ListDecisionsResponse\x12[\n" +
+	"\x0eUpdateDecision\x12#.specgraph.v1.UpdateDecisionRequest\x1a$.specgraph.v1.UpdateDecisionResponseB=Z;github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
 
 var (
 	file_specgraph_v1_decision_proto_rawDescOnce sync.Once
@@ -557,37 +695,43 @@ func file_specgraph_v1_decision_proto_rawDescGZIP() []byte {
 }
 
 var file_specgraph_v1_decision_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_specgraph_v1_decision_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_specgraph_v1_decision_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_specgraph_v1_decision_proto_goTypes = []any{
-	(DecisionStatus)(0),           // 0: specgraph.v1.DecisionStatus
-	(*Decision)(nil),              // 1: specgraph.v1.Decision
-	(*CreateDecisionRequest)(nil), // 2: specgraph.v1.CreateDecisionRequest
-	(*GetDecisionRequest)(nil),    // 3: specgraph.v1.GetDecisionRequest
-	(*ListDecisionsRequest)(nil),  // 4: specgraph.v1.ListDecisionsRequest
-	(*ListDecisionsResponse)(nil), // 5: specgraph.v1.ListDecisionsResponse
-	(*UpdateDecisionRequest)(nil), // 6: specgraph.v1.UpdateDecisionRequest
-	(*timestamppb.Timestamp)(nil), // 7: google.protobuf.Timestamp
+	(DecisionStatus)(0),            // 0: specgraph.v1.DecisionStatus
+	(*Decision)(nil),               // 1: specgraph.v1.Decision
+	(*CreateDecisionRequest)(nil),  // 2: specgraph.v1.CreateDecisionRequest
+	(*GetDecisionRequest)(nil),     // 3: specgraph.v1.GetDecisionRequest
+	(*ListDecisionsRequest)(nil),   // 4: specgraph.v1.ListDecisionsRequest
+	(*ListDecisionsResponse)(nil),  // 5: specgraph.v1.ListDecisionsResponse
+	(*UpdateDecisionRequest)(nil),  // 6: specgraph.v1.UpdateDecisionRequest
+	(*CreateDecisionResponse)(nil), // 7: specgraph.v1.CreateDecisionResponse
+	(*GetDecisionResponse)(nil),    // 8: specgraph.v1.GetDecisionResponse
+	(*UpdateDecisionResponse)(nil), // 9: specgraph.v1.UpdateDecisionResponse
+	(*timestamppb.Timestamp)(nil),  // 10: google.protobuf.Timestamp
 }
 var file_specgraph_v1_decision_proto_depIdxs = []int32{
 	0,  // 0: specgraph.v1.Decision.status:type_name -> specgraph.v1.DecisionStatus
-	7,  // 1: specgraph.v1.Decision.created_at:type_name -> google.protobuf.Timestamp
-	7,  // 2: specgraph.v1.Decision.updated_at:type_name -> google.protobuf.Timestamp
+	10, // 1: specgraph.v1.Decision.created_at:type_name -> google.protobuf.Timestamp
+	10, // 2: specgraph.v1.Decision.updated_at:type_name -> google.protobuf.Timestamp
 	0,  // 3: specgraph.v1.ListDecisionsRequest.status:type_name -> specgraph.v1.DecisionStatus
 	1,  // 4: specgraph.v1.ListDecisionsResponse.decisions:type_name -> specgraph.v1.Decision
 	0,  // 5: specgraph.v1.UpdateDecisionRequest.status:type_name -> specgraph.v1.DecisionStatus
-	2,  // 6: specgraph.v1.DecisionService.CreateDecision:input_type -> specgraph.v1.CreateDecisionRequest
-	3,  // 7: specgraph.v1.DecisionService.GetDecision:input_type -> specgraph.v1.GetDecisionRequest
-	4,  // 8: specgraph.v1.DecisionService.ListDecisions:input_type -> specgraph.v1.ListDecisionsRequest
-	6,  // 9: specgraph.v1.DecisionService.UpdateDecision:input_type -> specgraph.v1.UpdateDecisionRequest
-	1,  // 10: specgraph.v1.DecisionService.CreateDecision:output_type -> specgraph.v1.Decision
-	1,  // 11: specgraph.v1.DecisionService.GetDecision:output_type -> specgraph.v1.Decision
-	5,  // 12: specgraph.v1.DecisionService.ListDecisions:output_type -> specgraph.v1.ListDecisionsResponse
-	1,  // 13: specgraph.v1.DecisionService.UpdateDecision:output_type -> specgraph.v1.Decision
-	10, // [10:14] is the sub-list for method output_type
-	6,  // [6:10] is the sub-list for method input_type
-	6,  // [6:6] is the sub-list for extension type_name
-	6,  // [6:6] is the sub-list for extension extendee
-	0,  // [0:6] is the sub-list for field type_name
+	1,  // 6: specgraph.v1.CreateDecisionResponse.decision:type_name -> specgraph.v1.Decision
+	1,  // 7: specgraph.v1.GetDecisionResponse.decision:type_name -> specgraph.v1.Decision
+	1,  // 8: specgraph.v1.UpdateDecisionResponse.decision:type_name -> specgraph.v1.Decision
+	2,  // 9: specgraph.v1.DecisionService.CreateDecision:input_type -> specgraph.v1.CreateDecisionRequest
+	3,  // 10: specgraph.v1.DecisionService.GetDecision:input_type -> specgraph.v1.GetDecisionRequest
+	4,  // 11: specgraph.v1.DecisionService.ListDecisions:input_type -> specgraph.v1.ListDecisionsRequest
+	6,  // 12: specgraph.v1.DecisionService.UpdateDecision:input_type -> specgraph.v1.UpdateDecisionRequest
+	7,  // 13: specgraph.v1.DecisionService.CreateDecision:output_type -> specgraph.v1.CreateDecisionResponse
+	8,  // 14: specgraph.v1.DecisionService.GetDecision:output_type -> specgraph.v1.GetDecisionResponse
+	5,  // 15: specgraph.v1.DecisionService.ListDecisions:output_type -> specgraph.v1.ListDecisionsResponse
+	9,  // 16: specgraph.v1.DecisionService.UpdateDecision:output_type -> specgraph.v1.UpdateDecisionResponse
+	13, // [13:17] is the sub-list for method output_type
+	9,  // [9:13] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_specgraph_v1_decision_proto_init() }
@@ -602,7 +746,7 @@ func file_specgraph_v1_decision_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_specgraph_v1_decision_proto_rawDesc), len(file_specgraph_v1_decision_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   6,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/specgraph/v1/execution.pb.go
+++ b/gen/specgraph/v1/execution.pb.go
@@ -449,6 +449,50 @@ func (x *GenerateBundleRequest) GetEndpoint() string {
 	return ""
 }
 
+type GenerateBundleResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Bundle        *Bundle                `protobuf:"bytes,1,opt,name=bundle,proto3" json:"bundle,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GenerateBundleResponse) Reset() {
+	*x = GenerateBundleResponse{}
+	mi := &file_specgraph_v1_execution_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GenerateBundleResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GenerateBundleResponse) ProtoMessage() {}
+
+func (x *GenerateBundleResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_specgraph_v1_execution_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GenerateBundleResponse.ProtoReflect.Descriptor instead.
+func (*GenerateBundleResponse) Descriptor() ([]byte, []int) {
+	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *GenerateBundleResponse) GetBundle() *Bundle {
+	if x != nil {
+		return x.Bundle
+	}
+	return nil
+}
+
 type GetPrimeRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Slug          string                 `protobuf:"bytes,1,opt,name=slug,proto3" json:"slug,omitempty"`
@@ -458,7 +502,7 @@ type GetPrimeRequest struct {
 
 func (x *GetPrimeRequest) Reset() {
 	*x = GetPrimeRequest{}
-	mi := &file_specgraph_v1_execution_proto_msgTypes[5]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -470,7 +514,7 @@ func (x *GetPrimeRequest) String() string {
 func (*GetPrimeRequest) ProtoMessage() {}
 
 func (x *GetPrimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_execution_proto_msgTypes[5]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -483,7 +527,7 @@ func (x *GetPrimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPrimeRequest.ProtoReflect.Descriptor instead.
 func (*GetPrimeRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{5}
+	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *GetPrimeRequest) GetSlug() string {
@@ -504,7 +548,7 @@ type ReportProgressRequest struct {
 
 func (x *ReportProgressRequest) Reset() {
 	*x = ReportProgressRequest{}
-	mi := &file_specgraph_v1_execution_proto_msgTypes[6]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -516,7 +560,7 @@ func (x *ReportProgressRequest) String() string {
 func (*ReportProgressRequest) ProtoMessage() {}
 
 func (x *ReportProgressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_execution_proto_msgTypes[6]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -529,7 +573,7 @@ func (x *ReportProgressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportProgressRequest.ProtoReflect.Descriptor instead.
 func (*ReportProgressRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{6}
+	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ReportProgressRequest) GetSlug() string {
@@ -562,7 +606,7 @@ type ReportProgressResponse struct {
 
 func (x *ReportProgressResponse) Reset() {
 	*x = ReportProgressResponse{}
-	mi := &file_specgraph_v1_execution_proto_msgTypes[7]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -574,7 +618,7 @@ func (x *ReportProgressResponse) String() string {
 func (*ReportProgressResponse) ProtoMessage() {}
 
 func (x *ReportProgressResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_execution_proto_msgTypes[7]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -587,7 +631,7 @@ func (x *ReportProgressResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportProgressResponse.ProtoReflect.Descriptor instead.
 func (*ReportProgressResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{7}
+	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ReportProgressResponse) GetAcknowledged() bool {
@@ -608,7 +652,7 @@ type ReportBlockerRequest struct {
 
 func (x *ReportBlockerRequest) Reset() {
 	*x = ReportBlockerRequest{}
-	mi := &file_specgraph_v1_execution_proto_msgTypes[8]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -620,7 +664,7 @@ func (x *ReportBlockerRequest) String() string {
 func (*ReportBlockerRequest) ProtoMessage() {}
 
 func (x *ReportBlockerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_execution_proto_msgTypes[8]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -633,7 +677,7 @@ func (x *ReportBlockerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportBlockerRequest.ProtoReflect.Descriptor instead.
 func (*ReportBlockerRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{8}
+	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ReportBlockerRequest) GetSlug() string {
@@ -666,7 +710,7 @@ type ReportBlockerResponse struct {
 
 func (x *ReportBlockerResponse) Reset() {
 	*x = ReportBlockerResponse{}
-	mi := &file_specgraph_v1_execution_proto_msgTypes[9]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -678,7 +722,7 @@ func (x *ReportBlockerResponse) String() string {
 func (*ReportBlockerResponse) ProtoMessage() {}
 
 func (x *ReportBlockerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_execution_proto_msgTypes[9]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -691,7 +735,7 @@ func (x *ReportBlockerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportBlockerResponse.ProtoReflect.Descriptor instead.
 func (*ReportBlockerResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{9}
+	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ReportBlockerResponse) GetAcknowledged() bool {
@@ -711,7 +755,7 @@ type ReportCompletionRequest struct {
 
 func (x *ReportCompletionRequest) Reset() {
 	*x = ReportCompletionRequest{}
-	mi := &file_specgraph_v1_execution_proto_msgTypes[10]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -723,7 +767,7 @@ func (x *ReportCompletionRequest) String() string {
 func (*ReportCompletionRequest) ProtoMessage() {}
 
 func (x *ReportCompletionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_execution_proto_msgTypes[10]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -736,7 +780,7 @@ func (x *ReportCompletionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportCompletionRequest.ProtoReflect.Descriptor instead.
 func (*ReportCompletionRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{10}
+	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ReportCompletionRequest) GetSlug() string {
@@ -763,7 +807,7 @@ type ReportCompletionResponse struct {
 
 func (x *ReportCompletionResponse) Reset() {
 	*x = ReportCompletionResponse{}
-	mi := &file_specgraph_v1_execution_proto_msgTypes[11]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -775,7 +819,7 @@ func (x *ReportCompletionResponse) String() string {
 func (*ReportCompletionResponse) ProtoMessage() {}
 
 func (x *ReportCompletionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_execution_proto_msgTypes[11]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -788,7 +832,7 @@ func (x *ReportCompletionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportCompletionResponse.ProtoReflect.Descriptor instead.
 func (*ReportCompletionResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{11}
+	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ReportCompletionResponse) GetAcknowledged() bool {
@@ -815,7 +859,7 @@ type GetExecutionEventsRequest struct {
 
 func (x *GetExecutionEventsRequest) Reset() {
 	*x = GetExecutionEventsRequest{}
-	mi := &file_specgraph_v1_execution_proto_msgTypes[12]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -827,7 +871,7 @@ func (x *GetExecutionEventsRequest) String() string {
 func (*GetExecutionEventsRequest) ProtoMessage() {}
 
 func (x *GetExecutionEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_execution_proto_msgTypes[12]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -840,7 +884,7 @@ func (x *GetExecutionEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionEventsRequest.ProtoReflect.Descriptor instead.
 func (*GetExecutionEventsRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{12}
+	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *GetExecutionEventsRequest) GetSlug() string {
@@ -866,7 +910,7 @@ type GetExecutionEventsResponse struct {
 
 func (x *GetExecutionEventsResponse) Reset() {
 	*x = GetExecutionEventsResponse{}
-	mi := &file_specgraph_v1_execution_proto_msgTypes[13]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -878,7 +922,7 @@ func (x *GetExecutionEventsResponse) String() string {
 func (*GetExecutionEventsResponse) ProtoMessage() {}
 
 func (x *GetExecutionEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_execution_proto_msgTypes[13]
+	mi := &file_specgraph_v1_execution_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -891,7 +935,7 @@ func (x *GetExecutionEventsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExecutionEventsResponse.ProtoReflect.Descriptor instead.
 func (*GetExecutionEventsResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{13}
+	return file_specgraph_v1_execution_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *GetExecutionEventsResponse) GetEvents() []*ExecutionEvent {
@@ -938,7 +982,9 @@ const file_specgraph_v1_execution_proto_rawDesc = "" +
 	"created_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"G\n" +
 	"\x15GenerateBundleRequest\x12\x12\n" +
 	"\x04slug\x18\x01 \x01(\tR\x04slug\x12\x1a\n" +
-	"\bendpoint\x18\x02 \x01(\tR\bendpoint\"%\n" +
+	"\bendpoint\x18\x02 \x01(\tR\bendpoint\"F\n" +
+	"\x16GenerateBundleResponse\x12,\n" +
+	"\x06bundle\x18\x01 \x01(\v2\x14.specgraph.v1.BundleR\x06bundle\"%\n" +
 	"\x0fGetPrimeRequest\x12\x12\n" +
 	"\x04slug\x18\x01 \x01(\tR\x04slug\"[\n" +
 	"\x15ReportProgressRequest\x12\x12\n" +
@@ -968,9 +1014,9 @@ const file_specgraph_v1_execution_proto_rawDesc = "" +
 	" EXECUTION_EVENT_TYPE_UNSPECIFIED\x10\x00\x12!\n" +
 	"\x1dEXECUTION_EVENT_TYPE_PROGRESS\x10\x01\x12 \n" +
 	"\x1cEXECUTION_EVENT_TYPE_BLOCKER\x10\x02\x12#\n" +
-	"\x1fEXECUTION_EVENT_TYPE_COMPLETION\x10\x032\xaa\x04\n" +
-	"\x10ExecutionService\x12K\n" +
-	"\x0eGenerateBundle\x12#.specgraph.v1.GenerateBundleRequest\x1a\x14.specgraph.v1.Bundle\x12F\n" +
+	"\x1fEXECUTION_EVENT_TYPE_COMPLETION\x10\x032\xba\x04\n" +
+	"\x10ExecutionService\x12[\n" +
+	"\x0eGenerateBundle\x12#.specgraph.v1.GenerateBundleRequest\x1a$.specgraph.v1.GenerateBundleResponse\x12F\n" +
 	"\bGetPrime\x12\x1d.specgraph.v1.GetPrimeRequest\x1a\x1b.specgraph.v1.PrimeResponse\x12[\n" +
 	"\x0eReportProgress\x12#.specgraph.v1.ReportProgressRequest\x1a$.specgraph.v1.ReportProgressResponse\x12X\n" +
 	"\rReportBlocker\x12\".specgraph.v1.ReportBlockerRequest\x1a#.specgraph.v1.ReportBlockerResponse\x12a\n" +
@@ -990,7 +1036,7 @@ func file_specgraph_v1_execution_proto_rawDescGZIP() []byte {
 }
 
 var file_specgraph_v1_execution_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_specgraph_v1_execution_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_specgraph_v1_execution_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_specgraph_v1_execution_proto_goTypes = []any{
 	(ExecutionEventType)(0),            // 0: specgraph.v1.ExecutionEventType
 	(*CallbackConfig)(nil),             // 1: specgraph.v1.CallbackConfig
@@ -998,44 +1044,46 @@ var file_specgraph_v1_execution_proto_goTypes = []any{
 	(*PrimeResponse)(nil),              // 3: specgraph.v1.PrimeResponse
 	(*ExecutionEvent)(nil),             // 4: specgraph.v1.ExecutionEvent
 	(*GenerateBundleRequest)(nil),      // 5: specgraph.v1.GenerateBundleRequest
-	(*GetPrimeRequest)(nil),            // 6: specgraph.v1.GetPrimeRequest
-	(*ReportProgressRequest)(nil),      // 7: specgraph.v1.ReportProgressRequest
-	(*ReportProgressResponse)(nil),     // 8: specgraph.v1.ReportProgressResponse
-	(*ReportBlockerRequest)(nil),       // 9: specgraph.v1.ReportBlockerRequest
-	(*ReportBlockerResponse)(nil),      // 10: specgraph.v1.ReportBlockerResponse
-	(*ReportCompletionRequest)(nil),    // 11: specgraph.v1.ReportCompletionRequest
-	(*ReportCompletionResponse)(nil),   // 12: specgraph.v1.ReportCompletionResponse
-	(*GetExecutionEventsRequest)(nil),  // 13: specgraph.v1.GetExecutionEventsRequest
-	(*GetExecutionEventsResponse)(nil), // 14: specgraph.v1.GetExecutionEventsResponse
-	(*Spec)(nil),                       // 15: specgraph.v1.Spec
-	(*Decision)(nil),                   // 16: specgraph.v1.Decision
-	(*timestamppb.Timestamp)(nil),      // 17: google.protobuf.Timestamp
+	(*GenerateBundleResponse)(nil),     // 6: specgraph.v1.GenerateBundleResponse
+	(*GetPrimeRequest)(nil),            // 7: specgraph.v1.GetPrimeRequest
+	(*ReportProgressRequest)(nil),      // 8: specgraph.v1.ReportProgressRequest
+	(*ReportProgressResponse)(nil),     // 9: specgraph.v1.ReportProgressResponse
+	(*ReportBlockerRequest)(nil),       // 10: specgraph.v1.ReportBlockerRequest
+	(*ReportBlockerResponse)(nil),      // 11: specgraph.v1.ReportBlockerResponse
+	(*ReportCompletionRequest)(nil),    // 12: specgraph.v1.ReportCompletionRequest
+	(*ReportCompletionResponse)(nil),   // 13: specgraph.v1.ReportCompletionResponse
+	(*GetExecutionEventsRequest)(nil),  // 14: specgraph.v1.GetExecutionEventsRequest
+	(*GetExecutionEventsResponse)(nil), // 15: specgraph.v1.GetExecutionEventsResponse
+	(*Spec)(nil),                       // 16: specgraph.v1.Spec
+	(*Decision)(nil),                   // 17: specgraph.v1.Decision
+	(*timestamppb.Timestamp)(nil),      // 18: google.protobuf.Timestamp
 }
 var file_specgraph_v1_execution_proto_depIdxs = []int32{
-	15, // 0: specgraph.v1.Bundle.spec:type_name -> specgraph.v1.Spec
-	16, // 1: specgraph.v1.Bundle.decisions:type_name -> specgraph.v1.Decision
+	16, // 0: specgraph.v1.Bundle.spec:type_name -> specgraph.v1.Spec
+	17, // 1: specgraph.v1.Bundle.decisions:type_name -> specgraph.v1.Decision
 	1,  // 2: specgraph.v1.Bundle.callbacks:type_name -> specgraph.v1.CallbackConfig
-	16, // 3: specgraph.v1.PrimeResponse.decisions:type_name -> specgraph.v1.Decision
+	17, // 3: specgraph.v1.PrimeResponse.decisions:type_name -> specgraph.v1.Decision
 	0,  // 4: specgraph.v1.ExecutionEvent.type:type_name -> specgraph.v1.ExecutionEventType
-	17, // 5: specgraph.v1.ExecutionEvent.created_at:type_name -> google.protobuf.Timestamp
-	4,  // 6: specgraph.v1.GetExecutionEventsResponse.events:type_name -> specgraph.v1.ExecutionEvent
-	5,  // 7: specgraph.v1.ExecutionService.GenerateBundle:input_type -> specgraph.v1.GenerateBundleRequest
-	6,  // 8: specgraph.v1.ExecutionService.GetPrime:input_type -> specgraph.v1.GetPrimeRequest
-	7,  // 9: specgraph.v1.ExecutionService.ReportProgress:input_type -> specgraph.v1.ReportProgressRequest
-	9,  // 10: specgraph.v1.ExecutionService.ReportBlocker:input_type -> specgraph.v1.ReportBlockerRequest
-	11, // 11: specgraph.v1.ExecutionService.ReportCompletion:input_type -> specgraph.v1.ReportCompletionRequest
-	13, // 12: specgraph.v1.ExecutionService.GetExecutionEvents:input_type -> specgraph.v1.GetExecutionEventsRequest
-	2,  // 13: specgraph.v1.ExecutionService.GenerateBundle:output_type -> specgraph.v1.Bundle
-	3,  // 14: specgraph.v1.ExecutionService.GetPrime:output_type -> specgraph.v1.PrimeResponse
-	8,  // 15: specgraph.v1.ExecutionService.ReportProgress:output_type -> specgraph.v1.ReportProgressResponse
-	10, // 16: specgraph.v1.ExecutionService.ReportBlocker:output_type -> specgraph.v1.ReportBlockerResponse
-	12, // 17: specgraph.v1.ExecutionService.ReportCompletion:output_type -> specgraph.v1.ReportCompletionResponse
-	14, // 18: specgraph.v1.ExecutionService.GetExecutionEvents:output_type -> specgraph.v1.GetExecutionEventsResponse
-	13, // [13:19] is the sub-list for method output_type
-	7,  // [7:13] is the sub-list for method input_type
-	7,  // [7:7] is the sub-list for extension type_name
-	7,  // [7:7] is the sub-list for extension extendee
-	0,  // [0:7] is the sub-list for field type_name
+	18, // 5: specgraph.v1.ExecutionEvent.created_at:type_name -> google.protobuf.Timestamp
+	2,  // 6: specgraph.v1.GenerateBundleResponse.bundle:type_name -> specgraph.v1.Bundle
+	4,  // 7: specgraph.v1.GetExecutionEventsResponse.events:type_name -> specgraph.v1.ExecutionEvent
+	5,  // 8: specgraph.v1.ExecutionService.GenerateBundle:input_type -> specgraph.v1.GenerateBundleRequest
+	7,  // 9: specgraph.v1.ExecutionService.GetPrime:input_type -> specgraph.v1.GetPrimeRequest
+	8,  // 10: specgraph.v1.ExecutionService.ReportProgress:input_type -> specgraph.v1.ReportProgressRequest
+	10, // 11: specgraph.v1.ExecutionService.ReportBlocker:input_type -> specgraph.v1.ReportBlockerRequest
+	12, // 12: specgraph.v1.ExecutionService.ReportCompletion:input_type -> specgraph.v1.ReportCompletionRequest
+	14, // 13: specgraph.v1.ExecutionService.GetExecutionEvents:input_type -> specgraph.v1.GetExecutionEventsRequest
+	6,  // 14: specgraph.v1.ExecutionService.GenerateBundle:output_type -> specgraph.v1.GenerateBundleResponse
+	3,  // 15: specgraph.v1.ExecutionService.GetPrime:output_type -> specgraph.v1.PrimeResponse
+	9,  // 16: specgraph.v1.ExecutionService.ReportProgress:output_type -> specgraph.v1.ReportProgressResponse
+	11, // 17: specgraph.v1.ExecutionService.ReportBlocker:output_type -> specgraph.v1.ReportBlockerResponse
+	13, // 18: specgraph.v1.ExecutionService.ReportCompletion:output_type -> specgraph.v1.ReportCompletionResponse
+	15, // 19: specgraph.v1.ExecutionService.GetExecutionEvents:output_type -> specgraph.v1.GetExecutionEventsResponse
+	14, // [14:20] is the sub-list for method output_type
+	8,  // [8:14] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_specgraph_v1_execution_proto_init() }
@@ -1051,7 +1099,7 @@ func file_specgraph_v1_execution_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_specgraph_v1_execution_proto_rawDesc), len(file_specgraph_v1_execution_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   14,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/specgraph/v1/graph.pb.go
+++ b/gen/specgraph/v1/graph.pb.go
@@ -208,6 +208,50 @@ func (x *AddEdgeRequest) GetEdgeType() EdgeType {
 	return EdgeType_EDGE_TYPE_UNSPECIFIED
 }
 
+type AddEdgeResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Edge          *Edge                  `protobuf:"bytes,1,opt,name=edge,proto3" json:"edge,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddEdgeResponse) Reset() {
+	*x = AddEdgeResponse{}
+	mi := &file_specgraph_v1_graph_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddEdgeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddEdgeResponse) ProtoMessage() {}
+
+func (x *AddEdgeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_specgraph_v1_graph_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddEdgeResponse.ProtoReflect.Descriptor instead.
+func (*AddEdgeResponse) Descriptor() ([]byte, []int) {
+	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *AddEdgeResponse) GetEdge() *Edge {
+	if x != nil {
+		return x.Edge
+	}
+	return nil
+}
+
 type RemoveEdgeRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	FromSlug      string                 `protobuf:"bytes,1,opt,name=from_slug,json=fromSlug,proto3" json:"from_slug,omitempty"`
@@ -219,7 +263,7 @@ type RemoveEdgeRequest struct {
 
 func (x *RemoveEdgeRequest) Reset() {
 	*x = RemoveEdgeRequest{}
-	mi := &file_specgraph_v1_graph_proto_msgTypes[2]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -231,7 +275,7 @@ func (x *RemoveEdgeRequest) String() string {
 func (*RemoveEdgeRequest) ProtoMessage() {}
 
 func (x *RemoveEdgeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_graph_proto_msgTypes[2]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -244,7 +288,7 @@ func (x *RemoveEdgeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveEdgeRequest.ProtoReflect.Descriptor instead.
 func (*RemoveEdgeRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{2}
+	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *RemoveEdgeRequest) GetFromSlug() string {
@@ -276,7 +320,7 @@ type RemoveEdgeResponse struct {
 
 func (x *RemoveEdgeResponse) Reset() {
 	*x = RemoveEdgeResponse{}
-	mi := &file_specgraph_v1_graph_proto_msgTypes[3]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -288,7 +332,7 @@ func (x *RemoveEdgeResponse) String() string {
 func (*RemoveEdgeResponse) ProtoMessage() {}
 
 func (x *RemoveEdgeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_graph_proto_msgTypes[3]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -301,7 +345,7 @@ func (x *RemoveEdgeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveEdgeResponse.ProtoReflect.Descriptor instead.
 func (*RemoveEdgeResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{3}
+	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{4}
 }
 
 type ListEdgesRequest struct {
@@ -314,7 +358,7 @@ type ListEdgesRequest struct {
 
 func (x *ListEdgesRequest) Reset() {
 	*x = ListEdgesRequest{}
-	mi := &file_specgraph_v1_graph_proto_msgTypes[4]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -326,7 +370,7 @@ func (x *ListEdgesRequest) String() string {
 func (*ListEdgesRequest) ProtoMessage() {}
 
 func (x *ListEdgesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_graph_proto_msgTypes[4]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -339,7 +383,7 @@ func (x *ListEdgesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListEdgesRequest.ProtoReflect.Descriptor instead.
 func (*ListEdgesRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{4}
+	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ListEdgesRequest) GetSlug() string {
@@ -365,7 +409,7 @@ type ListEdgesResponse struct {
 
 func (x *ListEdgesResponse) Reset() {
 	*x = ListEdgesResponse{}
-	mi := &file_specgraph_v1_graph_proto_msgTypes[5]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -377,7 +421,7 @@ func (x *ListEdgesResponse) String() string {
 func (*ListEdgesResponse) ProtoMessage() {}
 
 func (x *ListEdgesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_graph_proto_msgTypes[5]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -390,7 +434,7 @@ func (x *ListEdgesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListEdgesResponse.ProtoReflect.Descriptor instead.
 func (*ListEdgesResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{5}
+	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ListEdgesResponse) GetEdges() []*Edge {
@@ -412,7 +456,7 @@ type NodeRef struct {
 
 func (x *NodeRef) Reset() {
 	*x = NodeRef{}
-	mi := &file_specgraph_v1_graph_proto_msgTypes[6]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -424,7 +468,7 @@ func (x *NodeRef) String() string {
 func (*NodeRef) ProtoMessage() {}
 
 func (x *NodeRef) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_graph_proto_msgTypes[6]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -437,7 +481,7 @@ func (x *NodeRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NodeRef.ProtoReflect.Descriptor instead.
 func (*NodeRef) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{6}
+	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *NodeRef) GetId() string {
@@ -477,7 +521,7 @@ type GetDependenciesRequest struct {
 
 func (x *GetDependenciesRequest) Reset() {
 	*x = GetDependenciesRequest{}
-	mi := &file_specgraph_v1_graph_proto_msgTypes[7]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -489,7 +533,7 @@ func (x *GetDependenciesRequest) String() string {
 func (*GetDependenciesRequest) ProtoMessage() {}
 
 func (x *GetDependenciesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_graph_proto_msgTypes[7]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -502,7 +546,7 @@ func (x *GetDependenciesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDependenciesRequest.ProtoReflect.Descriptor instead.
 func (*GetDependenciesRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{7}
+	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GetDependenciesRequest) GetSlug() string {
@@ -521,7 +565,7 @@ type GetDependenciesResponse struct {
 
 func (x *GetDependenciesResponse) Reset() {
 	*x = GetDependenciesResponse{}
-	mi := &file_specgraph_v1_graph_proto_msgTypes[8]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -533,7 +577,7 @@ func (x *GetDependenciesResponse) String() string {
 func (*GetDependenciesResponse) ProtoMessage() {}
 
 func (x *GetDependenciesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_graph_proto_msgTypes[8]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -546,7 +590,7 @@ func (x *GetDependenciesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDependenciesResponse.ProtoReflect.Descriptor instead.
 func (*GetDependenciesResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{8}
+	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *GetDependenciesResponse) GetDependencies() []*NodeRef {
@@ -565,7 +609,7 @@ type GetTransitiveDepsRequest struct {
 
 func (x *GetTransitiveDepsRequest) Reset() {
 	*x = GetTransitiveDepsRequest{}
-	mi := &file_specgraph_v1_graph_proto_msgTypes[9]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -577,7 +621,7 @@ func (x *GetTransitiveDepsRequest) String() string {
 func (*GetTransitiveDepsRequest) ProtoMessage() {}
 
 func (x *GetTransitiveDepsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_graph_proto_msgTypes[9]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -590,7 +634,7 @@ func (x *GetTransitiveDepsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTransitiveDepsRequest.ProtoReflect.Descriptor instead.
 func (*GetTransitiveDepsRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{9}
+	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *GetTransitiveDepsRequest) GetSlug() string {
@@ -609,7 +653,7 @@ type GetTransitiveDepsResponse struct {
 
 func (x *GetTransitiveDepsResponse) Reset() {
 	*x = GetTransitiveDepsResponse{}
-	mi := &file_specgraph_v1_graph_proto_msgTypes[10]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -621,7 +665,7 @@ func (x *GetTransitiveDepsResponse) String() string {
 func (*GetTransitiveDepsResponse) ProtoMessage() {}
 
 func (x *GetTransitiveDepsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_graph_proto_msgTypes[10]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -634,7 +678,7 @@ func (x *GetTransitiveDepsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTransitiveDepsResponse.ProtoReflect.Descriptor instead.
 func (*GetTransitiveDepsResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{10}
+	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *GetTransitiveDepsResponse) GetDependencies() []*NodeRef {
@@ -653,7 +697,7 @@ type GetImpactRequest struct {
 
 func (x *GetImpactRequest) Reset() {
 	*x = GetImpactRequest{}
-	mi := &file_specgraph_v1_graph_proto_msgTypes[11]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -665,7 +709,7 @@ func (x *GetImpactRequest) String() string {
 func (*GetImpactRequest) ProtoMessage() {}
 
 func (x *GetImpactRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_graph_proto_msgTypes[11]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -678,7 +722,7 @@ func (x *GetImpactRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetImpactRequest.ProtoReflect.Descriptor instead.
 func (*GetImpactRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{11}
+	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *GetImpactRequest) GetSlug() string {
@@ -697,7 +741,7 @@ type GetImpactResponse struct {
 
 func (x *GetImpactResponse) Reset() {
 	*x = GetImpactResponse{}
-	mi := &file_specgraph_v1_graph_proto_msgTypes[12]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -709,7 +753,7 @@ func (x *GetImpactResponse) String() string {
 func (*GetImpactResponse) ProtoMessage() {}
 
 func (x *GetImpactResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_graph_proto_msgTypes[12]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -722,7 +766,7 @@ func (x *GetImpactResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetImpactResponse.ProtoReflect.Descriptor instead.
 func (*GetImpactResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{12}
+	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *GetImpactResponse) GetImpacted() []*NodeRef {
@@ -740,7 +784,7 @@ type GetReadyRequest struct {
 
 func (x *GetReadyRequest) Reset() {
 	*x = GetReadyRequest{}
-	mi := &file_specgraph_v1_graph_proto_msgTypes[13]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -752,7 +796,7 @@ func (x *GetReadyRequest) String() string {
 func (*GetReadyRequest) ProtoMessage() {}
 
 func (x *GetReadyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_graph_proto_msgTypes[13]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -765,7 +809,7 @@ func (x *GetReadyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetReadyRequest.ProtoReflect.Descriptor instead.
 func (*GetReadyRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{13}
+	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{14}
 }
 
 type GetReadyResponse struct {
@@ -777,7 +821,7 @@ type GetReadyResponse struct {
 
 func (x *GetReadyResponse) Reset() {
 	*x = GetReadyResponse{}
-	mi := &file_specgraph_v1_graph_proto_msgTypes[14]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -789,7 +833,7 @@ func (x *GetReadyResponse) String() string {
 func (*GetReadyResponse) ProtoMessage() {}
 
 func (x *GetReadyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_graph_proto_msgTypes[14]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -802,7 +846,7 @@ func (x *GetReadyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetReadyResponse.ProtoReflect.Descriptor instead.
 func (*GetReadyResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{14}
+	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *GetReadyResponse) GetReady() []*NodeRef {
@@ -821,7 +865,7 @@ type GetCriticalPathRequest struct {
 
 func (x *GetCriticalPathRequest) Reset() {
 	*x = GetCriticalPathRequest{}
-	mi := &file_specgraph_v1_graph_proto_msgTypes[15]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -833,7 +877,7 @@ func (x *GetCriticalPathRequest) String() string {
 func (*GetCriticalPathRequest) ProtoMessage() {}
 
 func (x *GetCriticalPathRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_graph_proto_msgTypes[15]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -846,7 +890,7 @@ func (x *GetCriticalPathRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCriticalPathRequest.ProtoReflect.Descriptor instead.
 func (*GetCriticalPathRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{15}
+	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GetCriticalPathRequest) GetSlug() string {
@@ -865,7 +909,7 @@ type GetCriticalPathResponse struct {
 
 func (x *GetCriticalPathResponse) Reset() {
 	*x = GetCriticalPathResponse{}
-	mi := &file_specgraph_v1_graph_proto_msgTypes[16]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -877,7 +921,7 @@ func (x *GetCriticalPathResponse) String() string {
 func (*GetCriticalPathResponse) ProtoMessage() {}
 
 func (x *GetCriticalPathResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_graph_proto_msgTypes[16]
+	mi := &file_specgraph_v1_graph_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -890,7 +934,7 @@ func (x *GetCriticalPathResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCriticalPathResponse.ProtoReflect.Descriptor instead.
 func (*GetCriticalPathResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{16}
+	return file_specgraph_v1_graph_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GetCriticalPathResponse) GetPath() []*NodeRef {
@@ -912,7 +956,9 @@ const file_specgraph_v1_graph_proto_rawDesc = "" +
 	"\x0eAddEdgeRequest\x12\x1b\n" +
 	"\tfrom_slug\x18\x01 \x01(\tR\bfromSlug\x12\x17\n" +
 	"\ato_slug\x18\x02 \x01(\tR\x06toSlug\x123\n" +
-	"\tedge_type\x18\x03 \x01(\x0e2\x16.specgraph.v1.EdgeTypeR\bedgeType\"~\n" +
+	"\tedge_type\x18\x03 \x01(\x0e2\x16.specgraph.v1.EdgeTypeR\bedgeType\"9\n" +
+	"\x0fAddEdgeResponse\x12&\n" +
+	"\x04edge\x18\x01 \x01(\v2\x12.specgraph.v1.EdgeR\x04edge\"~\n" +
 	"\x11RemoveEdgeRequest\x12\x1b\n" +
 	"\tfrom_slug\x18\x01 \x01(\tR\bfromSlug\x12\x17\n" +
 	"\ato_slug\x18\x02 \x01(\tR\x06toSlug\x123\n" +
@@ -955,9 +1001,9 @@ const file_specgraph_v1_graph_proto_rawDesc = "" +
 	"\x14EDGE_TYPE_RELATES_TO\x10\x04\x12\x15\n" +
 	"\x11EDGE_TYPE_INFORMS\x10\x05\x12\x18\n" +
 	"\x14EDGE_TYPE_DECIDED_IN\x10\x06\x12\x18\n" +
-	"\x14EDGE_TYPE_SUPERSEDES\x10\a2\xa9\x05\n" +
-	"\fGraphService\x12;\n" +
-	"\aAddEdge\x12\x1c.specgraph.v1.AddEdgeRequest\x1a\x12.specgraph.v1.Edge\x12O\n" +
+	"\x14EDGE_TYPE_SUPERSEDES\x10\a2\xb4\x05\n" +
+	"\fGraphService\x12F\n" +
+	"\aAddEdge\x12\x1c.specgraph.v1.AddEdgeRequest\x1a\x1d.specgraph.v1.AddEdgeResponse\x12O\n" +
 	"\n" +
 	"RemoveEdge\x12\x1f.specgraph.v1.RemoveEdgeRequest\x1a .specgraph.v1.RemoveEdgeResponse\x12L\n" +
 	"\tListEdges\x12\x1e.specgraph.v1.ListEdgesRequest\x1a\x1f.specgraph.v1.ListEdgesResponse\x12^\n" +
@@ -980,59 +1026,61 @@ func file_specgraph_v1_graph_proto_rawDescGZIP() []byte {
 }
 
 var file_specgraph_v1_graph_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_specgraph_v1_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_specgraph_v1_graph_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_specgraph_v1_graph_proto_goTypes = []any{
 	(EdgeType)(0),                     // 0: specgraph.v1.EdgeType
 	(*Edge)(nil),                      // 1: specgraph.v1.Edge
 	(*AddEdgeRequest)(nil),            // 2: specgraph.v1.AddEdgeRequest
-	(*RemoveEdgeRequest)(nil),         // 3: specgraph.v1.RemoveEdgeRequest
-	(*RemoveEdgeResponse)(nil),        // 4: specgraph.v1.RemoveEdgeResponse
-	(*ListEdgesRequest)(nil),          // 5: specgraph.v1.ListEdgesRequest
-	(*ListEdgesResponse)(nil),         // 6: specgraph.v1.ListEdgesResponse
-	(*NodeRef)(nil),                   // 7: specgraph.v1.NodeRef
-	(*GetDependenciesRequest)(nil),    // 8: specgraph.v1.GetDependenciesRequest
-	(*GetDependenciesResponse)(nil),   // 9: specgraph.v1.GetDependenciesResponse
-	(*GetTransitiveDepsRequest)(nil),  // 10: specgraph.v1.GetTransitiveDepsRequest
-	(*GetTransitiveDepsResponse)(nil), // 11: specgraph.v1.GetTransitiveDepsResponse
-	(*GetImpactRequest)(nil),          // 12: specgraph.v1.GetImpactRequest
-	(*GetImpactResponse)(nil),         // 13: specgraph.v1.GetImpactResponse
-	(*GetReadyRequest)(nil),           // 14: specgraph.v1.GetReadyRequest
-	(*GetReadyResponse)(nil),          // 15: specgraph.v1.GetReadyResponse
-	(*GetCriticalPathRequest)(nil),    // 16: specgraph.v1.GetCriticalPathRequest
-	(*GetCriticalPathResponse)(nil),   // 17: specgraph.v1.GetCriticalPathResponse
+	(*AddEdgeResponse)(nil),           // 3: specgraph.v1.AddEdgeResponse
+	(*RemoveEdgeRequest)(nil),         // 4: specgraph.v1.RemoveEdgeRequest
+	(*RemoveEdgeResponse)(nil),        // 5: specgraph.v1.RemoveEdgeResponse
+	(*ListEdgesRequest)(nil),          // 6: specgraph.v1.ListEdgesRequest
+	(*ListEdgesResponse)(nil),         // 7: specgraph.v1.ListEdgesResponse
+	(*NodeRef)(nil),                   // 8: specgraph.v1.NodeRef
+	(*GetDependenciesRequest)(nil),    // 9: specgraph.v1.GetDependenciesRequest
+	(*GetDependenciesResponse)(nil),   // 10: specgraph.v1.GetDependenciesResponse
+	(*GetTransitiveDepsRequest)(nil),  // 11: specgraph.v1.GetTransitiveDepsRequest
+	(*GetTransitiveDepsResponse)(nil), // 12: specgraph.v1.GetTransitiveDepsResponse
+	(*GetImpactRequest)(nil),          // 13: specgraph.v1.GetImpactRequest
+	(*GetImpactResponse)(nil),         // 14: specgraph.v1.GetImpactResponse
+	(*GetReadyRequest)(nil),           // 15: specgraph.v1.GetReadyRequest
+	(*GetReadyResponse)(nil),          // 16: specgraph.v1.GetReadyResponse
+	(*GetCriticalPathRequest)(nil),    // 17: specgraph.v1.GetCriticalPathRequest
+	(*GetCriticalPathResponse)(nil),   // 18: specgraph.v1.GetCriticalPathResponse
 }
 var file_specgraph_v1_graph_proto_depIdxs = []int32{
 	0,  // 0: specgraph.v1.Edge.edge_type:type_name -> specgraph.v1.EdgeType
 	0,  // 1: specgraph.v1.AddEdgeRequest.edge_type:type_name -> specgraph.v1.EdgeType
-	0,  // 2: specgraph.v1.RemoveEdgeRequest.edge_type:type_name -> specgraph.v1.EdgeType
-	0,  // 3: specgraph.v1.ListEdgesRequest.edge_type:type_name -> specgraph.v1.EdgeType
-	1,  // 4: specgraph.v1.ListEdgesResponse.edges:type_name -> specgraph.v1.Edge
-	7,  // 5: specgraph.v1.GetDependenciesResponse.dependencies:type_name -> specgraph.v1.NodeRef
-	7,  // 6: specgraph.v1.GetTransitiveDepsResponse.dependencies:type_name -> specgraph.v1.NodeRef
-	7,  // 7: specgraph.v1.GetImpactResponse.impacted:type_name -> specgraph.v1.NodeRef
-	7,  // 8: specgraph.v1.GetReadyResponse.ready:type_name -> specgraph.v1.NodeRef
-	7,  // 9: specgraph.v1.GetCriticalPathResponse.path:type_name -> specgraph.v1.NodeRef
-	2,  // 10: specgraph.v1.GraphService.AddEdge:input_type -> specgraph.v1.AddEdgeRequest
-	3,  // 11: specgraph.v1.GraphService.RemoveEdge:input_type -> specgraph.v1.RemoveEdgeRequest
-	5,  // 12: specgraph.v1.GraphService.ListEdges:input_type -> specgraph.v1.ListEdgesRequest
-	8,  // 13: specgraph.v1.GraphService.GetDependencies:input_type -> specgraph.v1.GetDependenciesRequest
-	10, // 14: specgraph.v1.GraphService.GetTransitiveDeps:input_type -> specgraph.v1.GetTransitiveDepsRequest
-	12, // 15: specgraph.v1.GraphService.GetImpact:input_type -> specgraph.v1.GetImpactRequest
-	14, // 16: specgraph.v1.GraphService.GetReady:input_type -> specgraph.v1.GetReadyRequest
-	16, // 17: specgraph.v1.GraphService.GetCriticalPath:input_type -> specgraph.v1.GetCriticalPathRequest
-	1,  // 18: specgraph.v1.GraphService.AddEdge:output_type -> specgraph.v1.Edge
-	4,  // 19: specgraph.v1.GraphService.RemoveEdge:output_type -> specgraph.v1.RemoveEdgeResponse
-	6,  // 20: specgraph.v1.GraphService.ListEdges:output_type -> specgraph.v1.ListEdgesResponse
-	9,  // 21: specgraph.v1.GraphService.GetDependencies:output_type -> specgraph.v1.GetDependenciesResponse
-	11, // 22: specgraph.v1.GraphService.GetTransitiveDeps:output_type -> specgraph.v1.GetTransitiveDepsResponse
-	13, // 23: specgraph.v1.GraphService.GetImpact:output_type -> specgraph.v1.GetImpactResponse
-	15, // 24: specgraph.v1.GraphService.GetReady:output_type -> specgraph.v1.GetReadyResponse
-	17, // 25: specgraph.v1.GraphService.GetCriticalPath:output_type -> specgraph.v1.GetCriticalPathResponse
-	18, // [18:26] is the sub-list for method output_type
-	10, // [10:18] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	1,  // 2: specgraph.v1.AddEdgeResponse.edge:type_name -> specgraph.v1.Edge
+	0,  // 3: specgraph.v1.RemoveEdgeRequest.edge_type:type_name -> specgraph.v1.EdgeType
+	0,  // 4: specgraph.v1.ListEdgesRequest.edge_type:type_name -> specgraph.v1.EdgeType
+	1,  // 5: specgraph.v1.ListEdgesResponse.edges:type_name -> specgraph.v1.Edge
+	8,  // 6: specgraph.v1.GetDependenciesResponse.dependencies:type_name -> specgraph.v1.NodeRef
+	8,  // 7: specgraph.v1.GetTransitiveDepsResponse.dependencies:type_name -> specgraph.v1.NodeRef
+	8,  // 8: specgraph.v1.GetImpactResponse.impacted:type_name -> specgraph.v1.NodeRef
+	8,  // 9: specgraph.v1.GetReadyResponse.ready:type_name -> specgraph.v1.NodeRef
+	8,  // 10: specgraph.v1.GetCriticalPathResponse.path:type_name -> specgraph.v1.NodeRef
+	2,  // 11: specgraph.v1.GraphService.AddEdge:input_type -> specgraph.v1.AddEdgeRequest
+	4,  // 12: specgraph.v1.GraphService.RemoveEdge:input_type -> specgraph.v1.RemoveEdgeRequest
+	6,  // 13: specgraph.v1.GraphService.ListEdges:input_type -> specgraph.v1.ListEdgesRequest
+	9,  // 14: specgraph.v1.GraphService.GetDependencies:input_type -> specgraph.v1.GetDependenciesRequest
+	11, // 15: specgraph.v1.GraphService.GetTransitiveDeps:input_type -> specgraph.v1.GetTransitiveDepsRequest
+	13, // 16: specgraph.v1.GraphService.GetImpact:input_type -> specgraph.v1.GetImpactRequest
+	15, // 17: specgraph.v1.GraphService.GetReady:input_type -> specgraph.v1.GetReadyRequest
+	17, // 18: specgraph.v1.GraphService.GetCriticalPath:input_type -> specgraph.v1.GetCriticalPathRequest
+	3,  // 19: specgraph.v1.GraphService.AddEdge:output_type -> specgraph.v1.AddEdgeResponse
+	5,  // 20: specgraph.v1.GraphService.RemoveEdge:output_type -> specgraph.v1.RemoveEdgeResponse
+	7,  // 21: specgraph.v1.GraphService.ListEdges:output_type -> specgraph.v1.ListEdgesResponse
+	10, // 22: specgraph.v1.GraphService.GetDependencies:output_type -> specgraph.v1.GetDependenciesResponse
+	12, // 23: specgraph.v1.GraphService.GetTransitiveDeps:output_type -> specgraph.v1.GetTransitiveDepsResponse
+	14, // 24: specgraph.v1.GraphService.GetImpact:output_type -> specgraph.v1.GetImpactResponse
+	16, // 25: specgraph.v1.GraphService.GetReady:output_type -> specgraph.v1.GetReadyResponse
+	18, // 26: specgraph.v1.GraphService.GetCriticalPath:output_type -> specgraph.v1.GetCriticalPathResponse
+	19, // [19:27] is the sub-list for method output_type
+	11, // [11:19] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_specgraph_v1_graph_proto_init() }
@@ -1046,7 +1094,7 @@ func file_specgraph_v1_graph_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_specgraph_v1_graph_proto_rawDesc), len(file_specgraph_v1_graph_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   17,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/specgraph/v1/spec.pb.go
+++ b/gen/specgraph/v1/spec.pb.go
@@ -582,6 +582,138 @@ func (x *UpdateSpecRequest) GetNotes() string {
 	return ""
 }
 
+type CreateSpecResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Spec          *Spec                  `protobuf:"bytes,1,opt,name=spec,proto3" json:"spec,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateSpecResponse) Reset() {
+	*x = CreateSpecResponse{}
+	mi := &file_specgraph_v1_spec_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateSpecResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateSpecResponse) ProtoMessage() {}
+
+func (x *CreateSpecResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_specgraph_v1_spec_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateSpecResponse.ProtoReflect.Descriptor instead.
+func (*CreateSpecResponse) Descriptor() ([]byte, []int) {
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *CreateSpecResponse) GetSpec() *Spec {
+	if x != nil {
+		return x.Spec
+	}
+	return nil
+}
+
+type GetSpecResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Spec          *Spec                  `protobuf:"bytes,1,opt,name=spec,proto3" json:"spec,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSpecResponse) Reset() {
+	*x = GetSpecResponse{}
+	mi := &file_specgraph_v1_spec_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSpecResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSpecResponse) ProtoMessage() {}
+
+func (x *GetSpecResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_specgraph_v1_spec_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSpecResponse.ProtoReflect.Descriptor instead.
+func (*GetSpecResponse) Descriptor() ([]byte, []int) {
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *GetSpecResponse) GetSpec() *Spec {
+	if x != nil {
+		return x.Spec
+	}
+	return nil
+}
+
+type UpdateSpecResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Spec          *Spec                  `protobuf:"bytes,1,opt,name=spec,proto3" json:"spec,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateSpecResponse) Reset() {
+	*x = UpdateSpecResponse{}
+	mi := &file_specgraph_v1_spec_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateSpecResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateSpecResponse) ProtoMessage() {}
+
+func (x *UpdateSpecResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_specgraph_v1_spec_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateSpecResponse.ProtoReflect.Descriptor instead.
+func (*UpdateSpecResponse) Descriptor() ([]byte, []int) {
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *UpdateSpecResponse) GetSpec() *Spec {
+	if x != nil {
+		return x.Spec
+	}
+	return nil
+}
+
 var File_specgraph_v1_spec_proto protoreflect.FileDescriptor
 
 const file_specgraph_v1_spec_proto_rawDesc = "" +
@@ -641,18 +773,24 @@ const file_specgraph_v1_spec_proto_rawDesc = "" +
 	"\x06_stageB\v\n" +
 	"\t_priorityB\r\n" +
 	"\v_complexityB\b\n" +
-	"\x06_notes*c\n" +
+	"\x06_notes\"<\n" +
+	"\x12CreateSpecResponse\x12&\n" +
+	"\x04spec\x18\x01 \x01(\v2\x12.specgraph.v1.SpecR\x04spec\"9\n" +
+	"\x0fGetSpecResponse\x12&\n" +
+	"\x04spec\x18\x01 \x01(\v2\x12.specgraph.v1.SpecR\x04spec\"<\n" +
+	"\x12UpdateSpecResponse\x12&\n" +
+	"\x04spec\x18\x01 \x01(\v2\x12.specgraph.v1.SpecR\x04spec*c\n" +
 	"\rSpecLifecycle\x12\x1e\n" +
 	"\x1aSPEC_LIFECYCLE_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13SPEC_LIFECYCLE_TASK\x10\x01\x12\x19\n" +
-	"\x15SPEC_LIFECYCLE_LIVING\x10\x022\x9e\x02\n" +
-	"\vSpecService\x12A\n" +
+	"\x15SPEC_LIFECYCLE_LIVING\x10\x022\xc5\x02\n" +
+	"\vSpecService\x12O\n" +
 	"\n" +
-	"CreateSpec\x12\x1f.specgraph.v1.CreateSpecRequest\x1a\x12.specgraph.v1.Spec\x12;\n" +
-	"\aGetSpec\x12\x1c.specgraph.v1.GetSpecRequest\x1a\x12.specgraph.v1.Spec\x12L\n" +
-	"\tListSpecs\x12\x1e.specgraph.v1.ListSpecsRequest\x1a\x1f.specgraph.v1.ListSpecsResponse\x12A\n" +
+	"CreateSpec\x12\x1f.specgraph.v1.CreateSpecRequest\x1a .specgraph.v1.CreateSpecResponse\x12F\n" +
+	"\aGetSpec\x12\x1c.specgraph.v1.GetSpecRequest\x1a\x1d.specgraph.v1.GetSpecResponse\x12L\n" +
+	"\tListSpecs\x12\x1e.specgraph.v1.ListSpecsRequest\x1a\x1f.specgraph.v1.ListSpecsResponse\x12O\n" +
 	"\n" +
-	"UpdateSpec\x12\x1f.specgraph.v1.UpdateSpecRequest\x1a\x12.specgraph.v1.SpecB=Z;github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
+	"UpdateSpec\x12\x1f.specgraph.v1.UpdateSpecRequest\x1a .specgraph.v1.UpdateSpecResponseB=Z;github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1b\x06proto3"
 
 var (
 	file_specgraph_v1_spec_proto_rawDescOnce sync.Once
@@ -667,7 +805,7 @@ func file_specgraph_v1_spec_proto_rawDescGZIP() []byte {
 }
 
 var file_specgraph_v1_spec_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_specgraph_v1_spec_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_specgraph_v1_spec_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_specgraph_v1_spec_proto_goTypes = []any{
 	(SpecLifecycle)(0),            // 0: specgraph.v1.SpecLifecycle
 	(*Spec)(nil),                  // 1: specgraph.v1.Spec
@@ -677,26 +815,32 @@ var file_specgraph_v1_spec_proto_goTypes = []any{
 	(*ListSpecsRequest)(nil),      // 5: specgraph.v1.ListSpecsRequest
 	(*ListSpecsResponse)(nil),     // 6: specgraph.v1.ListSpecsResponse
 	(*UpdateSpecRequest)(nil),     // 7: specgraph.v1.UpdateSpecRequest
-	(*timestamppb.Timestamp)(nil), // 8: google.protobuf.Timestamp
+	(*CreateSpecResponse)(nil),    // 8: specgraph.v1.CreateSpecResponse
+	(*GetSpecResponse)(nil),       // 9: specgraph.v1.GetSpecResponse
+	(*UpdateSpecResponse)(nil),    // 10: specgraph.v1.UpdateSpecResponse
+	(*timestamppb.Timestamp)(nil), // 11: google.protobuf.Timestamp
 }
 var file_specgraph_v1_spec_proto_depIdxs = []int32{
-	8, // 0: specgraph.v1.Spec.created_at:type_name -> google.protobuf.Timestamp
-	8, // 1: specgraph.v1.Spec.updated_at:type_name -> google.protobuf.Timestamp
-	0, // 2: specgraph.v1.Spec.lifecycle:type_name -> specgraph.v1.SpecLifecycle
-	1, // 3: specgraph.v1.ListSpecsResponse.specs:type_name -> specgraph.v1.Spec
-	3, // 4: specgraph.v1.SpecService.CreateSpec:input_type -> specgraph.v1.CreateSpecRequest
-	4, // 5: specgraph.v1.SpecService.GetSpec:input_type -> specgraph.v1.GetSpecRequest
-	5, // 6: specgraph.v1.SpecService.ListSpecs:input_type -> specgraph.v1.ListSpecsRequest
-	7, // 7: specgraph.v1.SpecService.UpdateSpec:input_type -> specgraph.v1.UpdateSpecRequest
-	1, // 8: specgraph.v1.SpecService.CreateSpec:output_type -> specgraph.v1.Spec
-	1, // 9: specgraph.v1.SpecService.GetSpec:output_type -> specgraph.v1.Spec
-	6, // 10: specgraph.v1.SpecService.ListSpecs:output_type -> specgraph.v1.ListSpecsResponse
-	1, // 11: specgraph.v1.SpecService.UpdateSpec:output_type -> specgraph.v1.Spec
-	8, // [8:12] is the sub-list for method output_type
-	4, // [4:8] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	11, // 0: specgraph.v1.Spec.created_at:type_name -> google.protobuf.Timestamp
+	11, // 1: specgraph.v1.Spec.updated_at:type_name -> google.protobuf.Timestamp
+	0,  // 2: specgraph.v1.Spec.lifecycle:type_name -> specgraph.v1.SpecLifecycle
+	1,  // 3: specgraph.v1.ListSpecsResponse.specs:type_name -> specgraph.v1.Spec
+	1,  // 4: specgraph.v1.CreateSpecResponse.spec:type_name -> specgraph.v1.Spec
+	1,  // 5: specgraph.v1.GetSpecResponse.spec:type_name -> specgraph.v1.Spec
+	1,  // 6: specgraph.v1.UpdateSpecResponse.spec:type_name -> specgraph.v1.Spec
+	3,  // 7: specgraph.v1.SpecService.CreateSpec:input_type -> specgraph.v1.CreateSpecRequest
+	4,  // 8: specgraph.v1.SpecService.GetSpec:input_type -> specgraph.v1.GetSpecRequest
+	5,  // 9: specgraph.v1.SpecService.ListSpecs:input_type -> specgraph.v1.ListSpecsRequest
+	7,  // 10: specgraph.v1.SpecService.UpdateSpec:input_type -> specgraph.v1.UpdateSpecRequest
+	8,  // 11: specgraph.v1.SpecService.CreateSpec:output_type -> specgraph.v1.CreateSpecResponse
+	9,  // 12: specgraph.v1.SpecService.GetSpec:output_type -> specgraph.v1.GetSpecResponse
+	6,  // 13: specgraph.v1.SpecService.ListSpecs:output_type -> specgraph.v1.ListSpecsResponse
+	10, // 14: specgraph.v1.SpecService.UpdateSpec:output_type -> specgraph.v1.UpdateSpecResponse
+	11, // [11:15] is the sub-list for method output_type
+	7,  // [7:11] is the sub-list for method input_type
+	7,  // [7:7] is the sub-list for extension type_name
+	7,  // [7:7] is the sub-list for extension extendee
+	0,  // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_specgraph_v1_spec_proto_init() }
@@ -711,7 +855,7 @@ func file_specgraph_v1_spec_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_specgraph_v1_spec_proto_rawDesc), len(file_specgraph_v1_spec_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   7,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/specgraph/v1/specgraphv1connect/claim.connect.go
+++ b/gen/specgraph/v1/specgraphv1connect/claim.connect.go
@@ -47,9 +47,9 @@ const (
 
 // ClaimServiceClient is a client for the specgraph.v1.ClaimService service.
 type ClaimServiceClient interface {
-	ClaimSpec(context.Context, *connect.Request[v1.ClaimSpecRequest]) (*connect.Response[v1.Claim], error)
+	ClaimSpec(context.Context, *connect.Request[v1.ClaimSpecRequest]) (*connect.Response[v1.ClaimSpecResponse], error)
 	UnclaimSpec(context.Context, *connect.Request[v1.UnclaimSpecRequest]) (*connect.Response[v1.UnclaimSpecResponse], error)
-	Heartbeat(context.Context, *connect.Request[v1.HeartbeatRequest]) (*connect.Response[v1.Claim], error)
+	Heartbeat(context.Context, *connect.Request[v1.HeartbeatRequest]) (*connect.Response[v1.HeartbeatResponse], error)
 }
 
 // NewClaimServiceClient constructs a client for the specgraph.v1.ClaimService service. By default,
@@ -63,7 +63,7 @@ func NewClaimServiceClient(httpClient connect.HTTPClient, baseURL string, opts .
 	baseURL = strings.TrimRight(baseURL, "/")
 	claimServiceMethods := v1.File_specgraph_v1_claim_proto.Services().ByName("ClaimService").Methods()
 	return &claimServiceClient{
-		claimSpec: connect.NewClient[v1.ClaimSpecRequest, v1.Claim](
+		claimSpec: connect.NewClient[v1.ClaimSpecRequest, v1.ClaimSpecResponse](
 			httpClient,
 			baseURL+ClaimServiceClaimSpecProcedure,
 			connect.WithSchema(claimServiceMethods.ByName("ClaimSpec")),
@@ -75,7 +75,7 @@ func NewClaimServiceClient(httpClient connect.HTTPClient, baseURL string, opts .
 			connect.WithSchema(claimServiceMethods.ByName("UnclaimSpec")),
 			connect.WithClientOptions(opts...),
 		),
-		heartbeat: connect.NewClient[v1.HeartbeatRequest, v1.Claim](
+		heartbeat: connect.NewClient[v1.HeartbeatRequest, v1.HeartbeatResponse](
 			httpClient,
 			baseURL+ClaimServiceHeartbeatProcedure,
 			connect.WithSchema(claimServiceMethods.ByName("Heartbeat")),
@@ -86,13 +86,13 @@ func NewClaimServiceClient(httpClient connect.HTTPClient, baseURL string, opts .
 
 // claimServiceClient implements ClaimServiceClient.
 type claimServiceClient struct {
-	claimSpec   *connect.Client[v1.ClaimSpecRequest, v1.Claim]
+	claimSpec   *connect.Client[v1.ClaimSpecRequest, v1.ClaimSpecResponse]
 	unclaimSpec *connect.Client[v1.UnclaimSpecRequest, v1.UnclaimSpecResponse]
-	heartbeat   *connect.Client[v1.HeartbeatRequest, v1.Claim]
+	heartbeat   *connect.Client[v1.HeartbeatRequest, v1.HeartbeatResponse]
 }
 
 // ClaimSpec calls specgraph.v1.ClaimService.ClaimSpec.
-func (c *claimServiceClient) ClaimSpec(ctx context.Context, req *connect.Request[v1.ClaimSpecRequest]) (*connect.Response[v1.Claim], error) {
+func (c *claimServiceClient) ClaimSpec(ctx context.Context, req *connect.Request[v1.ClaimSpecRequest]) (*connect.Response[v1.ClaimSpecResponse], error) {
 	return c.claimSpec.CallUnary(ctx, req)
 }
 
@@ -102,15 +102,15 @@ func (c *claimServiceClient) UnclaimSpec(ctx context.Context, req *connect.Reque
 }
 
 // Heartbeat calls specgraph.v1.ClaimService.Heartbeat.
-func (c *claimServiceClient) Heartbeat(ctx context.Context, req *connect.Request[v1.HeartbeatRequest]) (*connect.Response[v1.Claim], error) {
+func (c *claimServiceClient) Heartbeat(ctx context.Context, req *connect.Request[v1.HeartbeatRequest]) (*connect.Response[v1.HeartbeatResponse], error) {
 	return c.heartbeat.CallUnary(ctx, req)
 }
 
 // ClaimServiceHandler is an implementation of the specgraph.v1.ClaimService service.
 type ClaimServiceHandler interface {
-	ClaimSpec(context.Context, *connect.Request[v1.ClaimSpecRequest]) (*connect.Response[v1.Claim], error)
+	ClaimSpec(context.Context, *connect.Request[v1.ClaimSpecRequest]) (*connect.Response[v1.ClaimSpecResponse], error)
 	UnclaimSpec(context.Context, *connect.Request[v1.UnclaimSpecRequest]) (*connect.Response[v1.UnclaimSpecResponse], error)
-	Heartbeat(context.Context, *connect.Request[v1.HeartbeatRequest]) (*connect.Response[v1.Claim], error)
+	Heartbeat(context.Context, *connect.Request[v1.HeartbeatRequest]) (*connect.Response[v1.HeartbeatResponse], error)
 }
 
 // NewClaimServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -155,7 +155,7 @@ func NewClaimServiceHandler(svc ClaimServiceHandler, opts ...connect.HandlerOpti
 // UnimplementedClaimServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedClaimServiceHandler struct{}
 
-func (UnimplementedClaimServiceHandler) ClaimSpec(context.Context, *connect.Request[v1.ClaimSpecRequest]) (*connect.Response[v1.Claim], error) {
+func (UnimplementedClaimServiceHandler) ClaimSpec(context.Context, *connect.Request[v1.ClaimSpecRequest]) (*connect.Response[v1.ClaimSpecResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("specgraph.v1.ClaimService.ClaimSpec is not implemented"))
 }
 
@@ -163,6 +163,6 @@ func (UnimplementedClaimServiceHandler) UnclaimSpec(context.Context, *connect.Re
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("specgraph.v1.ClaimService.UnclaimSpec is not implemented"))
 }
 
-func (UnimplementedClaimServiceHandler) Heartbeat(context.Context, *connect.Request[v1.HeartbeatRequest]) (*connect.Response[v1.Claim], error) {
+func (UnimplementedClaimServiceHandler) Heartbeat(context.Context, *connect.Request[v1.HeartbeatRequest]) (*connect.Response[v1.HeartbeatResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("specgraph.v1.ClaimService.Heartbeat is not implemented"))
 }

--- a/gen/specgraph/v1/specgraphv1connect/decision.connect.go
+++ b/gen/specgraph/v1/specgraphv1connect/decision.connect.go
@@ -52,10 +52,10 @@ const (
 
 // DecisionServiceClient is a client for the specgraph.v1.DecisionService service.
 type DecisionServiceClient interface {
-	CreateDecision(context.Context, *connect.Request[v1.CreateDecisionRequest]) (*connect.Response[v1.Decision], error)
-	GetDecision(context.Context, *connect.Request[v1.GetDecisionRequest]) (*connect.Response[v1.Decision], error)
+	CreateDecision(context.Context, *connect.Request[v1.CreateDecisionRequest]) (*connect.Response[v1.CreateDecisionResponse], error)
+	GetDecision(context.Context, *connect.Request[v1.GetDecisionRequest]) (*connect.Response[v1.GetDecisionResponse], error)
 	ListDecisions(context.Context, *connect.Request[v1.ListDecisionsRequest]) (*connect.Response[v1.ListDecisionsResponse], error)
-	UpdateDecision(context.Context, *connect.Request[v1.UpdateDecisionRequest]) (*connect.Response[v1.Decision], error)
+	UpdateDecision(context.Context, *connect.Request[v1.UpdateDecisionRequest]) (*connect.Response[v1.UpdateDecisionResponse], error)
 }
 
 // NewDecisionServiceClient constructs a client for the specgraph.v1.DecisionService service. By
@@ -69,13 +69,13 @@ func NewDecisionServiceClient(httpClient connect.HTTPClient, baseURL string, opt
 	baseURL = strings.TrimRight(baseURL, "/")
 	decisionServiceMethods := v1.File_specgraph_v1_decision_proto.Services().ByName("DecisionService").Methods()
 	return &decisionServiceClient{
-		createDecision: connect.NewClient[v1.CreateDecisionRequest, v1.Decision](
+		createDecision: connect.NewClient[v1.CreateDecisionRequest, v1.CreateDecisionResponse](
 			httpClient,
 			baseURL+DecisionServiceCreateDecisionProcedure,
 			connect.WithSchema(decisionServiceMethods.ByName("CreateDecision")),
 			connect.WithClientOptions(opts...),
 		),
-		getDecision: connect.NewClient[v1.GetDecisionRequest, v1.Decision](
+		getDecision: connect.NewClient[v1.GetDecisionRequest, v1.GetDecisionResponse](
 			httpClient,
 			baseURL+DecisionServiceGetDecisionProcedure,
 			connect.WithSchema(decisionServiceMethods.ByName("GetDecision")),
@@ -87,7 +87,7 @@ func NewDecisionServiceClient(httpClient connect.HTTPClient, baseURL string, opt
 			connect.WithSchema(decisionServiceMethods.ByName("ListDecisions")),
 			connect.WithClientOptions(opts...),
 		),
-		updateDecision: connect.NewClient[v1.UpdateDecisionRequest, v1.Decision](
+		updateDecision: connect.NewClient[v1.UpdateDecisionRequest, v1.UpdateDecisionResponse](
 			httpClient,
 			baseURL+DecisionServiceUpdateDecisionProcedure,
 			connect.WithSchema(decisionServiceMethods.ByName("UpdateDecision")),
@@ -98,19 +98,19 @@ func NewDecisionServiceClient(httpClient connect.HTTPClient, baseURL string, opt
 
 // decisionServiceClient implements DecisionServiceClient.
 type decisionServiceClient struct {
-	createDecision *connect.Client[v1.CreateDecisionRequest, v1.Decision]
-	getDecision    *connect.Client[v1.GetDecisionRequest, v1.Decision]
+	createDecision *connect.Client[v1.CreateDecisionRequest, v1.CreateDecisionResponse]
+	getDecision    *connect.Client[v1.GetDecisionRequest, v1.GetDecisionResponse]
 	listDecisions  *connect.Client[v1.ListDecisionsRequest, v1.ListDecisionsResponse]
-	updateDecision *connect.Client[v1.UpdateDecisionRequest, v1.Decision]
+	updateDecision *connect.Client[v1.UpdateDecisionRequest, v1.UpdateDecisionResponse]
 }
 
 // CreateDecision calls specgraph.v1.DecisionService.CreateDecision.
-func (c *decisionServiceClient) CreateDecision(ctx context.Context, req *connect.Request[v1.CreateDecisionRequest]) (*connect.Response[v1.Decision], error) {
+func (c *decisionServiceClient) CreateDecision(ctx context.Context, req *connect.Request[v1.CreateDecisionRequest]) (*connect.Response[v1.CreateDecisionResponse], error) {
 	return c.createDecision.CallUnary(ctx, req)
 }
 
 // GetDecision calls specgraph.v1.DecisionService.GetDecision.
-func (c *decisionServiceClient) GetDecision(ctx context.Context, req *connect.Request[v1.GetDecisionRequest]) (*connect.Response[v1.Decision], error) {
+func (c *decisionServiceClient) GetDecision(ctx context.Context, req *connect.Request[v1.GetDecisionRequest]) (*connect.Response[v1.GetDecisionResponse], error) {
 	return c.getDecision.CallUnary(ctx, req)
 }
 
@@ -120,16 +120,16 @@ func (c *decisionServiceClient) ListDecisions(ctx context.Context, req *connect.
 }
 
 // UpdateDecision calls specgraph.v1.DecisionService.UpdateDecision.
-func (c *decisionServiceClient) UpdateDecision(ctx context.Context, req *connect.Request[v1.UpdateDecisionRequest]) (*connect.Response[v1.Decision], error) {
+func (c *decisionServiceClient) UpdateDecision(ctx context.Context, req *connect.Request[v1.UpdateDecisionRequest]) (*connect.Response[v1.UpdateDecisionResponse], error) {
 	return c.updateDecision.CallUnary(ctx, req)
 }
 
 // DecisionServiceHandler is an implementation of the specgraph.v1.DecisionService service.
 type DecisionServiceHandler interface {
-	CreateDecision(context.Context, *connect.Request[v1.CreateDecisionRequest]) (*connect.Response[v1.Decision], error)
-	GetDecision(context.Context, *connect.Request[v1.GetDecisionRequest]) (*connect.Response[v1.Decision], error)
+	CreateDecision(context.Context, *connect.Request[v1.CreateDecisionRequest]) (*connect.Response[v1.CreateDecisionResponse], error)
+	GetDecision(context.Context, *connect.Request[v1.GetDecisionRequest]) (*connect.Response[v1.GetDecisionResponse], error)
 	ListDecisions(context.Context, *connect.Request[v1.ListDecisionsRequest]) (*connect.Response[v1.ListDecisionsResponse], error)
-	UpdateDecision(context.Context, *connect.Request[v1.UpdateDecisionRequest]) (*connect.Response[v1.Decision], error)
+	UpdateDecision(context.Context, *connect.Request[v1.UpdateDecisionRequest]) (*connect.Response[v1.UpdateDecisionResponse], error)
 }
 
 // NewDecisionServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -182,11 +182,11 @@ func NewDecisionServiceHandler(svc DecisionServiceHandler, opts ...connect.Handl
 // UnimplementedDecisionServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedDecisionServiceHandler struct{}
 
-func (UnimplementedDecisionServiceHandler) CreateDecision(context.Context, *connect.Request[v1.CreateDecisionRequest]) (*connect.Response[v1.Decision], error) {
+func (UnimplementedDecisionServiceHandler) CreateDecision(context.Context, *connect.Request[v1.CreateDecisionRequest]) (*connect.Response[v1.CreateDecisionResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("specgraph.v1.DecisionService.CreateDecision is not implemented"))
 }
 
-func (UnimplementedDecisionServiceHandler) GetDecision(context.Context, *connect.Request[v1.GetDecisionRequest]) (*connect.Response[v1.Decision], error) {
+func (UnimplementedDecisionServiceHandler) GetDecision(context.Context, *connect.Request[v1.GetDecisionRequest]) (*connect.Response[v1.GetDecisionResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("specgraph.v1.DecisionService.GetDecision is not implemented"))
 }
 
@@ -194,6 +194,6 @@ func (UnimplementedDecisionServiceHandler) ListDecisions(context.Context, *conne
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("specgraph.v1.DecisionService.ListDecisions is not implemented"))
 }
 
-func (UnimplementedDecisionServiceHandler) UpdateDecision(context.Context, *connect.Request[v1.UpdateDecisionRequest]) (*connect.Response[v1.Decision], error) {
+func (UnimplementedDecisionServiceHandler) UpdateDecision(context.Context, *connect.Request[v1.UpdateDecisionRequest]) (*connect.Response[v1.UpdateDecisionResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("specgraph.v1.DecisionService.UpdateDecision is not implemented"))
 }

--- a/gen/specgraph/v1/specgraphv1connect/execution.connect.go
+++ b/gen/specgraph/v1/specgraphv1connect/execution.connect.go
@@ -58,7 +58,7 @@ const (
 
 // ExecutionServiceClient is a client for the specgraph.v1.ExecutionService service.
 type ExecutionServiceClient interface {
-	GenerateBundle(context.Context, *connect.Request[v1.GenerateBundleRequest]) (*connect.Response[v1.Bundle], error)
+	GenerateBundle(context.Context, *connect.Request[v1.GenerateBundleRequest]) (*connect.Response[v1.GenerateBundleResponse], error)
 	GetPrime(context.Context, *connect.Request[v1.GetPrimeRequest]) (*connect.Response[v1.PrimeResponse], error)
 	ReportProgress(context.Context, *connect.Request[v1.ReportProgressRequest]) (*connect.Response[v1.ReportProgressResponse], error)
 	ReportBlocker(context.Context, *connect.Request[v1.ReportBlockerRequest]) (*connect.Response[v1.ReportBlockerResponse], error)
@@ -77,7 +77,7 @@ func NewExecutionServiceClient(httpClient connect.HTTPClient, baseURL string, op
 	baseURL = strings.TrimRight(baseURL, "/")
 	executionServiceMethods := v1.File_specgraph_v1_execution_proto.Services().ByName("ExecutionService").Methods()
 	return &executionServiceClient{
-		generateBundle: connect.NewClient[v1.GenerateBundleRequest, v1.Bundle](
+		generateBundle: connect.NewClient[v1.GenerateBundleRequest, v1.GenerateBundleResponse](
 			httpClient,
 			baseURL+ExecutionServiceGenerateBundleProcedure,
 			connect.WithSchema(executionServiceMethods.ByName("GenerateBundle")),
@@ -118,7 +118,7 @@ func NewExecutionServiceClient(httpClient connect.HTTPClient, baseURL string, op
 
 // executionServiceClient implements ExecutionServiceClient.
 type executionServiceClient struct {
-	generateBundle     *connect.Client[v1.GenerateBundleRequest, v1.Bundle]
+	generateBundle     *connect.Client[v1.GenerateBundleRequest, v1.GenerateBundleResponse]
 	getPrime           *connect.Client[v1.GetPrimeRequest, v1.PrimeResponse]
 	reportProgress     *connect.Client[v1.ReportProgressRequest, v1.ReportProgressResponse]
 	reportBlocker      *connect.Client[v1.ReportBlockerRequest, v1.ReportBlockerResponse]
@@ -127,7 +127,7 @@ type executionServiceClient struct {
 }
 
 // GenerateBundle calls specgraph.v1.ExecutionService.GenerateBundle.
-func (c *executionServiceClient) GenerateBundle(ctx context.Context, req *connect.Request[v1.GenerateBundleRequest]) (*connect.Response[v1.Bundle], error) {
+func (c *executionServiceClient) GenerateBundle(ctx context.Context, req *connect.Request[v1.GenerateBundleRequest]) (*connect.Response[v1.GenerateBundleResponse], error) {
 	return c.generateBundle.CallUnary(ctx, req)
 }
 
@@ -158,7 +158,7 @@ func (c *executionServiceClient) GetExecutionEvents(ctx context.Context, req *co
 
 // ExecutionServiceHandler is an implementation of the specgraph.v1.ExecutionService service.
 type ExecutionServiceHandler interface {
-	GenerateBundle(context.Context, *connect.Request[v1.GenerateBundleRequest]) (*connect.Response[v1.Bundle], error)
+	GenerateBundle(context.Context, *connect.Request[v1.GenerateBundleRequest]) (*connect.Response[v1.GenerateBundleResponse], error)
 	GetPrime(context.Context, *connect.Request[v1.GetPrimeRequest]) (*connect.Response[v1.PrimeResponse], error)
 	ReportProgress(context.Context, *connect.Request[v1.ReportProgressRequest]) (*connect.Response[v1.ReportProgressResponse], error)
 	ReportBlocker(context.Context, *connect.Request[v1.ReportBlockerRequest]) (*connect.Response[v1.ReportBlockerResponse], error)
@@ -232,7 +232,7 @@ func NewExecutionServiceHandler(svc ExecutionServiceHandler, opts ...connect.Han
 // UnimplementedExecutionServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedExecutionServiceHandler struct{}
 
-func (UnimplementedExecutionServiceHandler) GenerateBundle(context.Context, *connect.Request[v1.GenerateBundleRequest]) (*connect.Response[v1.Bundle], error) {
+func (UnimplementedExecutionServiceHandler) GenerateBundle(context.Context, *connect.Request[v1.GenerateBundleRequest]) (*connect.Response[v1.GenerateBundleResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("specgraph.v1.ExecutionService.GenerateBundle is not implemented"))
 }
 

--- a/gen/specgraph/v1/specgraphv1connect/graph.connect.go
+++ b/gen/specgraph/v1/specgraphv1connect/graph.connect.go
@@ -59,7 +59,7 @@ const (
 
 // GraphServiceClient is a client for the specgraph.v1.GraphService service.
 type GraphServiceClient interface {
-	AddEdge(context.Context, *connect.Request[v1.AddEdgeRequest]) (*connect.Response[v1.Edge], error)
+	AddEdge(context.Context, *connect.Request[v1.AddEdgeRequest]) (*connect.Response[v1.AddEdgeResponse], error)
 	RemoveEdge(context.Context, *connect.Request[v1.RemoveEdgeRequest]) (*connect.Response[v1.RemoveEdgeResponse], error)
 	ListEdges(context.Context, *connect.Request[v1.ListEdgesRequest]) (*connect.Response[v1.ListEdgesResponse], error)
 	GetDependencies(context.Context, *connect.Request[v1.GetDependenciesRequest]) (*connect.Response[v1.GetDependenciesResponse], error)
@@ -80,7 +80,7 @@ func NewGraphServiceClient(httpClient connect.HTTPClient, baseURL string, opts .
 	baseURL = strings.TrimRight(baseURL, "/")
 	graphServiceMethods := v1.File_specgraph_v1_graph_proto.Services().ByName("GraphService").Methods()
 	return &graphServiceClient{
-		addEdge: connect.NewClient[v1.AddEdgeRequest, v1.Edge](
+		addEdge: connect.NewClient[v1.AddEdgeRequest, v1.AddEdgeResponse](
 			httpClient,
 			baseURL+GraphServiceAddEdgeProcedure,
 			connect.WithSchema(graphServiceMethods.ByName("AddEdge")),
@@ -133,7 +133,7 @@ func NewGraphServiceClient(httpClient connect.HTTPClient, baseURL string, opts .
 
 // graphServiceClient implements GraphServiceClient.
 type graphServiceClient struct {
-	addEdge           *connect.Client[v1.AddEdgeRequest, v1.Edge]
+	addEdge           *connect.Client[v1.AddEdgeRequest, v1.AddEdgeResponse]
 	removeEdge        *connect.Client[v1.RemoveEdgeRequest, v1.RemoveEdgeResponse]
 	listEdges         *connect.Client[v1.ListEdgesRequest, v1.ListEdgesResponse]
 	getDependencies   *connect.Client[v1.GetDependenciesRequest, v1.GetDependenciesResponse]
@@ -144,7 +144,7 @@ type graphServiceClient struct {
 }
 
 // AddEdge calls specgraph.v1.GraphService.AddEdge.
-func (c *graphServiceClient) AddEdge(ctx context.Context, req *connect.Request[v1.AddEdgeRequest]) (*connect.Response[v1.Edge], error) {
+func (c *graphServiceClient) AddEdge(ctx context.Context, req *connect.Request[v1.AddEdgeRequest]) (*connect.Response[v1.AddEdgeResponse], error) {
 	return c.addEdge.CallUnary(ctx, req)
 }
 
@@ -185,7 +185,7 @@ func (c *graphServiceClient) GetCriticalPath(ctx context.Context, req *connect.R
 
 // GraphServiceHandler is an implementation of the specgraph.v1.GraphService service.
 type GraphServiceHandler interface {
-	AddEdge(context.Context, *connect.Request[v1.AddEdgeRequest]) (*connect.Response[v1.Edge], error)
+	AddEdge(context.Context, *connect.Request[v1.AddEdgeRequest]) (*connect.Response[v1.AddEdgeResponse], error)
 	RemoveEdge(context.Context, *connect.Request[v1.RemoveEdgeRequest]) (*connect.Response[v1.RemoveEdgeResponse], error)
 	ListEdges(context.Context, *connect.Request[v1.ListEdgesRequest]) (*connect.Response[v1.ListEdgesResponse], error)
 	GetDependencies(context.Context, *connect.Request[v1.GetDependenciesRequest]) (*connect.Response[v1.GetDependenciesResponse], error)
@@ -277,7 +277,7 @@ func NewGraphServiceHandler(svc GraphServiceHandler, opts ...connect.HandlerOpti
 // UnimplementedGraphServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedGraphServiceHandler struct{}
 
-func (UnimplementedGraphServiceHandler) AddEdge(context.Context, *connect.Request[v1.AddEdgeRequest]) (*connect.Response[v1.Edge], error) {
+func (UnimplementedGraphServiceHandler) AddEdge(context.Context, *connect.Request[v1.AddEdgeRequest]) (*connect.Response[v1.AddEdgeResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("specgraph.v1.GraphService.AddEdge is not implemented"))
 }
 

--- a/gen/specgraph/v1/specgraphv1connect/spec.connect.go
+++ b/gen/specgraph/v1/specgraphv1connect/spec.connect.go
@@ -48,10 +48,10 @@ const (
 
 // SpecServiceClient is a client for the specgraph.v1.SpecService service.
 type SpecServiceClient interface {
-	CreateSpec(context.Context, *connect.Request[v1.CreateSpecRequest]) (*connect.Response[v1.Spec], error)
-	GetSpec(context.Context, *connect.Request[v1.GetSpecRequest]) (*connect.Response[v1.Spec], error)
+	CreateSpec(context.Context, *connect.Request[v1.CreateSpecRequest]) (*connect.Response[v1.CreateSpecResponse], error)
+	GetSpec(context.Context, *connect.Request[v1.GetSpecRequest]) (*connect.Response[v1.GetSpecResponse], error)
 	ListSpecs(context.Context, *connect.Request[v1.ListSpecsRequest]) (*connect.Response[v1.ListSpecsResponse], error)
-	UpdateSpec(context.Context, *connect.Request[v1.UpdateSpecRequest]) (*connect.Response[v1.Spec], error)
+	UpdateSpec(context.Context, *connect.Request[v1.UpdateSpecRequest]) (*connect.Response[v1.UpdateSpecResponse], error)
 }
 
 // NewSpecServiceClient constructs a client for the specgraph.v1.SpecService service. By default, it
@@ -65,13 +65,13 @@ func NewSpecServiceClient(httpClient connect.HTTPClient, baseURL string, opts ..
 	baseURL = strings.TrimRight(baseURL, "/")
 	specServiceMethods := v1.File_specgraph_v1_spec_proto.Services().ByName("SpecService").Methods()
 	return &specServiceClient{
-		createSpec: connect.NewClient[v1.CreateSpecRequest, v1.Spec](
+		createSpec: connect.NewClient[v1.CreateSpecRequest, v1.CreateSpecResponse](
 			httpClient,
 			baseURL+SpecServiceCreateSpecProcedure,
 			connect.WithSchema(specServiceMethods.ByName("CreateSpec")),
 			connect.WithClientOptions(opts...),
 		),
-		getSpec: connect.NewClient[v1.GetSpecRequest, v1.Spec](
+		getSpec: connect.NewClient[v1.GetSpecRequest, v1.GetSpecResponse](
 			httpClient,
 			baseURL+SpecServiceGetSpecProcedure,
 			connect.WithSchema(specServiceMethods.ByName("GetSpec")),
@@ -83,7 +83,7 @@ func NewSpecServiceClient(httpClient connect.HTTPClient, baseURL string, opts ..
 			connect.WithSchema(specServiceMethods.ByName("ListSpecs")),
 			connect.WithClientOptions(opts...),
 		),
-		updateSpec: connect.NewClient[v1.UpdateSpecRequest, v1.Spec](
+		updateSpec: connect.NewClient[v1.UpdateSpecRequest, v1.UpdateSpecResponse](
 			httpClient,
 			baseURL+SpecServiceUpdateSpecProcedure,
 			connect.WithSchema(specServiceMethods.ByName("UpdateSpec")),
@@ -94,19 +94,19 @@ func NewSpecServiceClient(httpClient connect.HTTPClient, baseURL string, opts ..
 
 // specServiceClient implements SpecServiceClient.
 type specServiceClient struct {
-	createSpec *connect.Client[v1.CreateSpecRequest, v1.Spec]
-	getSpec    *connect.Client[v1.GetSpecRequest, v1.Spec]
+	createSpec *connect.Client[v1.CreateSpecRequest, v1.CreateSpecResponse]
+	getSpec    *connect.Client[v1.GetSpecRequest, v1.GetSpecResponse]
 	listSpecs  *connect.Client[v1.ListSpecsRequest, v1.ListSpecsResponse]
-	updateSpec *connect.Client[v1.UpdateSpecRequest, v1.Spec]
+	updateSpec *connect.Client[v1.UpdateSpecRequest, v1.UpdateSpecResponse]
 }
 
 // CreateSpec calls specgraph.v1.SpecService.CreateSpec.
-func (c *specServiceClient) CreateSpec(ctx context.Context, req *connect.Request[v1.CreateSpecRequest]) (*connect.Response[v1.Spec], error) {
+func (c *specServiceClient) CreateSpec(ctx context.Context, req *connect.Request[v1.CreateSpecRequest]) (*connect.Response[v1.CreateSpecResponse], error) {
 	return c.createSpec.CallUnary(ctx, req)
 }
 
 // GetSpec calls specgraph.v1.SpecService.GetSpec.
-func (c *specServiceClient) GetSpec(ctx context.Context, req *connect.Request[v1.GetSpecRequest]) (*connect.Response[v1.Spec], error) {
+func (c *specServiceClient) GetSpec(ctx context.Context, req *connect.Request[v1.GetSpecRequest]) (*connect.Response[v1.GetSpecResponse], error) {
 	return c.getSpec.CallUnary(ctx, req)
 }
 
@@ -116,16 +116,16 @@ func (c *specServiceClient) ListSpecs(ctx context.Context, req *connect.Request[
 }
 
 // UpdateSpec calls specgraph.v1.SpecService.UpdateSpec.
-func (c *specServiceClient) UpdateSpec(ctx context.Context, req *connect.Request[v1.UpdateSpecRequest]) (*connect.Response[v1.Spec], error) {
+func (c *specServiceClient) UpdateSpec(ctx context.Context, req *connect.Request[v1.UpdateSpecRequest]) (*connect.Response[v1.UpdateSpecResponse], error) {
 	return c.updateSpec.CallUnary(ctx, req)
 }
 
 // SpecServiceHandler is an implementation of the specgraph.v1.SpecService service.
 type SpecServiceHandler interface {
-	CreateSpec(context.Context, *connect.Request[v1.CreateSpecRequest]) (*connect.Response[v1.Spec], error)
-	GetSpec(context.Context, *connect.Request[v1.GetSpecRequest]) (*connect.Response[v1.Spec], error)
+	CreateSpec(context.Context, *connect.Request[v1.CreateSpecRequest]) (*connect.Response[v1.CreateSpecResponse], error)
+	GetSpec(context.Context, *connect.Request[v1.GetSpecRequest]) (*connect.Response[v1.GetSpecResponse], error)
 	ListSpecs(context.Context, *connect.Request[v1.ListSpecsRequest]) (*connect.Response[v1.ListSpecsResponse], error)
-	UpdateSpec(context.Context, *connect.Request[v1.UpdateSpecRequest]) (*connect.Response[v1.Spec], error)
+	UpdateSpec(context.Context, *connect.Request[v1.UpdateSpecRequest]) (*connect.Response[v1.UpdateSpecResponse], error)
 }
 
 // NewSpecServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -178,11 +178,11 @@ func NewSpecServiceHandler(svc SpecServiceHandler, opts ...connect.HandlerOption
 // UnimplementedSpecServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedSpecServiceHandler struct{}
 
-func (UnimplementedSpecServiceHandler) CreateSpec(context.Context, *connect.Request[v1.CreateSpecRequest]) (*connect.Response[v1.Spec], error) {
+func (UnimplementedSpecServiceHandler) CreateSpec(context.Context, *connect.Request[v1.CreateSpecRequest]) (*connect.Response[v1.CreateSpecResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("specgraph.v1.SpecService.CreateSpec is not implemented"))
 }
 
-func (UnimplementedSpecServiceHandler) GetSpec(context.Context, *connect.Request[v1.GetSpecRequest]) (*connect.Response[v1.Spec], error) {
+func (UnimplementedSpecServiceHandler) GetSpec(context.Context, *connect.Request[v1.GetSpecRequest]) (*connect.Response[v1.GetSpecResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("specgraph.v1.SpecService.GetSpec is not implemented"))
 }
 
@@ -190,6 +190,6 @@ func (UnimplementedSpecServiceHandler) ListSpecs(context.Context, *connect.Reque
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("specgraph.v1.SpecService.ListSpecs is not implemented"))
 }
 
-func (UnimplementedSpecServiceHandler) UpdateSpec(context.Context, *connect.Request[v1.UpdateSpecRequest]) (*connect.Response[v1.Spec], error) {
+func (UnimplementedSpecServiceHandler) UpdateSpec(context.Context, *connect.Request[v1.UpdateSpecRequest]) (*connect.Response[v1.UpdateSpecResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("specgraph.v1.SpecService.UpdateSpec is not implemented"))
 }

--- a/internal/auth/interceptor_test.go
+++ b/internal/auth/interceptor_test.go
@@ -29,12 +29,12 @@ type stubSpecHandler struct {
 	specgraphv1connect.UnimplementedSpecServiceHandler
 }
 
-func (h *stubSpecHandler) GetSpec(_ context.Context, _ *connect.Request[specgraphv1.GetSpecRequest]) (*connect.Response[specgraphv1.Spec], error) {
-	return connect.NewResponse(&specgraphv1.Spec{}), nil
+func (h *stubSpecHandler) GetSpec(_ context.Context, _ *connect.Request[specgraphv1.GetSpecRequest]) (*connect.Response[specgraphv1.GetSpecResponse], error) {
+	return connect.NewResponse(&specgraphv1.GetSpecResponse{Spec: &specgraphv1.Spec{}}), nil
 }
 
-func (h *stubSpecHandler) CreateSpec(_ context.Context, _ *connect.Request[specgraphv1.CreateSpecRequest]) (*connect.Response[specgraphv1.Spec], error) {
-	return connect.NewResponse(&specgraphv1.Spec{}), nil
+func (h *stubSpecHandler) CreateSpec(_ context.Context, _ *connect.Request[specgraphv1.CreateSpecRequest]) (*connect.Response[specgraphv1.CreateSpecResponse], error) {
+	return connect.NewResponse(&specgraphv1.CreateSpecResponse{Spec: &specgraphv1.Spec{}}), nil
 }
 
 func newTestServer(t *testing.T, authCfg config.AuthConfig) (*httptest.Server, specgraphv1connect.SpecServiceClient, specgraphv1connect.ServerServiceClient) {

--- a/internal/server/claim_handler.go
+++ b/internal/server/claim_handler.go
@@ -28,7 +28,7 @@ type ClaimHandler struct {
 var _ specgraphv1connect.ClaimServiceHandler = (*ClaimHandler)(nil)
 
 // ClaimSpec handles the ClaimSpec RPC.
-func (h *ClaimHandler) ClaimSpec(ctx context.Context, req *connect.Request[specv1.ClaimSpecRequest]) (*connect.Response[specv1.Claim], error) {
+func (h *ClaimHandler) ClaimSpec(ctx context.Context, req *connect.Request[specv1.ClaimSpecRequest]) (*connect.Response[specv1.ClaimSpecResponse], error) {
 	store, err := scopeStore(ctx, h.scoper)
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func (h *ClaimHandler) ClaimSpec(ctx context.Context, req *connect.Request[specv
 		}
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	return connect.NewResponse(claimToProto(claim)), nil
+	return connect.NewResponse(&specv1.ClaimSpecResponse{Claim: claimToProto(claim)}), nil
 }
 
 // UnclaimSpec handles the UnclaimSpec RPC.
@@ -74,7 +74,7 @@ func (h *ClaimHandler) UnclaimSpec(ctx context.Context, req *connect.Request[spe
 }
 
 // Heartbeat handles the Heartbeat RPC.
-func (h *ClaimHandler) Heartbeat(ctx context.Context, req *connect.Request[specv1.HeartbeatRequest]) (*connect.Response[specv1.Claim], error) {
+func (h *ClaimHandler) Heartbeat(ctx context.Context, req *connect.Request[specv1.HeartbeatRequest]) (*connect.Response[specv1.HeartbeatResponse], error) {
 	store, err := scopeStore(ctx, h.scoper)
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func (h *ClaimHandler) Heartbeat(ctx context.Context, req *connect.Request[specv
 	if err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, err)
 	}
-	return connect.NewResponse(claimToProto(claim)), nil
+	return connect.NewResponse(&specv1.HeartbeatResponse{Claim: claimToProto(claim)}), nil
 }
 
 // RegisterClaimService registers the ClaimService on the given mux.

--- a/internal/server/claim_handler_test.go
+++ b/internal/server/claim_handler_test.go
@@ -96,9 +96,9 @@ func TestClaimHandler_ClaimAndUnclaim(t *testing.T) {
 		LeaseDuration: durationpb.New(10 * time.Minute),
 	}))
 	require.NoError(t, err)
-	require.Equal(t, "my-spec", claimResp.Msg.SpecSlug)
-	require.Equal(t, "agent-1", claimResp.Msg.Agent)
-	require.True(t, claimResp.Msg.LeaseExpires.AsTime().After(time.Now()))
+	require.Equal(t, "my-spec", claimResp.Msg.GetClaim().GetSpecSlug())
+	require.Equal(t, "agent-1", claimResp.Msg.GetClaim().GetAgent())
+	require.True(t, claimResp.Msg.GetClaim().GetLeaseExpires().AsTime().After(time.Now()))
 
 	// Unclaim
 	_, err = client.UnclaimSpec(ctx, connect.NewRequest(&specv1.UnclaimSpecRequest{
@@ -126,7 +126,7 @@ func TestClaimHandler_Heartbeat(t *testing.T) {
 		ExtendBy: durationpb.New(30 * time.Minute),
 	}))
 	require.NoError(t, err)
-	require.True(t, hbResp.Msg.LeaseExpires.AsTime().After(time.Now().Add(29*time.Minute)))
+	require.True(t, hbResp.Msg.GetClaim().GetLeaseExpires().AsTime().After(time.Now().Add(29*time.Minute)))
 
 	// Heartbeat on non-existent claim
 	_, err = client.Heartbeat(ctx, connect.NewRequest(&specv1.HeartbeatRequest{

--- a/internal/server/decision_handler.go
+++ b/internal/server/decision_handler.go
@@ -24,7 +24,7 @@ type DecisionHandler struct {
 var _ specgraphv1connect.DecisionServiceHandler = (*DecisionHandler)(nil)
 
 // CreateDecision handles the CreateDecision RPC.
-func (h *DecisionHandler) CreateDecision(ctx context.Context, req *connect.Request[specv1.CreateDecisionRequest]) (*connect.Response[specv1.Decision], error) {
+func (h *DecisionHandler) CreateDecision(ctx context.Context, req *connect.Request[specv1.CreateDecisionRequest]) (*connect.Response[specv1.CreateDecisionResponse], error) {
 	store, scopeErr := scopeStore(ctx, h.scoper)
 	if scopeErr != nil {
 		return nil, scopeErr
@@ -42,11 +42,11 @@ func (h *DecisionHandler) CreateDecision(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	return connect.NewResponse(pb), nil
+	return connect.NewResponse(&specv1.CreateDecisionResponse{Decision: pb}), nil
 }
 
 // GetDecision handles the GetDecision RPC.
-func (h *DecisionHandler) GetDecision(ctx context.Context, req *connect.Request[specv1.GetDecisionRequest]) (*connect.Response[specv1.Decision], error) {
+func (h *DecisionHandler) GetDecision(ctx context.Context, req *connect.Request[specv1.GetDecisionRequest]) (*connect.Response[specv1.GetDecisionResponse], error) {
 	store, scopeErr := scopeStore(ctx, h.scoper)
 	if scopeErr != nil {
 		return nil, scopeErr
@@ -66,7 +66,7 @@ func (h *DecisionHandler) GetDecision(ctx context.Context, req *connect.Request[
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	return connect.NewResponse(pb), nil
+	return connect.NewResponse(&specv1.GetDecisionResponse{Decision: pb}), nil
 }
 
 // ListDecisions handles the ListDecisions RPC.
@@ -103,7 +103,7 @@ func (h *DecisionHandler) ListDecisions(ctx context.Context, req *connect.Reques
 }
 
 // UpdateDecision handles the UpdateDecision RPC.
-func (h *DecisionHandler) UpdateDecision(ctx context.Context, req *connect.Request[specv1.UpdateDecisionRequest]) (*connect.Response[specv1.Decision], error) {
+func (h *DecisionHandler) UpdateDecision(ctx context.Context, req *connect.Request[specv1.UpdateDecisionRequest]) (*connect.Response[specv1.UpdateDecisionResponse], error) {
 	store, scopeErr := scopeStore(ctx, h.scoper)
 	if scopeErr != nil {
 		return nil, scopeErr
@@ -139,7 +139,7 @@ func (h *DecisionHandler) UpdateDecision(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	return connect.NewResponse(pb), nil
+	return connect.NewResponse(&specv1.UpdateDecisionResponse{Decision: pb}), nil
 }
 
 // RegisterDecisionService registers the DecisionService on the given mux.

--- a/internal/server/decision_handler_test.go
+++ b/internal/server/decision_handler_test.go
@@ -126,15 +126,15 @@ func TestDecisionHandler_CreateAndGet(t *testing.T) {
 		Rationale: "Native Cypher support, good performance for our scale.",
 	}))
 	require.NoError(t, err)
-	require.Equal(t, "use-memgraph", createResp.Msg.Slug)
-	require.Equal(t, specv1.DecisionStatus_DECISION_STATUS_PROPOSED, createResp.Msg.Status)
-	require.NotEmpty(t, createResp.Msg.Id)
+	require.Equal(t, "use-memgraph", createResp.Msg.GetDecision().GetSlug())
+	require.Equal(t, specv1.DecisionStatus_DECISION_STATUS_PROPOSED, createResp.Msg.GetDecision().GetStatus())
+	require.NotEmpty(t, createResp.Msg.GetDecision().GetId())
 
 	getResp, err := client.GetDecision(ctx, connect.NewRequest(&specv1.GetDecisionRequest{
 		Slug: "use-memgraph",
 	}))
 	require.NoError(t, err)
-	require.Equal(t, createResp.Msg.Id, getResp.Msg.Id)
+	require.Equal(t, createResp.Msg.GetDecision().GetId(), getResp.Msg.GetDecision().GetId())
 
 	_, err = client.GetDecision(ctx, connect.NewRequest(&specv1.GetDecisionRequest{
 		Slug: "nonexistent",
@@ -201,5 +201,5 @@ func TestDecisionHandler_ListAndUpdate(t *testing.T) {
 		Status: &newStatus,
 	}))
 	require.NoError(t, err)
-	require.Equal(t, specv1.DecisionStatus_DECISION_STATUS_ACCEPTED, updateResp.Msg.Status)
+	require.Equal(t, specv1.DecisionStatus_DECISION_STATUS_ACCEPTED, updateResp.Msg.GetDecision().GetStatus())
 }

--- a/internal/server/execution_handler.go
+++ b/internal/server/execution_handler.go
@@ -34,7 +34,7 @@ func RegisterExecutionService(mux *http.ServeMux, scoper storage.Scoper, opts ..
 }
 
 // GenerateBundle handles the GenerateBundle RPC.
-func (h *ExecutionHandler) GenerateBundle(ctx context.Context, req *connect.Request[specv1.GenerateBundleRequest]) (*connect.Response[specv1.Bundle], error) {
+func (h *ExecutionHandler) GenerateBundle(ctx context.Context, req *connect.Request[specv1.GenerateBundleRequest]) (*connect.Response[specv1.GenerateBundleResponse], error) {
 	store, err := scopeStore(ctx, h.scoper)
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func (h *ExecutionHandler) GenerateBundle(ctx context.Context, req *connect.Requ
 	}
 	pb.BundleYaml = renderBundleYAML(b)
 
-	return connect.NewResponse(pb), nil
+	return connect.NewResponse(&specv1.GenerateBundleResponse{Bundle: pb}), nil
 }
 
 // GetPrime handles the GetPrime RPC.

--- a/internal/server/execution_handler_test.go
+++ b/internal/server/execution_handler_test.go
@@ -174,16 +174,16 @@ func TestExecutionHandler_GenerateBundle(t *testing.T) {
 		Endpoint: "http://localhost:8080",
 	}))
 	require.NoError(t, err)
-	require.Equal(t, int32(1), resp.Msg.Version)
-	require.Equal(t, "my-spec", resp.Msg.Spec.Slug)
-	require.Equal(t, "build a widget", resp.Msg.Spec.Intent)
-	require.Len(t, resp.Msg.Decisions, 1)
-	require.Equal(t, "adr-001", resp.Msg.Decisions[0].Slug)
-	require.NotNil(t, resp.Msg.Callbacks)
-	require.Equal(t, "http://localhost:8080", resp.Msg.Callbacks.Endpoint)
-	require.Equal(t, "http://localhost:8080/progress", resp.Msg.Callbacks.Progress)
-	require.NotEmpty(t, resp.Msg.BundleYaml)
-	require.Contains(t, resp.Msg.BundleYaml, "my-spec")
+	require.Equal(t, int32(1), resp.Msg.GetBundle().GetVersion())
+	require.Equal(t, "my-spec", resp.Msg.GetBundle().GetSpec().GetSlug())
+	require.Equal(t, "build a widget", resp.Msg.GetBundle().GetSpec().GetIntent())
+	require.Len(t, resp.Msg.GetBundle().GetDecisions(), 1)
+	require.Equal(t, "adr-001", resp.Msg.GetBundle().GetDecisions()[0].GetSlug())
+	require.NotNil(t, resp.Msg.GetBundle().GetCallbacks())
+	require.Equal(t, "http://localhost:8080", resp.Msg.GetBundle().GetCallbacks().GetEndpoint())
+	require.Equal(t, "http://localhost:8080/progress", resp.Msg.GetBundle().GetCallbacks().GetProgress())
+	require.NotEmpty(t, resp.Msg.GetBundle().GetBundleYaml())
+	require.Contains(t, resp.Msg.GetBundle().GetBundleYaml(), "my-spec")
 }
 
 func TestExecutionHandler_GenerateBundle_NotFound(t *testing.T) {

--- a/internal/server/graph_handler.go
+++ b/internal/server/graph_handler.go
@@ -22,7 +22,7 @@ type GraphHandler struct {
 var _ specgraphv1connect.GraphServiceHandler = (*GraphHandler)(nil)
 
 // AddEdge handles the AddEdge RPC.
-func (h *GraphHandler) AddEdge(ctx context.Context, req *connect.Request[specv1.AddEdgeRequest]) (*connect.Response[specv1.Edge], error) {
+func (h *GraphHandler) AddEdge(ctx context.Context, req *connect.Request[specv1.AddEdgeRequest]) (*connect.Response[specv1.AddEdgeResponse], error) {
 	store, scopeErr := scopeStore(ctx, h.scoper)
 	if scopeErr != nil {
 		return nil, scopeErr
@@ -45,7 +45,7 @@ func (h *GraphHandler) AddEdge(ctx context.Context, req *connect.Request[specv1.
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	return connect.NewResponse(pb), nil
+	return connect.NewResponse(&specv1.AddEdgeResponse{Edge: pb}), nil
 }
 
 // RemoveEdge handles the RemoveEdge RPC.

--- a/internal/server/graph_handler_test.go
+++ b/internal/server/graph_handler_test.go
@@ -150,7 +150,7 @@ func TestGraphHandler_AddAndListEdges(t *testing.T) {
 		EdgeType: specv1.EdgeType_EDGE_TYPE_DEPENDS_ON,
 	}))
 	require.NoError(t, err)
-	require.Equal(t, specv1.EdgeType_EDGE_TYPE_DEPENDS_ON, addResp.Msg.EdgeType)
+	require.Equal(t, specv1.EdgeType_EDGE_TYPE_DEPENDS_ON, addResp.Msg.GetEdge().GetEdgeType())
 
 	// List edges
 	listResp, err := client.ListEdges(ctx, connect.NewRequest(&specv1.ListEdgesRequest{

--- a/internal/server/spec_handler.go
+++ b/internal/server/spec_handler.go
@@ -34,7 +34,7 @@ func NewSpecHandler(scoper storage.Scoper) *SpecHandler {
 }
 
 // CreateSpec handles the CreateSpec RPC.
-func (h *SpecHandler) CreateSpec(ctx context.Context, req *connect.Request[specv1.CreateSpecRequest]) (*connect.Response[specv1.Spec], error) {
+func (h *SpecHandler) CreateSpec(ctx context.Context, req *connect.Request[specv1.CreateSpecRequest]) (*connect.Response[specv1.CreateSpecResponse], error) {
 	store, scopeErr := scopeStore(ctx, h.scoper)
 	if scopeErr != nil {
 		return nil, scopeErr
@@ -63,11 +63,11 @@ func (h *SpecHandler) CreateSpec(ctx context.Context, req *connect.Request[specv
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	return connect.NewResponse(pb), nil
+	return connect.NewResponse(&specv1.CreateSpecResponse{Spec: pb}), nil
 }
 
 // GetSpec handles the GetSpec RPC.
-func (h *SpecHandler) GetSpec(ctx context.Context, req *connect.Request[specv1.GetSpecRequest]) (*connect.Response[specv1.Spec], error) {
+func (h *SpecHandler) GetSpec(ctx context.Context, req *connect.Request[specv1.GetSpecRequest]) (*connect.Response[specv1.GetSpecResponse], error) {
 	store, scopeErr := scopeStore(ctx, h.scoper)
 	if scopeErr != nil {
 		return nil, scopeErr
@@ -86,7 +86,7 @@ func (h *SpecHandler) GetSpec(ctx context.Context, req *connect.Request[specv1.G
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	return connect.NewResponse(pb), nil
+	return connect.NewResponse(&specv1.GetSpecResponse{Spec: pb}), nil
 }
 
 // ListSpecs handles the ListSpecs RPC.
@@ -113,7 +113,7 @@ func (h *SpecHandler) ListSpecs(ctx context.Context, req *connect.Request[specv1
 }
 
 // UpdateSpec handles the UpdateSpec RPC.
-func (h *SpecHandler) UpdateSpec(ctx context.Context, req *connect.Request[specv1.UpdateSpecRequest]) (*connect.Response[specv1.Spec], error) {
+func (h *SpecHandler) UpdateSpec(ctx context.Context, req *connect.Request[specv1.UpdateSpecRequest]) (*connect.Response[specv1.UpdateSpecResponse], error) {
 	store, scopeErr := scopeStore(ctx, h.scoper)
 	if scopeErr != nil {
 		return nil, scopeErr
@@ -138,5 +138,5 @@ func (h *SpecHandler) UpdateSpec(ctx context.Context, req *connect.Request[specv
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	return connect.NewResponse(pb), nil
+	return connect.NewResponse(&specv1.UpdateSpecResponse{Spec: pb}), nil
 }

--- a/internal/server/spec_handler_test.go
+++ b/internal/server/spec_handler_test.go
@@ -129,20 +129,20 @@ func TestSpecHandler_CreateAndGet(t *testing.T) {
 		Intent: "Implement OAuth refresh token rotation",
 	}))
 	require.NoError(t, err)
-	require.Equal(t, "oauth-refresh", createResp.Msg.Slug)
-	require.Equal(t, "Implement OAuth refresh token rotation", createResp.Msg.Intent)
-	require.Equal(t, "p2", createResp.Msg.Priority)       // defaulted
-	require.Equal(t, "medium", createResp.Msg.Complexity) // defaulted
-	require.Equal(t, "spark", createResp.Msg.Stage)
-	require.NotEmpty(t, createResp.Msg.Id)
+	require.Equal(t, "oauth-refresh", createResp.Msg.GetSpec().GetSlug())
+	require.Equal(t, "Implement OAuth refresh token rotation", createResp.Msg.GetSpec().GetIntent())
+	require.Equal(t, "p2", createResp.Msg.GetSpec().GetPriority())       // defaulted
+	require.Equal(t, "medium", createResp.Msg.GetSpec().GetComplexity()) // defaulted
+	require.Equal(t, "spark", createResp.Msg.GetSpec().GetStage())
+	require.NotEmpty(t, createResp.Msg.GetSpec().GetId())
 
 	// Get it back.
 	getResp, err := client.GetSpec(ctx, connect.NewRequest(&specv1.GetSpecRequest{
 		Slug: "oauth-refresh",
 	}))
 	require.NoError(t, err)
-	require.Equal(t, createResp.Msg.Id, getResp.Msg.Id)
-	require.Equal(t, "oauth-refresh", getResp.Msg.Slug)
+	require.Equal(t, createResp.Msg.GetSpec().GetId(), getResp.Msg.GetSpec().GetId())
+	require.Equal(t, "oauth-refresh", getResp.Msg.GetSpec().GetSlug())
 
 	// Get non-existent returns not found.
 	_, err = client.GetSpec(ctx, connect.NewRequest(&specv1.GetSpecRequest{
@@ -174,9 +174,9 @@ func TestSpecHandler_UpdateSpec(t *testing.T) {
 		Intent: &newIntent,
 	}))
 	require.NoError(t, err)
-	require.Equal(t, "Updated intent", updateResp.Msg.Intent)
-	require.Equal(t, int32(2), updateResp.Msg.Version)
-	require.Equal(t, "p2", updateResp.Msg.Priority) // unchanged
+	require.Equal(t, "Updated intent", updateResp.Msg.GetSpec().GetIntent())
+	require.Equal(t, int32(2), updateResp.Msg.GetSpec().GetVersion())
+	require.Equal(t, "p2", updateResp.Msg.GetSpec().GetPriority()) // unchanged
 
 	// Update non-existent spec.
 	_, err = client.UpdateSpec(ctx, connect.NewRequest(&specv1.UpdateSpecRequest{

--- a/proto/specgraph/v1/claim.proto
+++ b/proto/specgraph/v1/claim.proto
@@ -38,10 +38,13 @@ message HeartbeatRequest {
   google.protobuf.Duration extend_by = 3;   // extend lease by this duration (default 15m)
 }
 
+message ClaimSpecResponse { Claim claim = 1; }
+message HeartbeatResponse { Claim claim = 1; }
+
 // --- Service ---
 
 service ClaimService {
-  rpc ClaimSpec(ClaimSpecRequest) returns (Claim);
+  rpc ClaimSpec(ClaimSpecRequest) returns (ClaimSpecResponse);
   rpc UnclaimSpec(UnclaimSpecRequest) returns (UnclaimSpecResponse);
-  rpc Heartbeat(HeartbeatRequest) returns (Claim);
+  rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
 }

--- a/proto/specgraph/v1/decision.proto
+++ b/proto/specgraph/v1/decision.proto
@@ -63,11 +63,15 @@ message UpdateDecisionRequest {
   optional string superseded_by = 6;
 }
 
+message CreateDecisionResponse { Decision decision = 1; }
+message GetDecisionResponse { Decision decision = 1; }
+message UpdateDecisionResponse { Decision decision = 1; }
+
 // --- Service ---
 
 service DecisionService {
-  rpc CreateDecision(CreateDecisionRequest) returns (Decision);
-  rpc GetDecision(GetDecisionRequest) returns (Decision);
+  rpc CreateDecision(CreateDecisionRequest) returns (CreateDecisionResponse);
+  rpc GetDecision(GetDecisionRequest) returns (GetDecisionResponse);
   rpc ListDecisions(ListDecisionsRequest) returns (ListDecisionsResponse);
-  rpc UpdateDecision(UpdateDecisionRequest) returns (Decision);
+  rpc UpdateDecision(UpdateDecisionRequest) returns (UpdateDecisionResponse);
 }

--- a/proto/specgraph/v1/execution.proto
+++ b/proto/specgraph/v1/execution.proto
@@ -63,6 +63,8 @@ message GenerateBundleRequest {
   string endpoint = 2;
 }
 
+message GenerateBundleResponse { Bundle bundle = 1; }
+
 message GetPrimeRequest {
   string slug = 1;
 }
@@ -109,7 +111,7 @@ message GetExecutionEventsResponse {
 // --- Service ---
 
 service ExecutionService {
-  rpc GenerateBundle(GenerateBundleRequest) returns (Bundle);
+  rpc GenerateBundle(GenerateBundleRequest) returns (GenerateBundleResponse);
   rpc GetPrime(GetPrimeRequest) returns (PrimeResponse);
   rpc ReportProgress(ReportProgressRequest) returns (ReportProgressResponse);
   rpc ReportBlocker(ReportBlockerRequest) returns (ReportBlockerResponse);

--- a/proto/specgraph/v1/graph.proto
+++ b/proto/specgraph/v1/graph.proto
@@ -34,6 +34,8 @@ message AddEdgeRequest {
   EdgeType edge_type = 3;
 }
 
+message AddEdgeResponse { Edge edge = 1; }
+
 message RemoveEdgeRequest {
   string from_slug = 1;
   string to_slug = 2;
@@ -99,7 +101,7 @@ message GetCriticalPathResponse {
 // --- Service ---
 
 service GraphService {
-  rpc AddEdge(AddEdgeRequest) returns (Edge);
+  rpc AddEdge(AddEdgeRequest) returns (AddEdgeResponse);
   rpc RemoveEdge(RemoveEdgeRequest) returns (RemoveEdgeResponse);
   rpc ListEdges(ListEdgesRequest) returns (ListEdgesResponse);
   rpc GetDependencies(GetDependenciesRequest) returns (GetDependenciesResponse);

--- a/proto/specgraph/v1/spec.proto
+++ b/proto/specgraph/v1/spec.proto
@@ -74,11 +74,15 @@ message UpdateSpecRequest {
   optional string notes = 6;
 }
 
+message CreateSpecResponse { Spec spec = 1; }
+message GetSpecResponse { Spec spec = 1; }
+message UpdateSpecResponse { Spec spec = 1; }
+
 // --- Service ---
 
 service SpecService {
-  rpc CreateSpec(CreateSpecRequest) returns (Spec);
-  rpc GetSpec(GetSpecRequest) returns (Spec);
+  rpc CreateSpec(CreateSpecRequest) returns (CreateSpecResponse);
+  rpc GetSpec(GetSpecRequest) returns (GetSpecResponse);
   rpc ListSpecs(ListSpecsRequest) returns (ListSpecsResponse);
-  rpc UpdateSpec(UpdateSpecRequest) returns (Spec);
+  rpc UpdateSpec(UpdateSpecRequest) returns (UpdateSpecResponse);
 }


### PR DESCRIPTION
## Summary

Wrap 10 RPCs that returned bare entity types in proper Response wrapper messages, following the pattern used by all other RPCs in the project.

## RPCs wrapped

| Proto | RPCs | Response messages added |
|-------|------|----------------------|
| `spec.proto` | CreateSpec, GetSpec, UpdateSpec | CreateSpecResponse, GetSpecResponse, UpdateSpecResponse |
| `decision.proto` | CreateDecision, GetDecision, UpdateDecision | CreateDecisionResponse, GetDecisionResponse, UpdateDecisionResponse |
| `graph.proto` | AddEdge | AddEdgeResponse |
| `execution.proto` | GenerateBundle | GenerateBundleResponse |
| `claim.proto` | ClaimSpec, Heartbeat | ClaimSpecResponse, HeartbeatResponse |

## Motivation

Returning bare entities prevents adding response-level fields (e.g., authoring outputs in GetSpecResponse) without polluting the entity message used everywhere. This is a prerequisite for spgr-f3s (markdown CLI output) which needs GetSpecResponse to include authoring stage data.

WIRE-BREAK at 0.2.0-dev — no production data to migrate.

## Changes

| Area | Files |
|------|-------|
| Proto (5 files) | Added Response messages, updated `rpc` return types |
| Handlers (5 files) | Updated return types and response construction |
| Handler tests (6 files) | Updated field access through wrapper getters (e.g., `resp.Msg.GetSpec().GetSlug()`) |
| CLI (5 files) | Updated response field access |
| Auth test | Updated stub handler signatures |

## Test plan

- [x] `task check` passes (lint, build, all unit tests)
- [ ] `task pr-prep` (integration + e2e — requires CI)

Closes: spgr-1v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * RPCs now return consistent wrapper response messages that nest entity payloads (specs, decisions, claims, edges, bundles), standardizing API response shapes.

* **Tests**
  * Unit and end-to-end tests updated to validate fields through the new nested response shapes.

* **CLI**
  * Command-line outputs remain functionally equivalent; visible CLI behavior unchanged despite response shape updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->