### PR TITLE
docs: add graph visualization UI design spec (spgr-p1l)

### DIFF
--- a/.superpowers/brainstorm/31453-1774227435/.server-info
+++ b/.superpowers/brainstorm/31453-1774227435/.server-info
@@ -1,0 +1,1 @@
+{"type":"server-started","port":59767,"host":"127.0.0.1","url_host":"localhost","url":"http://localhost:59767","screen_dir":"/Volumes/Code/github.com/specgraph/specgraph/.superpowers/brainstorm/31453-1774227435"}

--- a/.superpowers/brainstorm/31453-1774227435/dashboard-layout.html
+++ b/.superpowers/brainstorm/31453-1774227435/dashboard-layout.html
@@ -1,0 +1,156 @@
+<h2>Dashboard Layout</h2>
+<p class="subtitle">What should the landing page show? The dashboard gives context before diving into the graph.</p>
+
+<div class="options">
+  <div class="option" data-choice="a" onclick="toggleSelect(this)">
+    <div class="letter">A</div>
+    <div class="content">
+      <h3>Stats + Funnel + Graph Preview</h3>
+      <p>Top-level numbers, authoring funnel distribution, and a miniature graph you can click into.</p>
+      <div style="margin-top:12px; padding:16px; background:#0d1117; border-radius:8px; font-size:13px; color:#c9d1d9;">
+        <!-- Stats row -->
+        <div style="display:flex; gap:12px; margin-bottom:16px;">
+          <div style="flex:1; background:#161b22; border:1px solid #30363d; border-radius:8px; padding:12px; text-align:center;">
+            <div style="font-size:24px; font-weight:bold; color:#58a6ff;">12</div>
+            <div style="font-size:11px; color:#8b949e;">Total Specs</div>
+          </div>
+          <div style="flex:1; background:#161b22; border:1px solid #30363d; border-radius:8px; padding:12px; text-align:center;">
+            <div style="font-size:24px; font-weight:bold; color:#3fb950;">3</div>
+            <div style="font-size:11px; color:#8b949e;">Ready</div>
+          </div>
+          <div style="flex:1; background:#161b22; border:1px solid #30363d; border-radius:8px; padding:12px; text-align:center;">
+            <div style="font-size:24px; font-weight:bold; color:#f0ad4e;">2</div>
+            <div style="font-size:11px; color:#8b949e;">Drift</div>
+          </div>
+          <div style="flex:1; background:#161b22; border:1px solid #30363d; border-radius:8px; padding:12px; text-align:center;">
+            <div style="font-size:24px; font-weight:bold; color:#8b949e;">5</div>
+            <div style="font-size:11px; color:#8b949e;">Decisions</div>
+          </div>
+        </div>
+        <!-- Funnel -->
+        <div style="background:#161b22; border:1px solid #30363d; border-radius:8px; padding:12px; margin-bottom:16px;">
+          <div style="font-size:12px; color:#8b949e; margin-bottom:8px;">Authoring Funnel</div>
+          <div style="display:flex; gap:4px; height:24px;">
+            <div style="flex:2; background:#6e40c9; border-radius:4px 0 0 4px; display:flex; align-items:center; justify-content:center; font-size:10px; color:white;">spark (2)</div>
+            <div style="flex:3; background:#58a6ff; display:flex; align-items:center; justify-content:center; font-size:10px; color:white;">shape (3)</div>
+            <div style="flex:4; background:#3fb950; display:flex; align-items:center; justify-content:center; font-size:10px; color:white;">specify (4)</div>
+            <div style="flex:1; background:#f0ad4e; display:flex; align-items:center; justify-content:center; font-size:10px; color:white;">decompose (1)</div>
+            <div style="flex:2; background:#238636; border-radius:0 4px 4px 0; display:flex; align-items:center; justify-content:center; font-size:10px; color:white;">done (2)</div>
+          </div>
+        </div>
+        <!-- Mini graph -->
+        <div style="background:#161b22; border:1px solid #30363d; border-radius:8px; padding:12px;">
+          <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:8px;">
+            <div style="font-size:12px; color:#8b949e;">Dependency Graph</div>
+            <div style="font-size:11px; color:#58a6ff; cursor:pointer;">View full graph &rarr;</div>
+          </div>
+          <div style="display:flex; flex-direction:column; gap:12px; align-items:center; min-height:80px;">
+            <div style="display:flex;gap:20px;">
+              <div style="padding:4px 10px;border:1px solid #58a6ff;border-radius:4px;color:#58a6ff;font-size:10px;">gateway</div>
+            </div>
+            <div style="color:#30363d;font-size:10px;">&darr;</div>
+            <div style="display:flex;gap:20px;">
+              <div style="padding:4px 10px;border:1px solid #3fb950;border-radius:4px;color:#3fb950;font-size:10px;">login</div>
+              <div style="padding:4px 10px;border:1px solid #f0ad4e;border-radius:4px;color:#f0ad4e;font-size:10px;">hooks</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="option" data-choice="b" onclick="toggleSelect(this)">
+    <div class="letter">B</div>
+    <div class="content">
+      <h3>Stats + Recent Activity</h3>
+      <p>Numbers at top, then a feed of recent spec changes (like a project pulse).</p>
+      <div style="margin-top:12px; padding:16px; background:#0d1117; border-radius:8px; font-size:13px; color:#c9d1d9;">
+        <!-- Stats row (same) -->
+        <div style="display:flex; gap:12px; margin-bottom:16px;">
+          <div style="flex:1; background:#161b22; border:1px solid #30363d; border-radius:8px; padding:12px; text-align:center;">
+            <div style="font-size:24px; font-weight:bold; color:#58a6ff;">12</div>
+            <div style="font-size:11px; color:#8b949e;">Total Specs</div>
+          </div>
+          <div style="flex:1; background:#161b22; border:1px solid #30363d; border-radius:8px; padding:12px; text-align:center;">
+            <div style="font-size:24px; font-weight:bold; color:#3fb950;">3</div>
+            <div style="font-size:11px; color:#8b949e;">Ready</div>
+          </div>
+          <div style="flex:1; background:#161b22; border:1px solid #30363d; border-radius:8px; padding:12px; text-align:center;">
+            <div style="font-size:24px; font-weight:bold; color:#f0ad4e;">2</div>
+            <div style="font-size:11px; color:#8b949e;">Drift</div>
+          </div>
+          <div style="flex:1; background:#161b22; border:1px solid #30363d; border-radius:8px; padding:12px; text-align:center;">
+            <div style="font-size:24px; font-weight:bold; color:#8b949e;">5</div>
+            <div style="font-size:11px; color:#8b949e;">Decisions</div>
+          </div>
+        </div>
+        <!-- Activity feed -->
+        <div style="background:#161b22; border:1px solid #30363d; border-radius:8px; padding:12px;">
+          <div style="font-size:12px; color:#8b949e; margin-bottom:10px;">Recent Activity</div>
+          <div style="border-bottom:1px solid #21262d; padding:8px 0;">
+            <span style="color:#3fb950;font-size:11px;">&#9679;</span>
+            <span style="color:#58a6ff;font-size:12px;">login-api</span>
+            <span style="color:#8b949e;font-size:11px;"> advanced to </span>
+            <span style="color:#c9d1d9;font-size:12px;">specify</span>
+            <span style="color:#484f58;font-size:11px; float:right;">2h ago</span>
+          </div>
+          <div style="border-bottom:1px solid #21262d; padding:8px 0;">
+            <span style="color:#f0ad4e;font-size:11px;">&#9679;</span>
+            <span style="color:#58a6ff;font-size:12px;">token-storage</span>
+            <span style="color:#8b949e;font-size:11px;"> drift detected</span>
+            <span style="color:#484f58;font-size:11px; float:right;">4h ago</span>
+          </div>
+          <div style="padding:8px 0;">
+            <span style="color:#6e40c9;font-size:11px;">&#9679;</span>
+            <span style="color:#58a6ff;font-size:12px;">webhook-events</span>
+            <span style="color:#8b949e;font-size:11px;"> sparked</span>
+            <span style="color:#484f58;font-size:11px; float:right;">yesterday</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="option" data-choice="c" onclick="toggleSelect(this)">
+    <div class="letter">C</div>
+    <div class="content">
+      <h3>Stats + Funnel Only (Minimal)</h3>
+      <p>Just the numbers and funnel bar. Simple, fast, gets you oriented then you navigate to graph/specs.</p>
+      <div style="margin-top:12px; padding:16px; background:#0d1117; border-radius:8px; font-size:13px; color:#c9d1d9;">
+        <div style="display:flex; gap:12px; margin-bottom:16px;">
+          <div style="flex:1; background:#161b22; border:1px solid #30363d; border-radius:8px; padding:12px; text-align:center;">
+            <div style="font-size:24px; font-weight:bold; color:#58a6ff;">12</div>
+            <div style="font-size:11px; color:#8b949e;">Specs</div>
+          </div>
+          <div style="flex:1; background:#161b22; border:1px solid #30363d; border-radius:8px; padding:12px; text-align:center;">
+            <div style="font-size:24px; font-weight:bold; color:#3fb950;">3</div>
+            <div style="font-size:11px; color:#8b949e;">Ready</div>
+          </div>
+          <div style="flex:1; background:#161b22; border:1px solid #30363d; border-radius:8px; padding:12px; text-align:center;">
+            <div style="font-size:24px; font-weight:bold; color:#f0ad4e;">2</div>
+            <div style="font-size:11px; color:#8b949e;">Drift</div>
+          </div>
+          <div style="flex:1; background:#161b22; border:1px solid #30363d; border-radius:8px; padding:12px; text-align:center;">
+            <div style="font-size:24px; font-weight:bold; color:#8b949e;">5</div>
+            <div style="font-size:11px; color:#8b949e;">Decisions</div>
+          </div>
+        </div>
+        <div style="background:#161b22; border:1px solid #30363d; border-radius:8px; padding:12px;">
+          <div style="font-size:12px; color:#8b949e; margin-bottom:8px;">Authoring Funnel</div>
+          <div style="display:flex; gap:4px; height:24px;">
+            <div style="flex:2; background:#6e40c9; border-radius:4px 0 0 4px; display:flex; align-items:center; justify-content:center; font-size:10px; color:white;">spark (2)</div>
+            <div style="flex:3; background:#58a6ff; display:flex; align-items:center; justify-content:center; font-size:10px; color:white;">shape (3)</div>
+            <div style="flex:4; background:#3fb950; display:flex; align-items:center; justify-content:center; font-size:10px; color:white;">specify (4)</div>
+            <div style="flex:1; background:#f0ad4e; display:flex; align-items:center; justify-content:center; font-size:10px; color:white;">decompose (1)</div>
+            <div style="flex:2; background:#238636; border-radius:0 4px 4px 0; display:flex; align-items:center; justify-content:center; font-size:10px; color:white;">done (2)</div>
+          </div>
+        </div>
+        <div style="text-align:center; margin-top:16px;">
+          <div style="display:inline-block; padding:8px 24px; background:#238636; border-radius:6px; color:white; font-size:13px; cursor:pointer;">View Graph &rarr;</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<p style="margin-top:24px; color:#888; font-size:14px;"><strong>My recommendation:</strong> <strong>A (Stats + Funnel + Graph Preview)</strong> &mdash; gives the full picture at a glance. The mini graph preview is the hook that draws people into the full graph view. Activity feed (B) is nice but needs ChangeLog data we'd have to aggregate, adding scope.</p>

--- a/.superpowers/brainstorm/31453-1774227435/graph-lib-options.html
+++ b/.superpowers/brainstorm/31453-1774227435/graph-lib-options.html
@@ -1,0 +1,78 @@
+<h2>Graph Visualization Library</h2>
+<p class="subtitle">Which rendering approach fits best for an interactive spec dependency graph?</p>
+
+<div class="options">
+  <div class="option" data-choice="a" onclick="toggleSelect(this)">
+    <div class="letter">A</div>
+    <div class="content">
+      <h3>D3-force + SVG</h3>
+      <p><strong>Force-directed layout</strong> &mdash; nodes push/pull each other into natural clusters. The classic interactive graph look.</p>
+      <div style="margin-top:12px; padding:16px; background:#1a1a2e; border-radius:8px; font-family:monospace; font-size:13px; color:#888;">
+        <div style="display:flex; gap:40px; align-items:center; justify-content:center; min-height:120px; position:relative;">
+          <div style="width:60px;height:60px;border-radius:50%;background:#4a90d9;display:flex;align-items:center;justify-content:center;color:white;font-size:11px;">login-api</div>
+          <div style="width:50px;height:50px;border-radius:50%;background:#5cb85c;display:flex;align-items:center;justify-content:center;color:white;font-size:10px;">token</div>
+          <div style="width:55px;height:55px;border-radius:50%;background:#f0ad4e;display:flex;align-items:center;justify-content:center;color:white;font-size:10px;">gateway</div>
+          <div style="width:45px;height:45px;border-radius:50%;background:#d9534f;display:flex;align-items:center;justify-content:center;color:white;font-size:10px;">crypto</div>
+        </div>
+        <div style="text-align:center;color:#666;font-size:11px;margin-top:8px;">Nodes float organically &bull; drag to rearrange &bull; zoom/pan</div>
+      </div>
+      <div class="pros-cons" style="margin-top:12px;">
+        <div class="pros"><h4>Pros</h4><ul><li>Most intuitive for exploring relationships</li><li>Handles organic, non-hierarchical graphs well</li><li>D3 is battle-tested, huge ecosystem</li></ul></div>
+        <div class="cons"><h4>Cons</h4><ul><li>Can be chaotic with 50+ nodes</li><li>Layout isn't deterministic (different each load)</li><li>Heavier JS bundle (~50KB)</li></ul></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="option" data-choice="b" onclick="toggleSelect(this)">
+    <div class="letter">B</div>
+    <div class="content">
+      <h3>ELK / Dagre Layered Layout</h3>
+      <p><strong>Hierarchical/layered layout</strong> &mdash; nodes arranged in layers by dependency depth. Like a refined Graphviz output but interactive.</p>
+      <div style="margin-top:12px; padding:16px; background:#1a1a2e; border-radius:8px; font-family:monospace; font-size:13px; color:#888;">
+        <div style="display:flex; flex-direction:column; gap:20px; align-items:center; min-height:120px;">
+          <div style="display:flex;gap:30px;">
+            <div style="padding:8px 16px;border:2px solid #4a90d9;border-radius:6px;color:#4a90d9;font-size:11px;">gateway</div>
+          </div>
+          <div style="color:#555;">&darr;</div>
+          <div style="display:flex;gap:30px;">
+            <div style="padding:8px 16px;border:2px solid #5cb85c;border-radius:6px;color:#5cb85c;font-size:11px;">login-api</div>
+            <div style="padding:8px 16px;border:2px solid #f0ad4e;border-radius:6px;color:#f0ad4e;font-size:11px;">webhooks</div>
+          </div>
+          <div style="color:#555;">&darr;</div>
+          <div style="display:flex;gap:30px;">
+            <div style="padding:8px 16px;border:2px solid #d9534f;border-radius:6px;color:#d9534f;font-size:11px;">token-storage</div>
+            <div style="padding:8px 16px;border:2px solid #888;border-radius:6px;color:#888;font-size:11px;">crypto-utils</div>
+          </div>
+        </div>
+        <div style="text-align:center;color:#666;font-size:11px;margin-top:8px;">Layers = dependency depth &bull; deterministic layout &bull; click to expand</div>
+      </div>
+      <div class="pros-cons" style="margin-top:12px;">
+        <div class="pros"><h4>Pros</h4><ul><li>Dependency flow is immediately obvious (top &rarr; bottom)</li><li>Deterministic &mdash; same graph = same layout every time</li><li>Scales better to large graphs (clear structure)</li><li>Natural fit for spec dependency graphs</li></ul></div>
+        <div class="cons"><h4>Cons</h4><ul><li>Less "organic" feel than force-directed</li><li>ELK is larger (~200KB) but Dagre is lighter (~30KB)</li><li>Cross-edges (relates_to) can create visual clutter</li></ul></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="option" data-choice="c" onclick="toggleSelect(this)">
+    <div class="letter">C</div>
+    <div class="content">
+      <h3>Mermaid.js (rendered)</h3>
+      <p><strong>Generate Mermaid diagrams</strong> &mdash; server sends Mermaid syntax, browser renders it. Simplest to build, familiar output.</p>
+      <div style="margin-top:12px; padding:16px; background:#1a1a2e; border-radius:8px; font-family:monospace; font-size:13px; color:#ccc;">
+        <pre style="margin:0;font-size:12px;">graph TD
+  gateway --> login-api
+  gateway --> webhooks
+  login-api --> token-storage
+  login-api --> crypto-utils
+  webhooks --> token-storage</pre>
+        <div style="text-align:center;color:#666;font-size:11px;margin-top:8px;">Text-based &bull; click nodes for details &bull; limited interactivity</div>
+      </div>
+      <div class="pros-cons" style="margin-top:12px;">
+        <div class="pros"><h4>Pros</h4><ul><li>Fastest to implement (generate text, render client-side)</li><li>CLI can also emit Mermaid for README/docs</li><li>Lightweight, familiar format</li></ul></div>
+        <div class="cons"><h4>Cons</h4><ul><li>Limited interactivity (no drag, limited click handling)</li><li>Doesn't scale well past ~30 nodes</li><li>Less "wow factor" for demos</li><li>Hard to customize node styling</li></ul></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<p style="margin-top:24px; color:#888; font-size:14px;"><strong>My recommendation:</strong> <strong>B (ELK/Dagre layered)</strong> &mdash; spec dependency graphs have natural hierarchy (dependency depth). A layered layout makes the flow immediately obvious, is deterministic (great for screenshots/embedding), and scales better. We can add Mermaid CLI export as a bonus without it being the primary visualization.</p>

--- a/.superpowers/brainstorm/31453-1774227435/waiting.html
+++ b/.superpowers/brainstorm/31453-1774227435/waiting.html
@@ -1,0 +1,3 @@
+<div style="display:flex;align-items:center;justify-content:center;min-height:60vh">
+  <p class="subtitle">Continuing in terminal...</p>
+</div>

--- a/docs/superpowers/specs/2026-03-22-graph-visualization-ui-design.md
+++ b/docs/superpowers/specs/2026-03-22-graph-visualization-ui-design.md
@@ -1,0 +1,239 @@
+# Graph Visualization UI
+
+**Date:** 2026-03-22
+**Closes:** spgr-p1l
+
+## Problem
+
+SpecGraph has no visual representation of the spec dependency graph. The CLI
+outputs text/markdown tables, which work for AI agents and terminal users but
+don't give an at-a-glance picture of project structure. For demos, onboarding,
+and non-engineering stakeholders, a visual graph explorer is essential.
+
+## Approach
+
+Embed an interactive SvelteKit web application in the specgraph Go binary.
+The UI is read-only — a graph explorer and dashboard served from the same
+port as the ConnectRPC API. Write operations stay in the CLI and external
+tools (Slack, ADO, GitHub Issues).
+
+Primary consumers: demo audiences, non-engineering stakeholders reviewing
+project structure, and developers wanting a visual overview. Deep-linkable
+URLs enable future Slack/ADO embedding.
+
+## Architecture
+
+### Embedded SPA
+
+- SvelteKit app lives in `web/` within the repo
+- `adapter-static` produces static files at build time
+- `web/embed.go` at the repo root declares `//go:embed build/*` (the embed
+  directive must be in the same module-relative directory as the files)
+- `cmd/specgraph/serve.go` imports the embed FS from `web/` package
+- `specgraph serve` serves both ConnectRPC API and UI on the same port
+- During development: Vite dev server on `:5173` proxies API calls to Go on `:8080`
+
+### Server Changes
+
+Go server additions:
+
+1. **CORS middleware** — wraps the outermost handler (before `ProjectMiddleware`)
+   so preflight `OPTIONS` requests without `X-Specgraph-Project` are handled.
+   Only enabled when a `--cors-origin` flag is set (dev mode).
+2. **Static file serving** — `http.FileServer` with the embedded FS, registered
+   on the mux before the catch-all.
+3. **Catch-all routing** — Go's `http.ServeMux` matches longest prefix first.
+   ConnectRPC services register exact paths (`/specgraph.v1.GraphService/`).
+   Static assets register under a prefix (e.g., `/_app/`). A final `/` handler
+   serves `index.html` for all unmatched paths, enabling SvelteKit deep links.
+
+### New RPC: GetFullGraph
+
+```protobuf
+message GetFullGraphRequest {}
+
+message GraphNode {
+  string slug = 1;
+  string label = 2;      // "Spec" or "Decision"
+  string stage = 3;       // stage or status
+  string intent = 4;      // spec intent or decision title
+  string priority = 5;    // p0-p3 (specs only)
+}
+
+message GetFullGraphResponse {
+  repeated GraphNode nodes = 1;
+  repeated Edge edges = 2;  // reuses existing Edge message from graph.proto
+}
+```
+
+Added to `GraphService`. Returns all specs and decisions as nodes plus all
+edges in a single response. `GraphNode` is richer than `NodeRef` — includes
+`intent` and `priority` to avoid N+1 `GetSpec` calls for tooltips.
+
+**Join key:** `Edge.from_id` and `Edge.to_id` contain **slugs** (despite the
+field name). This matches `GraphNode.slug`. The existing storage layer returns
+slugs in these fields (see `graph.go` Cypher: `a.slug AS from_slug`). The
+frontend joins edges to nodes via slug matching.
+
+**Excluded edges:** Internal-only edge types (`HAS_CHANGE`, `HAS_FINDING`)
+are excluded from the response. Only user-facing edge types in the `EdgeType`
+proto enum are returned.
+
+## Frontend Stack
+
+| Technology | Purpose |
+|-----------|---------|
+| SvelteKit | Framework with file-based routing, `adapter-static` for production |
+| TypeScript | Type safety, generated ConnectRPC client types |
+| `@connectrpc/connect-web` | Typed RPC calls from browser to Go server |
+| `@dagrejs/dagre` (~30KB) | Layered graph layout algorithm |
+| SVG | Graph rendering (DOM events for click/hover on nodes) |
+| Svelte scoped CSS | Styling (no Tailwind) |
+
+### Proto Codegen
+
+Extend `buf.gen.yaml` to generate `@connectrpc/connect-es` TypeScript stubs
+into `web/src/lib/api/gen/`. Same proto sources, additional output target.
+
+## URL Structure
+
+| Route | View | Data Source |
+|-------|------|-------------|
+| `/` | Dashboard (stats + funnel + mini graph) | `ListSpecs`, `GetReady`, `CheckDrift` (empty slug = all), `GetFullGraph`, `ListDecisions` |
+| `/graph` | Full interactive graph | `GetFullGraph` |
+| `/spec/:slug` | Spec detail | `GetSpec` |
+| `/decision/:slug` | Decision detail | `GetDecision` |
+
+All routes are deep-linkable. The Go catch-all returns `index.html` for any
+path not matching a ConnectRPC service or static asset.
+
+## Dashboard (/)
+
+Three sections stacked vertically:
+
+1. **Stats bar** — cards showing total specs, ready count, drift count,
+   decision count. Data derived from existing RPCs.
+
+2. **Authoring funnel** — horizontal stacked bar showing spec count per stage
+   (spark, shape, specify, decompose, approved, done). Color-coded. Derived
+   from `ListSpecs` response.
+
+3. **Mini graph preview** — compact version of the full graph in a smaller
+   SVG viewport. Simplified labels, click navigates to `/graph`.
+
+## Graph View (/graph)
+
+### Layout
+
+Dagre layered layout with dependency depth as the layer axis (top to bottom).
+Specs and decisions as nodes, edges as directed lines between them.
+
+### Visual Encoding
+
+- **Node color by stage:** spark=purple, shape=blue, specify=green,
+  decompose=amber, approved=teal, done=gray
+- **Node shape:** rounded rectangles for specs, diamonds or hexagons for decisions
+- **Edge style by type:** solid=DEPENDS_ON, dashed=RELATES_TO, dotted=COMPOSES,
+  colored=INFORMS/DECIDED_IN
+- **Edge direction:** arrows point from dependent to dependency (A→B means A depends on B)
+
+### Interactions (V1)
+
+- **Pan and zoom** — mouse wheel + drag on background
+- **Click node** — navigate to `/spec/:slug` or `/decision/:slug`
+- **Hover node** — tooltip showing slug, intent/title, stage, priority
+- **Client-side search/filter** — text input filters nodes by slug, intent,
+  stage, or priority. Matching nodes stay highlighted, non-matching fade out.
+
+## Spec Detail (/spec/:slug)
+
+Renders spec data from `GetSpec` response. Same content as `specgraph show`
+CLI output but in a web layout. Includes metadata table, notes, and a link
+back to the graph view (centered on this spec).
+
+## Decision Detail (/decision/:slug)
+
+Renders decision data from `GetDecision` response. Same content as
+`specgraph decision show`. Metadata, decision text, rationale.
+
+## Directory Structure
+
+```text
+web/
+  src/
+    lib/
+      api/                        # ConnectRPC client setup
+        gen/                      # Generated TS types from proto
+      components/
+        Graph.svelte              # Dagre-layouted SVG graph
+        GraphMini.svelte          # Compact dashboard version
+        StatsBar.svelte           # Stat cards row
+        FunnelBar.svelte          # Authoring funnel bar
+        SearchFilter.svelte       # Text filter input
+    routes/
+      +layout.svelte              # Nav bar, shared layout
+      +page.svelte                # Dashboard (/)
+      graph/+page.svelte          # Full graph (/graph)
+      spec/[slug]/+page.svelte    # Spec detail
+      decision/[slug]/+page.svelte # Decision detail
+  static/                         # Favicon, etc.
+  svelte.config.js
+  vite.config.ts                  # Dev proxy to Go server
+```
+
+## Build & Dev Workflow
+
+### Development
+
+1. `specgraph serve` — Go API on `:8080`
+2. `cd web && npm run dev` — Vite on `:5173`, proxying API calls to `:8080`
+3. Svelte hot-reload on file changes
+
+### Production
+
+1. `task web:build` — SvelteKit builds to `web/build/`
+2. `web/embed.go` provides `//go:embed build/*` FS
+3. `task build` compiles Go binary (imports embed FS from `web/` package)
+4. `specgraph serve` serves everything on one port
+
+### Taskfile
+
+- `task web:dev` — start Vite dev server
+- `task web:build` — production build
+- `task build` — runs `web:build` then Go build
+
+## Testing
+
+- **Go:** Unit test for `GetFullGraph` handler and storage method, following
+  existing graph test patterns in `internal/server/graph_handler_test.go`
+- **Integration:** Extend e2e API tests to cover `GetFullGraph` RPC
+- **Frontend:** Manual verification via dev server. No JS test framework in V1.
+
+## Out of Scope
+
+- Write operations from the UI (approvals, edits, comments)
+- Server-side search RPC (client-side filtering is sufficient for V1)
+- Real-time updates / WebSocket push (refresh to see changes)
+- Authentication UI (inherits server auth, no login page)
+- Activity feed / changelog view on dashboard
+- Mermaid/dot CLI export (separate follow-up task)
+- Graph export as image/PDF
+- Mobile responsive layout
+- Slack unfurl integration (deep links enable this later)
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `proto/specgraph/v1/graph.proto` | Add `GetFullGraph` RPC, `GraphNode` message |
+| `gen/specgraph/v1/` | Regenerated Go + new TS output |
+| `internal/server/graph_handler.go` | New `GetFullGraph` handler |
+| `internal/server/server.go` | CORS middleware, static file serving, catch-all |
+| `internal/storage/graph.go` | New `GetFullGraph` method on `GraphBackend` interface |
+| `internal/storage/memgraph/graph.go` | Cypher query for all nodes + edges |
+| `web/embed.go` | `//go:embed build/*` — embed FS declaration |
+| `cmd/specgraph/serve.go` | Import embed FS, serve static assets, catch-all route |
+| `buf.gen.yaml` | Add TypeScript/connect-es output |
+| `Taskfile.yml` | Add `web:dev`, `web:build` tasks |
+| `web/` | Entire SvelteKit application (new) |
+| `.gitignore` | Add `web/node_modules/`, `web/build/`, `.superpowers/` |


### PR DESCRIPTION
## Summary
- Add design spec for graph visualization UI (`docs/superpowers/specs/2026-03-22-graph-visualization-ui-design.md`)
- Covers embedded SvelteKit SPA with Dagre layout, dashboard, spec/decision detail pages, new GetFullGraph RPC
- Read-only V1 scope; writes stay in CLI/Slack/ADO

## Test plan
- [ ] Markdown renders correctly
- [ ] No broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive graph visualization dashboard for exploring specifications and decisions with multiple layout options.
  * Introduced visual decision interface allowing users to compare and select architectural configurations.
  * Enhanced navigation with pan, zoom, and interactive filtering capabilities for dependency graphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->