### PR TITLE
feat: batch improvements — dashboard stats, constitution view, status command, template overrides, bug fixes

### DIFF
--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -46,7 +46,8 @@
       }
       stageCounts = counts;
 
-      readyCount = (readyRes.ready ?? []).length;
+      const readySpecs = (readyRes.ready ?? []).filter((s) => !sliceSlugs.has(s.slug));
+      readyCount = readySpecs.length;
       graphNodes = graphRes.nodes ?? [];
       graphEdges = graphRes.edges ?? [];
       decisionCount = (decisionsRes.decisions ?? []).length;

--- a/web/src/routes/constitution/+page.svelte
+++ b/web/src/routes/constitution/+page.svelte
@@ -43,7 +43,8 @@
     return labels[rt] ?? 'Ref';
   }
 
-  function mapEntries(m: { [key: string]: string }): [string, string][] {
+  function mapEntries(m: { [key: string]: string } | undefined): [string, string][] {
+    if (!m) return [];
     return Object.entries(m).sort(([a], [b]) => a.localeCompare(b));
   }
 </script>


### PR DESCRIPTION
## Summary

Six items in one PR — 2 bug fixes + 4 features:

### Bug Fixes
- **spgr-8ec**: Approve skill guardrails — agent cannot self-approve specs it authored. Explicit human sign-off required per checkpoint.
- **spgr-5sd**: `SilenceUsage: true` on rootCmd — CLI errors show the actual message instead of cobra usage dump.

### Features
- **spgr-r40**: Dashboard stats filter decompose slices from top-level spec count. Shows "Specs: N (M slices)" when slices exist. Funnel bar only counts top-level specs.
- **spgr-qdl**: Constitution web UI page at `/constitution` — calls `GetConstitution` RPC, renders all sections (tech stack, principles, constraints, antipatterns, process, references) via AccordionSection components. Nav link added.
- **spgr-qu2**: `specgraph status` command — health check via ConnectRPC, reports server URL + status. `--json` flag for machine output. Clean "not running" on connection failure.
- **spgr-9n8**: Analytical pass template overrides — place `<pass_type>.md` in a local directory (e.g., `.specgraph/templates/`), handler checks there first, falls back to embedded defaults. CLAUDE.md gotcha added.

## Test plan

- [x] `task check` green
- [x] Template override unit tests (2 new tests in `analytical_pass_handler_test.go`)
- [x] `pnpm build` clean for web changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)