### PR TITLE
fix(ci): build web UI before goreleaser in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,15 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+      - uses: pnpm/action-setup@02f6c237bd2518259fed6c71566509edfb3f2b74 # v4
+        with:
+          run_install: false
+      - name: Build web UI
+        working-directory: web
+        run: pnpm install --frozen-lockfile && pnpm build
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.mod


### PR DESCRIPTION
## Summary
- GoReleaser failed on v0.2.0 release because `web/embed.go` requires `web/build/` (`//go:embed all:build`) but the release workflow never built the SvelteKit frontend
- Add `setup-node`, `pnpm/action-setup`, and `pnpm build` steps before GoReleaser runs
- All action pins use commit SHAs per supply chain hardening policy

## Test plan
- [ ] Merge and verify release-please creates a 0.2.1 release PR
- [ ] Confirm goreleaser succeeds with web build artifacts present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>