### PR TITLE
fix(ci): set cancel-in-progress to unblock stuck release run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 permissions: {}
 concurrency:
   group: release
-  cancel-in-progress: false
+  cancel-in-progress: true
 jobs:
   release:
     permissions:


### PR DESCRIPTION
## Summary
- Set `cancel-in-progress: true` on the release workflow concurrency group to unblock a zombie queued run
- After the first successful release, this should be reverted to `false` to prevent accidental cancellation of in-progress releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>