### PR TITLE
fix(ci): revert cancel-in-progress to false for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 permissions: {}
 concurrency:
   group: release
-  cancel-in-progress: true
+  cancel-in-progress: false
 jobs:
   release:
     permissions:


### PR DESCRIPTION
## Summary
- Revert `cancel-in-progress` back to `false` now that the zombie queued run has been cleared
- Prevents accidental cancellation of in-progress releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>