### PR TITLE
feat(sync): idempotent push — FindOrCreate to prevent orphaned external items (spgr-ylq)

### DIFF
--- a/docs/superpowers/plans/2026-03-26-idempotent-push.md
+++ b/docs/superpowers/plans/2026-03-26-idempotent-push.md
@@ -1,0 +1,586 @@
+# Idempotent Push Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `FindOrCreate` to the sync Adapter interface so adapters search for existing external items before creating new ones, preventing orphaned duplicates.
+
+**Architecture:** Each adapter implements `FindOrCreate` with a title-search-then-create strategy. The sync handler calls `FindOrCreate` instead of `Push`. When an existing item is found, the handler still records the sync mapping to heal orphans.
+
+**Tech Stack:** Go, `gh` CLI (GitHub search), `bd` CLI (beads search), ConnectRPC handler
+
+**Spec:** `docs/superpowers/specs/2026-03-26-idempotent-push-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `internal/sync/adapter.go` | Modify | Add `FindOrCreate` to `Adapter` interface |
+| `internal/sync/beads.go` | Modify | Implement `BeadsAdapter.FindOrCreate` |
+| `internal/sync/beads_test.go` | Modify | Add sequencing mock, FindOrCreate tests |
+| `internal/sync/github.go` | Modify | Implement `GitHubAdapter.FindOrCreate` |
+| `internal/sync/github_test.go` | Modify | Add FindOrCreate tests |
+| `internal/server/sync_handler.go` | Modify | Call `FindOrCreate` instead of `Push` |
+| `internal/server/sync_handler_test.go` | Modify | Add `findOrCreateFn` to mock, add handler tests |
+
+---
+
+## Chunk 1: Interface + Sequencing Mock + BeadsAdapter
+
+### Task 1: Add FindOrCreate to Adapter interface
+
+**Files:**
+
+- Modify: `internal/sync/adapter.go:22-35`
+
+- [ ] **Step 1: Add FindOrCreate to the Adapter interface**
+
+In `internal/sync/adapter.go`, add the `FindOrCreate` method to the `Adapter` interface after `Push`:
+
+```go
+// FindOrCreate searches for an existing external item matching this spec.
+// If found, returns its ID with created=false.
+// If not found, creates a new one (like Push) and returns created=true.
+FindOrCreate(ctx context.Context, spec *storage.Spec) (externalID string, created bool, err error)
+```
+
+- [ ] **Step 2: Verify build fails**
+
+Run: `go build ./internal/sync/ ./internal/server/`
+
+Expected: Compile errors — `GitHubAdapter`, `BeadsAdapter`, and test mocks don't implement `FindOrCreate` yet.
+
+### Task 2: Add sequencing mock runner
+
+**Files:**
+
+- Modify: `internal/sync/beads_test.go`
+
+The existing `mockRunner` returns a single output/error. `FindOrCreate` makes two sequential CLI calls (search, then optionally create). We need a mock that returns different results per call.
+
+- [ ] **Step 1: Add `sequenceRunner` to `beads_test.go`**
+
+Add after the existing `mockRunner` (around line 23):
+
+```go
+// sequenceRunner returns different output/error for each sequential call.
+type sequenceRunner struct {
+	calls []struct {
+		output []byte
+		err    error
+	}
+	idx int
+}
+
+func (s *sequenceRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	if s.idx >= len(s.calls) {
+		return nil, errors.New("sequenceRunner: unexpected call")
+	}
+	c := s.calls[s.idx]
+	s.idx++
+	return c.output, c.err
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `go build ./internal/sync/`
+
+Expected: Compile error (FindOrCreate not yet on BeadsAdapter). That's expected — we add it in Task 3.
+
+### Task 3: Implement BeadsAdapter.FindOrCreate
+
+**Files:**
+
+- Modify: `internal/sync/beads.go`
+- Modify: `internal/sync/beads_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/sync/beads_test.go`:
+
+```go
+func TestBeadsAdapter_FindOrCreate_ExistingItem(t *testing.T) {
+	runner := &sequenceRunner{
+		calls: []struct {
+			output []byte
+			err    error
+		}{
+			{output: []byte(`[{"id": "bead-existing"}]`), err: nil}, // search finds it
+		},
+	}
+	b := NewBeadsAdapter(runner)
+	spec := &storage.Spec{
+		Slug:     "my-spec",
+		Intent:   "Build a thing",
+		Stage:    storage.SpecStageSpark,
+		Priority: storage.SpecPriorityP2,
+	}
+	id, created, err := b.FindOrCreate(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("FindOrCreate() unexpected error: %v", err)
+	}
+	if created {
+		t.Error("FindOrCreate() created = true, want false")
+	}
+	if id != "bead-existing" {
+		t.Errorf("FindOrCreate() id = %q, want %q", id, "bead-existing")
+	}
+}
+
+func TestBeadsAdapter_FindOrCreate_NewItem(t *testing.T) {
+	runner := &sequenceRunner{
+		calls: []struct {
+			output []byte
+			err    error
+		}{
+			{output: []byte(`[]`), err: nil},                                        // search finds nothing
+			{output: []byte(`{"id": "bead-new123"}`), err: nil},                     // create succeeds
+		},
+	}
+	b := NewBeadsAdapter(runner)
+	spec := &storage.Spec{
+		Slug:     "my-spec",
+		Intent:   "Build a thing",
+		Stage:    storage.SpecStageSpark,
+		Priority: storage.SpecPriorityP2,
+	}
+	id, created, err := b.FindOrCreate(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("FindOrCreate() unexpected error: %v", err)
+	}
+	if !created {
+		t.Error("FindOrCreate() created = false, want true")
+	}
+	if id != "bead-new123" {
+		t.Errorf("FindOrCreate() id = %q, want %q", id, "bead-new123")
+	}
+}
+
+func TestBeadsAdapter_FindOrCreate_SearchError(t *testing.T) {
+	runner := &sequenceRunner{
+		calls: []struct {
+			output []byte
+			err    error
+		}{
+			{output: nil, err: errors.New("bd search failed")}, // search errors
+		},
+	}
+	b := NewBeadsAdapter(runner)
+	spec := &storage.Spec{
+		Slug:     "my-spec",
+		Intent:   "Build a thing",
+		Stage:    storage.SpecStageSpark,
+		Priority: storage.SpecPriorityP2,
+	}
+	_, _, err := b.FindOrCreate(context.Background(), spec)
+	if err == nil {
+		t.Fatal("FindOrCreate() expected error, got nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/sync/ -run TestBeadsAdapter_FindOrCreate -v`
+
+Expected: Compile error — `FindOrCreate` not defined on `BeadsAdapter`.
+
+- [ ] **Step 3: Implement BeadsAdapter.FindOrCreate**
+
+Add to `internal/sync/beads.go` after the `Push` method:
+
+```go
+// beadsSearchResponse captures one entry from bd search --json output.
+type beadsSearchResponse struct {
+	ID string `json:"id"`
+}
+
+// FindOrCreate searches for an existing bead matching "[spec] <slug>".
+// If found, returns its ID with created=false.
+// If not found, creates via Push and returns created=true.
+func (b *BeadsAdapter) FindOrCreate(ctx context.Context, spec *storage.Spec) (string, bool, error) {
+	if spec.Slug == "" {
+		return "", false, fmt.Errorf("%w: spec slug is required", errPushFailed)
+	}
+
+	searchTitle := fmt.Sprintf("[spec] %s", spec.Slug)
+	out, err := b.runner.Run(ctx, "bd", "search", searchTitle, "--json", "--limit", "1")
+	if err != nil {
+		return "", false, fmt.Errorf("failed to search for existing bead: %w", err)
+	}
+
+	var results []beadsSearchResponse
+	if err := json.Unmarshal(out, &results); err != nil {
+		return "", false, fmt.Errorf("failed to parse search results: %w", err)
+	}
+
+	if len(results) > 0 && results[0].ID != "" {
+		return results[0].ID, false, nil
+	}
+
+	externalID, pushErr := b.Push(ctx, spec)
+	if pushErr != nil {
+		return "", false, pushErr
+	}
+	return externalID, true, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/sync/ -run TestBeadsAdapter_FindOrCreate -v`
+
+Expected: All 3 tests PASS.
+
+- [ ] **Step 5: Run full sync package tests**
+
+Run: `go test ./internal/sync/ -v`
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj --no-pager describe -m "feat(sync): add FindOrCreate to Adapter interface, implement for BeadsAdapter (spgr-ylq)"
+```
+
+---
+
+## Chunk 2: GitHubAdapter.FindOrCreate
+
+### Task 4: Implement GitHubAdapter.FindOrCreate
+
+**Files:**
+
+- Modify: `internal/sync/github.go`
+- Modify: `internal/sync/github_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/sync/github_test.go`:
+
+```go
+func TestGitHubAdapter_FindOrCreate_ExistingItem(t *testing.T) {
+	runner := &sequenceRunner{
+		calls: []struct {
+			output []byte
+			err    error
+		}{
+			{output: []byte(`[{"number":42,"url":"https://github.com/owner/repo/issues/42"}]`), err: nil},
+		},
+	}
+	g := NewGitHubAdapter(runner, "owner/repo")
+	spec := &storage.Spec{
+		Slug:     "my-spec",
+		Intent:   "Build a thing",
+		Stage:    storage.SpecStageSpark,
+		Priority: storage.SpecPriorityP1,
+	}
+	id, created, err := g.FindOrCreate(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("FindOrCreate() unexpected error: %v", err)
+	}
+	if created {
+		t.Error("FindOrCreate() created = true, want false")
+	}
+	if id != "https://github.com/owner/repo/issues/42" {
+		t.Errorf("FindOrCreate() id = %q, want URL", id)
+	}
+}
+
+func TestGitHubAdapter_FindOrCreate_NewItem(t *testing.T) {
+	runner := &sequenceRunner{
+		calls: []struct {
+			output []byte
+			err    error
+		}{
+			{output: []byte(`[]`), err: nil},                                                  // search empty
+			{output: []byte("https://github.com/owner/repo/issues/99\n"), err: nil},           // create
+		},
+	}
+	g := NewGitHubAdapter(runner, "owner/repo")
+	spec := &storage.Spec{
+		Slug:     "new-spec",
+		Intent:   "Build a thing",
+		Stage:    storage.SpecStageSpark,
+		Priority: storage.SpecPriorityP1,
+	}
+	id, created, err := g.FindOrCreate(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("FindOrCreate() unexpected error: %v", err)
+	}
+	if !created {
+		t.Error("FindOrCreate() created = false, want true")
+	}
+	if id != "https://github.com/owner/repo/issues/99" {
+		t.Errorf("FindOrCreate() id = %q, want URL", id)
+	}
+}
+
+func TestGitHubAdapter_FindOrCreate_SearchError(t *testing.T) {
+	runner := &sequenceRunner{
+		calls: []struct {
+			output []byte
+			err    error
+		}{
+			{output: nil, err: errors.New("gh search failed")},
+		},
+	}
+	g := NewGitHubAdapter(runner, "owner/repo")
+	spec := &storage.Spec{
+		Slug:     "my-spec",
+		Intent:   "Build a thing",
+		Stage:    storage.SpecStageSpark,
+		Priority: storage.SpecPriorityP1,
+	}
+	_, _, err := g.FindOrCreate(context.Background(), spec)
+	if err == nil {
+		t.Fatal("FindOrCreate() expected error, got nil")
+	}
+}
+```
+
+Note: `sequenceRunner` is defined in `beads_test.go` and is accessible since both files are in the `sync` package.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/sync/ -run TestGitHubAdapter_FindOrCreate -v`
+
+Expected: Compile error — `FindOrCreate` not defined on `GitHubAdapter`.
+
+- [ ] **Step 3: Implement GitHubAdapter.FindOrCreate**
+
+Add to `internal/sync/github.go` after the `Push` method:
+
+```go
+// ghSearchResult captures one entry from gh issue list --json output.
+type ghSearchResult struct {
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+}
+
+// FindOrCreate searches for an existing GitHub issue matching "[spec] <slug>".
+// If found, returns its URL with created=false.
+// If not found, creates via Push and returns created=true.
+func (g *GitHubAdapter) FindOrCreate(ctx context.Context, spec *storage.Spec) (string, bool, error) {
+	if spec.Slug == "" {
+		return "", false, fmt.Errorf("%w: spec slug is required", errPushFailed)
+	}
+	if g.repo == "" {
+		return "", false, fmt.Errorf("%w: repo is required", errPushFailed)
+	}
+
+	searchTitle := fmt.Sprintf("in:title [spec] %s", spec.Slug)
+	out, err := g.runner.Run(ctx, "gh", "issue", "list",
+		"--search", searchTitle,
+		"--repo", g.repo,
+		"--json", "number,url",
+		"--limit", "1",
+	)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to search for existing issue: %w", err)
+	}
+
+	var results []ghSearchResult
+	if err := json.Unmarshal(out, &results); err != nil {
+		return "", false, fmt.Errorf("failed to parse search results: %w", err)
+	}
+
+	if len(results) > 0 && results[0].URL != "" {
+		return results[0].URL, false, nil
+	}
+
+	externalID, pushErr := g.Push(ctx, spec)
+	if pushErr != nil {
+		return "", false, pushErr
+	}
+	return externalID, true, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/sync/ -run TestGitHubAdapter_FindOrCreate -v`
+
+Expected: All 3 tests PASS.
+
+- [ ] **Step 5: Run full sync package tests**
+
+Run: `go test ./internal/sync/ -v`
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj --no-pager describe -m "feat(sync): implement GitHubAdapter.FindOrCreate with title search (spgr-ylq)"
+```
+
+---
+
+## Chunk 3: Handler + Mock Update + Integration Tests
+
+### Task 5: Update mock adapter and sync handler
+
+**Files:**
+
+- Modify: `internal/server/sync_handler.go:145`
+- Modify: `internal/server/sync_handler_test.go` (mockAdapter around line 382)
+
+- [ ] **Step 1: Add `findOrCreateFn` to mockAdapter**
+
+In `internal/server/sync_handler_test.go`, update the `mockAdapter` struct (around line 382):
+
+```go
+type mockAdapter struct {
+	name            storage.SyncAdapterType
+	pushFn          func(ctx context.Context, spec *storage.Spec) (string, error)
+	findOrCreateFn  func(ctx context.Context, spec *storage.Spec) (string, bool, error)
+	available       bool
+}
+```
+
+Add the `FindOrCreate` method:
+
+```go
+func (m *mockAdapter) FindOrCreate(ctx context.Context, spec *storage.Spec) (string, bool, error) {
+	if m.findOrCreateFn != nil {
+		return m.findOrCreateFn(ctx, spec)
+	}
+	// Fall back to Push for backward compatibility with existing tests.
+	id, err := m.pushFn(ctx, spec)
+	return id, true, err
+}
+```
+
+- [ ] **Step 2: Verify existing tests still pass**
+
+Run: `go test ./internal/server/ -run TestSyncHandler -v -count=1`
+
+Expected: All existing sync handler tests PASS (the fallback to `pushFn` preserves compatibility).
+
+- [ ] **Step 3: Update sync handler to call FindOrCreate**
+
+In `internal/server/sync_handler.go`, replace line 145:
+
+```go
+externalID, pushErr := adapter.Push(ctx, spec)
+```
+
+With:
+
+```go
+externalID, created, pushErr := adapter.FindOrCreate(ctx, spec)
+```
+
+And update the success log/message at line 202. Replace:
+
+```go
+result.Message = "synced"
+```
+
+With:
+
+```go
+if created {
+	result.Message = "synced"
+} else {
+	result.Message = "synced (recovered existing external item)"
+}
+```
+
+- [ ] **Step 4: Add handler test for orphan recovery**
+
+Add to `internal/server/sync_handler_test.go`:
+
+```go
+func TestSyncHandler_SyncBeads_FindOrCreate_Recovery(t *testing.T) {
+	adapter := &mockAdapter{
+		name:      storage.SyncAdapterBeads,
+		available: true,
+		findOrCreateFn: func(_ context.Context, spec *storage.Spec) (string, bool, error) {
+			return "beads-recovered-" + spec.Slug, false, nil // found existing, not created
+		},
+	}
+	client := setupSyncServerWithAdapter(t, adapter)
+	resp, err := client.SyncBeads(context.Background(),
+		connect.NewRequest(&specv1.SyncBeadsRequest{
+			Config: &specv1.SyncConfig{},
+		}))
+	require.NoError(t, err)
+	require.Equal(t, int32(1), resp.Msg.Synced)
+	require.Len(t, resp.Msg.Results, 1)
+	require.Equal(t, specv1.SyncState_SYNC_STATE_SYNCED, resp.Msg.Results[0].State)
+	require.Contains(t, resp.Msg.Results[0].Message, "recovered")
+}
+```
+
+- [ ] **Step 5: Run all sync handler tests**
+
+Run: `go test ./internal/server/ -run TestSyncHandler -v -count=1`
+
+Expected: All tests PASS including the new recovery test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj --no-pager describe -m "feat(sync): handler calls FindOrCreate instead of Push, orphan recovery (spgr-ylq)"
+```
+
+---
+
+## Chunk 4: Final Verification + PR
+
+### Task 6: Verify and create PR
+
+- [ ] **Step 1: Run task check**
+
+```bash
+task check
+```
+
+Expected: All checks pass (fmt, lint, build, test).
+
+- [ ] **Step 2: Squash changes**
+
+If working on separate jj changes, squash into one:
+
+```bash
+jj --no-pager squash --into <first-change-id> -m "feat(sync): idempotent push — FindOrCreate to prevent orphaned external items (spgr-ylq)"
+```
+
+- [ ] **Step 3: Create bookmark and push**
+
+```bash
+jj --no-pager bookmark set feat/idempotent-push -r @
+jj --no-pager git push --bookmark feat/idempotent-push
+```
+
+- [ ] **Step 4: Create PR**
+
+```bash
+gh pr create \
+  --title "feat(sync): idempotent push — FindOrCreate to prevent orphaned external items (spgr-ylq)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Add `FindOrCreate` method to sync `Adapter` interface
+- GitHubAdapter searches by `[spec] <slug>` title via `gh issue list --search`
+- BeadsAdapter searches by title via `bd search`
+- Sync handler calls `FindOrCreate` instead of `Push`, healing orphaned mappings
+- Existing retry logic on `CreateSyncMapping` unchanged
+
+Closes #166
+
+## Test plan
+- [ ] Unit tests for FindOrCreate on both adapters (found, not-found, search-error)
+- [ ] Handler test for orphan recovery path (found existing, mapping created)
+- [ ] All existing sync tests pass unchanged
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-03-26-idempotent-push-design.md
+++ b/docs/superpowers/specs/2026-03-26-idempotent-push-design.md
@@ -1,0 +1,81 @@
+# Idempotent Push: FindOrCreate for Sync Adapters
+
+**Date**: 2026-03-26
+**Status**: Approved
+**Bead**: spgr-ylq
+
+## Problem
+
+When `adapter.Push` succeeds but `store.CreateSyncMapping` fails, an orphaned external item is created (a GitHub issue or bead with no corresponding sync mapping in the graph). On the next sync run, `GetSyncMapping` returns `ErrSyncMappingNotFound`, so the handler calls `Push` again — creating a duplicate external item.
+
+The current retry-once logic in `sync_handler.go` mitigates transient store failures but does not prevent duplicates when the store is persistently unavailable or when the process crashes between Push and CreateSyncMapping.
+
+## Decision
+
+Add a `FindOrCreate` method to the `Adapter` interface. Each adapter searches for an existing external item by title convention before creating a new one. The sync handler calls `FindOrCreate` instead of `Push`.
+
+## Adapter Interface
+
+```go
+type Adapter interface {
+    Name() storage.SyncAdapterType
+    Available(ctx context.Context) error
+    Push(ctx context.Context, spec *storage.Spec) (externalID string, err error)
+    FindOrCreate(ctx context.Context, spec *storage.Spec) (externalID string, created bool, err error)
+    Pull(ctx context.Context, externalID string) (status string, err error)
+}
+```
+
+`Push` remains on the interface for backward compatibility. `FindOrCreate` is the primary method the handler uses. Each adapter's `FindOrCreate` calls `Push` internally when no existing item is found.
+
+## Adapter Implementations
+
+### GitHubAdapter.FindOrCreate
+
+1. Search: `gh issue list --search "in:title [spec] <slug>" --repo <repo> --json number,url --limit 1`
+2. If result found: return existing issue URL, `created=false`
+3. If no result: call `Push(ctx, spec)`, return new URL, `created=true`
+
+### BeadsAdapter.FindOrCreate
+
+1. Search: `bd search "[spec] <slug>" --json --limit 1`
+2. If result found: return existing bead ID, `created=false`
+3. If no result: call `Push(ctx, spec)`, return new ID, `created=true`
+
+## Handler Change
+
+In `syncWithAdapter` (sync_handler.go:145), replace:
+
+```go
+externalID, pushErr := adapter.Push(ctx, spec)
+```
+
+With:
+
+```go
+externalID, created, pushErr := adapter.FindOrCreate(ctx, spec)
+```
+
+The `created` bool informs logging and the result message. When `created=false`, the handler still calls `CreateSyncMapping` to heal the orphan. The existing `ErrSyncMappingExists` handling covers the race where the mapping already exists.
+
+The retry-once logic on `CreateSyncMapping` failure remains unchanged.
+
+## Scope
+
+- **In scope**: FindOrCreate on both adapters, handler wiring, tests
+- **Out of scope**: Updating existing external items when spec state changes. Create-only; updates are a separate concern.
+
+## File Changes
+
+### Modify
+
+- `internal/sync/adapter.go` — add `FindOrCreate` to `Adapter` interface
+- `internal/sync/github.go` — implement `GitHubAdapter.FindOrCreate`
+- `internal/sync/beads.go` — implement `BeadsAdapter.FindOrCreate`
+- `internal/server/sync_handler.go` — call `FindOrCreate` instead of `Push`
+
+### Test Files
+
+- `internal/sync/github_test.go` — tests for FindOrCreate (found, not-found, search-error)
+- `internal/sync/beads_test.go` — tests for FindOrCreate (found, not-found, search-error)
+- `internal/server/sync_handler_test.go` — update mock adapter, test FindOrCreate integration (orphan healing, created vs found paths)

--- a/internal/server/sync_handler.go
+++ b/internal/server/sync_handler.go
@@ -142,7 +142,7 @@ func (h *SyncHandler) syncWithAdapter(ctx context.Context, store storage.ScopedB
 			continue
 		}
 
-		externalID, pushErr := adapter.Push(ctx, spec)
+		externalID, created, pushErr := adapter.FindOrCreate(ctx, spec)
 		if pushErr != nil {
 			slog.WarnContext(ctx, "failed to push spec to adapter", "spec", spec.Slug, "adapter", adapter.Name(), "error", pushErr)
 			result.State = specv1.SyncState_SYNC_STATE_ERROR
@@ -199,7 +199,11 @@ func (h *SyncHandler) syncWithAdapter(ctx context.Context, store storage.ScopedB
 
 		result.ExternalId = externalID
 		result.State = specv1.SyncState_SYNC_STATE_SYNCED
-		result.Message = "synced"
+		if created {
+			result.Message = "synced"
+		} else {
+			result.Message = "synced (recovered existing external item)"
+		}
 		resp.Synced++
 		resp.Results = append(resp.Results, result)
 	}

--- a/internal/server/sync_handler_test.go
+++ b/internal/server/sync_handler_test.go
@@ -381,9 +381,10 @@ func TestSyncHandler_Inject_SuccessAgentsMD(t *testing.T) {
 
 // mockAdapter implements syncpkg.Adapter for testing syncWithAdapter.
 type mockAdapter struct {
-	name      storage.SyncAdapterType
-	pushFn    func(ctx context.Context, spec *storage.Spec) (string, error)
-	available bool
+	name           storage.SyncAdapterType
+	pushFn         func(ctx context.Context, spec *storage.Spec) (string, error)
+	findOrCreateFn func(ctx context.Context, spec *storage.Spec) (string, bool, error)
+	available      bool
 }
 
 func (m *mockAdapter) Name() storage.SyncAdapterType { return m.name }
@@ -397,6 +398,15 @@ func (m *mockAdapter) Available(_ context.Context) error {
 func (m *mockAdapter) Push(ctx context.Context, spec *storage.Spec) (string, error) {
 	return m.pushFn(ctx, spec)
 }
+
+func (m *mockAdapter) FindOrCreate(ctx context.Context, spec *storage.Spec) (string, bool, error) {
+	if m.findOrCreateFn != nil {
+		return m.findOrCreateFn(ctx, spec)
+	}
+	id, err := m.pushFn(ctx, spec)
+	return id, true, err
+}
+
 func (m *mockAdapter) Pull(_ context.Context, _ string) (string, error) { return "", nil }
 
 var _ syncpkg.Adapter = (*mockAdapter)(nil)
@@ -449,6 +459,26 @@ func TestSyncHandler_SyncBeads_Success(t *testing.T) {
 	require.Equal(t, int32(1), resp.Msg.Synced)
 	require.Len(t, resp.Msg.Results, 1)
 	require.Equal(t, specv1.SyncState_SYNC_STATE_SYNCED, resp.Msg.Results[0].State)
+}
+
+func TestSyncHandler_SyncBeads_FindOrCreate_Recovery(t *testing.T) {
+	adapter := &mockAdapter{
+		name:      storage.SyncAdapterBeads,
+		available: true,
+		findOrCreateFn: func(_ context.Context, spec *storage.Spec) (string, bool, error) {
+			return "beads-recovered-" + spec.Slug, false, nil
+		},
+	}
+	client := setupSyncServerWithAdapter(t, adapter)
+	resp, err := client.SyncBeads(context.Background(),
+		connect.NewRequest(&specv1.SyncBeadsRequest{
+			Config: &specv1.SyncConfig{},
+		}))
+	require.NoError(t, err)
+	require.Equal(t, int32(1), resp.Msg.Synced)
+	require.Len(t, resp.Msg.Results, 1)
+	require.Equal(t, specv1.SyncState_SYNC_STATE_SYNCED, resp.Msg.Results[0].State)
+	require.Contains(t, resp.Msg.Results[0].Message, "recovered")
 }
 
 func TestSyncHandler_SyncBeads_PushError(t *testing.T) {

--- a/internal/sync/adapter.go
+++ b/internal/sync/adapter.go
@@ -30,6 +30,11 @@ type Adapter interface {
 	// Returns the external system's ID for the created item.
 	Push(ctx context.Context, spec *storage.Spec) (externalID string, err error)
 
+	// FindOrCreate searches for an existing external item matching this spec.
+	// If found, returns its ID with created=false.
+	// If not found, creates a new one (like Push) and returns created=true.
+	FindOrCreate(ctx context.Context, spec *storage.Spec) (externalID string, created bool, err error)
+
 	// Pull retrieves the current status of an external work item.
 	Pull(ctx context.Context, externalID string) (status string, err error)
 }

--- a/internal/sync/beads.go
+++ b/internal/sync/beads.go
@@ -83,6 +83,41 @@ func (b *BeadsAdapter) Push(ctx context.Context, spec *storage.Spec) (string, er
 	return resp.ID, nil
 }
 
+// beadsSearchResponse captures one entry from bd search --json output.
+type beadsSearchResponse struct {
+	ID string `json:"id"`
+}
+
+// FindOrCreate searches for an existing bead matching "[spec] <slug>".
+// If found, returns its ID with created=false.
+// If not found, creates via Push and returns created=true.
+func (b *BeadsAdapter) FindOrCreate(ctx context.Context, spec *storage.Spec) (externalID string, created bool, err error) {
+	if spec.Slug == "" {
+		return "", false, fmt.Errorf("%w: spec slug is required", errPushFailed)
+	}
+
+	searchTitle := fmt.Sprintf("[spec] %s", spec.Slug)
+	out, err := b.runner.Run(ctx, "bd", "search", searchTitle, "--json", "--limit", "1")
+	if err != nil {
+		return "", false, fmt.Errorf("failed to search for existing bead: %w", err)
+	}
+
+	var results []beadsSearchResponse
+	if err := json.Unmarshal(out, &results); err != nil {
+		return "", false, fmt.Errorf("failed to parse search results: %w", err)
+	}
+
+	if len(results) > 0 && results[0].ID != "" {
+		return results[0].ID, false, nil
+	}
+
+	externalID, pushErr := b.Push(ctx, spec)
+	if pushErr != nil {
+		return "", false, pushErr
+	}
+	return externalID, true, nil
+}
+
 // Pull retrieves the status of a bead by its external ID.
 func (b *BeadsAdapter) Pull(ctx context.Context, externalID string) (string, error) {
 	if externalID == "" || !beadsIDPattern.MatchString(externalID) {

--- a/internal/sync/beads_test.go
+++ b/internal/sync/beads_test.go
@@ -22,6 +22,24 @@ func (m *mockRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, erro
 	return m.output, m.err
 }
 
+// sequenceRunner returns different output/error for each sequential call.
+type sequenceRunner struct {
+	calls []struct {
+		output []byte
+		err    error
+	}
+	idx int
+}
+
+func (s *sequenceRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	if s.idx >= len(s.calls) {
+		return nil, errors.New("sequenceRunner: unexpected call")
+	}
+	c := s.calls[s.idx]
+	s.idx++
+	return c.output, c.err
+}
+
 func TestBeadsAdapter_Name(t *testing.T) {
 	b := NewBeadsAdapter(&mockRunner{})
 	if got := b.Name(); got != storage.SyncAdapterBeads {
@@ -260,5 +278,140 @@ func TestBeadsAdapter_PullEmptyStatus(t *testing.T) {
 	}
 	if !errors.Is(err, errPullFailed) {
 		t.Errorf("Pull() error = %v, want errPullFailed", err)
+	}
+}
+
+func TestBeadsAdapter_FindOrCreate_ExistingItem(t *testing.T) {
+	runner := &sequenceRunner{
+		calls: []struct {
+			output []byte
+			err    error
+		}{
+			{output: []byte(`[{"id": "bead-existing"}]`), err: nil},
+		},
+	}
+	b := NewBeadsAdapter(runner)
+	spec := &storage.Spec{
+		Slug:     "my-spec",
+		Intent:   "Build a thing",
+		Stage:    storage.SpecStageSpark,
+		Priority: storage.SpecPriorityP2,
+	}
+	id, created, err := b.FindOrCreate(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("FindOrCreate() unexpected error: %v", err)
+	}
+	if created {
+		t.Error("FindOrCreate() created = true, want false")
+	}
+	if id != "bead-existing" {
+		t.Errorf("FindOrCreate() id = %q, want %q", id, "bead-existing")
+	}
+}
+
+func TestBeadsAdapter_FindOrCreate_NewItem(t *testing.T) {
+	runner := &sequenceRunner{
+		calls: []struct {
+			output []byte
+			err    error
+		}{
+			{output: []byte(`[]`), err: nil},
+			{output: []byte(`{"id": "bead-new123"}`), err: nil},
+		},
+	}
+	b := NewBeadsAdapter(runner)
+	spec := &storage.Spec{
+		Slug:     "my-spec",
+		Intent:   "Build a thing",
+		Stage:    storage.SpecStageSpark,
+		Priority: storage.SpecPriorityP2,
+	}
+	id, created, err := b.FindOrCreate(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("FindOrCreate() unexpected error: %v", err)
+	}
+	if !created {
+		t.Error("FindOrCreate() created = false, want true")
+	}
+	if id != "bead-new123" {
+		t.Errorf("FindOrCreate() id = %q, want %q", id, "bead-new123")
+	}
+}
+
+func TestBeadsAdapter_FindOrCreate_EmptySlug(t *testing.T) {
+	b := NewBeadsAdapter(&mockRunner{})
+	spec := &storage.Spec{Slug: ""}
+	_, _, err := b.FindOrCreate(context.Background(), spec)
+	if err == nil {
+		t.Fatal("FindOrCreate() expected error for empty slug, got nil")
+	}
+	if !errors.Is(err, errPushFailed) {
+		t.Errorf("FindOrCreate() error = %v, want errPushFailed", err)
+	}
+}
+
+func TestBeadsAdapter_FindOrCreate_InvalidJSON(t *testing.T) {
+	runner := &sequenceRunner{
+		calls: []struct {
+			output []byte
+			err    error
+		}{
+			{output: []byte(`not-json`), err: nil},
+		},
+	}
+	b := NewBeadsAdapter(runner)
+	spec := &storage.Spec{
+		Slug:   "my-spec",
+		Intent: "Build a thing",
+		Stage:  storage.SpecStageSpark,
+	}
+	_, _, err := b.FindOrCreate(context.Background(), spec)
+	if err == nil {
+		t.Fatal("FindOrCreate() expected error for invalid JSON, got nil")
+	}
+}
+
+func TestBeadsAdapter_FindOrCreate_PushError(t *testing.T) {
+	runner := &sequenceRunner{
+		calls: []struct {
+			output []byte
+			err    error
+		}{
+			{output: []byte(`[]`), err: nil},
+			{output: nil, err: errors.New("bd create failed")},
+		},
+	}
+	b := NewBeadsAdapter(runner)
+	spec := &storage.Spec{
+		Slug:     "my-spec",
+		Intent:   "Build a thing",
+		Stage:    storage.SpecStageSpark,
+		Priority: storage.SpecPriorityP2,
+	}
+	_, _, err := b.FindOrCreate(context.Background(), spec)
+	if err == nil {
+		t.Fatal("FindOrCreate() expected error when push fails, got nil")
+	}
+}
+
+func TestBeadsAdapter_FindOrCreate_SearchError(t *testing.T) {
+	runner := &sequenceRunner{
+		calls: []struct {
+			output []byte
+			err    error
+		}{
+			{output: nil, err: errors.New("bd search failed")},
+		},
+	}
+	b := NewBeadsAdapter(runner)
+	spec := &storage.Spec{
+		Slug:     "my-spec",
+		Intent:   "Build a thing",
+		Stage:    storage.SpecStageSpark,
+		Priority: storage.SpecPriorityP2,
+	}
+	_, _, err := b.FindOrCreate(context.Background(), spec)
+	if err == nil {
+		t.Fatal("FindOrCreate() expected error, got nil")
 	}
 }

--- a/internal/sync/github.go
+++ b/internal/sync/github.go
@@ -111,6 +111,50 @@ func (g *GitHubAdapter) Push(ctx context.Context, spec *storage.Spec) (string, e
 	return issueURL, nil
 }
 
+// ghSearchResult captures one entry from gh issue list --json output.
+type ghSearchResult struct {
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+}
+
+// FindOrCreate searches for an existing GitHub issue matching "[spec] <slug>".
+// If found, returns its URL with created=false.
+// If not found, creates via Push and returns created=true.
+func (g *GitHubAdapter) FindOrCreate(ctx context.Context, spec *storage.Spec) (externalID string, created bool, err error) {
+	if spec.Slug == "" {
+		return "", false, fmt.Errorf("%w: spec slug is required", errPushFailed)
+	}
+	if g.repo == "" {
+		return "", false, fmt.Errorf("%w: repo is required", errPushFailed)
+	}
+
+	searchTitle := fmt.Sprintf("in:title [spec] %s", spec.Slug)
+	out, err := g.runner.Run(ctx, "gh", "issue", "list",
+		"--search", searchTitle,
+		"--repo", g.repo,
+		"--json", "number,url",
+		"--limit", "1",
+	)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to search for existing issue: %w", err)
+	}
+
+	var results []ghSearchResult
+	if err := json.Unmarshal(out, &results); err != nil {
+		return "", false, fmt.Errorf("failed to parse search results: %w", err)
+	}
+
+	if len(results) > 0 && results[0].URL != "" {
+		return results[0].URL, false, nil
+	}
+
+	externalID, pushErr := g.Push(ctx, spec)
+	if pushErr != nil {
+		return "", false, pushErr
+	}
+	return externalID, true, nil
+}
+
 // Pull retrieves the current state of a GitHub issue by its URL or number.
 func (g *GitHubAdapter) Pull(ctx context.Context, externalID string) (string, error) {
 	if externalID == "" {

--- a/internal/sync/github_test.go
+++ b/internal/sync/github_test.go
@@ -424,3 +424,150 @@ func TestGitHubAdapter_AvailableNoRepo(t *testing.T) {
 		t.Errorf("Available() error = %v, want ErrAdapterNotAvailable", err)
 	}
 }
+
+func TestGitHubAdapter_FindOrCreate_ExistingItem(t *testing.T) {
+	runner := &sequenceRunner{
+		calls: []struct {
+			output []byte
+			err    error
+		}{
+			{output: []byte(`[{"number":42,"url":"https://github.com/owner/repo/issues/42"}]`), err: nil},
+		},
+	}
+	g := NewGitHubAdapter(runner, "owner/repo")
+	spec := &storage.Spec{
+		Slug:     "my-spec",
+		Intent:   "Build a thing",
+		Stage:    storage.SpecStageSpark,
+		Priority: storage.SpecPriorityP1,
+	}
+	id, created, err := g.FindOrCreate(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("FindOrCreate() unexpected error: %v", err)
+	}
+	if created {
+		t.Error("FindOrCreate() created = true, want false")
+	}
+	if id != "https://github.com/owner/repo/issues/42" {
+		t.Errorf("FindOrCreate() id = %q, want URL", id)
+	}
+}
+
+func TestGitHubAdapter_FindOrCreate_NewItem(t *testing.T) {
+	runner := &sequenceRunner{
+		calls: []struct {
+			output []byte
+			err    error
+		}{
+			{output: []byte(`[]`), err: nil},
+			{output: []byte("https://github.com/owner/repo/issues/99\n"), err: nil},
+		},
+	}
+	g := NewGitHubAdapter(runner, "owner/repo")
+	spec := &storage.Spec{
+		Slug:     "new-spec",
+		Intent:   "Build a thing",
+		Stage:    storage.SpecStageSpark,
+		Priority: storage.SpecPriorityP1,
+	}
+	id, created, err := g.FindOrCreate(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("FindOrCreate() unexpected error: %v", err)
+	}
+	if !created {
+		t.Error("FindOrCreate() created = false, want true")
+	}
+	if id != "https://github.com/owner/repo/issues/99" {
+		t.Errorf("FindOrCreate() id = %q, want URL", id)
+	}
+}
+
+func TestGitHubAdapter_FindOrCreate_EmptySlug(t *testing.T) {
+	g := NewGitHubAdapter(&mockRunner{}, "owner/repo")
+	spec := &storage.Spec{Slug: ""}
+	_, _, err := g.FindOrCreate(context.Background(), spec)
+	if err == nil {
+		t.Fatal("FindOrCreate() expected error for empty slug, got nil")
+	}
+	if !errors.Is(err, errPushFailed) {
+		t.Errorf("FindOrCreate() error = %v, want errPushFailed", err)
+	}
+}
+
+func TestGitHubAdapter_FindOrCreate_EmptyRepo(t *testing.T) {
+	g := NewGitHubAdapter(&mockRunner{}, "")
+	spec := &storage.Spec{Slug: "my-spec"}
+	_, _, err := g.FindOrCreate(context.Background(), spec)
+	if err == nil {
+		t.Fatal("FindOrCreate() expected error for empty repo, got nil")
+	}
+	if !errors.Is(err, errPushFailed) {
+		t.Errorf("FindOrCreate() error = %v, want errPushFailed", err)
+	}
+}
+
+func TestGitHubAdapter_FindOrCreate_InvalidJSON(t *testing.T) {
+	runner := &sequenceRunner{
+		calls: []struct {
+			output []byte
+			err    error
+		}{
+			{output: []byte(`not-json`), err: nil},
+		},
+	}
+	g := NewGitHubAdapter(runner, "owner/repo")
+	spec := &storage.Spec{
+		Slug:   "my-spec",
+		Intent: "Build a thing",
+		Stage:  storage.SpecStageSpark,
+	}
+	_, _, err := g.FindOrCreate(context.Background(), spec)
+	if err == nil {
+		t.Fatal("FindOrCreate() expected error for invalid JSON, got nil")
+	}
+}
+
+func TestGitHubAdapter_FindOrCreate_PushError(t *testing.T) {
+	runner := &sequenceRunner{
+		calls: []struct {
+			output []byte
+			err    error
+		}{
+			{output: []byte(`[]`), err: nil},
+			{output: nil, err: errors.New("gh issue create failed")},
+		},
+	}
+	g := NewGitHubAdapter(runner, "owner/repo")
+	spec := &storage.Spec{
+		Slug:     "new-spec",
+		Intent:   "Build a thing",
+		Stage:    storage.SpecStageSpark,
+		Priority: storage.SpecPriorityP1,
+	}
+	_, _, err := g.FindOrCreate(context.Background(), spec)
+	if err == nil {
+		t.Fatal("FindOrCreate() expected error when push fails, got nil")
+	}
+}
+
+func TestGitHubAdapter_FindOrCreate_SearchError(t *testing.T) {
+	runner := &sequenceRunner{
+		calls: []struct {
+			output []byte
+			err    error
+		}{
+			{output: nil, err: errors.New("gh search failed")},
+		},
+	}
+	g := NewGitHubAdapter(runner, "owner/repo")
+	spec := &storage.Spec{
+		Slug:     "my-spec",
+		Intent:   "Build a thing",
+		Stage:    storage.SpecStageSpark,
+		Priority: storage.SpecPriorityP1,
+	}
+	_, _, err := g.FindOrCreate(context.Background(), spec)
+	if err == nil {
+		t.Fatal("FindOrCreate() expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `FindOrCreate` method to sync `Adapter` interface
- GitHubAdapter searches by `[spec] <slug>` title via `gh issue list --search` before creating
- BeadsAdapter searches by title via `bd search` before creating
- Sync handler calls `FindOrCreate` instead of `Push`, healing orphaned mappings when existing items are found
- Existing retry logic on `CreateSyncMapping` unchanged

Closes #166

## Test plan
- [x] Unit tests for FindOrCreate on both adapters (found, not-found, search-error)
- [x] Handler test for orphan recovery path (found existing, mapping created)
- [x] All existing sync tests pass unchanged
- [x] `task check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>