### PR TITLE
fix(web): dashboard counts all specs, remove slice filtering, UX label fixes (spgr-scd)

### DIFF
--- a/web/src/lib/components/SpecTable.svelte
+++ b/web/src/lib/components/SpecTable.svelte
@@ -55,7 +55,7 @@
 <table class="spec-table">
   <thead>
     <tr>
-      <th aria-sort={ariaSort('slug')}><button type="button" class="sort-btn" onclick={() => toggleSort('slug')}>Slug {sortIndicator('slug')}</button></th>
+      <th aria-sort={ariaSort('slug')}><button type="button" class="sort-btn" onclick={() => toggleSort('slug')}>Spec {sortIndicator('slug')}</button></th>
       <th aria-sort={ariaSort('stage')}><button type="button" class="sort-btn" onclick={() => toggleSort('stage')}>Stage {sortIndicator('stage')}</button></th>
       <th aria-sort={ariaSort('priority')}><button type="button" class="sort-btn" onclick={() => toggleSort('priority')}>Pri {sortIndicator('priority')}</button></th>
       {#if showConversations}<th>💬</th>{/if}

--- a/web/src/lib/components/StatsBar.svelte
+++ b/web/src/lib/components/StatsBar.svelte
@@ -1,18 +1,15 @@
 <script lang="ts">
   interface Props {
     totalSpecs: number;
-    sliceCount?: number;
     readyCount: number;
     driftCount: number;
     decisionCount: number;
   }
 
-  let { totalSpecs, sliceCount = 0, readyCount, driftCount, decisionCount }: Props = $props();
-
-  let specLabel = $derived(sliceCount > 0 ? `Specs (${sliceCount} slices)` : 'Specs');
+  let { totalSpecs, readyCount, driftCount, decisionCount }: Props = $props();
 
   const cards = $derived([
-    { label: specLabel, value: totalSpecs, color: '#2563eb', href: '/graph' },
+    { label: 'Specs', value: totalSpecs, color: '#2563eb', href: '/graph' },
     { label: 'Ready', value: readyCount, color: '#16a34a', href: '/graph' },
     { label: 'Drift', value: driftCount, color: '#dc2626', href: '/graph' },
     { label: 'Decisions', value: decisionCount, color: '#7c3aed', href: '/graph' },

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -23,7 +23,6 @@
   import SpecTable from '$lib/components/SpecTable.svelte';
 
   let totalSpecs = $state(0);
-  let sliceCount = $state(0);
   let readyCount = $state(0);
   let driftCount = $state(0);
   let decisionCount = $state(0);
@@ -70,25 +69,15 @@
 
       const specsList = specsRes.specs ?? [];
       specs = specsList;
-      const allEdges = graphRes.edges ?? [];
+      totalSpecs = specsList.length;
 
-      // Slices are specs that have an incoming COMPOSES edge (a parent "composes" them).
-      const sliceSlugs = new Set(
-        allEdges.filter((e) => e.edgeType === EdgeType.COMPOSES).map((e) => e.toId)
-      );
-      const topLevel = specsList.filter((s) => !sliceSlugs.has(s.slug));
-      totalSpecs = topLevel.length;
-      sliceCount = specsList.length - topLevel.length;
-
-      // Funnel counts only top-level specs (not slices).
       const counts: Record<string, number> = {};
-      for (const s of topLevel) {
+      for (const s of specsList) {
         counts[s.stage] = (counts[s.stage] ?? 0) + 1;
       }
       stageCounts = counts;
 
-      const readySpecs = (readyRes.ready ?? []).filter((s) => !sliceSlugs.has(s.slug));
-      readyCount = readySpecs.length;
+      readyCount = (readyRes.ready ?? []).length;
       graphNodes = graphRes.nodes ?? [];
       graphEdges = graphRes.edges ?? [];
       decisions = decisionsRes.decisions ?? [];
@@ -114,7 +103,7 @@
   <p class="status error">Error: {error}</p>
 {:else}
   <section class="dashboard">
-    <StatsBar {totalSpecs} {sliceCount} {readyCount} {driftCount} {decisionCount} />
+    <StatsBar {totalSpecs} {readyCount} {driftCount} {decisionCount} />
 
     <div class="row">
       <div class="col-funnel">
@@ -141,7 +130,7 @@
     {:else if activeTab === 'Decisions'}
       <table class="decision-table">
         <thead>
-          <tr><th>Slug</th><th>Title</th><th>Status</th><th>Linked Specs</th></tr>
+          <tr><th>Decision</th><th>Title</th><th>Status</th><th>Linked Specs</th></tr>
         </thead>
         <tbody>
           {#each decisions as d}


### PR DESCRIPTION
## Summary
- **Bug fix**: Dashboard COMPOSES edge direction was inverted — `e.toId` excluded the parent spec instead of child slices. Removed slice filtering entirely since all specs should be counted.
- **Stats bar**: Removed `sliceCount` prop and "(N slices)" label — just shows "Specs" with total count
- **Funnel**: Counts all specs, not just "top-level" (was excluding slices from stage counts)
- **Ready count**: Includes all ready specs (was excluding slices)
- **Column headers**: "Slug" → "Spec" in spec table, "Slug" → "Decision" in decision table

## Root cause
COMPOSES edges go `(child)-[:COMPOSES]->(parent)`, so `e.toId` is the parent. Dashboard was filtering the parent out of counts instead of the children. Rather than just flipping the direction, removed the slice filtering entirely — the dashboard should show all specs.

Separate bead spgr-6sw tracks introducing Slice as a first-class graph vertex.

## Test plan
- [ ] Dashboard shows correct total spec count (no slice exclusion)
- [ ] Funnel counts match total
- [ ] Column headers say "Spec" and "Decision"
- [ ] `task check` passes
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>