### PR TITLE
feat(storage): implement Memgraph Slice CRUD + integration tests (spgr-6sw.2)

### DIFF
--- a/internal/storage/memgraph/slice.go
+++ b/internal/storage/memgraph/slice.go
@@ -5,32 +5,272 @@ package memgraph
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/specgraph/specgraph/internal/storage"
 )
 
-// CreateSlice persists a new Slice node. Full implementation in spgr-6sw.2.
-func (s *Store) CreateSlice(_ context.Context, _ *storage.Slice) error {
-	return fmt.Errorf("memgraph: CreateSlice not yet implemented")
+// CreateSlice persists a new :Slice node with BELONGS_TO and COMPOSES edges.
+func (s *Store) CreateSlice(ctx context.Context, sl *storage.Slice) error {
+	if sl == nil {
+		return fmt.Errorf("memgraph: CreateSlice: slice must not be nil")
+	}
+
+	id := newID("slc")
+	nowStr := s.now()
+
+	verifyJSON := marshalStringSlice(sl.Verify)
+	touchesJSON := marshalStringSlice(sl.Touches)
+	dependsOnJSON := marshalStringSlice(sl.DependsOn)
+
+	query := `
+		MATCH (p:Project {slug: $project})<-[:BELONGS_TO]-(parent:Spec {slug: $parent_slug})
+		CREATE (sl:Slice {
+			id: $id,
+			slug: $slug,
+			parent_slug: $parent_slug,
+			slice_id: $slice_id,
+			intent: $intent,
+			verify_json: $verify_json,
+			touches_json: $touches_json,
+			depends_on_json: $depends_on_json,
+			status: $status,
+			assigned_to: '',
+			created_at: $now,
+			updated_at: $now
+		})
+		CREATE (sl)-[:BELONGS_TO]->(p)
+		CREATE (sl)-[:COMPOSES]->(parent)
+		RETURN sl.id
+	`
+	params := mergeParams(s.projectParam(), map[string]any{
+		"id":              id,
+		"slug":            sl.Slug,
+		"parent_slug":     sl.ParentSlug,
+		"slice_id":        sl.SliceID,
+		"intent":          sl.Intent,
+		"verify_json":     string(verifyJSON),
+		"touches_json":    string(touchesJSON),
+		"depends_on_json": string(dependsOnJSON),
+		"status":          string(storage.SliceStatusOpen),
+		"now":             nowStr,
+	})
+
+	records, err := s.executeQuery(ctx, query, params)
+	if err != nil {
+		return fmt.Errorf("memgraph: create slice %q: %w", sl.Slug, err)
+	}
+	if len(records) == 0 {
+		return fmt.Errorf("memgraph: create slice %q: parent spec %q not found", sl.Slug, sl.ParentSlug)
+	}
+	return nil
 }
 
-// ListSlices returns slices for a parent spec. Full implementation in spgr-6sw.2.
-func (s *Store) ListSlices(_ context.Context, _ string) ([]*storage.Slice, error) {
-	return nil, fmt.Errorf("memgraph: ListSlices not yet implemented")
+// ListSlices returns all slices for a parent spec, ordered by creation time.
+func (s *Store) ListSlices(ctx context.Context, parentSlug string) ([]*storage.Slice, error) {
+	query := `
+		MATCH (p:Project {slug: $project})<-[:BELONGS_TO]-(sl:Slice)-[:COMPOSES]->(parent:Spec {slug: $parent_slug})
+		RETURN sl.id, sl.slug, sl.parent_slug, sl.slice_id, sl.intent,
+		       sl.verify_json, sl.touches_json, sl.depends_on_json, sl.status,
+		       sl.assigned_to, sl.created_at, sl.updated_at
+		ORDER BY sl.created_at
+	`
+	params := mergeParams(s.projectParam(), map[string]any{"parent_slug": parentSlug})
+
+	records, err := s.executeQuery(ctx, query, params)
+	if err != nil {
+		return nil, fmt.Errorf("memgraph: list slices for %q: %w", parentSlug, err)
+	}
+
+	slices := make([]*storage.Slice, 0, len(records))
+	for _, rec := range records {
+		sl, err := recordToSlice(rec)
+		if err != nil {
+			return nil, err
+		}
+		slices = append(slices, sl)
+	}
+	return slices, nil
 }
 
-// GetSlice returns a single slice by slug. Full implementation in spgr-6sw.2.
-func (s *Store) GetSlice(_ context.Context, _ string) (*storage.Slice, error) {
-	return nil, fmt.Errorf("memgraph: GetSlice not yet implemented")
+// GetSlice returns a single slice by its full slug.
+func (s *Store) GetSlice(ctx context.Context, slug string) (*storage.Slice, error) {
+	query := `
+		MATCH (p:Project {slug: $project})<-[:BELONGS_TO]-(sl:Slice {slug: $slug})
+		RETURN sl.id, sl.slug, sl.parent_slug, sl.slice_id, sl.intent,
+		       sl.verify_json, sl.touches_json, sl.depends_on_json, sl.status,
+		       sl.assigned_to, sl.created_at, sl.updated_at
+	`
+	params := mergeParams(s.projectParam(), map[string]any{"slug": slug})
+
+	records, err := s.executeQuery(ctx, query, params)
+	if err != nil {
+		return nil, fmt.Errorf("memgraph: get slice %q: %w", slug, err)
+	}
+	if len(records) == 0 {
+		return nil, storage.ErrSliceNotFound
+	}
+	return recordToSlice(records[0])
 }
 
-// ClaimSlice transitions a slice to claimed. Full implementation in spgr-6sw.2.
-func (s *Store) ClaimSlice(_ context.Context, _, _ string) error {
-	return fmt.Errorf("memgraph: ClaimSlice not yet implemented")
+// ClaimSlice transitions a slice to claimed status and records the assignee.
+func (s *Store) ClaimSlice(ctx context.Context, slug, assignee string) error {
+	if strings.TrimSpace(assignee) == "" {
+		return fmt.Errorf("memgraph: claim slice %q: assignee must not be blank", slug)
+	}
+	nowStr := s.now()
+	query := `
+		MATCH (p:Project {slug: $project})<-[:BELONGS_TO]-(sl:Slice {slug: $slug})
+		WHERE sl.status = $expected_status
+		SET sl.status = $new_status, sl.assigned_to = $assignee, sl.updated_at = $now
+		RETURN sl.id
+	`
+	params := mergeParams(s.projectParam(), map[string]any{
+		"slug":            slug,
+		"expected_status": string(storage.SliceStatusOpen),
+		"new_status":      string(storage.SliceStatusClaimed),
+		"assignee":        assignee,
+		"now":             nowStr,
+	})
+
+	records, err := s.executeQuery(ctx, query, params)
+	if err != nil {
+		return fmt.Errorf("memgraph: claim slice %q: %w", slug, err)
+	}
+	if len(records) == 0 {
+		return fmt.Errorf("memgraph: claim slice %q: %w", slug, storage.ErrSliceWrongStatus)
+	}
+	return nil
 }
 
-// CompleteSlice transitions a slice to done. Full implementation in spgr-6sw.2.
-func (s *Store) CompleteSlice(_ context.Context, _ string) error {
-	return fmt.Errorf("memgraph: CompleteSlice not yet implemented")
+// CompleteSlice transitions a slice to done status.
+func (s *Store) CompleteSlice(ctx context.Context, slug string) error {
+	nowStr := s.now()
+	query := `
+		MATCH (p:Project {slug: $project})<-[:BELONGS_TO]-(sl:Slice {slug: $slug})
+		WHERE sl.status = $expected_status
+		SET sl.status = $new_status, sl.updated_at = $now
+		RETURN sl.id
+	`
+	params := mergeParams(s.projectParam(), map[string]any{
+		"slug":            slug,
+		"expected_status": string(storage.SliceStatusClaimed),
+		"new_status":      string(storage.SliceStatusDone),
+		"assignee":        "",
+		"now":             nowStr,
+	})
+
+	records, err := s.executeQuery(ctx, query, params)
+	if err != nil {
+		return fmt.Errorf("memgraph: complete slice %q: %w", slug, err)
+	}
+	if len(records) == 0 {
+		return fmt.Errorf("memgraph: complete slice %q: %w", slug, storage.ErrSliceWrongStatus)
+	}
+	return nil
+}
+
+// marshalStringSlice marshals a []string to JSON. This cannot fail because
+// []string contains no unmarshalable types (channels, funcs, complex numbers).
+func marshalStringSlice(s []string) []byte {
+	b, _ := json.Marshal(s) //nolint:errcheck // []string marshal is infallible
+	return b
+}
+
+// recordToSlice converts a neo4j record to a *storage.Slice.
+func recordToSlice(rec *neo4j.Record) (*storage.Slice, error) {
+	id, err := recordString(rec, 0, "id")
+	if err != nil {
+		return nil, err
+	}
+	slug, err := recordString(rec, 1, "slug")
+	if err != nil {
+		return nil, err
+	}
+	parentSlug, err := recordString(rec, 2, "parent_slug")
+	if err != nil {
+		return nil, err
+	}
+	sliceID, err := recordString(rec, 3, "slice_id")
+	if err != nil {
+		return nil, err
+	}
+	intent, err := recordString(rec, 4, "intent")
+	if err != nil {
+		return nil, err
+	}
+	verifyJSON, err := recordStringOptional(rec, 5, "verify_json")
+	if err != nil {
+		return nil, err
+	}
+	touchesJSON, err := recordStringOptional(rec, 6, "touches_json")
+	if err != nil {
+		return nil, err
+	}
+	dependsOnJSON, err := recordStringOptional(rec, 7, "depends_on_json")
+	if err != nil {
+		return nil, err
+	}
+	status, err := recordString(rec, 8, "status")
+	if err != nil {
+		return nil, err
+	}
+	assignedTo, err := recordStringOptional(rec, 9, "assigned_to")
+	if err != nil {
+		return nil, err
+	}
+	createdAtStr, err := recordString(rec, 10, "created_at")
+	if err != nil {
+		return nil, err
+	}
+	updatedAtStr, err := recordString(rec, 11, "updated_at")
+	if err != nil {
+		return nil, err
+	}
+
+	createdAt, err := parseRFC3339("created_at", createdAtStr)
+	if err != nil {
+		return nil, err
+	}
+	updatedAt, err := parseRFC3339("updated_at", updatedAtStr)
+	if err != nil {
+		return nil, err
+	}
+
+	var verify []string
+	if verifyJSON != "" {
+		if err := json.Unmarshal([]byte(verifyJSON), &verify); err != nil {
+			return nil, fmt.Errorf("memgraph: unmarshal verify_json: %w", err)
+		}
+	}
+	var touches []string
+	if touchesJSON != "" {
+		if err := json.Unmarshal([]byte(touchesJSON), &touches); err != nil {
+			return nil, fmt.Errorf("memgraph: unmarshal touches_json: %w", err)
+		}
+	}
+	var dependsOn []string
+	if dependsOnJSON != "" {
+		if err := json.Unmarshal([]byte(dependsOnJSON), &dependsOn); err != nil {
+			return nil, fmt.Errorf("memgraph: unmarshal depends_on_json: %w", err)
+		}
+	}
+
+	return &storage.Slice{
+		ID:         id,
+		Slug:       slug,
+		ParentSlug: parentSlug,
+		SliceID:    sliceID,
+		Intent:     intent,
+		Verify:     verify,
+		Touches:    touches,
+		DependsOn:  dependsOn,
+		Status:     storage.SliceStatus(status),
+		AssignedTo: assignedTo,
+		CreatedAt:  createdAt,
+		UpdatedAt:  updatedAt,
+	}, nil
 }

--- a/internal/storage/memgraph/slice_test.go
+++ b/internal/storage/memgraph/slice_test.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+//go:build integration
+
+package memgraph_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateAndListSlices(t *testing.T) {
+	clearDatabase(t)
+
+	ctx := context.Background()
+	store, err := newStore(ctx, boltURI)
+	require.NoError(t, err)
+	defer store.Close(ctx)
+
+	// Create parent spec.
+	_, err = store.CreateSpec(ctx, "parent-spec", "Parent intent", "p2", "medium")
+	require.NoError(t, err)
+
+	// Create two slices.
+	err = store.CreateSlice(ctx, &storage.Slice{
+		Slug:       "parent-spec/backend",
+		ParentSlug: "parent-spec",
+		SliceID:    "backend",
+		Intent:     "Implement backend API",
+		Verify:     []string{"API tests pass"},
+		Touches:    []string{"internal/server/"},
+	})
+	require.NoError(t, err)
+
+	err = store.CreateSlice(ctx, &storage.Slice{
+		Slug:       "parent-spec/frontend",
+		ParentSlug: "parent-spec",
+		SliceID:    "frontend",
+		Intent:     "Implement frontend UI",
+		Verify:     []string{"UI renders"},
+		Touches:    []string{"web/src/"},
+	})
+	require.NoError(t, err)
+
+	// List slices.
+	slices, err := store.ListSlices(ctx, "parent-spec")
+	require.NoError(t, err)
+	require.Len(t, slices, 2)
+
+	assert.Equal(t, "parent-spec/backend", slices[0].Slug)
+	assert.Equal(t, "backend", slices[0].SliceID)
+	assert.Equal(t, "Implement backend API", slices[0].Intent)
+	assert.Equal(t, storage.SliceStatusOpen, slices[0].Status)
+	assert.Equal(t, []string{"API tests pass"}, slices[0].Verify)
+	assert.Equal(t, []string{"internal/server/"}, slices[0].Touches)
+
+	assert.Equal(t, "parent-spec/frontend", slices[1].Slug)
+}
+
+func TestGetSlice(t *testing.T) {
+	clearDatabase(t)
+
+	ctx := context.Background()
+	store, err := newStore(ctx, boltURI)
+	require.NoError(t, err)
+	defer store.Close(ctx)
+
+	_, err = store.CreateSpec(ctx, "get-slice-parent", "Parent", "p2", "medium")
+	require.NoError(t, err)
+
+	err = store.CreateSlice(ctx, &storage.Slice{
+		Slug:       "get-slice-parent/api",
+		ParentSlug: "get-slice-parent",
+		SliceID:    "api",
+		Intent:     "Build the API",
+		Verify:     []string{"test passes"},
+	})
+	require.NoError(t, err)
+
+	sl, err := store.GetSlice(ctx, "get-slice-parent/api")
+	require.NoError(t, err)
+	assert.Equal(t, "get-slice-parent/api", sl.Slug)
+	assert.Equal(t, "get-slice-parent", sl.ParentSlug)
+	assert.Equal(t, "api", sl.SliceID)
+	assert.Equal(t, "Build the API", sl.Intent)
+	assert.Equal(t, storage.SliceStatusOpen, sl.Status)
+	assert.NotZero(t, sl.CreatedAt)
+	assert.NotZero(t, sl.UpdatedAt)
+}
+
+func TestGetSlice_NotFound(t *testing.T) {
+	clearDatabase(t)
+
+	ctx := context.Background()
+	store, err := newStore(ctx, boltURI)
+	require.NoError(t, err)
+	defer store.Close(ctx)
+
+	_, err = store.GetSlice(ctx, "nonexistent/slice")
+	require.ErrorIs(t, err, storage.ErrSliceNotFound)
+}
+
+func TestClaimSlice(t *testing.T) {
+	clearDatabase(t)
+
+	ctx := context.Background()
+	store, err := newStore(ctx, boltURI)
+	require.NoError(t, err)
+	defer store.Close(ctx)
+
+	_, err = store.CreateSpec(ctx, "claim-parent", "Parent", "p2", "medium")
+	require.NoError(t, err)
+
+	err = store.CreateSlice(ctx, &storage.Slice{
+		Slug:       "claim-parent/work",
+		ParentSlug: "claim-parent",
+		SliceID:    "work",
+		Intent:     "Do the work",
+	})
+	require.NoError(t, err)
+
+	// Claim it.
+	err = store.ClaimSlice(ctx, "claim-parent/work", "alice")
+	require.NoError(t, err)
+
+	// Verify status changed.
+	sl, err := store.GetSlice(ctx, "claim-parent/work")
+	require.NoError(t, err)
+	assert.Equal(t, storage.SliceStatusClaimed, sl.Status)
+	assert.Equal(t, "alice", sl.AssignedTo)
+
+	// Claiming again should fail (not open) with sentinel error.
+	err = store.ClaimSlice(ctx, "claim-parent/work", "bob")
+	require.ErrorIs(t, err, storage.ErrSliceWrongStatus)
+}
+
+func TestCompleteSlice(t *testing.T) {
+	clearDatabase(t)
+
+	ctx := context.Background()
+	store, err := newStore(ctx, boltURI)
+	require.NoError(t, err)
+	defer store.Close(ctx)
+
+	_, err = store.CreateSpec(ctx, "complete-parent", "Parent", "p2", "medium")
+	require.NoError(t, err)
+
+	err = store.CreateSlice(ctx, &storage.Slice{
+		Slug:       "complete-parent/task",
+		ParentSlug: "complete-parent",
+		SliceID:    "task",
+		Intent:     "A task",
+	})
+	require.NoError(t, err)
+
+	// Must claim before completing — should return sentinel error.
+	err = store.CompleteSlice(ctx, "complete-parent/task")
+	require.ErrorIs(t, err, storage.ErrSliceWrongStatus)
+
+	// Claim then complete.
+	err = store.ClaimSlice(ctx, "complete-parent/task", "alice")
+	require.NoError(t, err)
+
+	err = store.CompleteSlice(ctx, "complete-parent/task")
+	require.NoError(t, err)
+
+	sl, err := store.GetSlice(ctx, "complete-parent/task")
+	require.NoError(t, err)
+	assert.Equal(t, storage.SliceStatusDone, sl.Status)
+}
+
+func TestCreateSlice_ParentNotFound(t *testing.T) {
+	clearDatabase(t)
+
+	ctx := context.Background()
+	store, err := newStore(ctx, boltURI)
+	require.NoError(t, err)
+	defer store.Close(ctx)
+
+	err = store.CreateSlice(ctx, &storage.Slice{
+		Slug:       "ghost/slice",
+		ParentSlug: "ghost",
+		SliceID:    "slice",
+		Intent:     "orphan",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/internal/storage/memgraph/slice_unit_test.go
+++ b/internal/storage/memgraph/slice_unit_test.go
@@ -7,22 +7,208 @@ import (
 	"context"
 	"testing"
 
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestSliceStubs_ReturnNotImplemented(t *testing.T) {
+func TestRecordToSlice(t *testing.T) {
+	now := "2026-03-26T12:00:00.000000000Z"
+	rec := &neo4j.Record{
+		Values: []any{
+			"slc-123",             // id
+			"parent/backend",      // slug
+			"parent",              // parent_slug
+			"backend",             // slice_id
+			"Build the API",       // intent
+			`["test passes"]`,     // verify_json
+			`["internal/server"]`, // touches_json
+			`["parent/frontend"]`, // depends_on_json
+			"open",                // status
+			"",                    // assigned_to
+			now,                   // created_at
+			now,                   // updated_at
+		},
+	}
+
+	sl, err := recordToSlice(rec)
+	require.NoError(t, err)
+	assert.Equal(t, "slc-123", sl.ID)
+	assert.Equal(t, "parent/backend", sl.Slug)
+	assert.Equal(t, "parent", sl.ParentSlug)
+	assert.Equal(t, "backend", sl.SliceID)
+	assert.Equal(t, "Build the API", sl.Intent)
+	assert.Equal(t, []string{"test passes"}, sl.Verify)
+	assert.Equal(t, []string{"internal/server"}, sl.Touches)
+	assert.Equal(t, []string{"parent/frontend"}, sl.DependsOn)
+	assert.Equal(t, storage.SliceStatusOpen, sl.Status)
+	assert.Empty(t, sl.AssignedTo)
+	assert.NotZero(t, sl.CreatedAt)
+}
+
+func TestRecordToSlice_EmptyJSON(t *testing.T) {
+	now := "2026-03-26T12:00:00.000000000Z"
+	rec := &neo4j.Record{
+		Values: []any{
+			"slc-456", "parent/fe", "parent", "fe", "Frontend",
+			"", "", "", // empty verify_json, touches_json, depends_on_json
+			"claimed", "alice", now, now,
+		},
+	}
+
+	sl, err := recordToSlice(rec)
+	require.NoError(t, err)
+	assert.Nil(t, sl.Verify)
+	assert.Nil(t, sl.Touches)
+	assert.Nil(t, sl.DependsOn)
+	assert.Equal(t, storage.SliceStatusClaimed, sl.Status)
+	assert.Equal(t, "alice", sl.AssignedTo)
+}
+
+func TestRecordToSlice_InvalidVerifyJSON(t *testing.T) {
+	now := "2026-03-26T12:00:00.000000000Z"
+	rec := &neo4j.Record{
+		Values: []any{
+			"slc-789", "parent/bad", "parent", "bad", "Bad",
+			`{invalid`, "", "",
+			"open", "", now, now,
+		},
+	}
+	_, err := recordToSlice(rec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal verify_json")
+}
+
+func TestRecordToSlice_InvalidTouchesJSON(t *testing.T) {
+	now := "2026-03-26T12:00:00.000000000Z"
+	rec := &neo4j.Record{
+		Values: []any{
+			"slc-790", "parent/bad2", "parent", "bad2", "Bad",
+			`[]`, `{invalid`, "",
+			"open", "", now, now,
+		},
+	}
+	_, err := recordToSlice(rec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal touches_json")
+}
+
+func TestRecordToSlice_InvalidDependsOnJSON(t *testing.T) {
+	now := "2026-03-26T12:00:00.000000000Z"
+	rec := &neo4j.Record{
+		Values: []any{
+			"slc-791", "parent/bad3", "parent", "bad3", "Bad",
+			`[]`, `[]`, `{invalid`,
+			"open", "", now, now,
+		},
+	}
+	_, err := recordToSlice(rec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal depends_on_json")
+}
+
+func TestCreateSlice_NilSlice(t *testing.T) {
+	s := &Store{}
+	err := s.CreateSlice(context.Background(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be nil")
+}
+
+func TestClaimSlice_BlankAssignee(t *testing.T) {
 	s := &Store{}
 	ctx := context.Background()
 
-	assert.Error(t, s.CreateSlice(ctx, &storage.Slice{}))
+	err := s.ClaimSlice(ctx, "any/slug", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be blank")
 
-	_, err := s.ListSlices(ctx, "any")
-	assert.Error(t, err)
+	err = s.ClaimSlice(ctx, "any/slug", "   ")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be blank")
+}
 
-	_, err = s.GetSlice(ctx, "any")
-	assert.Error(t, err)
+func TestRecordToSlice_WrongType(t *testing.T) {
+	rec := &neo4j.Record{
+		Values: []any{
+			42, // id should be string, not int — triggers recordString error
+		},
+	}
+	_, err := recordToSlice(rec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "id")
+}
 
-	assert.Error(t, s.ClaimSlice(ctx, "any", "alice"))
-	assert.Error(t, s.CompleteSlice(ctx, "any"))
+func TestRecordToSlice_BadTimestamp(t *testing.T) {
+	rec := &neo4j.Record{
+		Values: []any{
+			"slc-999", "parent/ts", "parent", "ts", "Test",
+			"", "", "",
+			"open", "",
+			"not-a-timestamp", // bad created_at
+			"2026-03-26T12:00:00.000000000Z",
+		},
+	}
+	_, err := recordToSlice(rec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "created_at")
+}
+
+func TestRecordToSlice_FieldErrors(t *testing.T) {
+	now := "2026-03-26T12:00:00.000000000Z"
+	// Base valid record — 12 fields matching recordToSlice column order.
+	base := func() []any {
+		return []any{
+			"slc-err", "parent/err", "parent", "err", "intent",
+			`[]`, `[]`, `[]`, // verify, touches, depends_on
+			"open", "", now, now,
+		}
+	}
+
+	// Each test replaces one position with an invalid type to trigger the
+	// corresponding recordString/recordStringOptional error branch.
+	tests := []struct {
+		name string
+		pos  int
+		val  any
+		want string // substring of expected error
+	}{
+		{"id", 0, 42, "id"},
+		{"slug", 1, 42, "slug"},
+		{"parent_slug", 2, 42, "parent_slug"},
+		{"slice_id", 3, 42, "slice_id"},
+		{"intent", 4, 42, "intent"},
+		{"verify_json", 5, 42, "verify_json"},
+		{"touches_json", 6, 42, "touches_json"},
+		{"depends_on_json", 7, 42, "depends_on_json"},
+		{"status", 8, 42, "status"},
+		{"assigned_to", 9, 42, "assigned_to"},
+		{"created_at", 10, 42, "created_at"},
+		{"updated_at", 11, 42, "updated_at"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vals := base()
+			vals[tt.pos] = tt.val
+			rec := &neo4j.Record{Values: vals}
+			_, err := recordToSlice(rec)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestRecordToSlice_BadUpdatedAt(t *testing.T) {
+	rec := &neo4j.Record{
+		Values: []any{
+			"slc-ts2", "parent/ts2", "parent", "ts2", "intent",
+			"", "", "",
+			"open", "",
+			"2026-03-26T12:00:00.000000000Z", // valid created_at
+			"not-a-timestamp",                 // bad updated_at
+		},
+	}
+	_, err := recordToSlice(rec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "updated_at")
 }

--- a/internal/storage/slice.go
+++ b/internal/storage/slice.go
@@ -38,8 +38,12 @@ const (
 	SliceStatusDone SliceStatus = "done"
 )
 
-// ErrSliceNotFound is returned when a slice lookup finds no matching node.
-var ErrSliceNotFound = errors.New("slice not found")
+var (
+	// ErrSliceNotFound is returned when a slice lookup finds no matching node.
+	ErrSliceNotFound = errors.New("slice not found")
+	// ErrSliceWrongStatus is returned when a status transition is invalid.
+	ErrSliceWrongStatus = errors.New("slice status precondition not met")
+)
 
 // SliceBackend provides CRUD operations for decomposition slices.
 type SliceBackend interface {


### PR DESCRIPTION
## Summary
Replaces the stub implementations from #687 with real Memgraph Slice CRUD:

- **CreateSlice**: Creates `:Slice` node with BELONGS_TO + COMPOSES edges to parent Spec
- **ListSlices**: Queries slices by parent slug via COMPOSES traversal, ordered by creation time
- **GetSlice**: Fetches single slice by slug, returns `ErrSliceNotFound` if missing
- **ClaimSlice**: Transitions open → claimed with assignee validation
- **CompleteSlice**: Transitions claimed → done with status guard

JSON arrays (`verify_json`, `touches_json`) follow the existing pattern from Spec authoring outputs.

## Integration Tests (6 tests)
- `TestCreateAndListSlices` — create 2 slices, verify list returns both with correct fields
- `TestGetSlice` — verify all fields including timestamps
- `TestGetSlice_NotFound` — sentinel error check
- `TestClaimSlice` — open → claimed, verify assignee, reject double-claim
- `TestCompleteSlice` — must claim first, then complete
- `TestCreateSlice_ParentNotFound` — error when parent spec doesn't exist

## Test plan
- [ ] All 6 integration tests pass against Memgraph
- [ ] `task check` passes
- [ ] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>