### PR TITLE
feat(storage)!: StoreDecomposeOutput creates Slices + GetFullGraph includes Slices (spgr-6sw.3)

### DIFF
--- a/internal/server/convert.go
+++ b/internal/server/convert.go
@@ -863,8 +863,9 @@ func decomposeOutputToProto(o *storage.DecomposeOutput) *specv1.DecomposeOutput 
 		}
 	}
 	return &specv1.DecomposeOutput{
-		Strategy: decomposeStrategyStringToProto(o.Strategy),
-		Slices:   slices,
+		Strategy:   decomposeStrategyStringToProto(o.Strategy),
+		Slices:     slices,
+		SliceSlugs: o.SliceSlugs,
 	}
 }
 

--- a/internal/storage/authoring.go
+++ b/internal/storage/authoring.go
@@ -122,9 +122,13 @@ type DecomposeSlice struct {
 }
 
 // DecomposeOutput captures the decomposition strategy and resulting slices.
+// Slices carries the full input data used by StoreDecomposeOutput to create
+// Slice graph nodes. SliceSlugs is populated after creation and stored as the
+// parent spec's decompose_output JSON (Slices data lives in the Slice nodes).
 type DecomposeOutput struct {
-	Strategy DecompositionStrategy `json:"strategy,omitempty"`
-	Slices   []DecomposeSlice      `json:"slices,omitempty"`
+	Strategy   DecompositionStrategy `json:"strategy,omitempty"`
+	Slices     []DecomposeSlice      `json:"slices,omitempty"`       // input: full slice data for creation
+	SliceSlugs []string              `json:"slice_slugs,omitempty"` // stored output: slug references to Slice nodes
 }
 
 // FindingSeverity indicates how severe a finding is.

--- a/internal/storage/memgraph/authoring.go
+++ b/internal/storage/memgraph/authoring.go
@@ -14,10 +14,6 @@ import (
 	"github.com/specgraph/specgraph/internal/storage/contenthash"
 )
 
-const (
-	defaultChildPriority   = "p2"
-	defaultChildComplexity = "medium"
-)
 
 // hashInputProperties lists the spec node properties that affect the content hash.
 // Only these properties trigger a hash recomputation after storeJSONProperty succeeds.
@@ -188,11 +184,11 @@ func (s *Store) StoreSpecifyOutput(ctx context.Context, slug string, output *sto
 	})
 }
 
-// StoreDecomposeOutput persists the decompose output and creates child spec nodes with edges.
+// StoreDecomposeOutput persists the decompose output and creates Slice nodes.
 // When called within a transaction (via RunInTransaction), partial failures roll back automatically.
-// Child spec creation is idempotent: GetSpec is called first; if the child does not exist,
-// CreateSpec is used to create it. MERGE is used only for the COMPOSES and DEPENDS_ON edges.
-// It returns the slugs of the created (or already-existing) child specs.
+// Slice creation is idempotent: GetSlice is called first; if the slice does not exist,
+// CreateSlice creates it (with BELONGS_TO + COMPOSES edges). MERGE is used for DEPENDS_ON edges.
+// It returns the slugs of the created (or already-existing) slices.
 func (s *Store) StoreDecomposeOutput(ctx context.Context, slug string, output *storage.DecomposeOutput) ([]string, error) {
 	if err := storage.ValidateStrategy(output.Strategy); err != nil {
 		return nil, fmt.Errorf("memgraph: invalid decomposition strategy: %w", err)
@@ -216,42 +212,44 @@ func (s *Store) StoreDecomposeOutput(ctx context.Context, slug string, output *s
 		if rfErr != nil {
 			return rfErr
 		}
-		if err := s.storeJSONProperty(txCtx, slug, "decompose_output", output); err != nil {
-			return err
-		}
-		// Pass 1: create all child Spec nodes and COMPOSES edges.
+		// Pass 1: create all Slice nodes (with BELONGS_TO + COMPOSES edges).
 		// This ensures every node exists before any DEPENDS_ON edge is attempted,
 		// so out-of-order dependencies (slice B depends on slice C listed later)
 		// are handled correctly.
 		var slugs []string
 		for _, sl := range output.Slices {
 			childSlug := fmt.Sprintf("%s/%s", slug, sl.ID)
-			// Check if child spec already exists (idempotency for retries).
-			_, getErr := s.GetSpec(txCtx, childSlug)
-			if getErr != nil {
-				if !errors.Is(getErr, storage.ErrSpecNotFound) {
-					return fmt.Errorf("memgraph: check child spec %q: %w", childSlug, getErr)
-				}
-				// Not found — proceed to create.
-				if _, err := s.CreateSpec(txCtx, childSlug, sl.Intent, defaultChildPriority, defaultChildComplexity); err != nil {
-					return fmt.Errorf("memgraph: create child spec %q: %w", childSlug, err)
-				}
+			// Resolve local dependency IDs to full sibling slugs.
+			resolvedDeps := make([]string, len(sl.DependsOn))
+			for i, dep := range sl.DependsOn {
+				resolvedDeps[i] = fmt.Sprintf("%s/%s", slug, dep)
 			}
-			// If getErr == nil, child spec already exists (idempotent retry).
-			composeQuery := `
-				MATCH (p:Project {slug: $project})<-[:BELONGS_TO]-(child:Spec {slug: $child_slug}),
-				      (p)<-[:BELONGS_TO]-(parent:Spec {slug: $parent_slug})
-				MERGE (child)-[:COMPOSES]->(parent)
-			`
-			_, err := s.executeQuery(txCtx, composeQuery,
-				mergeParams(s.projectParam(), map[string]any{"child_slug": childSlug, "parent_slug": slug}))
-			if err != nil {
-				return fmt.Errorf("memgraph: merge COMPOSES edge: %w", err)
+			// Check if slice already exists (idempotency for retries).
+			_, getErr := s.sliceOps.GetSlice(txCtx, childSlug)
+			if getErr != nil {
+				if !errors.Is(getErr, storage.ErrSliceNotFound) {
+					return fmt.Errorf("memgraph: check slice %q: %w", childSlug, getErr)
+				}
+				// Not found — create the slice node.
+				sliceDomain := &storage.Slice{
+					Slug:       childSlug,
+					ParentSlug: slug,
+					SliceID:    sl.ID,
+					Intent:     sl.Intent,
+					Verify:     sl.Verify,
+					Touches:    sl.Touches,
+					DependsOn:  resolvedDeps,
+				}
+				if err := s.sliceOps.CreateSlice(txCtx, sliceDomain); err != nil {
+					return fmt.Errorf("memgraph: create slice %q: %w", childSlug, err)
+				}
 			}
 			slugs = append(slugs, childSlug)
 		}
 
-		// Pass 2: create all DEPENDS_ON edges now that all child nodes exist.
+		// Pass 2: create all DEPENDS_ON edges now that all Slice nodes exist.
+		// Slice-to-Slice DEPENDS_ON edges carry no content_hash_at_link (slices
+		// have no content hash).
 		for _, sl := range output.Slices {
 			childSlug := fmt.Sprintf("%s/%s", slug, sl.ID)
 			for _, dep := range sl.DependsOn {
@@ -260,10 +258,9 @@ func (s *Store) StoreDecomposeOutput(ctx context.Context, slug string, output *s
 				}
 				depSlug := fmt.Sprintf("%s/%s", slug, dep)
 				depQuery := `
-					MATCH (p:Project {slug: $project})<-[:BELONGS_TO]-(from:Spec {slug: $from_slug}),
-					      (p)<-[:BELONGS_TO]-(to:Spec {slug: $to_slug})
-					MERGE (from)-[dep:DEPENDS_ON]->(to)
-					ON CREATE SET dep.content_hash_at_link = COALESCE(to.content_hash, "")
+					MATCH (p:Project {slug: $project})<-[:BELONGS_TO]-(from:Slice {slug: $from_slug}),
+					      (p)<-[:BELONGS_TO]-(to:Slice {slug: $to_slug})
+					MERGE (from)-[:DEPENDS_ON]->(to)
 				`
 				_, err := s.executeQuery(txCtx, depQuery,
 					mergeParams(s.projectParam(), map[string]any{"from_slug": childSlug, "to_slug": depSlug}))
@@ -272,13 +269,22 @@ func (s *Store) StoreDecomposeOutput(ctx context.Context, slug string, output *s
 				}
 			}
 		}
+		// Store slimmed output on the parent spec: strategy + slug references only.
+		// Full slice data lives in the Slice nodes themselves.
+		storedOutput := &storage.DecomposeOutput{
+			Strategy:   output.Strategy,
+			SliceSlugs: slugs,
+		}
+		if err := s.storeJSONProperty(txCtx, slug, "decompose_output", storedOutput); err != nil {
+			return err
+		}
 		// Create a non-checkpoint ChangeLog for the decompose_output field change
-		// on the parent spec. Child specs get their own changelogs via CreateSpec.
+		// on the parent spec.
 		if clErr := s.authoringOutputChangeLog(txCtx, slug, "decompose_output", &oldFields, oldHash); clErr != nil {
 			return clErr
 		}
 		// Only set childSlugs after all operations succeed — if the transaction
-		// rolls back, returning slugs of non-existent specs would be misleading.
+		// rolls back, returning slugs of non-existent slices would be misleading.
 		childSlugs = slugs
 		return nil
 	})

--- a/internal/storage/memgraph/authoring_decompose_test.go
+++ b/internal/storage/memgraph/authoring_decompose_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+//go:build integration
+
+package memgraph_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage/memgraph"
+)
+
+// faultingSliceOps injects errors into SliceBackend operations for testing
+// StoreDecomposeOutput error paths against a real database.
+type faultingSliceOps struct {
+	getSliceErr    error
+	createSliceErr error
+}
+
+func (f *faultingSliceOps) CreateSlice(context.Context, *storage.Slice) error {
+	return f.createSliceErr
+}
+
+func (f *faultingSliceOps) GetSlice(context.Context, string) (*storage.Slice, error) {
+	if f.getSliceErr != nil {
+		return nil, f.getSliceErr
+	}
+	// Default: slice not found (triggers CreateSlice path).
+	return nil, storage.ErrSliceNotFound
+}
+
+func (f *faultingSliceOps) ListSlices(context.Context, string) ([]*storage.Slice, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *faultingSliceOps) ClaimSlice(context.Context, string, string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (f *faultingSliceOps) CompleteSlice(context.Context, string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func TestStoreDecomposeOutput_GetSliceError(t *testing.T) {
+	clearDatabase(t)
+	ctx := context.Background()
+
+	store, err := newStore(ctx, boltURI, memgraph.WithSliceOps(&faultingSliceOps{
+		getSliceErr: fmt.Errorf("connection reset"),
+	}))
+	require.NoError(t, err)
+	defer store.Close(ctx) //nolint:errcheck
+
+	_, err = store.CreateSpec(ctx, "fault-parent", "Fault test", "p1", "medium")
+	require.NoError(t, err)
+
+	_, err = store.StoreDecomposeOutput(ctx, "fault-parent", &storage.DecomposeOutput{
+		Strategy: storage.StrategyVerticalSlice,
+		Slices: []storage.DecomposeSlice{
+			{ID: "a", Intent: "test slice"},
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "check slice")
+	require.Contains(t, err.Error(), "connection reset")
+}
+
+func TestStoreDecomposeOutput_CreateSliceError(t *testing.T) {
+	clearDatabase(t)
+	ctx := context.Background()
+
+	store, err := newStore(ctx, boltURI, memgraph.WithSliceOps(&faultingSliceOps{
+		createSliceErr: fmt.Errorf("disk full"),
+	}))
+	require.NoError(t, err)
+	defer store.Close(ctx) //nolint:errcheck
+
+	_, err = store.CreateSpec(ctx, "fault-parent-2", "Fault test 2", "p1", "medium")
+	require.NoError(t, err)
+
+	_, err = store.StoreDecomposeOutput(ctx, "fault-parent-2", &storage.DecomposeOutput{
+		Strategy: storage.StrategyVerticalSlice,
+		Slices: []storage.DecomposeSlice{
+			{ID: "a", Intent: "test slice"},
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "create slice")
+	require.Contains(t, err.Error(), "disk full")
+}

--- a/internal/storage/memgraph/authoring_test.go
+++ b/internal/storage/memgraph/authoring_test.go
@@ -117,6 +117,45 @@ func TestAuthoring(t *testing.T) {
 		require.Len(t, children, 2)
 		require.Equal(t, "decomp-parent/slice-1", children[0])
 		require.Equal(t, "decomp-parent/slice-2", children[1])
+
+		// Verify Slice nodes were created (not Spec nodes).
+		sl1, err := store.GetSlice(ctx, "decomp-parent/slice-1")
+		require.NoError(t, err)
+		require.Equal(t, "Auth endpoint", sl1.Intent)
+		require.Equal(t, []string{"login works"}, sl1.Verify)
+		require.Equal(t, []string{"auth.go"}, sl1.Touches)
+		require.Equal(t, storage.SliceStatusOpen, sl1.Status)
+		require.Empty(t, sl1.DependsOn, "slice-1 has no dependencies")
+
+		sl2, err := store.GetSlice(ctx, "decomp-parent/slice-2")
+		require.NoError(t, err)
+		require.Equal(t, "Token refresh", sl2.Intent)
+		require.Equal(t, []string{"decomp-parent/slice-1"}, sl2.DependsOn, "slice-2 depends on slice-1 (resolved slug)")
+
+		// Verify no child Spec nodes were created.
+		_, err = store.GetSpec(ctx, "decomp-parent/slice-1")
+		require.ErrorIs(t, err, storage.ErrSpecNotFound)
+
+		// Verify Slices appear in GetFullGraph.
+		graph, err := store.GetFullGraph(ctx)
+		require.NoError(t, err)
+		slugLabels := make(map[string]storage.NodeLabel)
+		for _, n := range graph.Nodes {
+			slugLabels[n.Slug] = n.Label
+		}
+		require.Equal(t, storage.NodeLabelSpec, slugLabels["decomp-parent"])
+		require.Equal(t, storage.NodeLabelSlice, slugLabels["decomp-parent/slice-1"])
+		require.Equal(t, storage.NodeLabelSlice, slugLabels["decomp-parent/slice-2"])
+
+		// Verify COMPOSES and DEPENDS_ON edges in the graph.
+		edgeSet := make(map[string]storage.EdgeType)
+		for _, e := range graph.Edges {
+			key := e.FromID + "->" + e.ToID
+			edgeSet[key] = e.EdgeType
+		}
+		require.Equal(t, storage.EdgeTypeComposes, edgeSet["decomp-parent/slice-1->decomp-parent"])
+		require.Equal(t, storage.EdgeTypeComposes, edgeSet["decomp-parent/slice-2->decomp-parent"])
+		require.Equal(t, storage.EdgeTypeDependsOn, edgeSet["decomp-parent/slice-2->decomp-parent/slice-1"])
 	})
 
 	t.Run("AmendSpec", func(t *testing.T) {

--- a/internal/storage/memgraph/graph.go
+++ b/internal/storage/memgraph/graph.go
@@ -263,12 +263,12 @@ func (s *Store) GetCriticalPath(ctx context.Context, slug string) ([]storage.Nod
 	return s.queryNodeRefs(ctx, query, mergeParams(s.projectParam(), map[string]any{"slug": slug}))
 }
 
-// GetFullGraph returns all spec and decision nodes with all user-facing edges.
+// GetFullGraph returns all spec, decision, and slice nodes with all user-facing edges.
 func (s *Store) GetFullGraph(ctx context.Context) (*storage.FullGraph, error) {
-	// Query 1: All nodes (Spec + Decision)
+	// Query 1: All nodes (Spec + Decision + Slice)
 	nodeQuery := `
 		MATCH (p:Project {slug: $project})<-[:BELONGS_TO]-(n)
-		WHERE n:Spec OR n:Decision
+		WHERE n:Spec OR n:Decision OR n:Slice
 		RETURN DISTINCT n.slug AS slug, labels(n)[0] AS label,
 		       COALESCE(n.stage, n.status, "") AS stage,
 		       COALESCE(n.intent, n.title, "") AS intent,
@@ -310,7 +310,7 @@ func (s *Store) GetFullGraph(ctx context.Context) (*storage.FullGraph, error) {
 	edgeQuery := `
 		MATCH (p:Project {slug: $project})<-[:BELONGS_TO]-(a)-[r]->(b)
 		WHERE type(r) <> "BELONGS_TO" AND type(r) <> "HAS_CHANGE" AND type(r) <> "HAS_FINDING" AND type(r) <> "AUTHORED_VIA" AND type(r) <> "CONTINUES" AND type(r) <> "EXPLAINS"
-		  AND (b:Spec OR b:Decision)
+		  AND (b:Spec OR b:Decision OR b:Slice)
 		RETURN a.slug AS from_slug, b.slug AS to_slug, type(r) AS rel_type
 	`
 	edgeRecords, err := s.executeQuery(ctx, edgeQuery, s.projectParam())

--- a/internal/storage/memgraph/memgraph.go
+++ b/internal/storage/memgraph/memgraph.go
@@ -36,9 +36,10 @@ var (
 // Store implements storage.Backend using Memgraph (Bolt protocol).
 type Store struct {
 	driver     neo4j.DriverWithContext
-	nowFunc    func() time.Time // injectable clock; defaults to time.Now
-	project    string           // project slug for graph namespacing
-	ownsDriver bool             // true for stores created by New(); false for Scoped() stores
+	nowFunc    func() time.Time    // injectable clock; defaults to time.Now
+	sliceOps   storage.SliceBackend // injectable slice operations; defaults to self
+	project    string               // project slug for graph namespacing
+	ownsDriver bool                 // true for stores created by New(); false for Scoped() stores
 }
 
 // Option configures a Store.
@@ -54,6 +55,12 @@ func WithClock(fn func() time.Time) Option {
 // Required — New() returns an error if no project is set.
 func WithProject(slug string) Option {
 	return func(s *Store) { s.project = slug }
+}
+
+// WithSliceOps overrides the default SliceBackend used by StoreDecomposeOutput.
+// Intended for testing — production callers should omit this option.
+func WithSliceOps(ops storage.SliceBackend) Option {
+	return func(s *Store) { s.sliceOps = ops }
 }
 
 // New creates a new Memgraph-backed Store and verifies connectivity.
@@ -73,6 +80,9 @@ func New(ctx context.Context, boltURI string, opts ...Option) (*Store, error) {
 	if s.project == "" {
 		driver.Close(ctx) //nolint:errcheck // best-effort cleanup on init failure
 		return nil, fmt.Errorf("memgraph: project slug required: use memgraph.WithProject(slug)")
+	}
+	if s.sliceOps == nil {
+		s.sliceOps = s
 	}
 	if err := s.ensureIndexes(ctx); err != nil {
 		driver.Close(ctx) //nolint:errcheck // best-effort cleanup on init failure
@@ -154,6 +164,7 @@ func (s *Store) Scoped(ctx context.Context, project string) (storage.ScopedBacke
 		return nil, fmt.Errorf("memgraph: project slug required")
 	}
 	scoped := &Store{driver: s.driver, nowFunc: s.nowFunc, project: project}
+	scoped.sliceOps = scoped // default to self; inherit pattern, not parent's ops
 	if err := scoped.ensureProjectNode(ctx); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- **Rewrite `StoreDecomposeOutput`** to create first-class `:Slice` graph nodes via `CreateSlice` instead of child Spec nodes via `CreateSpec`
- **Update `GetFullGraph`** node and edge queries to include `:Slice` label, so Slices appear in graph visualization
- **Add `SliceSlugs []string`** to `DecomposeOutput` domain struct — stored output on the parent spec is slimmed to strategy + slug references (full slice data lives in Slice nodes)

### What changed

| File | Change |
|------|--------|
| `internal/storage/authoring.go` | Add `SliceSlugs` field to `DecomposeOutput` |
| `internal/storage/memgraph/authoring.go` | Rewrite Pass 1 (CreateSlice not CreateSpec), Pass 2 (Slice-to-Slice DEPENDS_ON, no content_hash_at_link), store slimmed JSON |
| `internal/storage/memgraph/graph.go` | `WHERE n:Spec OR n:Decision OR n:Slice` in both node and edge queries |
| `internal/storage/memgraph/authoring_test.go` | Verify: Slice nodes created, no child Specs, GetFullGraph returns Slices with correct labels + edges |

### Key design decisions

- **No `content_hash_at_link` on Slice DEPENDS_ON edges** — Slices have no content hash (per spec §3)
- **Idempotency via `GetSlice`/`ErrSliceNotFound`** — same pattern as before but using Slice primitives
- **Stored JSON is slimmed** — parent spec's `decompose_output` stores `{strategy, slice_slugs}` not inline slice data, avoiding two sources of truth

### Bead

Closes spgr-6sw.3 (depends on spgr-6sw.2 / PR #688, blocks spgr-6sw.4)

## Test plan

- [x] Unit tests pass (`go test ./internal/storage/...`)
- [x] Integration tests pass (`task test:integration`) — all 5 StoreDecomposeOutput subtests + changelog test
- [x] Go lint clean (`golangci-lint run` — 0 issues)
- [x] Full build passes (`go build ./...`)
- [x] New test assertions verify Slice nodes created, no child Spec nodes, GetFullGraph includes Slices with correct labels and COMPOSES/DEPENDS_ON edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>