### PR TITLE
test(e2e): add SliceService E2E tests + update decompose assertions (spgr-6sw.8)

### DIFF
--- a/e2e/api/authoring_test.go
+++ b/e2e/api/authoring_test.go
@@ -120,6 +120,9 @@ var _ = Describe("Authoring funnel", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.Msg.Output).NotTo(BeNil())
 		Expect(resp.Msg.Output.Slices).To(HaveLen(2))
+		Expect(resp.Msg.SliceSlugs).To(HaveLen(2))
+		Expect(resp.Msg.SliceSlugs[0]).To(HaveSuffix("/slice-1"))
+		Expect(resp.Msg.SliceSlugs[1]).To(HaveSuffix("/slice-2"))
 	})
 
 	It("approves a decomposed spec", func() {

--- a/e2e/api/helpers_test.go
+++ b/e2e/api/helpers_test.go
@@ -71,6 +71,10 @@ func newExecutionClient() specgraphv1connect.ExecutionServiceClient {
 	return specgraphv1connect.NewExecutionServiceClient(projectClient(), serverInfo.BaseURL)
 }
 
+func newSliceClient() specgraphv1connect.SliceServiceClient {
+	return specgraphv1connect.NewSliceServiceClient(projectClient(), serverInfo.BaseURL)
+}
+
 // projectClientFor returns an HTTP client with a custom project header.
 // Used by isolation tests to target different projects.
 func projectClientFor(slug string) *http.Client {

--- a/e2e/api/slice_test.go
+++ b/e2e/api/slice_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+//go:build e2e
+
+package api_test
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+)
+
+var _ = Describe("SliceService", Ordered, func() {
+	var (
+		sliceClient     specgraphv1connect.SliceServiceClient
+		authoringClient specgraphv1connect.AuthoringServiceClient
+		ctx             = context.Background()
+		parentSlug      = "slice-svc-e2e"
+	)
+
+	// Setup: create clients and advance a spec through decompose to create slices.
+	// Uses POSTURE_DRIVE which creates the spec on Spark if it doesn't exist.
+	BeforeAll(func() {
+		sliceClient = newSliceClient()
+		authoringClient = newAuthoringClient()
+
+		// Spark (POSTURE_DRIVE creates the spec automatically)
+		_, err := authoringClient.Spark(ctx, connect.NewRequest(&specv1.SparkRequest{
+			Slug: parentSlug,
+			Output: &specv1.SparkOutput{
+				Seed:   "test seed",
+				Signal: "test signal",
+			},
+			Posture: specv1.Posture_POSTURE_DRIVE,
+		}))
+		Expect(err).NotTo(HaveOccurred())
+
+		// Shape
+		_, err = authoringClient.Shape(ctx, connect.NewRequest(&specv1.ShapeRequest{
+			Slug: parentSlug,
+			Output: &specv1.ShapeOutput{
+				ScopeIn:        []string{"slice testing"},
+				ChosenApproach: "test approach",
+			},
+			Posture: specv1.Posture_POSTURE_DRIVE,
+		}))
+		Expect(err).NotTo(HaveOccurred())
+
+		// Specify
+		_, err = authoringClient.Specify(ctx, connect.NewRequest(&specv1.SpecifyRequest{
+			Slug: parentSlug,
+			Output: &specv1.SpecifyOutput{
+				Interfaces: []*specv1.InterfaceSection{{Name: "API", Body: "REST"}},
+			},
+			Posture: specv1.Posture_POSTURE_DRIVE,
+		}))
+		Expect(err).NotTo(HaveOccurred())
+
+		// Decompose — creates slices
+		_, err = authoringClient.Decompose(ctx, connect.NewRequest(&specv1.DecomposeRequest{
+			Slug: parentSlug,
+			Output: &specv1.DecomposeOutput{
+				Strategy: specv1.DecompositionStrategy_DECOMPOSITION_STRATEGY_VERTICAL_SLICE,
+				Slices: []*specv1.DecompositionSlice{
+					{Id: "backend", Intent: "Backend API", Verify: []string{"tests pass"}},
+					{Id: "frontend", Intent: "Frontend UI", Verify: []string{"renders"}, DependsOn: []string{"backend"}},
+				},
+			},
+			Posture: specv1.Posture_POSTURE_DRIVE,
+		}))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("lists slices for a parent spec", func() {
+		resp, err := sliceClient.ListSlices(ctx, connect.NewRequest(&specv1.ListSlicesRequest{
+			ParentSlug: parentSlug,
+		}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Msg.Slices).To(HaveLen(2))
+
+		// Verify slice fields are populated
+		slugs := make([]string, len(resp.Msg.Slices))
+		for i, s := range resp.Msg.Slices {
+			slugs[i] = s.SliceId
+			Expect(s.ParentSlug).To(Equal(parentSlug))
+			Expect(s.Intent).NotTo(BeEmpty())
+			Expect(s.Status).To(Equal(specv1.SliceStatus_SLICE_STATUS_OPEN))
+		}
+		Expect(slugs).To(ContainElements("backend", "frontend"))
+	})
+
+	It("gets a single slice by slug", func() {
+		resp, err := sliceClient.GetSlice(ctx, connect.NewRequest(&specv1.GetSliceRequest{
+			Slug: parentSlug + "/backend",
+		}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Msg.Slice.SliceId).To(Equal("backend"))
+		Expect(resp.Msg.Slice.Intent).To(Equal("Backend API"))
+		Expect(resp.Msg.Slice.Status).To(Equal(specv1.SliceStatus_SLICE_STATUS_OPEN))
+	})
+
+	It("returns not-found for nonexistent slice", func() {
+		_, err := sliceClient.GetSlice(ctx, connect.NewRequest(&specv1.GetSliceRequest{
+			Slug: parentSlug + "/nonexistent",
+		}))
+		Expect(err).To(HaveOccurred())
+		Expect(connect.CodeOf(err)).To(Equal(connect.CodeNotFound))
+	})
+
+	It("claims a slice", func() {
+		resp, err := sliceClient.ClaimSlice(ctx, connect.NewRequest(&specv1.ClaimSliceRequest{
+			Slug:     parentSlug + "/backend",
+			Assignee: "e2e-agent",
+		}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Msg.Slice.Status).To(Equal(specv1.SliceStatus_SLICE_STATUS_CLAIMED))
+		Expect(resp.Msg.Slice.AssignedTo).To(Equal("e2e-agent"))
+	})
+
+	It("rejects claim on already-claimed slice", func() {
+		_, err := sliceClient.ClaimSlice(ctx, connect.NewRequest(&specv1.ClaimSliceRequest{
+			Slug:     parentSlug + "/backend",
+			Assignee: "another-agent",
+		}))
+		Expect(err).To(HaveOccurred())
+		Expect(connect.CodeOf(err)).To(Equal(connect.CodeFailedPrecondition))
+	})
+
+	It("completes a claimed slice", func() {
+		resp, err := sliceClient.CompleteSlice(ctx, connect.NewRequest(&specv1.CompleteSliceRequest{
+			Slug: parentSlug + "/backend",
+		}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Msg.Slice.Status).To(Equal(specv1.SliceStatus_SLICE_STATUS_DONE))
+	})
+
+	It("rejects complete on unclaimed slice", func() {
+		_, err := sliceClient.CompleteSlice(ctx, connect.NewRequest(&specv1.CompleteSliceRequest{
+			Slug: parentSlug + "/frontend",
+		}))
+		Expect(err).To(HaveOccurred())
+		Expect(connect.CodeOf(err)).To(Equal(connect.CodeFailedPrecondition))
+	})
+
+	It("includes slices in GetFullGraph", func() {
+		graphClient := newGraphClient()
+		resp, err := graphClient.GetFullGraph(ctx, connect.NewRequest(&specv1.GetFullGraphRequest{}))
+		Expect(err).NotTo(HaveOccurred())
+
+		sliceNodes := 0
+		for _, n := range resp.Msg.Nodes {
+			if n.Label == "Slice" {
+				sliceNodes++
+			}
+		}
+		Expect(sliceNodes).To(BeNumerically(">=", 2))
+	})
+})

--- a/e2e/testutil/server.go
+++ b/e2e/testutil/server.go
@@ -53,6 +53,7 @@ func StartServer(ctx context.Context, boltURI string, opts ...connect.HandlerOpt
 	server.RegisterConstitutionService(mux, store, opts...)
 	server.RegisterAuthoringService(mux, store, opts...)
 	server.RegisterExecutionService(mux, store, opts...)
+	server.RegisterSliceService(mux, store, opts...)
 	driftEngine := drift.NewEngine(store, nil)
 	lintEngine := linter.NewEngine(store, nil)
 	server.RegisterLifecycleService(mux, store, driftEngine, lintEngine, nil, opts...)


### PR DESCRIPTION
## Summary

- **8 new SliceService E2E tests** covering the full slice lifecycle
- **Update decompose E2E** to verify `slice_slugs` in response
- **Register `SliceService`** in E2E test server (`e2e/testutil/server.go`)
- **Add `newSliceClient`** helper in E2E helpers

### Tests

| Test | What it verifies |
|------|------------------|
| lists slices for a parent spec | ListSlices returns 2 slices with correct fields |
| gets a single slice by slug | GetSlice returns correct slice-id, intent, status |
| returns not-found for nonexistent | CodeNotFound |
| claims a slice | Status→claimed, assignedTo set |
| rejects claim on already-claimed | CodeFailedPrecondition |
| completes a claimed slice | Status→done |
| rejects complete on unclaimed | CodeFailedPrecondition |
| includes slices in GetFullGraph | Graph contains Slice label nodes |

### Files

| Action | File |
|--------|------|
| Create | `e2e/api/slice_test.go` |
| Modify | `e2e/api/helpers_test.go` (add `newSliceClient`) |
| Modify | `e2e/api/authoring_test.go` (add `slice_slugs` assertions) |
| Modify | `e2e/testutil/server.go` (register SliceService) |

### Bead

Closes spgr-6sw.8

## Test plan

- [x] 147 API E2E specs pass (was 139 — 8 new)
- [x] 19 CLI E2E specs pass
- [x] 3 Docker E2E specs pass
- [x] `go vet -tags e2e` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>