### PR TITLE
fix(server): codebase review wave 1 — security fixes + foundations (spgr-dec)

### DIFF
--- a/cmd/specgraph/approve.go
+++ b/cmd/specgraph/approve.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -24,12 +23,12 @@ func init() {
 	rootCmd.AddCommand(approveCmd)
 }
 
-func runApprove(_ *cobra.Command, args []string) error {
+func runApprove(cmd *cobra.Command, args []string) error {
 	client, err := authoringClient()
 	if err != nil {
 		return err
 	}
-	resp, err := client.Approve(context.Background(), connect.NewRequest(&specv1.ApproveRequest{
+	resp, err := client.Approve(cmd.Context(), connect.NewRequest(&specv1.ApproveRequest{
 		Slug: args[0],
 	}))
 	if err != nil {

--- a/cmd/specgraph/authoring_test.go
+++ b/cmd/specgraph/authoring_test.go
@@ -31,7 +31,7 @@ func (fakeSparkHandler) Spark(_ context.Context, req *connect.Request[specv1.Spa
 
 func TestRunSpark_HappyPath(t *testing.T) {
 	startFakeAuthoringServer(t, fakeSparkHandler{})
-	err := runSpark(nil, []string{"my-spec"})
+	err := runSpark(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -62,7 +62,7 @@ func TestRunSpark_WithSeedAndPrompts(t *testing.T) {
 	sparkSeed = "test seed idea"
 	t.Cleanup(func() { sparkSeed = old })
 
-	err := runSpark(nil, []string{"my-spec"})
+	err := runSpark(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -76,14 +76,14 @@ func (fakeSparkErrorHandler) Spark(context.Context, *connect.Request[specv1.Spar
 
 func TestRunSpark_RPCError(t *testing.T) {
 	startFakeAuthoringServer(t, fakeSparkErrorHandler{})
-	err := runSpark(nil, []string{"my-spec"})
+	err := runSpark(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "spark:")
 }
 
 func TestRunSpark_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runSpark(nil, []string{"my-spec"})
+	err := runSpark(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
@@ -106,7 +106,7 @@ func (fakeShapeHandler) Shape(_ context.Context, _ *connect.Request[specv1.Shape
 
 func TestRunShape_HappyPath(t *testing.T) {
 	startFakeAuthoringServer(t, fakeShapeHandler{})
-	err := runShape(nil, []string{"my-spec"})
+	err := runShape(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -118,7 +118,7 @@ func TestRunShape_WithJSONFile(t *testing.T) {
 	shapeJSONFile = path
 	t.Cleanup(func() { shapeJSONFile = old })
 
-	err := runShape(nil, []string{"my-spec"})
+	err := runShape(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -130,7 +130,7 @@ func TestRunShape_InvalidJSONFile(t *testing.T) {
 	shapeJSONFile = path
 	t.Cleanup(func() { shapeJSONFile = old })
 
-	err := runShape(nil, []string{"my-spec"})
+	err := runShape(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "shape:")
 }
@@ -142,7 +142,7 @@ func TestRunShape_MissingJSONFile(t *testing.T) {
 	shapeJSONFile = t.TempDir() + "/no-such-file.json"
 	t.Cleanup(func() { shapeJSONFile = old })
 
-	err := runShape(nil, []string{"my-spec"})
+	err := runShape(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "shape:")
 }
@@ -157,14 +157,14 @@ func (fakeShapeErrorHandler) Shape(context.Context, *connect.Request[specv1.Shap
 
 func TestRunShape_RPCError(t *testing.T) {
 	startFakeAuthoringServer(t, fakeShapeErrorHandler{})
-	err := runShape(nil, []string{"my-spec"})
+	err := runShape(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "shape:")
 }
 
 func TestRunShape_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runShape(nil, []string{"my-spec"})
+	err := runShape(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
@@ -187,7 +187,7 @@ func (fakeSpecifyHandler) Specify(_ context.Context, _ *connect.Request[specv1.S
 
 func TestRunSpecify_HappyPath(t *testing.T) {
 	startFakeAuthoringServer(t, fakeSpecifyHandler{})
-	err := runSpecify(nil, []string{"my-spec"})
+	err := runSpecify(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -199,7 +199,7 @@ func TestRunSpecify_WithJSONFile(t *testing.T) {
 	specifyJSONFile = path
 	t.Cleanup(func() { specifyJSONFile = old })
 
-	err := runSpecify(nil, []string{"my-spec"})
+	err := runSpecify(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -211,14 +211,14 @@ func TestRunSpecify_InvalidJSONFile(t *testing.T) {
 	specifyJSONFile = path
 	t.Cleanup(func() { specifyJSONFile = old })
 
-	err := runSpecify(nil, []string{"my-spec"})
+	err := runSpecify(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "specify:")
 }
 
 func TestRunSpecify_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runSpecify(nil, []string{"my-spec"})
+	err := runSpecify(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
@@ -241,7 +241,7 @@ func (fakeDecomposeHandler) Decompose(_ context.Context, _ *connect.Request[spec
 
 func TestRunDecompose_HappyPath(t *testing.T) {
 	startFakeAuthoringServer(t, fakeDecomposeHandler{})
-	err := runDecompose(nil, []string{"my-spec"})
+	err := runDecompose(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -263,7 +263,7 @@ func (fakeDecomposeWithSlicesHandler) Decompose(_ context.Context, _ *connect.Re
 
 func TestRunDecompose_WithSlices(t *testing.T) {
 	startFakeAuthoringServer(t, fakeDecomposeWithSlicesHandler{})
-	err := runDecompose(nil, []string{"my-spec"})
+	err := runDecompose(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -275,14 +275,14 @@ func TestRunDecompose_InvalidJSONFile(t *testing.T) {
 	decomposeJSONFile = path
 	t.Cleanup(func() { decomposeJSONFile = old })
 
-	err := runDecompose(nil, []string{"my-spec"})
+	err := runDecompose(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "decompose:")
 }
 
 func TestRunDecompose_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runDecompose(nil, []string{"my-spec"})
+	err := runDecompose(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
@@ -308,7 +308,7 @@ func (fakeApproveHandler) Approve(_ context.Context, req *connect.Request[specv1
 
 func TestRunApprove_HappyPath(t *testing.T) {
 	startFakeAuthoringServer(t, fakeApproveHandler{})
-	err := runApprove(nil, []string{"my-spec"})
+	err := runApprove(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -322,14 +322,14 @@ func (fakeApproveErrorHandler) Approve(context.Context, *connect.Request[specv1.
 
 func TestRunApprove_RPCError(t *testing.T) {
 	startFakeAuthoringServer(t, fakeApproveErrorHandler{})
-	err := runApprove(nil, []string{"my-spec"})
+	err := runApprove(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "approve:")
 }
 
 func TestRunApprove_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runApprove(nil, []string{"my-spec"})
+	err := runApprove(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 

--- a/cmd/specgraph/bundle.go
+++ b/cmd/specgraph/bundle.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -36,12 +35,12 @@ func init() {
 	rootCmd.AddCommand(bundleCmd)
 }
 
-func runBundle(_ *cobra.Command, args []string) error {
+func runBundle(cmd *cobra.Command, args []string) error {
 	client, err := executionClient()
 	if err != nil {
 		return err
 	}
-	resp, err := client.GenerateBundle(context.Background(), connect.NewRequest(&specv1.GenerateBundleRequest{
+	resp, err := client.GenerateBundle(cmd.Context(), connect.NewRequest(&specv1.GenerateBundleRequest{
 		Slug:     args[0],
 		Endpoint: bundleEndpoint,
 	}))

--- a/cmd/specgraph/bundle_test.go
+++ b/cmd/specgraph/bundle_test.go
@@ -45,7 +45,7 @@ func TestRunBundle_HappyPath_Stdout(t *testing.T) {
 	bundleOutput = ""
 	t.Cleanup(func() { bundleOutput = old })
 
-	err := runBundle(nil, []string{"my-spec"})
+	err := runBundle(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -59,7 +59,7 @@ func TestRunBundle_HappyPath_File(t *testing.T) {
 	bundleOutput = outPath
 	t.Cleanup(func() { bundleOutput = old })
 
-	err := runBundle(nil, []string{"my-spec"})
+	err := runBundle(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(outPath)
@@ -74,7 +74,7 @@ func TestRunBundle_RPCError(t *testing.T) {
 	bundleOutput = ""
 	t.Cleanup(func() { bundleOutput = old })
 
-	err := runBundle(nil, []string{"my-spec"})
+	err := runBundle(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "generate bundle")
 }
@@ -82,7 +82,7 @@ func TestRunBundle_RPCError(t *testing.T) {
 func TestRunBundle_ClientError(t *testing.T) {
 	setMissingConfig(t)
 
-	err := runBundle(nil, []string{"my-spec"})
+	err := runBundle(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 

--- a/cmd/specgraph/claim.go
+++ b/cmd/specgraph/claim.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -44,12 +43,12 @@ func init() {
 	rootCmd.AddCommand(unclaimCmd)
 }
 
-func runClaim(_ *cobra.Command, args []string) error {
+func runClaim(cmd *cobra.Command, args []string) error {
 	client, err := claimClient()
 	if err != nil {
 		return err
 	}
-	resp, err := client.ClaimSpec(context.Background(), connect.NewRequest(&specv1.ClaimSpecRequest{
+	resp, err := client.ClaimSpec(cmd.Context(), connect.NewRequest(&specv1.ClaimSpecRequest{
 		SpecSlug:      args[0],
 		Agent:         claimAgent,
 		LeaseDuration: durationpb.New(claimDuration),
@@ -74,12 +73,12 @@ var unclaimCmd = &cobra.Command{
 
 var unclaimAgent string
 
-func runUnclaim(_ *cobra.Command, args []string) error {
+func runUnclaim(cmd *cobra.Command, args []string) error {
 	client, err := claimClient()
 	if err != nil {
 		return err
 	}
-	_, err = client.UnclaimSpec(context.Background(), connect.NewRequest(&specv1.UnclaimSpecRequest{
+	_, err = client.UnclaimSpec(cmd.Context(), connect.NewRequest(&specv1.UnclaimSpecRequest{
 		SpecSlug: args[0],
 		Agent:    unclaimAgent,
 	}))

--- a/cmd/specgraph/claim_test.go
+++ b/cmd/specgraph/claim_test.go
@@ -65,7 +65,7 @@ func TestRunClaim_HappyPath(t *testing.T) {
 	claimDuration = 10 * time.Minute
 	t.Cleanup(func() { claimDuration = oldDur })
 
-	err := runClaim(nil, []string{"my-spec"})
+	err := runClaim(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -76,7 +76,7 @@ func TestRunUnclaim_HappyPath(t *testing.T) {
 	unclaimAgent = "test-agent"
 	t.Cleanup(func() { unclaimAgent = old })
 
-	err := runUnclaim(nil, []string{"my-spec"})
+	err := runUnclaim(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -93,7 +93,7 @@ func TestRunClaim_RPCError(t *testing.T) {
 	claimDuration = 10 * time.Minute
 	t.Cleanup(func() { claimDuration = oldDur })
 
-	err := runClaim(nil, []string{"my-spec"})
+	err := runClaim(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "claim spec")
 }
@@ -105,7 +105,7 @@ func TestRunUnclaim_RPCError(t *testing.T) {
 	unclaimAgent = "test-agent"
 	t.Cleanup(func() { unclaimAgent = old })
 
-	err := runUnclaim(nil, []string{"my-spec"})
+	err := runUnclaim(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unclaim spec")
 }

--- a/cmd/specgraph/constitution.go
+++ b/cmd/specgraph/constitution.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -48,7 +47,7 @@ func runConstitutionShow(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.GetConstitution(context.Background(), connect.NewRequest(&specv1.GetConstitutionRequest{}))
+	resp, err := client.GetConstitution(cmd.Context(), connect.NewRequest(&specv1.GetConstitutionRequest{}))
 	if err != nil {
 		return fmt.Errorf("get constitution: %w", err)
 	}
@@ -77,7 +76,7 @@ var outputFormatMap = map[string]specv1.OutputFormat{
 	"agents-md":   specv1.OutputFormat_OUTPUT_FORMAT_AGENTS_MD,
 }
 
-func runConstitutionEmit(_ *cobra.Command, _ []string) error {
+func runConstitutionEmit(cmd *cobra.Command, _ []string) error {
 	format, ok := outputFormatMap[emitFormat]
 	if !ok {
 		return fmt.Errorf("unsupported format %q; valid values: claude-md, cursorrules, agents-md", emitFormat)
@@ -86,7 +85,7 @@ func runConstitutionEmit(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.EmitToolFiles(context.Background(), connect.NewRequest(&specv1.EmitToolFilesRequest{
+	resp, err := client.EmitToolFiles(cmd.Context(), connect.NewRequest(&specv1.EmitToolFilesRequest{
 		Format: format,
 	}))
 	if err != nil {
@@ -129,7 +128,7 @@ var constitutionImportCmd = &cobra.Command{
 
 var importProjectSlug string
 
-func runConstitutionImport(_ *cobra.Command, args []string) error {
+func runConstitutionImport(cmd *cobra.Command, args []string) error {
 	var data []byte
 	var err error
 
@@ -162,7 +161,7 @@ func runConstitutionImport(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	_, err = client.UpdateConstitution(context.Background(), connect.NewRequest(&specv1.UpdateConstitutionRequest{
+	_, err = client.UpdateConstitution(cmd.Context(), connect.NewRequest(&specv1.UpdateConstitutionRequest{
 		Constitution: pb,
 	}))
 	if err != nil {

--- a/cmd/specgraph/constitution_test.go
+++ b/cmd/specgraph/constitution_test.go
@@ -14,7 +14,6 @@ import (
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/specgraph/specgraph/internal/config"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -187,7 +186,7 @@ func TestRunConstitutionShow_HappyPath(t *testing.T) {
 	constitutionShowJSON = false
 	t.Cleanup(func() { constitutionShowJSON = oldJSON })
 
-	err := runConstitutionShow(&cobra.Command{}, nil)
+	err := runConstitutionShow(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
@@ -198,7 +197,7 @@ func TestRunConstitutionShow_HappyPath_JSON(t *testing.T) {
 	constitutionShowJSON = true
 	t.Cleanup(func() { constitutionShowJSON = oldJSON })
 
-	cmd := &cobra.Command{}
+	cmd := newCmdWithCtx()
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 	err := runConstitutionShow(cmd, nil)
@@ -213,14 +212,14 @@ func TestRunConstitutionShow_RPCError(t *testing.T) {
 	constitutionShowJSON = false
 	t.Cleanup(func() { constitutionShowJSON = oldJSON })
 
-	err := runConstitutionShow(&cobra.Command{}, nil)
+	err := runConstitutionShow(newCmdWithCtx(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get constitution")
 }
 
 func TestRunConstitutionShow_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runConstitutionShow(&cobra.Command{}, nil)
+	err := runConstitutionShow(newCmdWithCtx(), nil)
 	require.Error(t, err)
 }
 
@@ -235,7 +234,7 @@ func TestRunConstitutionEmit_HappyPath_Stdout(t *testing.T) {
 	emitOutput = ""
 	t.Cleanup(func() { emitFormat = oldFmt; emitOutput = oldOut })
 
-	err := runConstitutionEmit(nil, nil)
+	err := runConstitutionEmit(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
@@ -251,7 +250,7 @@ func TestRunConstitutionEmit_HappyPath_File(t *testing.T) {
 	emitOutput = "out.md"
 	t.Cleanup(func() { emitFormat = oldFmt; emitOutput = oldOut })
 
-	err := runConstitutionEmit(nil, nil)
+	err := runConstitutionEmit(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 
 	data, err := os.ReadFile("out.md")
@@ -271,7 +270,7 @@ func TestRunConstitutionEmit_PathTraversal(t *testing.T) {
 	emitOutput = "../outside-cwd.md"
 	t.Cleanup(func() { emitFormat = oldFmt; emitOutput = oldOut })
 
-	err := runConstitutionEmit(nil, nil)
+	err := runConstitutionEmit(newCmdWithCtx(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "outside current directory")
 }
@@ -283,7 +282,7 @@ func TestRunConstitutionEmit_InvalidFormat(t *testing.T) {
 	emitOutput = ""
 	t.Cleanup(func() { emitFormat = oldFmt; emitOutput = oldOut })
 
-	err := runConstitutionEmit(nil, nil)
+	err := runConstitutionEmit(newCmdWithCtx(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported format")
 }
@@ -297,7 +296,7 @@ func TestRunConstitutionEmit_RPCError(t *testing.T) {
 	emitOutput = ""
 	t.Cleanup(func() { emitFormat = oldFmt; emitOutput = oldOut })
 
-	err := runConstitutionEmit(nil, nil)
+	err := runConstitutionEmit(newCmdWithCtx(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "emit tool files")
 }
@@ -311,7 +310,7 @@ func TestRunConstitutionEmit_ClientError(t *testing.T) {
 	emitOutput = ""
 	t.Cleanup(func() { emitFormat = oldFmt; emitOutput = oldOut })
 
-	err := runConstitutionEmit(nil, nil)
+	err := runConstitutionEmit(newCmdWithCtx(), nil)
 	require.Error(t, err)
 }
 

--- a/cmd/specgraph/decision.go
+++ b/cmd/specgraph/decision.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -40,12 +39,12 @@ var (
 	decisionRationale string
 )
 
-func runDecisionCreate(_ *cobra.Command, args []string) error {
+func runDecisionCreate(cmd *cobra.Command, args []string) error {
 	client, err := decisionClient()
 	if err != nil {
 		return err
 	}
-	resp, err := client.CreateDecision(context.Background(), connect.NewRequest(&specv1.CreateDecisionRequest{
+	resp, err := client.CreateDecision(cmd.Context(), connect.NewRequest(&specv1.CreateDecisionRequest{
 		Slug:      args[0],
 		Title:     decisionTitle,
 		Decision:  decisionText,
@@ -87,7 +86,7 @@ func runDecisionList(cmd *cobra.Command, _ []string) error {
 		statusFilter = specv1.DecisionStatus(val)
 	}
 
-	resp, err := client.ListDecisions(context.Background(), connect.NewRequest(&specv1.ListDecisionsRequest{
+	resp, err := client.ListDecisions(cmd.Context(), connect.NewRequest(&specv1.ListDecisionsRequest{
 		Status: statusFilter,
 	}))
 	if err != nil {
@@ -131,7 +130,7 @@ func runDecisionShow(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.GetDecision(context.Background(), connect.NewRequest(&specv1.GetDecisionRequest{
+	resp, err := client.GetDecision(cmd.Context(), connect.NewRequest(&specv1.GetDecisionRequest{
 		Slug: args[0],
 	}))
 	if err != nil {

--- a/cmd/specgraph/decision_test.go
+++ b/cmd/specgraph/decision_test.go
@@ -11,7 +11,6 @@ import (
 	"connectrpc.com/connect"
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -97,7 +96,7 @@ func TestRunDecisionCreate_HappyPath(t *testing.T) {
 		decisionRationale = oldRationale
 	})
 
-	err := runDecisionCreate(nil, []string{"use-memgraph"})
+	err := runDecisionCreate(newCmdWithCtx(), []string{"use-memgraph"})
 	require.NoError(t, err)
 }
 
@@ -108,7 +107,7 @@ func TestRunDecisionCreate_RPCError(t *testing.T) {
 	decisionTitle = "Fail"
 	t.Cleanup(func() { decisionTitle = oldTitle })
 
-	err := runDecisionCreate(nil, []string{"fail-slug"})
+	err := runDecisionCreate(newCmdWithCtx(), []string{"fail-slug"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "create decision")
 }
@@ -133,7 +132,7 @@ func TestRunDecisionList_HappyPath(t *testing.T) {
 		decisionListJSON = oldJSON
 	})
 
-	err := runDecisionList(&cobra.Command{}, nil)
+	err := runDecisionList(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
@@ -154,7 +153,7 @@ func TestRunDecisionList_HappyPath_JSON(t *testing.T) {
 		decisionListJSON = oldJSON
 	})
 
-	cmd := &cobra.Command{}
+	cmd := newCmdWithCtx()
 	cmd.SetOut(io.Discard)
 	err := runDecisionList(cmd, nil)
 	require.NoError(t, err)
@@ -173,7 +172,7 @@ func TestRunDecisionList_EmptyResults(t *testing.T) {
 		decisionListJSON = oldJSON
 	})
 
-	err := runDecisionList(&cobra.Command{}, nil)
+	err := runDecisionList(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
@@ -184,7 +183,7 @@ func TestRunDecisionList_RPCError(t *testing.T) {
 	decisionListStatus = ""
 	t.Cleanup(func() { decisionListStatus = oldStatus })
 
-	err := runDecisionList(&cobra.Command{}, nil)
+	err := runDecisionList(newCmdWithCtx(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "list decisions")
 }
@@ -199,7 +198,7 @@ func TestRunDecisionList_InvalidStatus_WithServer(t *testing.T) {
 	decisionListStatus = "bogus"
 	t.Cleanup(func() { decisionListStatus = oldStatus })
 
-	err := runDecisionList(&cobra.Command{}, nil)
+	err := runDecisionList(newCmdWithCtx(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown status")
 }
@@ -213,7 +212,7 @@ func TestRunDecisionShow_HappyPath(t *testing.T) {
 	decisionShowJSON = false
 	t.Cleanup(func() { decisionShowJSON = oldJSON })
 
-	err := runDecisionShow(&cobra.Command{}, []string{"use-memgraph"})
+	err := runDecisionShow(newCmdWithCtx(), []string{"use-memgraph"})
 	require.NoError(t, err)
 }
 
@@ -224,7 +223,7 @@ func TestRunDecisionShow_HappyPath_JSON(t *testing.T) {
 	decisionShowJSON = true
 	t.Cleanup(func() { decisionShowJSON = oldJSON })
 
-	cmd := &cobra.Command{}
+	cmd := newCmdWithCtx()
 	cmd.SetOut(io.Discard)
 	err := runDecisionShow(cmd, []string{"use-memgraph"})
 	require.NoError(t, err)
@@ -237,7 +236,7 @@ func TestRunDecisionShow_RPCError(t *testing.T) {
 	decisionShowJSON = false
 	t.Cleanup(func() { decisionShowJSON = oldJSON })
 
-	err := runDecisionShow(&cobra.Command{}, []string{"nonexistent"})
+	err := runDecisionShow(newCmdWithCtx(), []string{"nonexistent"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get decision")
 }

--- a/cmd/specgraph/decompose.go
+++ b/cmd/specgraph/decompose.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -26,7 +25,7 @@ func init() {
 	rootCmd.AddCommand(decomposeCmd)
 }
 
-func runDecompose(_ *cobra.Command, args []string) error {
+func runDecompose(cmd *cobra.Command, args []string) error {
 	client, err := authoringClient()
 	if err != nil {
 		return err
@@ -37,7 +36,7 @@ func runDecompose(_ *cobra.Command, args []string) error {
 			return fmt.Errorf("decompose: %w", loadErr)
 		}
 	}
-	resp, err := client.Decompose(context.Background(), connect.NewRequest(&specv1.DecomposeRequest{
+	resp, err := client.Decompose(cmd.Context(), connect.NewRequest(&specv1.DecomposeRequest{
 		Slug:   args[0],
 		Output: output,
 	}))

--- a/cmd/specgraph/edge.go
+++ b/cmd/specgraph/edge.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -44,7 +43,7 @@ var edgeAddCmd = &cobra.Command{
 
 var edgeAddType string
 
-func runEdgeAdd(_ *cobra.Command, args []string) error {
+func runEdgeAdd(cmd *cobra.Command, args []string) error {
 	client, err := graphClient()
 	if err != nil {
 		return err
@@ -54,7 +53,7 @@ func runEdgeAdd(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("unknown edge type: %s", edgeAddType)
 	}
 
-	resp, err := client.AddEdge(context.Background(), connect.NewRequest(&specv1.AddEdgeRequest{
+	resp, err := client.AddEdge(cmd.Context(), connect.NewRequest(&specv1.AddEdgeRequest{
 		FromSlug: args[0],
 		ToSlug:   args[1],
 		EdgeType: et,
@@ -77,7 +76,7 @@ var edgeRemoveCmd = &cobra.Command{
 
 var edgeRemoveType string
 
-func runEdgeRemove(_ *cobra.Command, args []string) error {
+func runEdgeRemove(cmd *cobra.Command, args []string) error {
 	client, err := graphClient()
 	if err != nil {
 		return err
@@ -87,7 +86,7 @@ func runEdgeRemove(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("unknown edge type: %s", edgeRemoveType)
 	}
 
-	_, err = client.RemoveEdge(context.Background(), connect.NewRequest(&specv1.RemoveEdgeRequest{
+	_, err = client.RemoveEdge(cmd.Context(), connect.NewRequest(&specv1.RemoveEdgeRequest{
 		FromSlug: args[0],
 		ToSlug:   args[1],
 		EdgeType: et,
@@ -141,7 +140,7 @@ func runEdgeList(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	resp, err := client.ListEdges(context.Background(), connect.NewRequest(&specv1.ListEdgesRequest{
+	resp, err := client.ListEdges(cmd.Context(), connect.NewRequest(&specv1.ListEdgesRequest{
 		Slug:     args[0],
 		EdgeType: et,
 	}))

--- a/cmd/specgraph/edge_test.go
+++ b/cmd/specgraph/edge_test.go
@@ -104,7 +104,7 @@ func TestRunEdgeAdd_HappyPath(t *testing.T) {
 	edgeAddType = "depends_on"
 	t.Cleanup(func() { edgeAddType = old })
 
-	err := runEdgeAdd(nil, []string{"spec-a", "spec-b"})
+	err := runEdgeAdd(newCmdWithCtx(), []string{"spec-a", "spec-b"})
 	require.NoError(t, err)
 }
 
@@ -115,7 +115,7 @@ func TestRunEdgeRemove_HappyPath(t *testing.T) {
 	edgeRemoveType = "blocks"
 	t.Cleanup(func() { edgeRemoveType = old })
 
-	err := runEdgeRemove(nil, []string{"spec-a", "spec-b"})
+	err := runEdgeRemove(newCmdWithCtx(), []string{"spec-a", "spec-b"})
 	require.NoError(t, err)
 }
 
@@ -130,7 +130,7 @@ func TestRunEdgeList_HappyPath(t *testing.T) {
 	edgeListJSON = false
 	t.Cleanup(func() { edgeListJSON = oldJSON })
 
-	err := runEdgeList(edgeListCmd, []string{"spec-a"})
+	err := runEdgeList(newCmdWithCtx(), []string{"spec-a"})
 	require.NoError(t, err)
 }
 
@@ -145,7 +145,7 @@ func TestRunEdgeList_HappyPath_JSON(t *testing.T) {
 	edgeListJSON = true
 	t.Cleanup(func() { edgeListJSON = oldJSON })
 
-	err := runEdgeList(edgeListCmd, []string{"spec-a"})
+	err := runEdgeList(newCmdWithCtx(), []string{"spec-a"})
 	require.NoError(t, err)
 }
 
@@ -160,7 +160,7 @@ func TestRunEdgeList_WithTypeFilter(t *testing.T) {
 	edgeListJSON = false
 	t.Cleanup(func() { edgeListJSON = oldJSON })
 
-	err := runEdgeList(edgeListCmd, []string{"spec-a"})
+	err := runEdgeList(newCmdWithCtx(), []string{"spec-a"})
 	require.NoError(t, err)
 }
 
@@ -173,7 +173,7 @@ func TestRunEdgeAdd_UnknownType_WithServer(t *testing.T) {
 	edgeAddType = "invalid"
 	t.Cleanup(func() { edgeAddType = old })
 
-	err := runEdgeAdd(nil, []string{"spec-a", "spec-b"})
+	err := runEdgeAdd(newCmdWithCtx(), []string{"spec-a", "spec-b"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown edge type")
 }
@@ -185,7 +185,7 @@ func TestRunEdgeRemove_UnknownType_WithServer(t *testing.T) {
 	edgeRemoveType = "invalid"
 	t.Cleanup(func() { edgeRemoveType = old })
 
-	err := runEdgeRemove(nil, []string{"spec-a", "spec-b"})
+	err := runEdgeRemove(newCmdWithCtx(), []string{"spec-a", "spec-b"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown edge type")
 }
@@ -197,7 +197,7 @@ func TestRunEdgeList_UnknownType_WithServer(t *testing.T) {
 	edgeListType = "invalid"
 	t.Cleanup(func() { edgeListType = old })
 
-	err := runEdgeList(edgeListCmd, []string{"spec-a"})
+	err := runEdgeList(newCmdWithCtx(), []string{"spec-a"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown edge type")
 }
@@ -211,7 +211,7 @@ func TestRunEdgeAdd_RPCError(t *testing.T) {
 	edgeAddType = "depends_on"
 	t.Cleanup(func() { edgeAddType = old })
 
-	err := runEdgeAdd(nil, []string{"spec-a", "spec-b"})
+	err := runEdgeAdd(newCmdWithCtx(), []string{"spec-a", "spec-b"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "add edge")
 }
@@ -223,7 +223,7 @@ func TestRunEdgeRemove_RPCError(t *testing.T) {
 	edgeRemoveType = "blocks"
 	t.Cleanup(func() { edgeRemoveType = old })
 
-	err := runEdgeRemove(nil, []string{"spec-a", "spec-b"})
+	err := runEdgeRemove(newCmdWithCtx(), []string{"spec-a", "spec-b"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "remove edge")
 }
@@ -235,7 +235,7 @@ func TestRunEdgeList_RPCError(t *testing.T) {
 	edgeListType = ""
 	t.Cleanup(func() { edgeListType = old })
 
-	err := runEdgeList(edgeListCmd, []string{"spec-a"})
+	err := runEdgeList(newCmdWithCtx(), []string{"spec-a"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "list edges")
 }

--- a/cmd/specgraph/findings.go
+++ b/cmd/specgraph/findings.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -67,7 +66,7 @@ func runFindingsList(cmd *cobra.Command, args []string) error {
 		req.PassType = pt
 	}
 
-	resp, err := client.ListFindings(context.Background(), connect.NewRequest(req))
+	resp, err := client.ListFindings(cmd.Context(), connect.NewRequest(req))
 	if err != nil {
 		return fmt.Errorf("list findings: %w", err)
 	}

--- a/cmd/specgraph/findings_test.go
+++ b/cmd/specgraph/findings_test.go
@@ -11,7 +11,6 @@ import (
 	"connectrpc.com/connect"
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -92,7 +91,7 @@ func TestRunFindingsList_HappyPath(t *testing.T) {
 		findingsListJSON = oldJSON
 	})
 
-	err := runFindingsList(&cobra.Command{}, []string{"my-spec"})
+	err := runFindingsList(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -108,7 +107,7 @@ func TestRunFindingsList_HappyPath_JSON(t *testing.T) {
 		findingsListJSON = oldJSON
 	})
 
-	cmd := &cobra.Command{}
+	cmd := newCmdWithCtx()
 	cmd.SetOut(io.Discard)
 	err := runFindingsList(cmd, []string{"my-spec"})
 	require.NoError(t, err)
@@ -126,7 +125,7 @@ func TestRunFindingsList_WithPassTypeFilter(t *testing.T) {
 		findingsListJSON = oldJSON
 	})
 
-	err := runFindingsList(&cobra.Command{}, []string{"my-spec"})
+	err := runFindingsList(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -142,7 +141,7 @@ func TestRunFindingsList_EmptyResults(t *testing.T) {
 		findingsListJSON = oldJSON
 	})
 
-	err := runFindingsList(&cobra.Command{}, []string{"my-spec"})
+	err := runFindingsList(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -160,7 +159,7 @@ func TestRunFindingsList_InvalidPassType(t *testing.T) {
 		findingsListJSON = oldJSON
 	})
 
-	err := runFindingsList(&cobra.Command{}, []string{"my-spec"})
+	err := runFindingsList(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown pass type")
 	assert.Contains(t, err.Error(), "bogus")
@@ -178,7 +177,7 @@ func TestRunFindingsList_RPCError(t *testing.T) {
 		findingsListJSON = oldJSON
 	})
 
-	err := runFindingsList(&cobra.Command{}, []string{"my-spec"})
+	err := runFindingsList(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "list findings")
 }
@@ -195,7 +194,7 @@ func TestRunFindingsList_ClientError(t *testing.T) {
 		findingsListJSON = oldJSON
 	})
 
-	err := runFindingsList(nil, []string{"my-spec"})
+	err := runFindingsList(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 

--- a/cmd/specgraph/graph.go
+++ b/cmd/specgraph/graph.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -47,7 +46,7 @@ func runDeps(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	ctx := context.Background()
+	ctx := cmd.Context()
 
 	if depsTransitive {
 		resp, tdErr := client.GetTransitiveDeps(ctx, connect.NewRequest(&specv1.GetTransitiveDepsRequest{Slug: args[0]}))
@@ -85,7 +84,7 @@ func runReady(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.GetReady(context.Background(), connect.NewRequest(&specv1.GetReadyRequest{}))
+	resp, err := client.GetReady(cmd.Context(), connect.NewRequest(&specv1.GetReadyRequest{}))
 	if err != nil {
 		return fmt.Errorf("get ready: %w", err)
 	}
@@ -110,7 +109,7 @@ func runCriticalPath(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.GetCriticalPath(context.Background(), connect.NewRequest(&specv1.GetCriticalPathRequest{Slug: args[0]}))
+	resp, err := client.GetCriticalPath(cmd.Context(), connect.NewRequest(&specv1.GetCriticalPathRequest{Slug: args[0]}))
 	if err != nil {
 		return fmt.Errorf("get critical path: %w", err)
 	}
@@ -135,7 +134,7 @@ func runImpact(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.GetImpact(context.Background(), connect.NewRequest(&specv1.GetImpactRequest{Slug: args[0]}))
+	resp, err := client.GetImpact(cmd.Context(), connect.NewRequest(&specv1.GetImpactRequest{Slug: args[0]}))
 	if err != nil {
 		return fmt.Errorf("get impact: %w", err)
 	}

--- a/cmd/specgraph/graph_test.go
+++ b/cmd/specgraph/graph_test.go
@@ -11,7 +11,6 @@ import (
 	"connectrpc.com/connect"
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -160,7 +159,7 @@ func TestRunDeps_HappyPath_Direct(t *testing.T) {
 	depsJSON = false
 	t.Cleanup(func() { depsJSON = oldJSON })
 
-	err := runDeps(&cobra.Command{}, []string{"my-spec"})
+	err := runDeps(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -175,7 +174,7 @@ func TestRunDeps_HappyPath_Transitive(t *testing.T) {
 	depsJSON = false
 	t.Cleanup(func() { depsJSON = oldJSON })
 
-	err := runDeps(&cobra.Command{}, []string{"my-spec"})
+	err := runDeps(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -190,7 +189,7 @@ func TestRunDeps_HappyPath_JSON(t *testing.T) {
 	depsJSON = true
 	t.Cleanup(func() { depsJSON = oldJSON })
 
-	cmd := &cobra.Command{}
+	cmd := newCmdWithCtx()
 	err := runDeps(cmd, []string{"my-spec"})
 	require.NoError(t, err)
 }
@@ -206,7 +205,7 @@ func TestRunDeps_EmptyResults(t *testing.T) {
 	depsJSON = false
 	t.Cleanup(func() { depsJSON = oldJSON })
 
-	err := runDeps(&cobra.Command{}, []string{"my-spec"})
+	err := runDeps(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -219,7 +218,7 @@ func TestRunReady_HappyPath(t *testing.T) {
 	readyJSON = false
 	t.Cleanup(func() { readyJSON = old })
 
-	err := runReady(&cobra.Command{}, nil)
+	err := runReady(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
@@ -230,7 +229,7 @@ func TestRunReady_HappyPath_JSON(t *testing.T) {
 	readyJSON = true
 	t.Cleanup(func() { readyJSON = old })
 
-	cmd := &cobra.Command{}
+	cmd := newCmdWithCtx()
 	err := runReady(cmd, nil)
 	require.NoError(t, err)
 }
@@ -242,7 +241,7 @@ func TestRunReady_EmptyResults(t *testing.T) {
 	readyJSON = false
 	t.Cleanup(func() { readyJSON = old })
 
-	err := runReady(&cobra.Command{}, nil)
+	err := runReady(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
@@ -255,7 +254,7 @@ func TestRunCriticalPath_HappyPath(t *testing.T) {
 	criticalPathJSON = false
 	t.Cleanup(func() { criticalPathJSON = old })
 
-	err := runCriticalPath(&cobra.Command{}, []string{"my-spec"})
+	err := runCriticalPath(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -266,7 +265,7 @@ func TestRunCriticalPath_HappyPath_JSON(t *testing.T) {
 	criticalPathJSON = true
 	t.Cleanup(func() { criticalPathJSON = old })
 
-	cmd := &cobra.Command{}
+	cmd := newCmdWithCtx()
 	err := runCriticalPath(cmd, []string{"my-spec"})
 	require.NoError(t, err)
 }
@@ -280,7 +279,7 @@ func TestRunImpact_HappyPath(t *testing.T) {
 	impactJSON = false
 	t.Cleanup(func() { impactJSON = old })
 
-	err := runImpact(&cobra.Command{}, []string{"my-spec"})
+	err := runImpact(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -291,7 +290,7 @@ func TestRunImpact_HappyPath_JSON(t *testing.T) {
 	impactJSON = true
 	t.Cleanup(func() { impactJSON = old })
 
-	cmd := &cobra.Command{}
+	cmd := newCmdWithCtx()
 	err := runImpact(cmd, []string{"my-spec"})
 	require.NoError(t, err)
 }
@@ -305,7 +304,7 @@ func TestRunDeps_RPCError(t *testing.T) {
 	depsTransitive = false
 	t.Cleanup(func() { depsTransitive = old })
 
-	err := runDeps(&cobra.Command{}, []string{"my-spec"})
+	err := runDeps(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get dependencies")
 }
@@ -317,7 +316,7 @@ func TestRunDeps_Transitive_RPCError(t *testing.T) {
 	depsTransitive = true
 	t.Cleanup(func() { depsTransitive = old })
 
-	err := runDeps(&cobra.Command{}, []string{"my-spec"})
+	err := runDeps(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get transitive deps")
 }
@@ -329,7 +328,7 @@ func TestRunReady_RPCError(t *testing.T) {
 	readyJSON = false
 	t.Cleanup(func() { readyJSON = old })
 
-	err := runReady(&cobra.Command{}, nil)
+	err := runReady(newCmdWithCtx(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get ready")
 }
@@ -341,7 +340,7 @@ func TestRunCriticalPath_RPCError(t *testing.T) {
 	criticalPathJSON = false
 	t.Cleanup(func() { criticalPathJSON = old })
 
-	err := runCriticalPath(&cobra.Command{}, []string{"my-spec"})
+	err := runCriticalPath(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get critical path")
 }
@@ -353,7 +352,7 @@ func TestRunImpact_RPCError(t *testing.T) {
 	impactJSON = false
 	t.Cleanup(func() { impactJSON = old })
 
-	err := runImpact(&cobra.Command{}, []string{"my-spec"})
+	err := runImpact(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get impact")
 }

--- a/cmd/specgraph/health.go
+++ b/cmd/specgraph/health.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -27,12 +26,12 @@ func healthClient() (specgraphv1connect.ServerServiceClient, error) {
 	return newClient(specgraphv1connect.NewServerServiceClient)
 }
 
-func runHealth(_ *cobra.Command, _ []string) error {
+func runHealth(cmd *cobra.Command, _ []string) error {
 	client, err := healthClient()
 	if err != nil {
 		return err
 	}
-	resp, err := client.Health(context.Background(), connect.NewRequest(&specv1.HealthRequest{}))
+	resp, err := client.Health(cmd.Context(), connect.NewRequest(&specv1.HealthRequest{}))
 	if err != nil {
 		return fmt.Errorf("health check: %w", err)
 	}

--- a/cmd/specgraph/init.go
+++ b/cmd/specgraph/init.go
@@ -25,8 +25,8 @@ func init() {
 	rootCmd.AddCommand(initCmd)
 }
 
-func runInit(_ *cobra.Command, args []string) error {
-	if err := runUp(nil, nil); err != nil {
+func runInit(cmd *cobra.Command, args []string) error {
+	if err := runUp(cmd, nil); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "warning: server not started: %v\n", err)
 	}
 

--- a/cmd/specgraph/inject.go
+++ b/cmd/specgraph/inject.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -32,7 +31,7 @@ var (
 	injectOutput string
 )
 
-func runInject(_ *cobra.Command, args []string) error {
+func runInject(cmd *cobra.Command, args []string) error {
 	var tool specv1.InjectTool
 	switch strings.ToLower(injectTool) {
 	case "claude-code", "claude":
@@ -59,7 +58,7 @@ func runInject(_ *cobra.Command, args []string) error {
 		output = wd
 	}
 
-	resp, err := client.Inject(context.Background(), connect.NewRequest(&specv1.InjectRequest{
+	resp, err := client.Inject(cmd.Context(), connect.NewRequest(&specv1.InjectRequest{
 		SpecSlug:  args[0],
 		Tool:      tool,
 		OutputDir: output,

--- a/cmd/specgraph/lifecycle.go
+++ b/cmd/specgraph/lifecycle.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -43,12 +42,12 @@ var (
 	amendReEntry string
 )
 
-func runAmend(_ *cobra.Command, args []string) error {
+func runAmend(cmd *cobra.Command, args []string) error {
 	client, err := lifecycleClient()
 	if err != nil {
 		return err
 	}
-	resp, err := client.TransitionAmend(context.Background(), connect.NewRequest(&specv1.TransitionAmendRequest{
+	resp, err := client.TransitionAmend(cmd.Context(), connect.NewRequest(&specv1.TransitionAmendRequest{
 		Slug:         args[0],
 		Reason:       amendReason,
 		ReEntryStage: amendReEntry,
@@ -72,12 +71,12 @@ var supersedeCmd = &cobra.Command{
 
 var supersedeWith string
 
-func runSupersede(_ *cobra.Command, args []string) error {
+func runSupersede(cmd *cobra.Command, args []string) error {
 	client, err := lifecycleClient()
 	if err != nil {
 		return err
 	}
-	resp, err := client.TransitionSupersede(context.Background(), connect.NewRequest(&specv1.TransitionSupersedeRequest{
+	resp, err := client.TransitionSupersede(cmd.Context(), connect.NewRequest(&specv1.TransitionSupersedeRequest{
 		Slug:    args[0],
 		NewSlug: supersedeWith,
 	}))
@@ -102,12 +101,12 @@ var abandonCmd = &cobra.Command{
 
 var abandonReason string
 
-func runAbandon(_ *cobra.Command, args []string) error {
+func runAbandon(cmd *cobra.Command, args []string) error {
 	client, err := lifecycleClient()
 	if err != nil {
 		return err
 	}
-	resp, err := client.TransitionAbandon(context.Background(), connect.NewRequest(&specv1.TransitionAbandonRequest{
+	resp, err := client.TransitionAbandon(cmd.Context(), connect.NewRequest(&specv1.TransitionAbandonRequest{
 		Slug:   args[0],
 		Reason: abandonReason,
 	}))
@@ -162,7 +161,7 @@ func runDrift(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		req.Slug = args[0]
 	}
-	resp, err := client.CheckDrift(context.Background(), connect.NewRequest(req))
+	resp, err := client.CheckDrift(cmd.Context(), connect.NewRequest(req))
 	if err != nil {
 		return fmt.Errorf("drift check: %w", err)
 	}
@@ -213,7 +212,7 @@ var (
 	driftAckAll      bool
 )
 
-func runDriftAck(_ *cobra.Command, args []string) error {
+func runDriftAck(cmd *cobra.Command, args []string) error {
 	if driftAckUpstream == "" && !driftAckAll {
 		return fmt.Errorf("specify --upstream <slug> or --all")
 	}
@@ -224,7 +223,7 @@ func runDriftAck(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.AcknowledgeDrift(context.Background(), connect.NewRequest(&specv1.DriftAcknowledgeRequest{
+	resp, err := client.AcknowledgeDrift(cmd.Context(), connect.NewRequest(&specv1.DriftAcknowledgeRequest{
 		Slug:         args[0],
 		Note:         driftAckNote,
 		UpstreamSlug: driftAckUpstream,
@@ -251,7 +250,7 @@ var lintCmd = &cobra.Command{
 	RunE:  runLint,
 }
 
-func runLint(_ *cobra.Command, args []string) error {
+func runLint(cmd *cobra.Command, args []string) error {
 	client, err := lifecycleClient()
 	if err != nil {
 		return err
@@ -260,7 +259,7 @@ func runLint(_ *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		req.Slug = args[0]
 	}
-	resp, err := client.Lint(context.Background(), connect.NewRequest(req))
+	resp, err := client.Lint(cmd.Context(), connect.NewRequest(req))
 	if err != nil {
 		return fmt.Errorf("lint: %w", err)
 	}

--- a/cmd/specgraph/lifecycle_test.go
+++ b/cmd/specgraph/lifecycle_test.go
@@ -73,25 +73,25 @@ func TestDriftScopeToProtoMap_SyncWithDriftscope(t *testing.T) {
 
 func TestRunAmend_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runAmend(nil, []string{"my-spec"})
+	err := runAmend(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
 func TestRunSupersede_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runSupersede(nil, []string{"my-spec"})
+	err := runSupersede(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
 func TestRunAbandon_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runAbandon(nil, []string{"my-spec"})
+	err := runAbandon(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
 func TestRunDrift_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runDrift(driftCmd, []string{"my-spec"})
+	err := runDrift(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
@@ -99,14 +99,14 @@ func TestRunDrift_InvalidScope(t *testing.T) {
 	old := driftScope
 	driftScope = "bogus"
 	t.Cleanup(func() { driftScope = old })
-	err := runDrift(driftCmd, []string{"my-spec"})
+	err := runDrift(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid scope")
 }
 
 func TestRunDriftAck_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runDriftAck(nil, []string{"my-spec"})
+	err := runDriftAck(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
@@ -130,7 +130,7 @@ func TestRunDriftAck_HappyPath_All(t *testing.T) {
 	driftAckAll = true
 	t.Cleanup(func() { driftAckAll = oldAll })
 
-	err := runDriftAck(nil, []string{"my-spec"})
+	err := runDriftAck(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -141,7 +141,7 @@ func TestRunDriftAck_HappyPath_Upstream(t *testing.T) {
 	driftAckUpstream = "dep-spec"
 	t.Cleanup(func() { driftAckUpstream = oldUpstream })
 
-	err := runDriftAck(nil, []string{"my-spec"})
+	err := runDriftAck(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -155,7 +155,7 @@ func TestRunDriftAck_RequiresUpstreamOrAll(t *testing.T) {
 		driftAckUpstream = oldUpstream
 	})
 
-	err := runDriftAck(nil, []string{"my-spec"})
+	err := runDriftAck(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--upstream")
 }
@@ -170,7 +170,7 @@ func TestRunDriftAck_CannotSpecifyBoth(t *testing.T) {
 		driftAckUpstream = oldUpstream
 	})
 
-	err := runDriftAck(nil, []string{"my-spec"})
+	err := runDriftAck(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot specify both")
 }
@@ -210,7 +210,7 @@ func TestRunAmend_HappyPath(t *testing.T) {
 	old := amendReason
 	amendReason = "test reason"
 	t.Cleanup(func() { amendReason = old })
-	err := runAmend(nil, []string{"my-spec"})
+	err := runAmend(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -230,7 +230,7 @@ func TestRunSupersede_HappyPath(t *testing.T) {
 	old := supersedeWith
 	supersedeWith = "new-spec"
 	t.Cleanup(func() { supersedeWith = old })
-	err := runSupersede(nil, []string{"old-spec"})
+	err := runSupersede(newCmdWithCtx(), []string{"old-spec"})
 	require.NoError(t, err)
 }
 
@@ -249,7 +249,7 @@ func TestRunAbandon_HappyPath(t *testing.T) {
 	old := abandonReason
 	abandonReason = "no longer needed"
 	t.Cleanup(func() { abandonReason = old })
-	err := runAbandon(nil, []string{"my-spec"})
+	err := runAbandon(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -265,13 +265,13 @@ func (fakeLintHandler) Lint(_ context.Context, _ *connect.Request[specv1.LintReq
 
 func TestRunLint_HappyPath(t *testing.T) {
 	startFakeLifecycleServer(t, fakeLintHandler{})
-	err := runLint(nil, nil)
+	err := runLint(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
 func TestRunLint_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runLint(nil, nil)
+	err := runLint(newCmdWithCtx(), nil)
 	require.Error(t, err)
 }
 
@@ -338,7 +338,7 @@ func (fakeLintFailHandler) Lint(_ context.Context, _ *connect.Request[specv1.Lin
 
 func TestRunLint_HappyPath_WithFailures(t *testing.T) {
 	startFakeLifecycleServer(t, fakeLintFailHandler{})
-	err := runLint(nil, nil)
+	err := runLint(newCmdWithCtx(), nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "spec(s) failed")
 }
@@ -364,7 +364,7 @@ func (fakeLintInfraErrHandler) Lint(_ context.Context, _ *connect.Request[specv1
 
 func TestRunLint_InfraError(t *testing.T) {
 	startFakeLifecycleServer(t, fakeLintInfraErrHandler{})
-	err := runLint(nil, nil)
+	err := runLint(newCmdWithCtx(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "infrastructure error")
 }
@@ -381,7 +381,7 @@ func (fakeDriftNoneHandler) CheckDrift(_ context.Context, _ *connect.Request[spe
 
 func TestRunDrift_HappyPath_NoDrift(t *testing.T) {
 	startFakeLifecycleServer(t, fakeDriftNoneHandler{})
-	err := runDrift(driftCmd, nil)
+	err := runDrift(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
@@ -412,7 +412,7 @@ func (fakeDriftItemsHandler) CheckDrift(_ context.Context, _ *connect.Request[sp
 
 func TestRunDrift_WithItemsAndErrors(t *testing.T) {
 	startFakeLifecycleServer(t, fakeDriftItemsHandler{})
-	err := runDrift(driftCmd, nil)
+	err := runDrift(newCmdWithCtx(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "drift check completed with errors")
 }
@@ -433,7 +433,7 @@ func (fakeDriftCleanReportHandler) CheckDrift(_ context.Context, _ *connect.Requ
 
 func TestRunDrift_CleanReport_NoDrift(t *testing.T) {
 	startFakeLifecycleServer(t, fakeDriftCleanReportHandler{})
-	err := runDrift(driftCmd, nil)
+	err := runDrift(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
@@ -456,7 +456,7 @@ func (fakeDriftMultiCleanHandler) CheckDrift(_ context.Context, _ *connect.Reque
 
 func TestRunDrift_MultiCleanReports_NoDrift(t *testing.T) {
 	startFakeLifecycleServer(t, fakeDriftMultiCleanHandler{})
-	err := runDrift(driftCmd, nil)
+	err := runDrift(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
@@ -479,7 +479,7 @@ func (fakeDriftErrorOnlyHandler) CheckDrift(_ context.Context, _ *connect.Reques
 
 func TestRunDrift_ErrorOnlyReport(t *testing.T) {
 	startFakeLifecycleServer(t, fakeDriftErrorOnlyHandler{})
-	err := runDrift(driftCmd, nil)
+	err := runDrift(newCmdWithCtx(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "drift check completed with errors")
 }
@@ -509,7 +509,7 @@ func (fakeDriftOnlyHandler) CheckDrift(_ context.Context, _ *connect.Request[spe
 
 func TestRunDrift_DriftOnly_NoErrors(t *testing.T) {
 	startFakeLifecycleServer(t, fakeDriftOnlyHandler{})
-	err := runDrift(driftCmd, nil)
+	err := runDrift(newCmdWithCtx(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "drift detected")
 }
@@ -529,7 +529,7 @@ func (h *fakeDriftSlugCapture) CheckDrift(_ context.Context, req *connect.Reques
 func TestRunDrift_HappyPath_WithSlug(t *testing.T) {
 	h := &fakeDriftSlugCapture{}
 	startFakeLifecycleServer(t, h)
-	err := runDrift(driftCmd, []string{"my-spec"})
+	err := runDrift(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 	assert.Equal(t, "my-spec", h.capturedSlug)
 }
@@ -544,6 +544,6 @@ func (fakeLintEmptyHandler) Lint(_ context.Context, _ *connect.Request[specv1.Li
 
 func TestRunLint_EmptyResults(t *testing.T) {
 	startFakeLifecycleServer(t, fakeLintEmptyHandler{})
-	err := runLint(nil, nil)
+	err := runLint(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }

--- a/cmd/specgraph/prime.go
+++ b/cmd/specgraph/prime.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"text/tabwriter"
 
@@ -57,7 +56,7 @@ func runPrime(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("create spec client: %w", err)
 	}
-	resp, err := client.ListSpecs(context.Background(), connect.NewRequest(&specv1.ListSpecsRequest{}))
+	resp, err := client.ListSpecs(cmd.Context(), connect.NewRequest(&specv1.ListSpecsRequest{}))
 	if err != nil {
 		return fmt.Errorf("list specs: %w", err)
 	}

--- a/cmd/specgraph/progress.go
+++ b/cmd/specgraph/progress.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -27,12 +26,12 @@ func init() {
 	rootCmd.AddCommand(progressCmd)
 }
 
-func runProgress(_ *cobra.Command, args []string) error {
+func runProgress(cmd *cobra.Command, args []string) error {
 	client, err := executionClient()
 	if err != nil {
 		return err
 	}
-	resp, err := client.GetExecutionEvents(context.Background(), connect.NewRequest(&specv1.GetExecutionEventsRequest{
+	resp, err := client.GetExecutionEvents(cmd.Context(), connect.NewRequest(&specv1.GetExecutionEventsRequest{
 		Slug:  args[0],
 		Limit: progressLimit,
 	}))

--- a/cmd/specgraph/progress_test.go
+++ b/cmd/specgraph/progress_test.go
@@ -68,7 +68,7 @@ func TestRunProgress_HappyPath(t *testing.T) {
 	progressLimit = 20
 	t.Cleanup(func() { progressLimit = old })
 
-	err := runProgress(nil, []string{"my-spec"})
+	err := runProgress(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -79,7 +79,7 @@ func TestRunProgress_EmptyEvents(t *testing.T) {
 	progressLimit = 20
 	t.Cleanup(func() { progressLimit = old })
 
-	err := runProgress(nil, []string{"my-spec"})
+	err := runProgress(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -90,7 +90,7 @@ func TestRunProgress_RPCError(t *testing.T) {
 	progressLimit = 20
 	t.Cleanup(func() { progressLimit = old })
 
-	err := runProgress(nil, []string{"my-spec"})
+	err := runProgress(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get execution events")
 }
@@ -98,7 +98,7 @@ func TestRunProgress_RPCError(t *testing.T) {
 func TestRunProgress_ClientError(t *testing.T) {
 	setMissingConfig(t)
 
-	err := runProgress(nil, []string{"my-spec"})
+	err := runProgress(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 

--- a/cmd/specgraph/run_functions_test.go
+++ b/cmd/specgraph/run_functions_test.go
@@ -6,7 +6,6 @@ package main
 import (
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,13 +22,13 @@ func setMissingConfig(t *testing.T) {
 
 func TestRunCreate_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runCreate(nil, []string{"my-spec"})
+	err := runCreate(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
 func TestRunUpdate_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	cmd := &cobra.Command{}
+	cmd := newCmdWithCtx()
 	cmd.Flags().String("intent", "", "")
 	err := runUpdate(cmd, []string{"my-spec"})
 	require.Error(t, err)
@@ -37,13 +36,13 @@ func TestRunUpdate_ClientError(t *testing.T) {
 
 func TestRunList_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runList(&cobra.Command{}, nil)
+	err := runList(newCmdWithCtx(), nil)
 	require.Error(t, err)
 }
 
 func TestRunShow_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runShow(nil, []string{"my-spec"})
+	err := runShow(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
@@ -51,13 +50,13 @@ func TestRunShow_ClientError(t *testing.T) {
 
 func TestRunClaim_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runClaim(nil, []string{"my-spec"})
+	err := runClaim(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
 func TestRunUnclaim_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runUnclaim(nil, []string{"my-spec"})
+	err := runUnclaim(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
@@ -65,7 +64,7 @@ func TestRunUnclaim_ClientError(t *testing.T) {
 
 func TestRunDecisionCreate_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runDecisionCreate(nil, []string{"my-decision"})
+	err := runDecisionCreate(newCmdWithCtx(), []string{"my-decision"})
 	require.Error(t, err)
 }
 
@@ -78,7 +77,7 @@ func TestRunDecisionList_InvalidStatus(t *testing.T) {
 	t.Cleanup(func() { decisionListStatus = old })
 
 	setMissingConfig(t)
-	err := runDecisionList(&cobra.Command{}, nil)
+	err := runDecisionList(newCmdWithCtx(), nil)
 	require.Error(t, err)
 }
 
@@ -88,13 +87,13 @@ func TestRunDecisionList_ClientError(t *testing.T) {
 	decisionListStatus = ""
 	t.Cleanup(func() { decisionListStatus = old })
 
-	err := runDecisionList(&cobra.Command{}, nil)
+	err := runDecisionList(newCmdWithCtx(), nil)
 	require.Error(t, err)
 }
 
 func TestRunDecisionShow_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runDecisionShow(nil, []string{"my-decision"})
+	err := runDecisionShow(newCmdWithCtx(), []string{"my-decision"})
 	require.Error(t, err)
 }
 
@@ -108,7 +107,7 @@ func TestRunEdgeAdd_UnknownType(t *testing.T) {
 	t.Cleanup(func() { edgeAddType = old })
 
 	setMissingConfig(t)
-	err := runEdgeAdd(nil, []string{"from-spec", "to-spec"})
+	err := runEdgeAdd(newCmdWithCtx(), []string{"from-spec", "to-spec"})
 	require.Error(t, err)
 }
 
@@ -118,7 +117,7 @@ func TestRunEdgeAdd_ClientError(t *testing.T) {
 	edgeAddType = "depends_on"
 	t.Cleanup(func() { edgeAddType = old })
 
-	err := runEdgeAdd(nil, []string{"from-spec", "to-spec"})
+	err := runEdgeAdd(newCmdWithCtx(), []string{"from-spec", "to-spec"})
 	require.Error(t, err)
 }
 
@@ -130,7 +129,7 @@ func TestRunEdgeRemove_UnknownType(t *testing.T) {
 	t.Cleanup(func() { edgeRemoveType = old })
 
 	setMissingConfig(t)
-	err := runEdgeRemove(nil, []string{"from-spec", "to-spec"})
+	err := runEdgeRemove(newCmdWithCtx(), []string{"from-spec", "to-spec"})
 	require.Error(t, err)
 }
 
@@ -140,7 +139,7 @@ func TestRunEdgeRemove_ClientError(t *testing.T) {
 	edgeRemoveType = "blocks"
 	t.Cleanup(func() { edgeRemoveType = old })
 
-	err := runEdgeRemove(nil, []string{"from-spec", "to-spec"})
+	err := runEdgeRemove(newCmdWithCtx(), []string{"from-spec", "to-spec"})
 	require.Error(t, err)
 }
 
@@ -152,7 +151,7 @@ func TestRunEdgeList_UnknownType(t *testing.T) {
 	t.Cleanup(func() { edgeListType = old })
 
 	setMissingConfig(t)
-	err := runEdgeList(&cobra.Command{}, []string{"my-spec"})
+	err := runEdgeList(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
@@ -162,7 +161,7 @@ func TestRunEdgeList_ClientError(t *testing.T) {
 	edgeListType = ""
 	t.Cleanup(func() { edgeListType = old })
 
-	err := runEdgeList(&cobra.Command{}, []string{"my-spec"})
+	err := runEdgeList(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
@@ -170,25 +169,25 @@ func TestRunEdgeList_ClientError(t *testing.T) {
 
 func TestRunDeps_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runDeps(&cobra.Command{}, []string{"my-spec"})
+	err := runDeps(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
 func TestRunReady_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runReady(&cobra.Command{}, nil)
+	err := runReady(newCmdWithCtx(), nil)
 	require.Error(t, err)
 }
 
 func TestRunCriticalPath_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runCriticalPath(&cobra.Command{}, []string{"my-spec"})
+	err := runCriticalPath(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 
 func TestRunImpact_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runImpact(&cobra.Command{}, []string{"my-spec"})
+	err := runImpact(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 }
 

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -45,7 +45,7 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("load global config: %w", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
 	if cfg.Server.Docker {
@@ -86,33 +86,34 @@ func runServe(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("auth config: %w", err)
 		}
 		interceptor := auth.NewAuthInterceptor(authStore)
+		maxBytes := connect.WithReadMaxBytes(4 << 20) // 4 MiB request body limit
 		opts := connect.WithInterceptors(interceptor)
 
-		mux := server.NewMux(store, opts)
-		server.RegisterHealthService(mux, opts)
-		server.RegisterDecisionService(mux, store, opts)
-		server.RegisterGraphService(mux, store, opts)
-		server.RegisterClaimService(mux, store, opts)
-		server.RegisterConstitutionService(mux, store, opts)
-		server.RegisterAuthoringService(mux, store, opts)
+		mux := server.NewMux(store, opts, maxBytes)
+		server.RegisterHealthService(mux, opts, maxBytes)
+		server.RegisterDecisionService(mux, store, opts, maxBytes)
+		server.RegisterGraphService(mux, store, opts, maxBytes)
+		server.RegisterClaimService(mux, store, opts, maxBytes)
+		server.RegisterConstitutionService(mux, store, opts, maxBytes)
+		server.RegisterAuthoringService(mux, store, opts, maxBytes)
 		// Template override dir defaults to .specgraph/templates in the working directory.
 		// Users can place <pass_type>.md files there to customize analytical pass prompts.
-		server.RegisterAnalyticalPassService(mux, store, ".specgraph/templates", opts)
-		server.RegisterExecutionService(mux, store, opts)
-		server.RegisterSliceService(mux, store, opts)
+		server.RegisterAnalyticalPassService(mux, store, ".specgraph/templates", opts, maxBytes)
+		server.RegisterExecutionService(mux, store, opts, maxBytes)
+		server.RegisterSliceService(mux, store, opts, maxBytes)
 		driftEngine := drift.NewEngine(store, nil)
 		lintEngine := linter.NewEngine(store, nil)
-		server.RegisterLifecycleService(mux, store, driftEngine, lintEngine, nil, opts)
+		server.RegisterLifecycleService(mux, store, driftEngine, lintEngine, nil, opts, maxBytes)
 
 		// TODO(slice-7): Project root for inject should come from request context,
 		// not daemon CWD. Pass empty string; inject handler needs rework.
-		syncHandler := server.RegisterSyncService(mux, store, "", opts)
+		syncHandler := server.RegisterSyncService(mux, store, "", opts, maxBytes)
 		runner := syncpkg.NewExecRunner()
 		syncHandler.RegisterAdapter(syncpkg.NewBeadsAdapter(runner))
 		syncHandler.RegisterAdapter(syncpkg.NewGitHubAdapter(runner, ""))
 
 		// Register lightweight HTTP API endpoints (before static handler catch-all)
-		server.RegisterAPIHandlers(mux, store)
+		server.RegisterAPIHandlers(mux, store, auth.RequireAuth(authStore))
 
 		// Serve embedded UI static files
 		webFS, err := fs.Sub(web.Build, "build")
@@ -122,7 +123,7 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		// Register static handler as catch-all (after ConnectRPC paths)
 		mux.Handle("/", server.StaticHandler(webFS))
 
-		handler := server.ProjectMiddleware(mux)
+		handler := server.SecurityHeaders(server.ProjectMiddleware(mux))
 
 		// Optional CORS for dev mode (Vite on :5173 → Go on :8080)
 		corsOrigin, err := cmd.Flags().GetString("cors-origin")
@@ -133,12 +134,17 @@ func runServe(cmd *cobra.Command, _ []string) error {
 			handler = server.CORSMiddleware(corsOrigin, handler)
 		}
 		addr := cfg.Server.Listen
-		srv := &http.Server{Addr: addr, Handler: handler, ReadHeaderTimeout: 10 * time.Second}
+		srv := &http.Server{
+			Addr:              addr,
+			Handler:           handler,
+			ReadHeaderTimeout: 10 * time.Second,
+			ReadTimeout:       30 * time.Second,
+			WriteTimeout:      60 * time.Second,
+			IdleTimeout:       120 * time.Second,
+		}
 
 		go func() {
-			sigCh := make(chan os.Signal, 1)
-			signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-			<-sigCh
+			<-ctx.Done()
 			fmt.Println("\nShutting down...")
 			stopSweeper()
 			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/cmd/specgraph/shape.go
+++ b/cmd/specgraph/shape.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -26,7 +25,7 @@ func init() {
 	rootCmd.AddCommand(shapeCmd)
 }
 
-func runShape(_ *cobra.Command, args []string) error {
+func runShape(cmd *cobra.Command, args []string) error {
 	client, err := authoringClient()
 	if err != nil {
 		return err
@@ -37,7 +36,7 @@ func runShape(_ *cobra.Command, args []string) error {
 			return fmt.Errorf("shape: %w", loadErr)
 		}
 	}
-	resp, err := client.Shape(context.Background(), connect.NewRequest(&specv1.ShapeRequest{
+	resp, err := client.Shape(cmd.Context(), connect.NewRequest(&specv1.ShapeRequest{
 		Slug:   args[0],
 		Output: output,
 	}))

--- a/cmd/specgraph/slice.go
+++ b/cmd/specgraph/slice.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -41,7 +40,7 @@ func runSliceList(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.ListSlices(context.Background(), connect.NewRequest(&specv1.ListSlicesRequest{
+	resp, err := client.ListSlices(cmd.Context(), connect.NewRequest(&specv1.ListSlicesRequest{
 		ParentSlug: args[0],
 	}))
 	if err != nil {
@@ -70,7 +69,7 @@ func runSliceGet(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.GetSlice(context.Background(), connect.NewRequest(&specv1.GetSliceRequest{
+	resp, err := client.GetSlice(cmd.Context(), connect.NewRequest(&specv1.GetSliceRequest{
 		Slug: args[0],
 	}))
 	if err != nil {
@@ -94,12 +93,12 @@ var sliceClaimCmd = &cobra.Command{
 
 var sliceClaimAssignee string
 
-func runSliceClaim(_ *cobra.Command, args []string) error {
+func runSliceClaim(cmd *cobra.Command, args []string) error {
 	client, err := sliceClient()
 	if err != nil {
 		return err
 	}
-	resp, err := client.ClaimSlice(context.Background(), connect.NewRequest(&specv1.ClaimSliceRequest{
+	resp, err := client.ClaimSlice(cmd.Context(), connect.NewRequest(&specv1.ClaimSliceRequest{
 		Slug:     args[0],
 		Assignee: sliceClaimAssignee,
 	}))
@@ -119,12 +118,12 @@ var sliceCompleteCmd = &cobra.Command{
 	RunE:  runSliceComplete,
 }
 
-func runSliceComplete(_ *cobra.Command, args []string) error {
+func runSliceComplete(cmd *cobra.Command, args []string) error {
 	client, err := sliceClient()
 	if err != nil {
 		return err
 	}
-	resp, err := client.CompleteSlice(context.Background(), connect.NewRequest(&specv1.CompleteSliceRequest{
+	resp, err := client.CompleteSlice(cmd.Context(), connect.NewRequest(&specv1.CompleteSliceRequest{
 		Slug: args[0],
 	}))
 	if err != nil {

--- a/cmd/specgraph/slice_test.go
+++ b/cmd/specgraph/slice_test.go
@@ -11,7 +11,6 @@ import (
 	"connectrpc.com/connect"
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -113,7 +112,7 @@ func TestRunSliceList_HappyPath(t *testing.T) {
 	sliceListJSON = false
 	t.Cleanup(func() { sliceListJSON = oldJSON })
 
-	err := runSliceList(nil, []string{"parent-spec"})
+	err := runSliceList(newCmdWithCtx(), []string{"parent-spec"})
 	require.NoError(t, err)
 }
 
@@ -124,7 +123,7 @@ func TestRunSliceList_HappyPath_JSON(t *testing.T) {
 	sliceListJSON = true
 	t.Cleanup(func() { sliceListJSON = oldJSON })
 
-	cmd := &cobra.Command{}
+	cmd := newCmdWithCtx()
 	cmd.SetOut(io.Discard)
 	err := runSliceList(cmd, []string{"parent-spec"})
 	require.NoError(t, err)
@@ -137,7 +136,7 @@ func TestRunSliceList_RPCError(t *testing.T) {
 	sliceListJSON = false
 	t.Cleanup(func() { sliceListJSON = oldJSON })
 
-	err := runSliceList(nil, []string{"parent-spec"})
+	err := runSliceList(newCmdWithCtx(), []string{"parent-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "list slices")
 }
@@ -151,7 +150,7 @@ func TestRunSliceGet_HappyPath(t *testing.T) {
 	sliceGetJSON = false
 	t.Cleanup(func() { sliceGetJSON = oldJSON })
 
-	err := runSliceGet(nil, []string{"parent/slice-1"})
+	err := runSliceGet(newCmdWithCtx(), []string{"parent/slice-1"})
 	require.NoError(t, err)
 }
 
@@ -162,7 +161,7 @@ func TestRunSliceGet_HappyPath_JSON(t *testing.T) {
 	sliceGetJSON = true
 	t.Cleanup(func() { sliceGetJSON = oldJSON })
 
-	cmd := &cobra.Command{}
+	cmd := newCmdWithCtx()
 	cmd.SetOut(io.Discard)
 	err := runSliceGet(cmd, []string{"parent/slice-1"})
 	require.NoError(t, err)
@@ -175,7 +174,7 @@ func TestRunSliceGet_RPCError(t *testing.T) {
 	sliceGetJSON = false
 	t.Cleanup(func() { sliceGetJSON = oldJSON })
 
-	err := runSliceGet(nil, []string{"parent/slice-1"})
+	err := runSliceGet(newCmdWithCtx(), []string{"parent/slice-1"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get slice")
 }
@@ -189,7 +188,7 @@ func TestRunSliceClaim_HappyPath(t *testing.T) {
 	sliceClaimAssignee = "alice"
 	t.Cleanup(func() { sliceClaimAssignee = oldAssignee })
 
-	err := runSliceClaim(nil, []string{"parent/slice-1"})
+	err := runSliceClaim(newCmdWithCtx(), []string{"parent/slice-1"})
 	require.NoError(t, err)
 }
 
@@ -200,7 +199,7 @@ func TestRunSliceClaim_RPCError(t *testing.T) {
 	sliceClaimAssignee = "alice"
 	t.Cleanup(func() { sliceClaimAssignee = oldAssignee })
 
-	err := runSliceClaim(nil, []string{"parent/slice-1"})
+	err := runSliceClaim(newCmdWithCtx(), []string{"parent/slice-1"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "claim slice")
 }
@@ -210,14 +209,14 @@ func TestRunSliceClaim_RPCError(t *testing.T) {
 func TestRunSliceComplete_HappyPath(t *testing.T) {
 	startFakeServer[specgraphv1connect.SliceServiceHandler](t, fakeSliceCompleteHandler{}, specgraphv1connect.NewSliceServiceHandler)
 
-	err := runSliceComplete(nil, []string{"parent/slice-1"})
+	err := runSliceComplete(newCmdWithCtx(), []string{"parent/slice-1"})
 	require.NoError(t, err)
 }
 
 func TestRunSliceComplete_RPCError(t *testing.T) {
 	startFakeServer[specgraphv1connect.SliceServiceHandler](t, fakeSliceCompleteErrorHandler{}, specgraphv1connect.NewSliceServiceHandler)
 
-	err := runSliceComplete(nil, []string{"parent/slice-1"})
+	err := runSliceComplete(newCmdWithCtx(), []string{"parent/slice-1"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "complete slice")
 }

--- a/cmd/specgraph/spark.go
+++ b/cmd/specgraph/spark.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -26,12 +25,12 @@ func init() {
 	rootCmd.AddCommand(sparkCmd)
 }
 
-func runSpark(_ *cobra.Command, args []string) error {
+func runSpark(cmd *cobra.Command, args []string) error {
 	client, err := authoringClient()
 	if err != nil {
 		return err
 	}
-	resp, err := client.Spark(context.Background(), connect.NewRequest(&specv1.SparkRequest{
+	resp, err := client.Spark(cmd.Context(), connect.NewRequest(&specv1.SparkRequest{
 		Slug:   args[0],
 		Output: &specv1.SparkOutput{Seed: sparkSeed},
 	}))

--- a/cmd/specgraph/spec.go
+++ b/cmd/specgraph/spec.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -32,12 +31,12 @@ var (
 	createPriority string
 )
 
-func runCreate(_ *cobra.Command, args []string) error {
+func runCreate(cmd *cobra.Command, args []string) error {
 	client, err := specClient()
 	if err != nil {
 		return err
 	}
-	resp, err := client.CreateSpec(context.Background(), connect.NewRequest(&specv1.CreateSpecRequest{
+	resp, err := client.CreateSpec(cmd.Context(), connect.NewRequest(&specv1.CreateSpecRequest{
 		Slug:     args[0],
 		Intent:   createIntent,
 		Priority: createPriority,
@@ -88,7 +87,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		req.Notes = &updateNotes
 	}
 
-	resp, err := client.UpdateSpec(context.Background(), connect.NewRequest(req))
+	resp, err := client.UpdateSpec(cmd.Context(), connect.NewRequest(req))
 	if err != nil {
 		return fmt.Errorf("update spec: %w", err)
 	}
@@ -114,7 +113,7 @@ func runList(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.ListSpecs(context.Background(), connect.NewRequest(&specv1.ListSpecsRequest{
+	resp, err := client.ListSpecs(cmd.Context(), connect.NewRequest(&specv1.ListSpecsRequest{
 		Stage:    listStage,
 		Priority: listPriority,
 	}))
@@ -169,7 +168,7 @@ func runShow(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.GetSpec(context.Background(), connect.NewRequest(&specv1.GetSpecRequest{
+	resp, err := client.GetSpec(cmd.Context(), connect.NewRequest(&specv1.GetSpecRequest{
 		Slug: args[0],
 	}))
 	if err != nil {

--- a/cmd/specgraph/spec_test.go
+++ b/cmd/specgraph/spec_test.go
@@ -11,7 +11,6 @@ import (
 	"connectrpc.com/connect"
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -118,14 +117,14 @@ func (fakeGetSpecErrHandler) GetSpec(_ context.Context, _ *connect.Request[specv
 
 func TestRunCreate_HappyPath(t *testing.T) {
 	startFakeSpecServer(t, fakeCreateSpecHandler{})
-	err := runCreate(nil, []string{"my-spec"})
+	err := runCreate(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
 func TestRunUpdate_HappyPath(t *testing.T) {
 	startFakeSpecServer(t, fakeUpdateSpecHandler{})
 
-	cmd := &cobra.Command{}
+	cmd := newCmdWithCtx()
 	cmd.Flags().String("intent", "", "")
 	cmd.Flags().String("stage", "", "")
 	cmd.Flags().String("priority", "", "")
@@ -148,7 +147,7 @@ func TestRunList_HappyPath(t *testing.T) {
 	listJSON = false
 	t.Cleanup(func() { listJSON = old })
 
-	err := runList(&cobra.Command{}, nil)
+	err := runList(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
@@ -159,7 +158,7 @@ func TestRunList_HappyPath_JSON(t *testing.T) {
 	listJSON = true
 	t.Cleanup(func() { listJSON = old })
 
-	cmd := &cobra.Command{}
+	cmd := newCmdWithCtx()
 	err := runList(cmd, nil)
 	require.NoError(t, err)
 }
@@ -171,7 +170,7 @@ func TestRunList_EmptyResults(t *testing.T) {
 	listJSON = false
 	t.Cleanup(func() { listJSON = old })
 
-	err := runList(&cobra.Command{}, nil)
+	err := runList(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
@@ -182,7 +181,7 @@ func TestRunShow_HappyPath(t *testing.T) {
 	showJSON = false
 	t.Cleanup(func() { showJSON = old })
 
-	err := runShow(&cobra.Command{}, []string{"my-spec"})
+	err := runShow(newCmdWithCtx(), []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -193,7 +192,7 @@ func TestRunShow_HappyPath_JSON(t *testing.T) {
 	showJSON = true
 	t.Cleanup(func() { showJSON = old })
 
-	cmd := &cobra.Command{}
+	cmd := newCmdWithCtx()
 	err := runShow(cmd, []string{"my-spec"})
 	require.NoError(t, err)
 }
@@ -202,7 +201,7 @@ func TestRunShow_HappyPath_JSON(t *testing.T) {
 
 func TestRunCreate_RPCError(t *testing.T) {
 	startFakeSpecServer(t, fakeCreateSpecErrHandler{})
-	err := runCreate(nil, []string{"my-spec"})
+	err := runCreate(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "create spec")
 }
@@ -210,7 +209,7 @@ func TestRunCreate_RPCError(t *testing.T) {
 func TestRunUpdate_RPCError(t *testing.T) {
 	startFakeSpecServer(t, fakeUpdateSpecErrHandler{})
 
-	cmd := &cobra.Command{}
+	cmd := newCmdWithCtx()
 	cmd.Flags().String("intent", "", "")
 	cmd.Flags().String("stage", "", "")
 	cmd.Flags().String("priority", "", "")
@@ -229,7 +228,7 @@ func TestRunShow_RPCError(t *testing.T) {
 	showJSON = false
 	t.Cleanup(func() { showJSON = old })
 
-	err := runShow(&cobra.Command{}, []string{"my-spec"})
+	err := runShow(newCmdWithCtx(), []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get spec")
 }
@@ -241,7 +240,7 @@ func TestRunList_RPCError(t *testing.T) {
 	listJSON = false
 	t.Cleanup(func() { listJSON = old })
 
-	err := runList(&cobra.Command{}, nil)
+	err := runList(newCmdWithCtx(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "list specs")
 }

--- a/cmd/specgraph/specify.go
+++ b/cmd/specgraph/specify.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"connectrpc.com/connect"
@@ -26,7 +25,7 @@ func init() {
 	rootCmd.AddCommand(specifyCmd)
 }
 
-func runSpecify(_ *cobra.Command, args []string) error {
+func runSpecify(cmd *cobra.Command, args []string) error {
 	client, err := authoringClient()
 	if err != nil {
 		return err
@@ -37,7 +36,7 @@ func runSpecify(_ *cobra.Command, args []string) error {
 			return fmt.Errorf("specify: %w", loadErr)
 		}
 	}
-	resp, err := client.Specify(context.Background(), connect.NewRequest(&specv1.SpecifyRequest{
+	resp, err := client.Specify(cmd.Context(), connect.NewRequest(&specv1.SpecifyRequest{
 		Slug:   args[0],
 		Output: output,
 	}))

--- a/cmd/specgraph/status.go
+++ b/cmd/specgraph/status.go
@@ -37,7 +37,7 @@ type statusOutput struct {
 	Version string `json:"version,omitempty"`
 }
 
-func runStatus(_ *cobra.Command, _ []string) error {
+func runStatus(cmd *cobra.Command, _ []string) error {
 	baseURL, _, err := resolveBaseURL()
 	if err != nil {
 		return err
@@ -48,7 +48,7 @@ func runStatus(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
 	defer cancel()
 
 	resp, connErr := client.Health(ctx, connect.NewRequest(&specv1.HealthRequest{}))

--- a/cmd/specgraph/status_test.go
+++ b/cmd/specgraph/status_test.go
@@ -45,7 +45,7 @@ func TestRunStatus_HappyPath(t *testing.T) {
 	statusJSON = false
 	t.Cleanup(func() { statusJSON = old })
 
-	err := runStatus(nil, nil)
+	err := runStatus(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
@@ -56,14 +56,14 @@ func TestRunStatus_HappyPath_JSON(t *testing.T) {
 	statusJSON = true
 	t.Cleanup(func() { statusJSON = old })
 
-	err := runStatus(nil, nil)
+	err := runStatus(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
 func TestRunStatus_ClientError(t *testing.T) {
 	setMissingConfig(t)
 
-	err := runStatus(nil, nil)
+	err := runStatus(newCmdWithCtx(), nil)
 	require.Error(t, err)
 }
 
@@ -81,7 +81,7 @@ func TestRunStatus_NotRunning(t *testing.T) {
 	t.Cleanup(func() { statusJSON = oldJSON })
 
 	// Should NOT return an error — prints "not running" instead.
-	err := runStatus(nil, nil)
+	err := runStatus(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
@@ -92,7 +92,7 @@ func TestRunStatus_RPCError(t *testing.T) {
 	statusJSON = false
 	t.Cleanup(func() { statusJSON = old })
 
-	err := runStatus(nil, nil)
+	err := runStatus(newCmdWithCtx(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "health check")
 }

--- a/cmd/specgraph/sync.go
+++ b/cmd/specgraph/sync.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"text/tabwriter"
@@ -52,7 +51,7 @@ func runSyncBeads(cmd *cobra.Command) error {
 		return err
 	}
 
-	resp, err := client.SyncBeads(context.Background(), connect.NewRequest(&specv1.SyncBeadsRequest{
+	resp, err := client.SyncBeads(cmd.Context(), connect.NewRequest(&specv1.SyncBeadsRequest{
 		Config: &specv1.SyncConfig{
 			FilterStage:    beadsFilterStage,
 			FilterPriority: beadsFilterPriority,
@@ -82,7 +81,7 @@ func runSyncGitHub(cmd *cobra.Command) error {
 		return err
 	}
 
-	resp, err := client.SyncGitHub(context.Background(), connect.NewRequest(&specv1.SyncGitHubRequest{
+	resp, err := client.SyncGitHub(cmd.Context(), connect.NewRequest(&specv1.SyncGitHubRequest{
 		Config: &specv1.SyncConfig{
 			FilterStage:    ghFilterStage,
 			FilterPriority: ghFilterPriority,
@@ -127,7 +126,7 @@ func runSyncStatus(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("unsupported adapter: %s (supported: beads, github)", statusAdapter)
 	}
 
-	resp, err := client.GetSyncStatus(context.Background(), connect.NewRequest(&specv1.SyncStatusRequest{
+	resp, err := client.GetSyncStatus(cmd.Context(), connect.NewRequest(&specv1.SyncStatusRequest{
 		Adapter:  adapter,
 		SpecSlug: statusSpec,
 	}))

--- a/cmd/specgraph/sync_test.go
+++ b/cmd/specgraph/sync_test.go
@@ -11,7 +11,6 @@ import (
 	"connectrpc.com/connect"
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -123,13 +122,13 @@ func TestRunSyncBeads_HappyPath(t *testing.T) {
 	beadsDryRun = false
 	t.Cleanup(func() { beadsDryRun = old })
 
-	err := runSyncBeads(&cobra.Command{})
+	err := runSyncBeads(newCmdWithCtx())
 	require.NoError(t, err)
 }
 
 func TestRunSyncBeads_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runSyncBeads(&cobra.Command{})
+	err := runSyncBeads(newCmdWithCtx())
 	require.Error(t, err)
 }
 
@@ -149,13 +148,13 @@ func (fakeSyncGitHubHandler) SyncGitHub(_ context.Context, _ *connect.Request[sp
 
 func TestRunSyncGitHub_HappyPath(t *testing.T) {
 	startFakeSyncServer(t, fakeSyncGitHubHandler{})
-	err := runSyncGitHub(&cobra.Command{})
+	err := runSyncGitHub(newCmdWithCtx())
 	require.NoError(t, err)
 }
 
 func TestRunSyncGitHub_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runSyncGitHub(&cobra.Command{})
+	err := runSyncGitHub(newCmdWithCtx())
 	require.Error(t, err)
 }
 
@@ -183,7 +182,7 @@ func TestRunSyncStatus_HappyPath(t *testing.T) {
 	statusAdapter = ""
 	t.Cleanup(func() { statusAdapter = old })
 
-	err := runSyncStatus(&cobra.Command{}, nil)
+	err := runSyncStatus(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
@@ -193,7 +192,7 @@ func TestRunSyncStatus_WithAdapterFilter(t *testing.T) {
 	statusAdapter = "beads"
 	t.Cleanup(func() { statusAdapter = old })
 
-	err := runSyncStatus(&cobra.Command{}, nil)
+	err := runSyncStatus(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
@@ -203,7 +202,7 @@ func TestRunSyncStatus_InvalidAdapter(t *testing.T) {
 	statusAdapter = "bogus"
 	t.Cleanup(func() { statusAdapter = old })
 
-	err := runSyncStatus(&cobra.Command{}, nil)
+	err := runSyncStatus(newCmdWithCtx(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported adapter")
 }
@@ -222,13 +221,13 @@ func TestRunSyncStatus_Empty(t *testing.T) {
 	statusAdapter = ""
 	t.Cleanup(func() { statusAdapter = old })
 
-	err := runSyncStatus(&cobra.Command{}, nil)
+	err := runSyncStatus(newCmdWithCtx(), nil)
 	require.NoError(t, err)
 }
 
 func TestRunSyncStatus_ClientError(t *testing.T) {
 	setMissingConfig(t)
-	err := runSyncStatus(&cobra.Command{}, nil)
+	err := runSyncStatus(newCmdWithCtx(), nil)
 	require.Error(t, err)
 }
 
@@ -244,7 +243,7 @@ func (fakeSyncBeadsErrHandler) SyncBeads(_ context.Context, _ *connect.Request[s
 
 func TestRunSyncBeads_RPCError(t *testing.T) {
 	startFakeSyncServer(t, fakeSyncBeadsErrHandler{})
-	err := runSyncBeads(&cobra.Command{})
+	err := runSyncBeads(newCmdWithCtx())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "sync beads")
 }
@@ -259,7 +258,7 @@ func (fakeSyncGitHubErrHandler) SyncGitHub(_ context.Context, _ *connect.Request
 
 func TestRunSyncGitHub_RPCError(t *testing.T) {
 	startFakeSyncServer(t, fakeSyncGitHubErrHandler{})
-	err := runSyncGitHub(&cobra.Command{})
+	err := runSyncGitHub(newCmdWithCtx())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "sync github")
 }

--- a/cmd/specgraph/up.go
+++ b/cmd/specgraph/up.go
@@ -32,7 +32,7 @@ func init() {
 	rootCmd.AddCommand(upCmd)
 }
 
-func runUp(_ *cobra.Command, _ []string) error {
+func runUp(cmd *cobra.Command, _ []string) error {
 	if err := xdg.EnsureDirs(); err != nil {
 		return fmt.Errorf("ensure XDG dirs: %w", err)
 	}
@@ -95,7 +95,7 @@ func runUp(_ *cobra.Command, _ []string) error {
 	// Health-check loop: up to 10 attempts, 1s apart, 2s timeout per attempt.
 	client := specgraphv1connect.NewServerServiceClient(http.DefaultClient, serverURL)
 	for range 10 {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Second)
 		resp, err := client.Health(ctx, connect.NewRequest(&specv1.HealthRequest{}))
 		cancel()
 		if err == nil && resp.Msg.Status != "" {

--- a/internal/auth/config_store.go
+++ b/internal/auth/config_store.go
@@ -5,6 +5,8 @@ package auth
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
 	"crypto/subtle"
 	"fmt"
 	"strings"
@@ -76,12 +78,25 @@ func NewConfigStore(cfg config.AuthConfig) (*ConfigStore, error) {
 	}, nil
 }
 
+// fixedLenCompare compares two strings in constant time regardless of length.
+// It hashes both values with HMAC-SHA256 so the inputs to ConstantTimeCompare
+// are always 32 bytes, eliminating the length side-channel.
+func fixedLenCompare(a, b string) bool {
+	mac := hmac.New(sha256.New, []byte("specgraph-key-compare"))
+	mac.Write([]byte(a))
+	ha := mac.Sum(nil)
+	mac.Reset()
+	mac.Write([]byte(b))
+	hb := mac.Sum(nil)
+	return subtle.ConstantTimeCompare(ha, hb) == 1
+}
+
 // ResolveAPIKey looks up the identity for the given API key using constant-time comparison.
 // Always iterates all keys to prevent timing side-channels from leaking which slot matched.
 func (s *ConfigStore) ResolveAPIKey(_ context.Context, key string) (*Identity, error) {
 	var matched *Identity
 	for storedKey, id := range s.identities {
-		if subtle.ConstantTimeCompare([]byte(storedKey), []byte(key)) == 1 {
+		if fixedLenCompare(storedKey, key) {
 			matched = id
 		}
 	}

--- a/internal/auth/config_store_test.go
+++ b/internal/auth/config_store_test.go
@@ -192,3 +192,47 @@ func TestConfigStore_BuiltinRolePermissions(t *testing.T) {
 		t.Error("admin should have graph:delete via *:*")
 	}
 }
+
+func TestConfigStore_DifferentLengthKeyRejected(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_abc", Name: "Test Key", Role: "admin"},
+		},
+	}
+	store, err := auth.NewConfigStore(cfg)
+	if err != nil {
+		t.Fatalf("NewConfigStore: %v", err)
+	}
+
+	// Shorter key — different length, must not match
+	_, err = store.ResolveAPIKey(context.Background(), "spgr_sk_ab")
+	if !errors.Is(err, auth.ErrUnknownKey) {
+		t.Errorf("shorter key: err = %v, want ErrUnknownKey", err)
+	}
+
+	// Longer key — different length, must not match
+	_, err = store.ResolveAPIKey(context.Background(), "spgr_sk_abcd")
+	if !errors.Is(err, auth.ErrUnknownKey) {
+		t.Errorf("longer key: err = %v, want ErrUnknownKey", err)
+	}
+}
+
+func TestConfigStore_SameContentKeyMatches(t *testing.T) {
+	cfg := config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_exactmatch", Name: "Test Key", Role: "admin"},
+		},
+	}
+	store, err := auth.NewConfigStore(cfg)
+	if err != nil {
+		t.Fatalf("NewConfigStore: %v", err)
+	}
+
+	id, err := store.ResolveAPIKey(context.Background(), "spgr_sk_exactmatch")
+	if err != nil {
+		t.Fatalf("exact match: unexpected error: %v", err)
+	}
+	if id.Subject != "apikey:k1" {
+		t.Errorf("subject = %q, want apikey:k1", id.Subject)
+	}
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+// RequireAuth returns HTTP middleware that enforces API key authentication.
+// When the store has no keys configured, requests pass through with a local
+// identity (matching the ConnectRPC interceptor behavior). When keys are
+// configured, the Authorization header must carry a valid Bearer token.
+func RequireAuth(store IdentityStore) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			id, ok := authenticate(r.Context(), store, r.Header.Get("Authorization"))
+			if !ok {
+				http.Error(w, `{"error":"unauthenticated"}`, http.StatusUnauthorized)
+				return
+			}
+			next.ServeHTTP(w, r.WithContext(WithIdentity(r.Context(), id)))
+		})
+	}
+}
+
+// authenticate resolves the caller identity from an Authorization header value.
+// Returns the identity and true on success, or nil and false on failure.
+func authenticate(ctx context.Context, store IdentityStore, authHeader string) (*Identity, bool) {
+	if authHeader == "" {
+		if !store.HasKeys() {
+			return localIdentity(), true
+		}
+		return nil, false
+	}
+
+	scheme, token, ok := strings.Cut(authHeader, " ")
+	token = strings.TrimSpace(token)
+	if !ok || !strings.EqualFold(scheme, "Bearer") || token == "" {
+		return nil, false
+	}
+
+	id, err := store.ResolveAPIKey(ctx, token)
+	if err != nil {
+		return nil, false
+	}
+	return id, true
+}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/config"
+)
+
+func TestRequireAuth_NoKeys_PassesThrough(t *testing.T) {
+	store, err := auth.NewConfigStore(config.AuthConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	handler := auth.RequireAuth(store)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/projects", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Fatal("handler not called when no keys configured")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestRequireAuth_WithKeys_NoToken_Returns401(t *testing.T) {
+	store, err := auth.NewConfigStore(config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_test", Name: "Admin", Role: "admin"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := auth.RequireAuth(store)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/projects", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestRequireAuth_WithKeys_ValidToken_PassesThrough(t *testing.T) {
+	store, err := auth.NewConfigStore(config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_test", Name: "Admin", Role: "admin"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	handler := auth.RequireAuth(store)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/projects", nil)
+	req.Header.Set("Authorization", "Bearer spgr_sk_test")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Fatal("handler not called with valid token")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestRequireAuth_WithKeys_InvalidToken_Returns401(t *testing.T) {
+	store, err := auth.NewConfigStore(config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_test", Name: "Admin", Role: "admin"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := auth.RequireAuth(store)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/projects", nil)
+	req.Header.Set("Authorization", "Bearer wrong_key")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestRequireAuth_MalformedAuthHeader_Returns401(t *testing.T) {
+	store, err := auth.NewConfigStore(config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_test", Name: "Admin", Role: "admin"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := auth.RequireAuth(store)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/projects", nil)
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}

--- a/internal/authoring/stages.go
+++ b/internal/authoring/stages.go
@@ -9,42 +9,41 @@ import (
 	"github.com/specgraph/specgraph/internal/storage"
 )
 
-// Stage is a typed authoring funnel stage name.
-type Stage string
+// Stage is an alias for storage.SpecStage, kept for backward compatibility
+// within the authoring package. New code should use storage.SpecStage directly.
+type Stage = storage.SpecStage
 
 // Stage name constants used across the authoring funnel.
+// These are aliases for the corresponding storage.SpecStage* constants.
 const (
-	StageSpark     Stage = "spark"
-	StageShape     Stage = "shape"
-	StageSpecify   Stage = "specify"
-	StageDecompose Stage = "decompose"
-	StageApproved  Stage = "approved"
+	StageSpark     = storage.SpecStageSpark
+	StageShape     = storage.SpecStageShape
+	StageSpecify   = storage.SpecStageSpecify
+	StageDecompose = storage.SpecStageDecompose
+	StageApproved  = storage.SpecStageApproved
 )
 
-// ToStorage converts a Stage to a storage.AuthoringStage.
-// Returns an error if the Stage value is not a known constant.
-func (s Stage) ToStorage() (storage.AuthoringStage, error) {
-	if indexOf(s) < 0 {
-		return "", fmt.Errorf("unknown authoring stage %q", s)
-	}
-	return storage.AuthoringStage(s), nil
-}
-
-// stages defines the ordered authoring funnel stages.
-var stages = []Stage{StageSpark, StageShape, StageSpecify, StageDecompose, StageApproved}
+// authoringStages defines the ordered authoring funnel stages.
+var authoringStages = []storage.SpecStage{StageSpark, StageShape, StageSpecify, StageDecompose, StageApproved}
 
 // AllStages returns a copy of the ordered stage list as strings (for backward compat with callers that need []string).
 func AllStages() []string {
-	out := make([]string, len(stages))
-	for i, s := range stages {
+	out := make([]string, len(authoringStages))
+	for i, s := range authoringStages {
 		out[i] = string(s)
 	}
 	return out
 }
 
-// validateStageNames returns an error if from or to are unknown stage names.
+// IsAuthoringStage reports whether the given SpecStage is one of the five
+// authoring funnel stages (spark, shape, specify, decompose, approved).
+func IsAuthoringStage(s storage.SpecStage) bool {
+	return indexOf(s) >= 0
+}
+
+// validateStageNames returns an error if from or to are unknown authoring stage names.
 // allowEmptyFrom controls whether from=="" is accepted (used for initial transitions).
-func validateStageNames(from, to Stage, allowEmptyFrom bool) (fromIdx, toIdx int, err error) {
+func validateStageNames(from, to storage.SpecStage, allowEmptyFrom bool) (fromIdx, toIdx int, err error) {
 	fromIdx = indexOf(from)
 	toIdx = indexOf(to)
 	var unknowns []string
@@ -64,7 +63,7 @@ func validateStageNames(from, to Stage, allowEmptyFrom bool) (fromIdx, toIdx int
 // Forward transitions must follow the defined order (no skipping).
 // Backward (amend) transitions are allowed to any earlier stage.
 // Same-to-same transitions are not allowed.
-func ValidateTransition(from, to Stage) error {
+func ValidateTransition(from, to storage.SpecStage) error {
 	if from == to {
 		return fmt.Errorf("transition from %q to %q is a no-op", from, to)
 	}
@@ -92,7 +91,7 @@ func ValidateTransition(from, to Stage) error {
 // ValidateAmendTransition checks whether an amend (backward) transition is valid.
 // It only allows moving to an earlier stage — forward transitions and same-to-same
 // are rejected. This is distinct from ValidateTransition which allows both directions.
-func ValidateAmendTransition(from, to Stage) error {
+func ValidateAmendTransition(from, to storage.SpecStage) error {
 	if from == to {
 		return fmt.Errorf("amend transition from %q to %q is a no-op", from, to)
 	}
@@ -109,9 +108,9 @@ func ValidateAmendTransition(from, to Stage) error {
 	return fmt.Errorf("amend requires backward transition: %q to %q is not backward", from, to)
 }
 
-// indexOf returns the position of a stage in the ordered list, or -1 if not found.
-func indexOf(stage Stage) int {
-	for i, s := range stages {
+// indexOf returns the position of a stage in the ordered authoring funnel list, or -1 if not found.
+func indexOf(stage storage.SpecStage) int {
+	for i, s := range authoringStages {
 		if s == stage {
 			return i
 		}

--- a/internal/authoring/stages_test.go
+++ b/internal/authoring/stages_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/specgraph/specgraph/internal/authoring"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -128,33 +129,40 @@ func TestValidateAmendTransition(t *testing.T) {
 	}
 }
 
-func TestStageToStorage(t *testing.T) {
-	t.Run("known stages convert without error", func(t *testing.T) {
-		known := []authoring.Stage{
-			authoring.StageSpark,
-			authoring.StageShape,
-			authoring.StageSpecify,
-			authoring.StageDecompose,
-			authoring.StageApproved,
+func TestIsAuthoringStage(t *testing.T) {
+	t.Run("known authoring stages return true", func(t *testing.T) {
+		known := []storage.SpecStage{
+			storage.SpecStageSpark,
+			storage.SpecStageShape,
+			storage.SpecStageSpecify,
+			storage.SpecStageDecompose,
+			storage.SpecStageApproved,
 		}
 		for _, s := range known {
-			v, err := s.ToStorage()
-			require.NoError(t, err)
-			require.Equal(t, string(s), string(v))
+			require.True(t, authoring.IsAuthoringStage(s), "expected %q to be an authoring stage", s)
 		}
 	})
 
-	t.Run("unknown stage returns error", func(t *testing.T) {
-		_, err := authoring.Stage("typo").ToStorage()
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "unknown authoring stage")
-		require.Contains(t, err.Error(), "typo")
+	t.Run("non-authoring stages return false", func(t *testing.T) {
+		nonAuthoring := []storage.SpecStage{
+			storage.SpecStageInProgress,
+			storage.SpecStageReview,
+			storage.SpecStageDone,
+			storage.SpecStageAmended,
+			storage.SpecStageSuperseded,
+			storage.SpecStageAbandoned,
+		}
+		for _, s := range nonAuthoring {
+			require.False(t, authoring.IsAuthoringStage(s), "expected %q to not be an authoring stage", s)
+		}
 	})
 
-	t.Run("empty string returns error", func(t *testing.T) {
-		_, err := authoring.Stage("").ToStorage()
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "unknown authoring stage")
+	t.Run("unknown stage returns false", func(t *testing.T) {
+		require.False(t, authoring.IsAuthoringStage(storage.SpecStage("typo")))
+	})
+
+	t.Run("empty string returns false", func(t *testing.T) {
+		require.False(t, authoring.IsAuthoringStage(storage.SpecStage("")))
 	})
 }
 

--- a/internal/server/analytical_pass_handler.go
+++ b/internal/server/analytical_pass_handler.go
@@ -8,6 +8,7 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -60,18 +61,16 @@ func (h *AnalyticalPassHandler) RunAnalyticalPass(ctx context.Context, req *conn
 
 	spec, err := store.GetSpec(ctx, msg.Slug)
 	if err != nil {
-		if errors.Is(err, storage.ErrSpecNotFound) {
-			return nil, connect.NewError(connect.CodeNotFound, err)
-		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, analyticalPassError(err)
 	}
 
 	tmplBytes, err := h.loadTemplate(pt)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("no template for pass %q: %w", pt, err))
+		slog.Error("analyticalPassError: template load failed", slog.Any("error", err))
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 
-	stage := authoring.Stage(spec.Stage)
+	stage := spec.Stage
 	offered := authoring.OfferedPasses(stage, authoring.PostureDrive)
 
 	return connect.NewResponse(&specv1.RunAnalyticalPassResponse{
@@ -151,10 +150,7 @@ func (h *AnalyticalPassHandler) StoreFindings(ctx context.Context, req *connect.
 
 	ids, sErr := store.StoreFindings(ctx, msg.Slug, pt, domain)
 	if sErr != nil {
-		if errors.Is(sErr, storage.ErrSpecNotFound) {
-			return nil, connect.NewError(connect.CodeNotFound, sErr)
-		}
-		return nil, connect.NewError(connect.CodeInternal, sErr)
+		return nil, analyticalPassError(sErr)
 	}
 
 	return connect.NewResponse(&specv1.StoreFindingsResponse{
@@ -185,10 +181,7 @@ func (h *AnalyticalPassHandler) ListFindings(ctx context.Context, req *connect.R
 
 	findings, err := store.ListFindings(ctx, msg.Slug, pt)
 	if err != nil {
-		if errors.Is(err, storage.ErrSpecNotFound) {
-			return nil, connect.NewError(connect.CodeNotFound, err)
-		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, analyticalPassError(err)
 	}
 
 	proto := make([]*specv1.AnalyticalFinding, len(findings))
@@ -196,11 +189,11 @@ func (h *AnalyticalPassHandler) ListFindings(ctx context.Context, req *connect.R
 		f := &findings[i]
 		protoSev, sevErr := findingSeverityToProto(f.Severity)
 		if sevErr != nil {
-			return nil, connect.NewError(connect.CodeInternal, sevErr)
+			return nil, analyticalPassError(sevErr)
 		}
 		protoPassType, ptErr := passTypeToProto(f.PassType)
 		if ptErr != nil {
-			return nil, connect.NewError(connect.CodeInternal, ptErr)
+			return nil, analyticalPassError(ptErr)
 		}
 		proto[i] = &specv1.AnalyticalFinding{
 			Id:         f.ID,
@@ -294,5 +287,20 @@ func passTypeToProto(p storage.PassType) (specv1.PassType, error) {
 		return specv1.PassType_PASS_TYPE_SIMPLICITY, nil
 	default:
 		return specv1.PassType_PASS_TYPE_UNSPECIFIED, fmt.Errorf("unknown pass_type %q", p)
+	}
+}
+
+// analyticalPassError maps storage errors to sanitized connect error codes.
+func analyticalPassError(err error) error {
+	var connErr *connect.Error
+	if errors.As(err, &connErr) {
+		return connErr
+	}
+	switch {
+	case errors.Is(err, storage.ErrSpecNotFound):
+		return connect.NewError(connect.CodeNotFound, errors.New("spec not found"))
+	default:
+		slog.Error("analyticalPassError: internal error", slog.Any("error", err))
+		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 }

--- a/internal/server/api_handler.go
+++ b/internal/server/api_handler.go
@@ -11,8 +11,13 @@ import (
 )
 
 // RegisterAPIHandlers registers lightweight HTTP endpoints for the UI.
-func RegisterAPIHandlers(mux *http.ServeMux, scoper storage.Scoper) {
-	mux.HandleFunc("/api/projects", func(w http.ResponseWriter, r *http.Request) {
+// The authMW parameter wraps each handler with authentication middleware,
+// ensuring API keys are enforced consistently with ConnectRPC endpoints.
+func RegisterAPIHandlers(mux *http.ServeMux, scoper storage.Scoper, authMW func(http.Handler) http.Handler) {
+	if authMW == nil {
+		panic("RegisterAPIHandlers: authMW must not be nil")
+	}
+	mux.Handle("/api/projects", authMW(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		store, err := scoper.Scoped(r.Context(), "_server")
 		if err != nil {
 			http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
@@ -31,5 +36,5 @@ func RegisterAPIHandlers(mux *http.ServeMux, scoper storage.Scoper) {
 			}
 		}
 		json.NewEncoder(w).Encode(map[string]any{"projects": slugs}) //nolint:errcheck // best-effort write to http.ResponseWriter
-	})
+	})))
 }

--- a/internal/server/api_handler_test.go
+++ b/internal/server/api_handler_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package server_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// fakeScoper returns a stubBackend that lists no projects (empty result set).
+type fakeScoper struct{}
+
+func (f *fakeScoper) Scoped(_ context.Context, _ string) (storage.ScopedBackend, error) {
+	return &fakeProjectBackend{}, nil
+}
+
+type fakeProjectBackend struct {
+	stubBackend
+}
+
+func (f *fakeProjectBackend) ListProjects(_ context.Context) ([]*storage.Project, error) {
+	return nil, nil
+}
+
+func TestAPIHandler_AuthRequired_NoToken_Returns401(t *testing.T) {
+	store, err := auth.NewConfigStore(config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_test", Name: "Admin", Role: "admin"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	server.RegisterAPIHandlers(mux, &fakeScoper{}, auth.RequireAuth(store))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/projects", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestAPIHandler_AuthRequired_ValidToken_Returns200(t *testing.T) {
+	store, err := auth.NewConfigStore(config.AuthConfig{
+		APIKeys: []config.APIKeyConfig{
+			{ID: "k1", Key: "spgr_sk_test", Name: "Admin", Role: "admin"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	server.RegisterAPIHandlers(mux, &fakeScoper{}, auth.RequireAuth(store))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/projects", nil)
+	req.Header.Set("Authorization", "Bearer spgr_sk_test")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestAPIHandler_NoKeys_PassesThrough(t *testing.T) {
+	store, err := auth.NewConfigStore(config.AuthConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	server.RegisterAPIHandlers(mux, &fakeScoper{}, auth.RequireAuth(store))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/projects", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}

--- a/internal/server/authoring_handler.go
+++ b/internal/server/authoring_handler.go
@@ -153,7 +153,7 @@ func (h *AuthoringHandler) Shape(ctx context.Context, req *connect.Request[specv
 	var safetyFlags []authoring.SafetyFlagResult
 	if err := runInTxOrSequential(ctx, store,
 		func(c context.Context) error {
-			return store.TransitionStage(c, msg.Slug, storage.AuthoringStage(authoring.StageSpark), storage.AuthoringStage(authoring.StageShape))
+			return store.TransitionStage(c, msg.Slug, storage.SpecStageSpark, storage.SpecStageShape)
 		},
 		func(c context.Context) error {
 			return store.StoreShapeOutput(c, msg.Slug, shapeDomain)
@@ -255,7 +255,7 @@ func (h *AuthoringHandler) Specify(ctx context.Context, req *connect.Request[spe
 	var safetyFlags []authoring.SafetyFlagResult
 	if err := runInTxOrSequential(ctx, store,
 		func(c context.Context) error {
-			return store.TransitionStage(c, msg.Slug, storage.AuthoringStage(authoring.StageShape), storage.AuthoringStage(authoring.StageSpecify))
+			return store.TransitionStage(c, msg.Slug, storage.SpecStageShape, storage.SpecStageSpecify)
 		},
 		func(c context.Context) error {
 			return store.StoreSpecifyOutput(c, msg.Slug, specifyDomain)
@@ -319,7 +319,7 @@ func (h *AuthoringHandler) Decompose(ctx context.Context, req *connect.Request[s
 	var childSlugs []string
 	if err := runInTxOrSequential(ctx, store,
 		func(c context.Context) error {
-			return store.TransitionStage(c, msg.Slug, storage.AuthoringStage(authoring.StageSpecify), storage.AuthoringStage(authoring.StageDecompose))
+			return store.TransitionStage(c, msg.Slug, storage.SpecStageSpecify, storage.SpecStageDecompose)
 		},
 		func(c context.Context) error {
 			slugs, err := store.StoreDecomposeOutput(c, msg.Slug, decomposeDomain)
@@ -363,7 +363,7 @@ func (h *AuthoringHandler) Approve(ctx context.Context, req *connect.Request[spe
 	slug := req.Msg.Slug
 	if err := runInTxOrSequential(ctx, store,
 		func(txCtx context.Context) error {
-			return store.TransitionStage(txCtx, slug, storage.AuthoringStage(authoring.StageDecompose), storage.AuthoringStage(authoring.StageApproved))
+			return store.TransitionStage(txCtx, slug, storage.SpecStageDecompose, storage.SpecStageApproved)
 		},
 		func(txCtx context.Context) error {
 			return acceptLinkedDecisions(txCtx, h.logger, store, store, slug)
@@ -382,12 +382,12 @@ func (h *AuthoringHandler) Approve(ctx context.Context, req *connect.Request[spe
 	if spec.UpdatedAt.IsZero() {
 		h.logger.ErrorContext(ctx, "spec.UpdatedAt is zero after TransitionStage",
 			"slug", slug, "specID", spec.ID, "stage", "approved")
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("spec %q has zero UpdatedAt after approval", slug))
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 	approvedAt := timestamppb.New(spec.UpdatedAt)
 	return connect.NewResponse(&specv1.ApproveResponse{
 		Slug:       req.Msg.Slug,
-		Stage:      stageToProto(authoring.StageApproved),
+		Stage:      stageToProto(storage.SpecStageApproved),
 		ApprovedAt: approvedAt,
 	}), nil
 }
@@ -421,9 +421,10 @@ func (h *AuthoringHandler) Amend(ctx context.Context, req *connect.Request[specv
 	if err != nil {
 		return nil, h.stageError(err)
 	}
-	protoStage := stageToProto(authoring.Stage(result.Stage))
+	protoStage := stageToProto(result.Stage)
 	if protoStage == specv1.AuthoringStage_AUTHORING_STAGE_UNSPECIFIED {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("unknown stage %q returned from storage", result.Stage))
+		h.logger.Error("unknown stage returned from storage", slog.String("stage", string(result.Stage)), slog.String("slug", req.Msg.Slug))
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 	return connect.NewResponse(&specv1.AmendResponse{
 		Slug:    result.Slug,
@@ -457,11 +458,7 @@ func (h *AuthoringHandler) Supersede(ctx context.Context, req *connect.Request[s
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("reason exceeds maximum length of %d", maxFieldLen))
 	}
 	if err := store.SupersedeSpec(ctx, req.Msg.Slug, req.Msg.SupersededBy, req.Msg.Reason); err != nil {
-		if errors.Is(err, storage.ErrSpecNotFound) {
-			return nil, connect.NewError(connect.CodeNotFound, errors.New("spec not found"))
-		}
-		h.logger.Error("supersede failed", slog.Any("error", err))
-		return nil, connect.NewError(connect.CodeInternal, errors.New("supersede failed"))
+		return nil, h.stageError(err)
 	}
 	return connect.NewResponse(&specv1.SupersedeResponse{
 		Slug:         req.Msg.Slug,
@@ -483,7 +480,7 @@ func (h *AuthoringHandler) GetPrompts(_ context.Context, req *connect.Request[sp
 	if req.Msg.Stage == specv1.AuthoringStage_AUTHORING_STAGE_APPROVED {
 		return connect.NewResponse(&specv1.GetPromptsResponse{}), nil
 	}
-	prompts := authoring.PromptsToProto(authoring.Stage(stage))
+	prompts := authoring.PromptsToProto(stage)
 	if len(prompts) == 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("no prompts defined for stage %q", stage))
 	}
@@ -791,27 +788,16 @@ func decomposeOutputToDomain(p *specv1.DecomposeOutput) (*storage.DecomposeOutpu
 // --- Stage mapping ---
 
 // stageToProto delegates to the canonical mapping in the authoring package.
-func stageToProto(stage authoring.Stage) specv1.AuthoringStage {
+func stageToProto(stage storage.SpecStage) specv1.AuthoringStage {
 	return authoring.StageToProto(stage)
 }
 
-var protoToStage map[specv1.AuthoringStage]storage.AuthoringStage
-
-func init() {
-	mustToStorage := func(s authoring.Stage) storage.AuthoringStage {
-		v, err := s.ToStorage()
-		if err != nil {
-			panic(fmt.Sprintf("invalid authoring stage constant: %v", err))
-		}
-		return v
-	}
-	protoToStage = map[specv1.AuthoringStage]storage.AuthoringStage{
-		specv1.AuthoringStage_AUTHORING_STAGE_SPARK:     mustToStorage(authoring.StageSpark),
-		specv1.AuthoringStage_AUTHORING_STAGE_SHAPE:     mustToStorage(authoring.StageShape),
-		specv1.AuthoringStage_AUTHORING_STAGE_SPECIFY:   mustToStorage(authoring.StageSpecify),
-		specv1.AuthoringStage_AUTHORING_STAGE_DECOMPOSE: mustToStorage(authoring.StageDecompose),
-		specv1.AuthoringStage_AUTHORING_STAGE_APPROVED:  mustToStorage(authoring.StageApproved),
-	}
+var protoToStage = map[specv1.AuthoringStage]storage.SpecStage{
+	specv1.AuthoringStage_AUTHORING_STAGE_SPARK:     storage.SpecStageSpark,
+	specv1.AuthoringStage_AUTHORING_STAGE_SHAPE:     storage.SpecStageShape,
+	specv1.AuthoringStage_AUTHORING_STAGE_SPECIFY:   storage.SpecStageSpecify,
+	specv1.AuthoringStage_AUTHORING_STAGE_DECOMPOSE: storage.SpecStageDecompose,
+	specv1.AuthoringStage_AUTHORING_STAGE_APPROVED:  storage.SpecStageApproved,
 }
 
 // runInTxOrSequential runs the given operations within a transaction if the

--- a/internal/server/authoring_handler_test.go
+++ b/internal/server/authoring_handler_test.go
@@ -33,7 +33,7 @@ type fakeAuthoringBackend struct {
 	storeSafetyFlagsErr     error
 }
 
-func (f *fakeAuthoringBackend) TransitionStage(_ context.Context, _ string, _, _ storage.AuthoringStage) error {
+func (f *fakeAuthoringBackend) TransitionStage(_ context.Context, _ string, _, _ storage.SpecStage) error {
 	return f.transitionStageErr
 }
 
@@ -68,7 +68,7 @@ func (f *fakeAuthoringBackend) SupersedeSpec(_ context.Context, _, _, _ string) 
 	return f.supersedeErr
 }
 
-func (f *fakeAuthoringBackend) AmendSpec(_ context.Context, _, _ string, _ storage.AuthoringStage) (*storage.AmendResult, error) {
+func (f *fakeAuthoringBackend) AmendSpec(_ context.Context, _, _ string, _ storage.SpecStage) (*storage.AmendResult, error) {
 	return f.amendResult, f.amendErr
 }
 
@@ -164,7 +164,7 @@ func (a *authoringTestBackend) Close(ctx context.Context) error {
 	return a.backend.Close(ctx)
 }
 
-func (a *authoringTestBackend) TransitionStage(ctx context.Context, slug string, from, to storage.AuthoringStage) error {
+func (a *authoringTestBackend) TransitionStage(ctx context.Context, slug string, from, to storage.SpecStage) error {
 	return a.authoring.TransitionStage(ctx, slug, from, to)
 }
 
@@ -192,7 +192,7 @@ func (a *authoringTestBackend) SupersedeSpec(ctx context.Context, slug, supersed
 	return a.authoring.SupersedeSpec(ctx, slug, supersededBy, reason)
 }
 
-func (a *authoringTestBackend) AmendSpec(ctx context.Context, slug, reason string, targetStage storage.AuthoringStage) (*storage.AmendResult, error) {
+func (a *authoringTestBackend) AmendSpec(ctx context.Context, slug, reason string, targetStage storage.SpecStage) (*storage.AmendResult, error) {
 	return a.authoring.AmendSpec(ctx, slug, reason, targetStage)
 }
 
@@ -404,7 +404,7 @@ func TestAuthoringHandler_Approve_HappyPath(t *testing.T) {
 
 func TestAuthoringHandler_Amend_HappyPath(t *testing.T) {
 	client := newAuthoringClient(t, &fakeAuthoringBackend{
-		amendResult: &storage.AmendResult{Slug: "my-spec", Stage: storage.AuthoringStage("shape"), Version: 2},
+		amendResult: &storage.AmendResult{Slug: "my-spec", Stage: storage.SpecStageShape, Version: 2},
 	}, &fakeBackend{})
 	resp, err := client.Amend(context.Background(), connect.NewRequest(&specv1.AmendRequest{
 		Slug:        "my-spec",
@@ -780,7 +780,7 @@ func TestAuthoringHandler_Supersede_SelfSupersede(t *testing.T) {
 
 func TestAuthoringHandler_Amend_EmptyReason(t *testing.T) {
 	client := newAuthoringClient(t, &fakeAuthoringBackend{
-		amendResult: &storage.AmendResult{Slug: "my-spec", Stage: storage.AuthoringStage("shape"), Version: 2},
+		amendResult: &storage.AmendResult{Slug: "my-spec", Stage: storage.SpecStageShape, Version: 2},
 	}, &fakeBackend{})
 	_, err := client.Amend(context.Background(), connect.NewRequest(&specv1.AmendRequest{
 		Slug:        "my-spec",
@@ -795,7 +795,7 @@ func TestAuthoringHandler_Amend_EmptyReason(t *testing.T) {
 
 func TestAuthoringHandler_Amend_UnspecifiedTargetStage(t *testing.T) {
 	client := newAuthoringClient(t, &fakeAuthoringBackend{
-		amendResult: &storage.AmendResult{Slug: "my-spec", Stage: storage.AuthoringStage("shape"), Version: 2},
+		amendResult: &storage.AmendResult{Slug: "my-spec", Stage: storage.SpecStageShape, Version: 2},
 	}, &fakeBackend{})
 	_, err := client.Amend(context.Background(), connect.NewRequest(&specv1.AmendRequest{
 		Slug:        "my-spec",
@@ -1028,7 +1028,7 @@ func TestAuthoringHandler_Shape_UnspecifiedPostureResolved(t *testing.T) {
 func TestAuthoringHandler_Amend_ApprovedTargetStageRejected(t *testing.T) {
 	// Amend with target_stage=APPROVED should return CodeInvalidArgument.
 	client := newAuthoringClient(t, &fakeAuthoringBackend{
-		amendResult: &storage.AmendResult{Slug: "my-spec", Stage: storage.AuthoringStage("shape"), Version: 2},
+		amendResult: &storage.AmendResult{Slug: "my-spec", Stage: storage.SpecStageShape, Version: 2},
 	}, &fakeBackend{})
 	_, err := client.Amend(context.Background(), connect.NewRequest(&specv1.AmendRequest{
 		Slug:        "my-spec",
@@ -1258,7 +1258,7 @@ func TestAuthoringHandler_Shape_InvalidDecisionSlug(t *testing.T) {
 func TestAuthoringHandler_Amend_UnknownStageFromStorage(t *testing.T) {
 	// When AmendSpec returns a stage unknown to stageToProto, handler returns CodeInternal.
 	authoringStore := &fakeAuthoringBackend{
-		amendResult: &storage.AmendResult{Slug: "my-spec", Stage: storage.AuthoringStage("bogus-stage"), Version: 3},
+		amendResult: &storage.AmendResult{Slug: "my-spec", Stage: storage.SpecStage("bogus-stage"), Version: 3},
 	}
 	client := newAuthoringClient(t, authoringStore, &fakeBackend{})
 	_, err := client.Amend(context.Background(), connect.NewRequest(&specv1.AmendRequest{
@@ -1270,7 +1270,7 @@ func TestAuthoringHandler_Amend_UnknownStageFromStorage(t *testing.T) {
 	var connErr *connect.Error
 	require.ErrorAs(t, err, &connErr)
 	require.Equal(t, connect.CodeInternal, connErr.Code())
-	require.Contains(t, connErr.Message(), "unknown stage")
+	require.Equal(t, "internal error", connErr.Message())
 }
 
 func TestAuthoringHandler_Specify_InterfacesMissingName(t *testing.T) {

--- a/internal/server/claim_handler.go
+++ b/internal/server/claim_handler.go
@@ -6,6 +6,7 @@ package server
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -42,13 +43,7 @@ func (h *ClaimHandler) ClaimSpec(ctx context.Context, req *connect.Request[specv
 
 	claim, err := store.ClaimSpec(ctx, msg.SpecSlug, msg.Agent, leaseDuration)
 	if err != nil {
-		if errors.Is(err, storage.ErrSpecNotFound) {
-			return nil, connect.NewError(connect.CodeNotFound, err)
-		}
-		if errors.Is(err, storage.ErrSpecAlreadyClaimed) {
-			return nil, connect.NewError(connect.CodeFailedPrecondition, err)
-		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, claimError(err)
 	}
 	return connect.NewResponse(&specv1.ClaimSpecResponse{Claim: claimToProto(claim)}), nil
 }
@@ -62,13 +57,7 @@ func (h *ClaimHandler) UnclaimSpec(ctx context.Context, req *connect.Request[spe
 	msg := req.Msg
 	err = store.UnclaimSpec(ctx, msg.SpecSlug, msg.Agent)
 	if err != nil {
-		if errors.Is(err, storage.ErrNotClaimOwner) {
-			return nil, connect.NewError(connect.CodePermissionDenied, err)
-		}
-		if errors.Is(err, storage.ErrSpecNotClaimed) {
-			return nil, connect.NewError(connect.CodeNotFound, err)
-		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, claimError(err)
 	}
 	return connect.NewResponse(&specv1.UnclaimSpecResponse{}), nil
 }
@@ -88,9 +77,30 @@ func (h *ClaimHandler) Heartbeat(ctx context.Context, req *connect.Request[specv
 
 	claim, err := store.Heartbeat(ctx, msg.SpecSlug, msg.Agent, extendBy)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeNotFound, err)
+		return nil, claimError(err)
 	}
 	return connect.NewResponse(&specv1.HeartbeatResponse{Claim: claimToProto(claim)}), nil
+}
+
+// claimError maps storage errors to sanitized connect error codes.
+func claimError(err error) error {
+	var connErr *connect.Error
+	if errors.As(err, &connErr) {
+		return connErr
+	}
+	switch {
+	case errors.Is(err, storage.ErrSpecNotFound):
+		return connect.NewError(connect.CodeNotFound, errors.New("spec not found"))
+	case errors.Is(err, storage.ErrSpecAlreadyClaimed):
+		return connect.NewError(connect.CodeFailedPrecondition, errors.New("spec already claimed"))
+	case errors.Is(err, storage.ErrNotClaimOwner):
+		return connect.NewError(connect.CodePermissionDenied, errors.New("agent does not own the claim"))
+	case errors.Is(err, storage.ErrSpecNotClaimed):
+		return connect.NewError(connect.CodeNotFound, errors.New("spec is not claimed"))
+	default:
+		slog.Error("claimError: internal error", slog.Any("error", err))
+		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
 }
 
 // RegisterClaimService registers the ClaimService on the given mux.

--- a/internal/server/constitution_handler.go
+++ b/internal/server/constitution_handler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"connectrpc.com/connect"
@@ -38,10 +39,7 @@ func (h *ConstitutionHandler) GetConstitution(ctx context.Context, _ *connect.Re
 	}
 	c, err := store.GetConstitution(ctx)
 	if err != nil {
-		if errors.Is(err, storage.ErrConstitutionNotFound) {
-			return nil, connect.NewError(connect.CodeNotFound, err)
-		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, constitutionError(err)
 	}
 	return connect.NewResponse(&specv1.GetConstitutionResponse{Constitution: constitutionToProto(c)}), nil
 }
@@ -58,7 +56,7 @@ func (h *ConstitutionHandler) UpdateConstitution(ctx context.Context, req *conne
 	}
 	c, err := store.UpdateConstitution(ctx, constitutionFromProto(msg.Constitution))
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, constitutionError(err)
 	}
 	return connect.NewResponse(&specv1.UpdateConstitutionResponse{Constitution: constitutionToProto(c)}), nil
 }
@@ -75,10 +73,7 @@ func (h *ConstitutionHandler) EmitToolFiles(ctx context.Context, req *connect.Re
 
 	c, err := store.GetConstitution(ctx)
 	if err != nil {
-		if errors.Is(err, storage.ErrConstitutionNotFound) {
-			return nil, connect.NewError(connect.CodeNotFound, err)
-		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, constitutionError(err)
 	}
 
 	formatStr, ok := outputFormatToString[req.Msg.Format]
@@ -95,4 +90,19 @@ func (h *ConstitutionHandler) EmitToolFiles(ctx context.Context, req *connect.Re
 		Content:  content,
 		Filename: filename,
 	}), nil
+}
+
+// constitutionError maps storage errors to sanitized connect error codes.
+func constitutionError(err error) error {
+	var connErr *connect.Error
+	if errors.As(err, &connErr) {
+		return connErr
+	}
+	switch {
+	case errors.Is(err, storage.ErrConstitutionNotFound):
+		return connect.NewError(connect.CodeNotFound, errors.New("constitution not found"))
+	default:
+		slog.Error("constitutionError: internal error", slog.Any("error", err))
+		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
 }

--- a/internal/server/decision_handler.go
+++ b/internal/server/decision_handler.go
@@ -35,12 +35,11 @@ func (h *DecisionHandler) CreateDecision(ctx context.Context, req *connect.Reque
 	}
 	d, err := store.CreateDecision(ctx, msg.Slug, msg.Title, msg.Decision, msg.Rationale)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "create decision failed", slog.Any("error", err))
-		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		return nil, h.decisionError(ctx, err)
 	}
 	pb, err := decisionToProto(d)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, h.decisionError(ctx, err)
 	}
 	return connect.NewResponse(&specv1.CreateDecisionResponse{Decision: pb}), nil
 }
@@ -56,15 +55,11 @@ func (h *DecisionHandler) GetDecision(ctx context.Context, req *connect.Request[
 	}
 	d, err := store.GetDecision(ctx, req.Msg.Slug)
 	if err != nil {
-		if errors.Is(err, storage.ErrDecisionNotFound) {
-			return nil, connect.NewError(connect.CodeNotFound, errors.New("decision not found"))
-		}
-		h.logger.ErrorContext(ctx, "get decision failed", slog.Any("error", err))
-		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		return nil, h.decisionError(ctx, err)
 	}
 	pb, err := decisionToProto(d)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, h.decisionError(ctx, err)
 	}
 	return connect.NewResponse(&specv1.GetDecisionResponse{Decision: pb}), nil
 }
@@ -92,12 +87,11 @@ func (h *DecisionHandler) ListDecisions(ctx context.Context, req *connect.Reques
 	}
 	decisions, err := store.ListDecisions(ctx, status, limit)
 	if err != nil {
-		h.logger.ErrorContext(ctx, "list decisions failed", slog.Any("error", err))
-		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		return nil, h.decisionError(ctx, err)
 	}
 	pbs, err := decisionsToProto(decisions)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, h.decisionError(ctx, err)
 	}
 	return connect.NewResponse(&specv1.ListDecisionsResponse{Decisions: pbs}), nil
 }
@@ -123,23 +117,32 @@ func (h *DecisionHandler) UpdateDecision(ctx context.Context, req *connect.Reque
 	}
 	d, err := store.UpdateDecision(ctx, msg.Slug, msg.Title, domainStatus, msg.Decision, msg.Rationale, msg.SupersededBy)
 	if err != nil {
-		if errors.Is(err, storage.ErrDecisionNotFound) {
-			return nil, connect.NewError(connect.CodeNotFound, errors.New("decision not found"))
-		}
-		if errors.Is(err, storage.ErrSupersededByRequired) {
-			return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("superseded_by is required when status is superseded"))
-		}
-		if errors.Is(err, storage.ErrConcurrentModification) {
-			return nil, connect.NewError(connect.CodeAborted, errors.New("concurrent modification — retry the operation"))
-		}
-		h.logger.ErrorContext(ctx, "update decision failed", slog.Any("error", err))
-		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
+		return nil, h.decisionError(ctx, err)
 	}
 	pb, err := decisionToProto(d)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, h.decisionError(ctx, err)
 	}
 	return connect.NewResponse(&specv1.UpdateDecisionResponse{Decision: pb}), nil
+}
+
+// decisionError maps storage errors to sanitized connect error codes.
+func (h *DecisionHandler) decisionError(ctx context.Context, err error) error {
+	var connErr *connect.Error
+	if errors.As(err, &connErr) {
+		return connErr
+	}
+	switch {
+	case errors.Is(err, storage.ErrDecisionNotFound):
+		return connect.NewError(connect.CodeNotFound, errors.New("decision not found"))
+	case errors.Is(err, storage.ErrSupersededByRequired):
+		return connect.NewError(connect.CodeInvalidArgument, errors.New("superseded_by is required when status is superseded"))
+	case errors.Is(err, storage.ErrConcurrentModification):
+		return connect.NewError(connect.CodeAborted, errors.New("concurrent modification — retry the operation"))
+	default:
+		h.logger.ErrorContext(ctx, "decisionError: internal error", slog.Any("error", err))
+		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
 }
 
 // RegisterDecisionService registers the DecisionService on the given mux.

--- a/internal/server/error_mapper_internal_test.go
+++ b/internal/server/error_mapper_internal_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assertConnectCode is a test helper that verifies err is a *connect.Error with the expected code.
+func assertConnectCode(t *testing.T, err error, wantCode connect.Code) {
+	t.Helper()
+	var connErr *connect.Error
+	require.True(t, errors.As(err, &connErr), "expected *connect.Error, got %T", err)
+	assert.Equal(t, wantCode, connErr.Code())
+}
+
+func TestSpecError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode connect.Code
+	}{
+		{"not found", storage.ErrSpecNotFound, connect.CodeNotFound},
+		{"already exists", storage.ErrSpecAlreadyExists, connect.CodeAlreadyExists},
+		{"concurrent modification", storage.ErrConcurrentModification, connect.CodeAborted},
+		{"connect error passthrough", connect.NewError(connect.CodePermissionDenied, errors.New("denied")), connect.CodePermissionDenied},
+		{"unknown error", errors.New("boom"), connect.CodeInternal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertConnectCode(t, specError(tt.err), tt.wantCode)
+		})
+	}
+}
+
+func TestClaimError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode connect.Code
+	}{
+		{"spec not found", storage.ErrSpecNotFound, connect.CodeNotFound},
+		{"already claimed", storage.ErrSpecAlreadyClaimed, connect.CodeFailedPrecondition},
+		{"not claim owner", storage.ErrNotClaimOwner, connect.CodePermissionDenied},
+		{"spec not claimed", storage.ErrSpecNotClaimed, connect.CodeNotFound},
+		{"connect error passthrough", connect.NewError(connect.CodeUnauthenticated, errors.New("no auth")), connect.CodeUnauthenticated},
+		{"unknown error", errors.New("boom"), connect.CodeInternal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertConnectCode(t, claimError(tt.err), tt.wantCode)
+		})
+	}
+}
+
+func TestDecisionError(t *testing.T) {
+	h := &DecisionHandler{logger: slog.Default()}
+	ctx := context.Background()
+	tests := []struct {
+		name     string
+		err      error
+		wantCode connect.Code
+	}{
+		{"decision not found", storage.ErrDecisionNotFound, connect.CodeNotFound},
+		{"superseded_by required", storage.ErrSupersededByRequired, connect.CodeInvalidArgument},
+		{"concurrent modification", storage.ErrConcurrentModification, connect.CodeAborted},
+		{"connect error passthrough", connect.NewError(connect.CodeResourceExhausted, errors.New("too many")), connect.CodeResourceExhausted},
+		{"unknown error", errors.New("boom"), connect.CodeInternal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertConnectCode(t, h.decisionError(ctx, tt.err), tt.wantCode)
+		})
+	}
+}
+
+func TestGraphError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode connect.Code
+	}{
+		{"spec not found", storage.ErrSpecNotFound, connect.CodeNotFound},
+		{"edge not found", storage.ErrEdgeNotFound, connect.CodeNotFound},
+		{"connect error passthrough", connect.NewError(connect.CodeInvalidArgument, errors.New("bad")), connect.CodeInvalidArgument},
+		{"unknown error", errors.New("boom"), connect.CodeInternal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertConnectCode(t, graphError(tt.err), tt.wantCode)
+		})
+	}
+}
+
+func TestAnalyticalPassError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode connect.Code
+	}{
+		{"spec not found", storage.ErrSpecNotFound, connect.CodeNotFound},
+		{"connect error passthrough", connect.NewError(connect.CodeDeadlineExceeded, errors.New("timeout")), connect.CodeDeadlineExceeded},
+		{"unknown error", errors.New("boom"), connect.CodeInternal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertConnectCode(t, analyticalPassError(tt.err), tt.wantCode)
+		})
+	}
+}
+
+func TestExecutionError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode connect.Code
+	}{
+		{"spec not found", storage.ErrSpecNotFound, connect.CodeNotFound},
+		{"spec not approved", storage.ErrSpecNotApproved, connect.CodeFailedPrecondition},
+		{"agent not claim owner", storage.ErrAgentNotClaimOwner, connect.CodePermissionDenied},
+		{"connect error passthrough", connect.NewError(connect.CodeCanceled, errors.New("canceled")), connect.CodeCanceled},
+		{"unknown error", errors.New("boom"), connect.CodeInternal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertConnectCode(t, executionError(tt.err), tt.wantCode)
+		})
+	}
+}
+
+func TestConstitutionError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode connect.Code
+	}{
+		{"constitution not found", storage.ErrConstitutionNotFound, connect.CodeNotFound},
+		{"connect error passthrough", connect.NewError(connect.CodeDataLoss, errors.New("lost")), connect.CodeDataLoss},
+		{"unknown error", errors.New("boom"), connect.CodeInternal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertConnectCode(t, constitutionError(tt.err), tt.wantCode)
+		})
+	}
+}
+
+func TestLifecycleError(t *testing.T) {
+	h := &LifecycleHandler{logger: slog.Default()}
+	tests := []struct {
+		name     string
+		err      error
+		wantCode connect.Code
+	}{
+		{"spec not found", storage.ErrSpecNotFound, connect.CodeNotFound},
+		{"spec not done", storage.ErrSpecNotDone, connect.CodeFailedPrecondition},
+		{"spec ineligible stage", storage.ErrSpecIneligibleStage, connect.CodeFailedPrecondition},
+		{"spec terminal", storage.ErrSpecTerminal, connect.CodeFailedPrecondition},
+		{"spec ineligible for drift", storage.ErrSpecIneligibleForDrift, connect.CodeFailedPrecondition},
+		{"new spec not found", storage.ErrNewSpecNotFound, connect.CodeNotFound},
+		{"new spec terminal", storage.ErrNewSpecTerminal, connect.CodeFailedPrecondition},
+		{"concurrent modification", storage.ErrConcurrentModification, connect.CodeAborted},
+		{"internal guard failure", storage.ErrInternalGuardFailure, connect.CodeInternal},
+		{"invalid re-entry stage", storage.ErrInvalidReEntryStage, connect.CodeInvalidArgument},
+		{"edge not found", storage.ErrEdgeNotFound, connect.CodeNotFound},
+		{"same slugs", storage.ErrSameSlugs, connect.CodeInvalidArgument},
+		{"connect error passthrough", connect.NewError(connect.CodeAborted, errors.New("abort")), connect.CodeAborted},
+		{"unknown error", errors.New("boom"), connect.CodeInternal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertConnectCode(t, h.lifecycleError("TestOp", "test-slug", tt.err), tt.wantCode)
+		})
+	}
+}

--- a/internal/server/error_sanitize_test.go
+++ b/internal/server/error_sanitize_test.go
@@ -1,0 +1,624 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package server_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// errRawDB simulates a raw database error that should never be exposed to clients.
+var errRawDB = errors.New("memgraph: bolt connection failed: MATCH (n:Spec {slug: $slug}) RETURN n")
+
+// assertSanitized verifies that an error response does not leak internal details.
+func assertSanitized(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	msg := err.Error()
+	for _, leak := range []string{"memgraph:", "bolt:", "MATCH", "RETURN", "Cypher"} {
+		require.False(t, strings.Contains(msg, leak),
+			"error message should not contain %q, got: %s", leak, msg)
+	}
+}
+
+// --- errorBackend returns raw DB errors for every method ---
+
+type errorBackend struct {
+	stubBackend
+}
+
+func (errorBackend) CreateSpec(context.Context, string, string, string, string) (*storage.Spec, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) GetSpec(context.Context, string) (*storage.Spec, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) ListSpecs(context.Context, string, string, int) ([]*storage.Spec, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) UpdateSpec(context.Context, string, *string, *string, *string, *string, *string) (*storage.Spec, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) AddEdge(context.Context, string, string, storage.EdgeType) (*storage.Edge, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) RemoveEdge(context.Context, string, string, storage.EdgeType) error {
+	return errRawDB
+}
+
+func (errorBackend) ListEdges(context.Context, string, storage.EdgeType) ([]*storage.Edge, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) GetDependencies(context.Context, string) ([]storage.NodeRef, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) GetTransitiveDeps(context.Context, string) ([]storage.NodeRef, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) GetImpact(context.Context, string) ([]storage.NodeRef, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) GetReady(context.Context) ([]storage.NodeRef, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) GetCriticalPath(context.Context, string) ([]storage.NodeRef, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) GetFullGraph(context.Context) (*storage.FullGraph, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) GetConstitution(context.Context) (*storage.Constitution, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) UpdateConstitution(context.Context, *storage.Constitution) (*storage.Constitution, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) ClaimSpec(context.Context, string, string, time.Duration) (*storage.Claim, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) UnclaimSpec(context.Context, string, string) error {
+	return errRawDB
+}
+
+func (errorBackend) Heartbeat(context.Context, string, string, time.Duration) (*storage.Claim, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) CreateDecision(context.Context, string, string, string, string) (*storage.Decision, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) GetDecision(context.Context, string) (*storage.Decision, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) ListDecisions(context.Context, storage.DecisionStatus, int) ([]*storage.Decision, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) UpdateDecision(context.Context, string, *string, *storage.DecisionStatus, *string, *string, *string) (*storage.Decision, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) GenerateBundle(context.Context, string) (*storage.Bundle, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) RecordProgress(context.Context, string, string, string) error {
+	return errRawDB
+}
+
+func (errorBackend) RecordBlocker(context.Context, string, string, string) error {
+	return errRawDB
+}
+
+func (errorBackend) RecordCompletion(context.Context, string, string) error {
+	return errRawDB
+}
+
+func (errorBackend) GetExecutionEvents(context.Context, string, int) ([]*storage.ExecutionEvent, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) GetPrimeData(context.Context, string) (*storage.PrimeData, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) StoreFindings(context.Context, string, storage.PassType, []storage.AnalyticalFindingInput) ([]string, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) ListFindings(context.Context, string, storage.PassType) ([]storage.AnalyticalFinding, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) LifecycleAmendSpec(context.Context, string, string, string) (*storage.Spec, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) LifecycleSupersedeSpec(context.Context, string, string) (*storage.Spec, *storage.Spec, error) {
+	return nil, nil, errRawDB
+}
+
+func (errorBackend) LifecycleAbandonSpec(context.Context, string, string) (*storage.Spec, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) LifecycleAcknowledgeDrift(context.Context, string, string, string) error {
+	return errRawDB
+}
+
+func (errorBackend) ListSlices(context.Context, string) ([]*storage.Slice, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) GetSlice(context.Context, string) (*storage.Slice, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) ClaimSlice(context.Context, string, string) (*storage.Slice, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) CompleteSlice(context.Context, string) (*storage.Slice, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) GetProject(context.Context, string) (*storage.Project, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) EnsureProject(context.Context, string) (*storage.Project, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) UpdateProject(context.Context, string, []string, string) (*storage.Project, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) ListProjects(context.Context) ([]*storage.Project, error) {
+	return nil, errRawDB
+}
+
+// --- SpecService error sanitization tests ---
+
+func TestSpecHandler_ErrorSanitization(t *testing.T) {
+	scoper := &testScoper{backend: errorBackend{}}
+	srv := httptest.NewServer(wrapTestProject(server.NewMux(scoper)))
+	t.Cleanup(srv.Close)
+	client := specgraphv1connect.NewSpecServiceClient(http.DefaultClient, srv.URL)
+	ctx := context.Background()
+
+	t.Run("CreateSpec", func(t *testing.T) {
+		_, err := client.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+			Slug: "test-spec", Intent: "test",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("GetSpec", func(t *testing.T) {
+		_, err := client.GetSpec(ctx, connect.NewRequest(&specv1.GetSpecRequest{
+			Slug: "test-spec",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("ListSpecs", func(t *testing.T) {
+		_, err := client.ListSpecs(ctx, connect.NewRequest(&specv1.ListSpecsRequest{}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("UpdateSpec", func(t *testing.T) {
+		_, err := client.UpdateSpec(ctx, connect.NewRequest(&specv1.UpdateSpecRequest{
+			Slug: "test-spec",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+}
+
+// --- GraphService error sanitization tests ---
+
+func TestGraphHandler_ErrorSanitization(t *testing.T) {
+	scoper := &testScoper{backend: errorBackend{}}
+	mux := http.NewServeMux()
+	server.RegisterGraphService(mux, scoper)
+	srv := httptest.NewServer(wrapTestProject(mux))
+	t.Cleanup(srv.Close)
+	client := specgraphv1connect.NewGraphServiceClient(http.DefaultClient, srv.URL)
+	ctx := context.Background()
+
+	t.Run("AddEdge", func(t *testing.T) {
+		_, err := client.AddEdge(ctx, connect.NewRequest(&specv1.AddEdgeRequest{
+			FromSlug: "spec-a", ToSlug: "spec-b",
+			EdgeType: specv1.EdgeType_EDGE_TYPE_DEPENDS_ON,
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("RemoveEdge", func(t *testing.T) {
+		_, err := client.RemoveEdge(ctx, connect.NewRequest(&specv1.RemoveEdgeRequest{
+			FromSlug: "spec-a", ToSlug: "spec-b",
+			EdgeType: specv1.EdgeType_EDGE_TYPE_DEPENDS_ON,
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("ListEdges", func(t *testing.T) {
+		_, err := client.ListEdges(ctx, connect.NewRequest(&specv1.ListEdgesRequest{
+			Slug: "spec-a",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("GetDependencies", func(t *testing.T) {
+		_, err := client.GetDependencies(ctx, connect.NewRequest(&specv1.GetDependenciesRequest{
+			Slug: "spec-a",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("GetTransitiveDeps", func(t *testing.T) {
+		_, err := client.GetTransitiveDeps(ctx, connect.NewRequest(&specv1.GetTransitiveDepsRequest{
+			Slug: "spec-a",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("GetImpact", func(t *testing.T) {
+		_, err := client.GetImpact(ctx, connect.NewRequest(&specv1.GetImpactRequest{
+			Slug: "spec-a",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("GetReady", func(t *testing.T) {
+		_, err := client.GetReady(ctx, connect.NewRequest(&specv1.GetReadyRequest{}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("GetCriticalPath", func(t *testing.T) {
+		_, err := client.GetCriticalPath(ctx, connect.NewRequest(&specv1.GetCriticalPathRequest{
+			Slug: "spec-a",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("GetFullGraph", func(t *testing.T) {
+		_, err := client.GetFullGraph(ctx, connect.NewRequest(&specv1.GetFullGraphRequest{}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+}
+
+// --- ConstitutionService error sanitization tests ---
+
+func TestConstitutionHandler_ErrorSanitization(t *testing.T) {
+	scoper := &testScoper{backend: errorBackend{}}
+	mux := http.NewServeMux()
+	server.RegisterConstitutionService(mux, scoper)
+	srv := httptest.NewServer(wrapTestProject(mux))
+	t.Cleanup(srv.Close)
+	client := specgraphv1connect.NewConstitutionServiceClient(http.DefaultClient, srv.URL)
+	ctx := context.Background()
+
+	t.Run("GetConstitution", func(t *testing.T) {
+		_, err := client.GetConstitution(ctx, connect.NewRequest(&specv1.GetConstitutionRequest{}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("UpdateConstitution", func(t *testing.T) {
+		_, err := client.UpdateConstitution(ctx, connect.NewRequest(&specv1.UpdateConstitutionRequest{
+			Constitution: &specv1.Constitution{Name: "test"},
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+}
+
+// --- ClaimService error sanitization tests ---
+
+func TestClaimHandler_ErrorSanitization(t *testing.T) {
+	scoper := &testScoper{backend: errorBackend{}}
+	mux := http.NewServeMux()
+	server.RegisterClaimService(mux, scoper)
+	srv := httptest.NewServer(wrapTestProject(mux))
+	t.Cleanup(srv.Close)
+	client := specgraphv1connect.NewClaimServiceClient(http.DefaultClient, srv.URL)
+	ctx := context.Background()
+
+	t.Run("ClaimSpec", func(t *testing.T) {
+		_, err := client.ClaimSpec(ctx, connect.NewRequest(&specv1.ClaimSpecRequest{
+			SpecSlug: "test-spec", Agent: "agent-1",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("UnclaimSpec", func(t *testing.T) {
+		_, err := client.UnclaimSpec(ctx, connect.NewRequest(&specv1.UnclaimSpecRequest{
+			SpecSlug: "test-spec", Agent: "agent-1",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("Heartbeat", func(t *testing.T) {
+		_, err := client.Heartbeat(ctx, connect.NewRequest(&specv1.HeartbeatRequest{
+			SpecSlug: "test-spec", Agent: "agent-1",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+}
+
+// --- ExecutionService error sanitization tests ---
+
+func TestExecutionHandler_ErrorSanitization(t *testing.T) {
+	scoper := &testScoper{backend: errorBackend{}}
+	mux := http.NewServeMux()
+	server.RegisterExecutionService(mux, scoper)
+	srv := httptest.NewServer(wrapTestProject(mux))
+	t.Cleanup(srv.Close)
+	client := specgraphv1connect.NewExecutionServiceClient(http.DefaultClient, srv.URL)
+	ctx := context.Background()
+
+	t.Run("GenerateBundle", func(t *testing.T) {
+		_, err := client.GenerateBundle(ctx, connect.NewRequest(&specv1.GenerateBundleRequest{
+			Slug: "test-spec",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("GetPrime", func(t *testing.T) {
+		_, err := client.GetPrime(ctx, connect.NewRequest(&specv1.GetPrimeRequest{
+			Slug: "test-spec",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("ReportProgress", func(t *testing.T) {
+		_, err := client.ReportProgress(ctx, connect.NewRequest(&specv1.ReportProgressRequest{
+			Slug: "test-spec", Agent: "agent-1", Message: "working",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("ReportBlocker", func(t *testing.T) {
+		_, err := client.ReportBlocker(ctx, connect.NewRequest(&specv1.ReportBlockerRequest{
+			Slug: "test-spec", Agent: "agent-1", Description: "stuck",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("ReportCompletion", func(t *testing.T) {
+		_, err := client.ReportCompletion(ctx, connect.NewRequest(&specv1.ReportCompletionRequest{
+			Slug: "test-spec", Agent: "agent-1",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("GetExecutionEvents", func(t *testing.T) {
+		_, err := client.GetExecutionEvents(ctx, connect.NewRequest(&specv1.GetExecutionEventsRequest{
+			Slug: "test-spec",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+}
+
+// --- DecisionService error sanitization tests ---
+
+func TestDecisionHandler_ErrorSanitization(t *testing.T) {
+	scoper := &testScoper{backend: errorBackend{}}
+	mux := http.NewServeMux()
+	server.RegisterDecisionService(mux, scoper)
+	srv := httptest.NewServer(wrapTestProject(mux))
+	t.Cleanup(srv.Close)
+	client := specgraphv1connect.NewDecisionServiceClient(http.DefaultClient, srv.URL)
+	ctx := context.Background()
+
+	t.Run("CreateDecision", func(t *testing.T) {
+		_, err := client.CreateDecision(ctx, connect.NewRequest(&specv1.CreateDecisionRequest{
+			Slug: "adr-001", Title: "test", Decision: "do it", Rationale: "because",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("GetDecision", func(t *testing.T) {
+		_, err := client.GetDecision(ctx, connect.NewRequest(&specv1.GetDecisionRequest{
+			Slug: "adr-001",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("ListDecisions", func(t *testing.T) {
+		_, err := client.ListDecisions(ctx, connect.NewRequest(&specv1.ListDecisionsRequest{}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("UpdateDecision", func(t *testing.T) {
+		_, err := client.UpdateDecision(ctx, connect.NewRequest(&specv1.UpdateDecisionRequest{
+			Slug: "adr-001",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+}
+
+// --- AnalyticalPassService error sanitization tests ---
+
+func TestAnalyticalPassHandler_ErrorSanitization(t *testing.T) {
+	scoper := &testScoper{backend: errorBackend{}}
+	mux := http.NewServeMux()
+	server.RegisterAnalyticalPassService(mux, scoper, "")
+	srv := httptest.NewServer(wrapTestProject(mux))
+	t.Cleanup(srv.Close)
+	client := specgraphv1connect.NewAnalyticalPassServiceClient(http.DefaultClient, srv.URL)
+	ctx := context.Background()
+
+	t.Run("RunAnalyticalPass", func(t *testing.T) {
+		_, err := client.RunAnalyticalPass(ctx, connect.NewRequest(&specv1.RunAnalyticalPassRequest{
+			Slug:     "test-spec",
+			PassType: specv1.PassType_PASS_TYPE_CONSTITUTION_CHECK,
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("StoreFindings", func(t *testing.T) {
+		_, err := client.StoreFindings(ctx, connect.NewRequest(&specv1.StoreFindingsRequest{
+			Slug:     "test-spec",
+			PassType: specv1.PassType_PASS_TYPE_CONSTITUTION_CHECK,
+			Findings: []*specv1.AnalyticalFindingInput{
+				{Summary: "test", Severity: specv1.FindingSeverity_FINDING_SEVERITY_NOTE},
+			},
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("ListFindings", func(t *testing.T) {
+		_, err := client.ListFindings(ctx, connect.NewRequest(&specv1.ListFindingsRequest{
+			Slug: "test-spec",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+}
+
+// --- LifecycleService error sanitization tests ---
+
+func TestLifecycleHandler_ErrorSanitization(t *testing.T) {
+	scoper := &testScoper{backend: errorBackend{}}
+	mux := http.NewServeMux()
+	server.RegisterLifecycleService(mux, scoper, nil, nil, nil)
+	srv := httptest.NewServer(wrapTestProject(mux))
+	t.Cleanup(srv.Close)
+	client := specgraphv1connect.NewLifecycleServiceClient(http.DefaultClient, srv.URL)
+	ctx := context.Background()
+
+	t.Run("TransitionAmend", func(t *testing.T) {
+		_, err := client.TransitionAmend(ctx, connect.NewRequest(&specv1.TransitionAmendRequest{
+			Slug: "test-spec", Reason: "needs rework",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("TransitionAbandon", func(t *testing.T) {
+		_, err := client.TransitionAbandon(ctx, connect.NewRequest(&specv1.TransitionAbandonRequest{
+			Slug: "test-spec", Reason: "no longer needed",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("TransitionSupersede", func(t *testing.T) {
+		_, err := client.TransitionSupersede(ctx, connect.NewRequest(&specv1.TransitionSupersedeRequest{
+			Slug: "spec-a", NewSlug: "spec-b",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("AcknowledgeDrift", func(t *testing.T) {
+		_, err := client.AcknowledgeDrift(ctx, connect.NewRequest(&specv1.DriftAcknowledgeRequest{
+			Slug: "test-spec", All: true,
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+}
+
+// --- SliceService error sanitization tests ---
+
+func TestSliceHandler_ErrorSanitization(t *testing.T) {
+	scoper := &testScoper{backend: errorBackend{}}
+	mux := http.NewServeMux()
+	server.RegisterSliceService(mux, scoper)
+	srv := httptest.NewServer(wrapTestProject(mux))
+	t.Cleanup(srv.Close)
+	client := specgraphv1connect.NewSliceServiceClient(http.DefaultClient, srv.URL)
+	ctx := context.Background()
+
+	t.Run("ListSlices", func(t *testing.T) {
+		_, err := client.ListSlices(ctx, connect.NewRequest(&specv1.ListSlicesRequest{
+			ParentSlug: "test-spec",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("GetSlice", func(t *testing.T) {
+		_, err := client.GetSlice(ctx, connect.NewRequest(&specv1.GetSliceRequest{
+			Slug: "test-spec",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("ClaimSlice", func(t *testing.T) {
+		_, err := client.ClaimSlice(ctx, connect.NewRequest(&specv1.ClaimSliceRequest{
+			Slug: "test-spec", Assignee: "agent-1",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+
+	t.Run("CompleteSlice", func(t *testing.T) {
+		_, err := client.CompleteSlice(ctx, connect.NewRequest(&specv1.CompleteSliceRequest{
+			Slug: "test-spec",
+		}))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		assertSanitized(t, err)
+	})
+}

--- a/internal/server/execution_handler.go
+++ b/internal/server/execution_handler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -61,7 +62,7 @@ func (h *ExecutionHandler) GenerateBundle(ctx context.Context, req *connect.Requ
 
 	pb, err := bundleToProto(b)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("convert bundle: %w", err))
+		return nil, executionError(err)
 	}
 	pb.BundleContent = renderBundleMarkdown(b)
 
@@ -86,7 +87,7 @@ func (h *ExecutionHandler) GetPrime(ctx context.Context, req *connect.Request[sp
 
 	decisions, err := decisionsToProto(pd.Decisions)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("convert decisions: %w", err))
+		return nil, executionError(err)
 	}
 
 	var constitutionSummary string
@@ -215,16 +216,21 @@ func (h *ExecutionHandler) GetExecutionEvents(ctx context.Context, req *connect.
 	}), nil
 }
 
-// executionError maps storage errors to appropriate connect error codes.
+// executionError maps storage errors to sanitized connect error codes.
 func executionError(err error) error {
+	var connErr *connect.Error
+	if errors.As(err, &connErr) {
+		return connErr
+	}
 	switch {
 	case errors.Is(err, storage.ErrSpecNotFound):
-		return connect.NewError(connect.CodeNotFound, err)
+		return connect.NewError(connect.CodeNotFound, errors.New("spec not found"))
 	case errors.Is(err, storage.ErrSpecNotApproved):
-		return connect.NewError(connect.CodeFailedPrecondition, err)
+		return connect.NewError(connect.CodeFailedPrecondition, errors.New("spec is not in an approved or in_progress stage"))
 	case errors.Is(err, storage.ErrAgentNotClaimOwner):
-		return connect.NewError(connect.CodePermissionDenied, err)
+		return connect.NewError(connect.CodePermissionDenied, errors.New("agent does not hold the claim for this spec"))
 	default:
-		return connect.NewError(connect.CodeInternal, err)
+		slog.Error("executionError: internal error", slog.Any("error", err))
+		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 }

--- a/internal/server/graph_handler.go
+++ b/internal/server/graph_handler.go
@@ -5,7 +5,9 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"connectrpc.com/connect"
@@ -39,11 +41,11 @@ func (h *GraphHandler) AddEdge(ctx context.Context, req *connect.Request[specv1.
 	}
 	edge, err := store.AddEdge(ctx, req.Msg.FromSlug, req.Msg.ToSlug, et)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, graphError(err)
 	}
 	pb, err := edgeToProto(edge)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, graphError(err)
 	}
 	return connect.NewResponse(&specv1.AddEdgeResponse{Edge: pb}), nil
 }
@@ -65,7 +67,7 @@ func (h *GraphHandler) RemoveEdge(ctx context.Context, req *connect.Request[spec
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	if err := store.RemoveEdge(ctx, req.Msg.FromSlug, req.Msg.ToSlug, et); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, graphError(err)
 	}
 	return connect.NewResponse(&specv1.RemoveEdgeResponse{}), nil
 }
@@ -90,11 +92,11 @@ func (h *GraphHandler) ListEdges(ctx context.Context, req *connect.Request[specv
 	}
 	edges, err := store.ListEdges(ctx, req.Msg.Slug, et)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, graphError(err)
 	}
 	pbs, err := edgesToProto(edges)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, graphError(err)
 	}
 	return connect.NewResponse(&specv1.ListEdgesResponse{Edges: pbs}), nil
 }
@@ -110,7 +112,7 @@ func (h *GraphHandler) GetDependencies(ctx context.Context, req *connect.Request
 	}
 	refs, err := store.GetDependencies(ctx, req.Msg.Slug)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, graphError(err)
 	}
 	return connect.NewResponse(&specv1.GetDependenciesResponse{Dependencies: nodeRefsToProto(refs)}), nil
 }
@@ -126,7 +128,7 @@ func (h *GraphHandler) GetTransitiveDeps(ctx context.Context, req *connect.Reque
 	}
 	refs, err := store.GetTransitiveDeps(ctx, req.Msg.Slug)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, graphError(err)
 	}
 	return connect.NewResponse(&specv1.GetTransitiveDepsResponse{Dependencies: nodeRefsToProto(refs)}), nil
 }
@@ -142,7 +144,7 @@ func (h *GraphHandler) GetImpact(ctx context.Context, req *connect.Request[specv
 	}
 	refs, err := store.GetImpact(ctx, req.Msg.Slug)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, graphError(err)
 	}
 	return connect.NewResponse(&specv1.GetImpactResponse{Impacted: nodeRefsToProto(refs)}), nil
 }
@@ -155,7 +157,7 @@ func (h *GraphHandler) GetReady(ctx context.Context, _ *connect.Request[specv1.G
 	}
 	refs, err := store.GetReady(ctx)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, graphError(err)
 	}
 	return connect.NewResponse(&specv1.GetReadyResponse{Ready: nodeRefsToProto(refs)}), nil
 }
@@ -171,7 +173,7 @@ func (h *GraphHandler) GetCriticalPath(ctx context.Context, req *connect.Request
 	}
 	refs, err := store.GetCriticalPath(ctx, req.Msg.Slug)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, graphError(err)
 	}
 	return connect.NewResponse(&specv1.GetCriticalPathResponse{Path: nodeRefsToProto(refs)}), nil
 }
@@ -184,16 +186,33 @@ func (h *GraphHandler) GetFullGraph(ctx context.Context, _ *connect.Request[spec
 	}
 	graph, err := store.GetFullGraph(ctx)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, graphError(err)
 	}
 	pbs, err := edgesToProto(graph.Edges)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, graphError(err)
 	}
 	return connect.NewResponse(&specv1.GetFullGraphResponse{
 		Nodes: graphNodesToProto(graph.Nodes),
 		Edges: pbs,
 	}), nil
+}
+
+// graphError maps storage/conversion errors to sanitized connect error codes.
+func graphError(err error) error {
+	var connErr *connect.Error
+	if errors.As(err, &connErr) {
+		return connErr
+	}
+	switch {
+	case errors.Is(err, storage.ErrSpecNotFound):
+		return connect.NewError(connect.CodeNotFound, errors.New("spec not found"))
+	case errors.Is(err, storage.ErrEdgeNotFound):
+		return connect.NewError(connect.CodeNotFound, errors.New("edge not found"))
+	default:
+		slog.Error("graphError: internal error", slog.Any("error", err))
+		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
 }
 
 // RegisterGraphService registers the GraphService on the given mux.

--- a/internal/server/lifecycle_handler.go
+++ b/internal/server/lifecycle_handler.go
@@ -66,7 +66,7 @@ func (h *LifecycleHandler) TransitionAmend(ctx context.Context, req *connect.Req
 	}
 	pb, err := specToProto(spec)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, h.lifecycleError("TransitionAmend", msg.Slug, err)
 	}
 	return connect.NewResponse(&specv1.TransitionAmendResponse{Spec: pb}), nil
 }
@@ -94,11 +94,11 @@ func (h *LifecycleHandler) TransitionSupersede(ctx context.Context, req *connect
 	}
 	oldPb, err := specToProto(oldSpec)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, h.lifecycleError("TransitionSupersede", msg.Slug, err)
 	}
 	newPb, err := specToProto(newSpec)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, h.lifecycleError("TransitionSupersede", msg.Slug, err)
 	}
 	return connect.NewResponse(&specv1.TransitionSupersedeResponse{
 		OldSpec: oldPb,
@@ -126,7 +126,7 @@ func (h *LifecycleHandler) TransitionAbandon(ctx context.Context, req *connect.R
 	}
 	pb, err := specToProto(spec)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, h.lifecycleError("TransitionAbandon", msg.Slug, err)
 	}
 	return connect.NewResponse(&specv1.TransitionAbandonResponse{Spec: pb}), nil
 }
@@ -159,7 +159,7 @@ func (h *LifecycleHandler) CheckDrift(ctx context.Context, req *connect.Request[
 
 	protoReports, err := driftReportsToProto(reports)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, h.lifecycleError("CheckDrift", msg.Slug, err)
 	}
 	return connect.NewResponse(&specv1.DriftCheckResponse{Reports: protoReports}), nil
 }
@@ -216,7 +216,7 @@ func (h *LifecycleHandler) AcknowledgeDrift(ctx context.Context, req *connect.Re
 
 	protoReport, err := driftReportToProto(report)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, h.lifecycleError("AcknowledgeDrift", msg.Slug, err)
 	}
 	return connect.NewResponse(&specv1.DriftAcknowledgeResponse{Report: protoReport}), nil
 }
@@ -247,7 +247,7 @@ func (h *LifecycleHandler) Lint(ctx context.Context, req *connect.Request[specv1
 	}
 	protoResults, err := lintResultsToProto(results)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, h.lifecycleError("Lint", msg.Slug, err)
 	}
 	return connect.NewResponse(&specv1.LintResponse{
 		Results: protoResults,

--- a/internal/server/project.go
+++ b/internal/server/project.go
@@ -5,7 +5,9 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"regexp"
 
@@ -59,8 +61,9 @@ func scopeStore(ctx context.Context, scoper storage.Scoper) (storage.ScopedBacke
 	}
 	store, err := scoper.Scoped(ctx, project)
 	if err != nil {
+		slog.Error("scopeStore: failed to scope storage", slog.Any("error", err))
 		return nil, connect.NewError(connect.CodeInternal,
-			fmt.Errorf("scope store: %w", err))
+			errors.New("internal error"))
 	}
 	return store, nil
 }

--- a/internal/server/request_limits_test.go
+++ b/internal/server/request_limits_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+)
+
+// stubHealthHandler implements a minimal ServerServiceHandler for testing.
+type stubHealthHandler struct {
+	specgraphv1connect.UnimplementedServerServiceHandler
+}
+
+func (h *stubHealthHandler) Health(_ context.Context, _ *connect.Request[specv1.HealthRequest]) (*connect.Response[specv1.HealthResponse], error) {
+	return connect.NewResponse(&specv1.HealthResponse{Status: "ok"}), nil
+}
+
+func TestReadMaxBytes_RejectsOversizedBody(t *testing.T) {
+	// Register a handler with a 4 MiB read limit.
+	mux := http.NewServeMux()
+	opts := connect.WithReadMaxBytes(4 << 20)
+	path, handler := specgraphv1connect.NewServerServiceHandler(&stubHealthHandler{}, opts)
+	mux.Handle(path, handler)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	// Build a syntactically valid ConnectRPC JSON request body that exceeds 4 MiB.
+	// The padding field doesn't exist in HealthRequest, but ConnectRPC still reads
+	// the full body before rejecting unknown fields, so the size limit triggers first.
+	padding := bytes.Repeat([]byte("a"), 5<<20) // 5 MiB
+	body := append([]byte(`{"padding":"`), padding...)
+	body = append(body, []byte(`"}`)...)
+
+	resp, err := http.Post(
+		srv.URL+path+"Health",
+		"application/json",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+
+	// ConnectRPC maps resource_exhausted to HTTP 429 (Too Many Requests).
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 for oversized body, got %d: %s", resp.StatusCode, string(respBody))
+	}
+	if !bytes.Contains(respBody, []byte("resource_exhausted")) {
+		t.Fatalf("expected resource_exhausted error code, got: %s", string(respBody))
+	}
+}
+
+func TestReadMaxBytes_AllowsNormalBody(t *testing.T) {
+	// Same setup with 4 MiB limit.
+	opts := connect.WithReadMaxBytes(4 << 20)
+	mux := http.NewServeMux()
+	server.RegisterHealthService(mux, opts)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client := specgraphv1connect.NewServerServiceClient(http.DefaultClient, srv.URL)
+	_, err := client.Health(context.Background(), connect.NewRequest(&specv1.HealthRequest{}))
+	if err != nil {
+		t.Fatalf("expected success for normal request, got: %v", err)
+	}
+}

--- a/internal/server/security_headers.go
+++ b/internal/server/security_headers.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package server
+
+import "net/http"
+
+// SecurityHeaders returns middleware that sets standard HTTP security headers
+// on every response.
+func SecurityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/server/security_headers_test.go
+++ b/internal/server/security_headers_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Sean Brandt
+
+package server_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/server"
+)
+
+func TestSecurityHeaders(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := server.SecurityHeaders(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	tests := []struct {
+		header string
+		want   string
+	}{
+		{"X-Content-Type-Options", "nosniff"},
+		{"X-Frame-Options", "DENY"},
+		{"Referrer-Policy", "strict-origin-when-cross-origin"},
+	}
+	for _, tt := range tests {
+		got := rec.Header().Get(tt.header)
+		if got != tt.want {
+			t.Errorf("%s = %q, want %q", tt.header, got, tt.want)
+		}
+	}
+}
+
+func TestSecurityHeaders_PreservesExistingHeaders(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Custom", "preserved")
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := server.SecurityHeaders(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("X-Custom"); got != "preserved" {
+		t.Errorf("X-Custom = %q, want %q", got, "preserved")
+	}
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("X-Content-Type-Options = %q, want %q", got, "nosniff")
+	}
+}

--- a/internal/server/spec_handler.go
+++ b/internal/server/spec_handler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"unicode/utf8"
 
 	"connectrpc.com/connect"
@@ -54,14 +55,11 @@ func (h *SpecHandler) CreateSpec(ctx context.Context, req *connect.Request[specv
 
 	spec, err := store.CreateSpec(ctx, msg.Slug, msg.Intent, priority, complexity)
 	if err != nil {
-		if errors.Is(err, storage.ErrSpecAlreadyExists) {
-			return nil, connect.NewError(connect.CodeAlreadyExists, errors.New("spec with this slug already exists"))
-		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, specError(err)
 	}
 	pb, err := specToProto(spec)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, specError(err)
 	}
 	return connect.NewResponse(&specv1.CreateSpecResponse{Spec: pb}), nil
 }
@@ -77,14 +75,11 @@ func (h *SpecHandler) GetSpec(ctx context.Context, req *connect.Request[specv1.G
 	}
 	spec, err := store.GetSpec(ctx, req.Msg.Slug)
 	if err != nil {
-		if errors.Is(err, storage.ErrSpecNotFound) {
-			return nil, connect.NewError(connect.CodeNotFound, err)
-		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, specError(err)
 	}
 	pb, err := specToProto(spec)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, specError(err)
 	}
 	return connect.NewResponse(&specv1.GetSpecResponse{Spec: pb}), nil
 }
@@ -103,11 +98,11 @@ func (h *SpecHandler) ListSpecs(ctx context.Context, req *connect.Request[specv1
 
 	specs, err := store.ListSpecs(ctx, msg.Stage, msg.Priority, limit)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, specError(err)
 	}
 	pbs, err := specsToProto(specs)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, specError(err)
 	}
 	return connect.NewResponse(&specv1.ListSpecsResponse{Specs: pbs}), nil
 }
@@ -129,14 +124,30 @@ func (h *SpecHandler) UpdateSpec(ctx context.Context, req *connect.Request[specv
 
 	spec, err := store.UpdateSpec(ctx, msg.Slug, msg.Intent, msg.Stage, msg.Priority, msg.Complexity, msg.Notes)
 	if err != nil {
-		if errors.Is(err, storage.ErrSpecNotFound) {
-			return nil, connect.NewError(connect.CodeNotFound, err)
-		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, specError(err)
 	}
 	pb, err := specToProto(spec)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, specError(err)
 	}
 	return connect.NewResponse(&specv1.UpdateSpecResponse{Spec: pb}), nil
+}
+
+// specError maps storage/conversion errors to sanitized connect error codes.
+func specError(err error) error {
+	var connErr *connect.Error
+	if errors.As(err, &connErr) {
+		return connErr
+	}
+	switch {
+	case errors.Is(err, storage.ErrSpecNotFound):
+		return connect.NewError(connect.CodeNotFound, errors.New("spec not found"))
+	case errors.Is(err, storage.ErrSpecAlreadyExists):
+		return connect.NewError(connect.CodeAlreadyExists, errors.New("spec already exists"))
+	case errors.Is(err, storage.ErrConcurrentModification):
+		return connect.NewError(connect.CodeAborted, errors.New("concurrent modification — retry the operation"))
+	default:
+		slog.Error("specError: internal error", slog.Any("error", err))
+		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
 }

--- a/internal/server/test_scoper_test.go
+++ b/internal/server/test_scoper_test.go
@@ -144,7 +144,7 @@ func (stubBackend) UpdateConstitution(context.Context, *storage.Constitution) (*
 
 // --- AuthoringBackend (StageWriter + AuthoringSpecLifecycle) ---
 
-func (stubBackend) TransitionStage(context.Context, string, storage.AuthoringStage, storage.AuthoringStage) error {
+func (stubBackend) TransitionStage(context.Context, string, storage.SpecStage, storage.SpecStage) error {
 	return errNotImplemented
 }
 
@@ -172,7 +172,7 @@ func (stubBackend) SupersedeSpec(context.Context, string, string, string) error 
 	return errNotImplemented
 }
 
-func (stubBackend) AmendSpec(context.Context, string, string, storage.AuthoringStage) (*storage.AmendResult, error) {
+func (stubBackend) AmendSpec(context.Context, string, string, storage.SpecStage) (*storage.AmendResult, error) {
 	return nil, errNotImplemented
 }
 
@@ -301,6 +301,18 @@ func (stubBackend) ClaimSlice(context.Context, string, string) (*storage.Slice, 
 }
 
 func (stubBackend) CompleteSlice(context.Context, string) (*storage.Slice, error) {
+	return nil, errNotImplemented
+}
+
+func (stubBackend) ListChanges(context.Context, string, storage.ChangeLogFilter) ([]*storage.ChangeLogEntry, error) {
+	return nil, errNotImplemented
+}
+
+func (stubBackend) RecordConversation(context.Context, string, storage.ConversationLogEntry) (*storage.ConversationLogEntry, error) {
+	return nil, errNotImplemented
+}
+
+func (stubBackend) ListConversations(context.Context, string, string) ([]*storage.ConversationLogEntry, error) {
 	return nil, errNotImplemented
 }
 

--- a/internal/storage/authoring.go
+++ b/internal/storage/authoring.go
@@ -151,19 +151,16 @@ type SafetyFlag struct {
 	Description string          `json:"description,omitempty"`
 }
 
-// AuthoringStage is a typed stage name for use in storage method signatures.
-type AuthoringStage string
-
 // AmendResult holds the minimal fields returned after amending a spec.
 type AmendResult struct {
 	Slug    string
-	Stage   AuthoringStage
+	Stage   SpecStage
 	Version int32
 }
 
 // StageWriter handles stage transitions and output storage.
 type StageWriter interface {
-	TransitionStage(ctx context.Context, slug string, from, to AuthoringStage) error
+	TransitionStage(ctx context.Context, slug string, from, to SpecStage) error
 	StoreSparkOutput(ctx context.Context, slug string, output *SparkOutput) error
 	StoreShapeOutput(ctx context.Context, slug string, output *ShapeOutput) error
 	StoreSpecifyOutput(ctx context.Context, slug string, output *SpecifyOutput) error
@@ -178,7 +175,7 @@ type StageWriter interface {
 // see LifecycleBackend in lifecycle.go.
 type AuthoringSpecLifecycle interface {
 	SupersedeSpec(ctx context.Context, slug, supersededBy, reason string) error
-	AmendSpec(ctx context.Context, slug, reason string, targetStage AuthoringStage) (*AmendResult, error)
+	AmendSpec(ctx context.Context, slug, reason string, targetStage SpecStage) (*AmendResult, error)
 }
 
 // AuthoringBackend composes all authoring storage operations.

--- a/internal/storage/memgraph/authoring.go
+++ b/internal/storage/memgraph/authoring.go
@@ -40,11 +40,11 @@ var allowedJSONProperties = map[string]bool{
 // a different stage than expected. Returns ErrSpecAlreadyApproved if from
 // is the approved stage — approved is terminal and cannot be a source stage
 // (AmendSpec handles the approved→X path with its own guard).
-func (s *Store) TransitionStage(ctx context.Context, slug string, from, to storage.AuthoringStage) error {
-	if from == storage.AuthoringStage(authoring.StageApproved) {
+func (s *Store) TransitionStage(ctx context.Context, slug string, from, to storage.SpecStage) error {
+	if from == storage.SpecStageApproved {
 		return storage.ErrSpecAlreadyApproved
 	}
-	if err := authoring.ValidateTransition(authoring.Stage(from), authoring.Stage(to)); err != nil {
+	if err := authoring.ValidateTransition(from, to); err != nil {
 		return fmt.Errorf("memgraph: %w: %w", storage.ErrInvalidStageTransition, err)
 	}
 	nowStr := s.now()
@@ -53,7 +53,7 @@ func (s *Store) TransitionStage(ctx context.Context, slug string, from, to stora
 	// When transitioning to approved, also persist approved_at so the
 	// timestamp is stored rather than computed at response time.
 	setClause := "s.stage = $to, s.updated_at = $updated_at"
-	if to == storage.AuthoringStage(authoring.StageApproved) {
+	if to == storage.SpecStageApproved {
 		setClause += ", s.approved_at = $updated_at"
 	}
 	query := fmt.Sprintf(`
@@ -106,7 +106,7 @@ func (s *Store) TransitionStage(ctx context.Context, slug string, from, to stora
 		if err := s.createChangeLog(txCtx, slug, clEntry, deltas); err != nil {
 			return err
 		}
-		if to == storage.AuthoringStage(storage.SpecStageDone) {
+		if to == storage.SpecStageDone {
 			if err := s.RefreshDependencyHashes(txCtx, slug); err != nil {
 				return fmt.Errorf("refresh dependency hashes after done transition: %w", err)
 			}
@@ -328,18 +328,18 @@ func (s *Store) SupersedeSpec(ctx context.Context, slug, supersededBy, reason st
 
 // AmendSpec moves a spec backward to an earlier stage, bumping its version.
 // This is the authoring-level amendment; for lifecycle-level amendment see LifecycleAmendSpec.
-func (s *Store) AmendSpec(ctx context.Context, slug, reason string, targetStage storage.AuthoringStage) (*storage.AmendResult, error) {
+func (s *Store) AmendSpec(ctx context.Context, slug, reason string, targetStage storage.SpecStage) (*storage.AmendResult, error) {
 	spec, err := s.GetSpec(ctx, slug)
 	if err != nil {
 		return nil, fmt.Errorf("amend spec %q: get current: %w", slug, err)
 	}
-	if string(spec.Stage) == string(authoring.StageApproved) {
+	if spec.Stage == storage.SpecStageApproved {
 		return nil, storage.ErrSpecAlreadyApproved
 	}
 	if spec.Stage == storage.SpecStageSuperseded {
 		return nil, fmt.Errorf("amend spec %q: %w", slug, storage.ErrSpecSuperseded)
 	}
-	if vErr := authoring.ValidateAmendTransition(authoring.Stage(spec.Stage), authoring.Stage(targetStage)); vErr != nil {
+	if vErr := authoring.ValidateAmendTransition(spec.Stage, targetStage); vErr != nil {
 		return nil, fmt.Errorf("memgraph: amend: %w: %w", storage.ErrInvalidStageTransition, vErr)
 	}
 	var result *storage.AmendResult
@@ -379,7 +379,7 @@ func (s *Store) AmendSpec(ctx context.Context, slug, reason string, targetStage 
 		}
 		r := &storage.AmendResult{
 			Slug:  fmt.Sprintf("%v", retSlug),
-			Stage: storage.AuthoringStage(fmt.Sprintf("%v", retStage)),
+			Stage: storage.SpecStage(fmt.Sprintf("%v", retStage)),
 		}
 		switch v := retVersion.(type) {
 		case int64:

--- a/internal/storage/memgraph/authoring_test.go
+++ b/internal/storage/memgraph/authoring_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	"github.com/specgraph/specgraph/internal/authoring"
 	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/specgraph/specgraph/internal/storage/memgraph"
 	"github.com/stretchr/testify/assert"
@@ -46,18 +45,18 @@ func TestAuthoring(t *testing.T) {
 		require.NoError(t, err)
 
 		// CreateSpec sets stage to "spark", so transition spark → shape.
-		err = store.TransitionStage(ctx, "funnel-test", storage.AuthoringStage(authoring.StageSpark), storage.AuthoringStage(authoring.StageShape))
+		err = store.TransitionStage(ctx, "funnel-test", storage.SpecStageSpark, storage.SpecStageShape)
 		require.NoError(t, err)
 
 		spec, err := store.GetSpec(ctx, "funnel-test")
 		require.NoError(t, err)
 		require.Equal(t, storage.SpecStageShape, spec.Stage)
 
-		err = store.TransitionStage(ctx, "funnel-test", storage.AuthoringStage(authoring.StageShape), storage.AuthoringStage(authoring.StageSpecify))
+		err = store.TransitionStage(ctx, "funnel-test", storage.SpecStageShape, storage.SpecStageSpecify)
 		require.NoError(t, err)
 
 		// Invalid: skipping from specify straight to approved (must go through decompose).
-		err = store.TransitionStage(ctx, "funnel-test", storage.AuthoringStage(authoring.StageSpecify), storage.AuthoringStage(authoring.StageApproved))
+		err = store.TransitionStage(ctx, "funnel-test", storage.SpecStageSpecify, storage.SpecStageApproved)
 		require.ErrorIs(t, err, storage.ErrInvalidStageTransition)
 	})
 
@@ -72,7 +71,7 @@ func TestAuthoring(t *testing.T) {
 		require.NoError(t, err)
 
 		// Spec is at "spark", but we claim it's at "shape" → should fail.
-		err = store.TransitionStage(ctx, "wrong-stage", storage.AuthoringStage(authoring.StageShape), storage.AuthoringStage(authoring.StageSpecify))
+		err = store.TransitionStage(ctx, "wrong-stage", storage.SpecStageShape, storage.SpecStageSpecify)
 		require.ErrorIs(t, err, storage.ErrInvalidStageTransition)
 	})
 
@@ -168,13 +167,13 @@ func TestAuthoring(t *testing.T) {
 		_, err = store.CreateSpec(ctx, "amend-test", "Amend test", "p1", "low")
 		require.NoError(t, err)
 		// CreateSpec sets stage to "spark". Advance through stages.
-		require.NoError(t, store.TransitionStage(ctx, "amend-test", storage.AuthoringStage(authoring.StageSpark), storage.AuthoringStage(authoring.StageShape)))
-		require.NoError(t, store.TransitionStage(ctx, "amend-test", storage.AuthoringStage(authoring.StageShape), storage.AuthoringStage(authoring.StageSpecify)))
+		require.NoError(t, store.TransitionStage(ctx, "amend-test", storage.SpecStageSpark, storage.SpecStageShape))
+		require.NoError(t, store.TransitionStage(ctx, "amend-test", storage.SpecStageShape, storage.SpecStageSpecify))
 
 		// Amend back to shape (valid backward transition).
-		spec, err := store.AmendSpec(ctx, "amend-test", "need to reconsider scope", storage.AuthoringStage(authoring.StageShape))
+		spec, err := store.AmendSpec(ctx, "amend-test", "need to reconsider scope", storage.SpecStageShape)
 		require.NoError(t, err)
-		require.Equal(t, storage.AuthoringStage(authoring.StageShape), spec.Stage)
+		require.Equal(t, storage.SpecStageShape, spec.Stage)
 		require.Equal(t, int32(2), spec.Version, "version should increment after amendment")
 	})
 
@@ -187,12 +186,12 @@ func TestAuthoring(t *testing.T) {
 
 		_, err = store.CreateSpec(ctx, "approved-spec", "Will be approved", "p1", "low")
 		require.NoError(t, err)
-		require.NoError(t, store.TransitionStage(ctx, "approved-spec", storage.AuthoringStage(authoring.StageSpark), storage.AuthoringStage(authoring.StageShape)))
-		require.NoError(t, store.TransitionStage(ctx, "approved-spec", storage.AuthoringStage(authoring.StageShape), storage.AuthoringStage(authoring.StageSpecify)))
-		require.NoError(t, store.TransitionStage(ctx, "approved-spec", storage.AuthoringStage(authoring.StageSpecify), storage.AuthoringStage(authoring.StageDecompose)))
-		require.NoError(t, store.TransitionStage(ctx, "approved-spec", storage.AuthoringStage(authoring.StageDecompose), storage.AuthoringStage(authoring.StageApproved)))
+		require.NoError(t, store.TransitionStage(ctx, "approved-spec", storage.SpecStageSpark, storage.SpecStageShape))
+		require.NoError(t, store.TransitionStage(ctx, "approved-spec", storage.SpecStageShape, storage.SpecStageSpecify))
+		require.NoError(t, store.TransitionStage(ctx, "approved-spec", storage.SpecStageSpecify, storage.SpecStageDecompose))
+		require.NoError(t, store.TransitionStage(ctx, "approved-spec", storage.SpecStageDecompose, storage.SpecStageApproved))
 
-		_, err = store.AmendSpec(ctx, "approved-spec", "too late", storage.AuthoringStage(authoring.StageShape))
+		_, err = store.AmendSpec(ctx, "approved-spec", "too late", storage.SpecStageShape)
 		require.ErrorIs(t, err, storage.ErrSpecAlreadyApproved)
 	})
 
@@ -205,10 +204,10 @@ func TestAuthoring(t *testing.T) {
 
 		_, err = store.CreateSpec(ctx, "amend-invalid", "Invalid amend", "p1", "low")
 		require.NoError(t, err)
-		require.NoError(t, store.TransitionStage(ctx, "amend-invalid", storage.AuthoringStage(authoring.StageSpark), storage.AuthoringStage(authoring.StageShape)))
+		require.NoError(t, store.TransitionStage(ctx, "amend-invalid", storage.SpecStageSpark, storage.SpecStageShape))
 
 		// Amend forward (shape → specify) should fail — amend only allows backward.
-		_, err = store.AmendSpec(ctx, "amend-invalid", "forward not allowed", storage.AuthoringStage(authoring.StageSpecify))
+		_, err = store.AmendSpec(ctx, "amend-invalid", "forward not allowed", storage.SpecStageSpecify)
 		require.ErrorIs(t, err, storage.ErrInvalidStageTransition)
 	})
 
@@ -220,7 +219,7 @@ func TestAuthoring(t *testing.T) {
 		defer store.Close(ctx) //nolint:errcheck
 
 		// AmendSpec on a non-existent slug should return ErrSpecNotFound.
-		_, err = store.AmendSpec(ctx, "nonexistent-spec", "reason", storage.AuthoringStage(authoring.StageShape))
+		_, err = store.AmendSpec(ctx, "nonexistent-spec", "reason", storage.SpecStageShape)
 		require.ErrorIs(t, err, storage.ErrSpecNotFound)
 	})
 
@@ -233,14 +232,14 @@ func TestAuthoring(t *testing.T) {
 
 		_, err = store.CreateSpec(ctx, "empty-reason", "Empty reason test", "p1", "low")
 		require.NoError(t, err)
-		require.NoError(t, store.TransitionStage(ctx, "empty-reason", storage.AuthoringStage(authoring.StageSpark), storage.AuthoringStage(authoring.StageShape)))
-		require.NoError(t, store.TransitionStage(ctx, "empty-reason", storage.AuthoringStage(authoring.StageShape), storage.AuthoringStage(authoring.StageSpecify)))
+		require.NoError(t, store.TransitionStage(ctx, "empty-reason", storage.SpecStageSpark, storage.SpecStageShape))
+		require.NoError(t, store.TransitionStage(ctx, "empty-reason", storage.SpecStageShape, storage.SpecStageSpecify))
 
 		// Amend with empty reason should still succeed at the storage layer
 		// (validation is the handler's responsibility), but verify the operation works.
-		result, err := store.AmendSpec(ctx, "empty-reason", "", storage.AuthoringStage(authoring.StageShape))
+		result, err := store.AmendSpec(ctx, "empty-reason", "", storage.SpecStageShape)
 		require.NoError(t, err)
-		require.Equal(t, storage.AuthoringStage(authoring.StageShape), result.Stage)
+		require.Equal(t, storage.SpecStageShape, result.Stage)
 	})
 
 	t.Run("SupersedeSpec", func(t *testing.T) {
@@ -386,17 +385,17 @@ func TestAuthoring(t *testing.T) {
 		require.NoError(t, err)
 
 		// Advance spark → shape → specify.
-		require.NoError(t, store.TransitionStage(ctx, "backward-test", storage.AuthoringStage(authoring.StageSpark), storage.AuthoringStage(authoring.StageShape)))
-		require.NoError(t, store.TransitionStage(ctx, "backward-test", storage.AuthoringStage(authoring.StageShape), storage.AuthoringStage(authoring.StageSpecify)))
+		require.NoError(t, store.TransitionStage(ctx, "backward-test", storage.SpecStageSpark, storage.SpecStageShape))
+		require.NoError(t, store.TransitionStage(ctx, "backward-test", storage.SpecStageShape, storage.SpecStageSpecify))
 
 		// AmendSpec back to spark (two stages back).
-		result, err := store.AmendSpec(ctx, "backward-test", "starting over", storage.AuthoringStage(authoring.StageSpark))
+		result, err := store.AmendSpec(ctx, "backward-test", "starting over", storage.SpecStageSpark)
 		require.NoError(t, err)
-		require.Equal(t, storage.AuthoringStage(authoring.StageSpark), result.Stage)
+		require.Equal(t, storage.SpecStageSpark, result.Stage)
 		require.Equal(t, int32(2), result.Version)
 
 		// After amend, can transition forward again from spark.
-		require.NoError(t, store.TransitionStage(ctx, "backward-test", storage.AuthoringStage(authoring.StageSpark), storage.AuthoringStage(authoring.StageShape)))
+		require.NoError(t, store.TransitionStage(ctx, "backward-test", storage.SpecStageSpark, storage.SpecStageShape))
 	})
 
 	t.Run("TransitionStage_ApprovedGuard", func(t *testing.T) {
@@ -410,13 +409,13 @@ func TestAuthoring(t *testing.T) {
 		require.NoError(t, err)
 
 		// Full forward path to approved.
-		require.NoError(t, store.TransitionStage(ctx, "approved-guard", storage.AuthoringStage(authoring.StageSpark), storage.AuthoringStage(authoring.StageShape)))
-		require.NoError(t, store.TransitionStage(ctx, "approved-guard", storage.AuthoringStage(authoring.StageShape), storage.AuthoringStage(authoring.StageSpecify)))
-		require.NoError(t, store.TransitionStage(ctx, "approved-guard", storage.AuthoringStage(authoring.StageSpecify), storage.AuthoringStage(authoring.StageDecompose)))
-		require.NoError(t, store.TransitionStage(ctx, "approved-guard", storage.AuthoringStage(authoring.StageDecompose), storage.AuthoringStage(authoring.StageApproved)))
+		require.NoError(t, store.TransitionStage(ctx, "approved-guard", storage.SpecStageSpark, storage.SpecStageShape))
+		require.NoError(t, store.TransitionStage(ctx, "approved-guard", storage.SpecStageShape, storage.SpecStageSpecify))
+		require.NoError(t, store.TransitionStage(ctx, "approved-guard", storage.SpecStageSpecify, storage.SpecStageDecompose))
+		require.NoError(t, store.TransitionStage(ctx, "approved-guard", storage.SpecStageDecompose, storage.SpecStageApproved))
 
 		// Once approved, further forward transitions should fail with ErrSpecAlreadyApproved.
-		err = store.TransitionStage(ctx, "approved-guard", storage.AuthoringStage(authoring.StageApproved), storage.AuthoringStage(authoring.StageSpark))
+		err = store.TransitionStage(ctx, "approved-guard", storage.SpecStageApproved, storage.SpecStageSpark)
 		require.ErrorIs(t, err, storage.ErrSpecAlreadyApproved)
 	})
 
@@ -438,7 +437,7 @@ func TestAuthoring(t *testing.T) {
 
 		// Attempting TransitionStage on a superseded spec should fail because
 		// "superseded" is not a valid funnel stage and ValidateTransition rejects it.
-		err = store.TransitionStage(ctx, "superseded-old", storage.AuthoringStage("superseded"), storage.AuthoringStage(authoring.StageShape))
+		err = store.TransitionStage(ctx, "superseded-old", storage.SpecStageSuperseded, storage.SpecStageShape)
 		require.ErrorIs(t, err, storage.ErrInvalidStageTransition)
 	})
 
@@ -614,8 +613,8 @@ func TestAuthoring(t *testing.T) {
 		initialHash := spec.ContentHash
 
 		err = store.TransitionStage(ctx, "stage-hash",
-			storage.AuthoringStage(authoring.StageSpark),
-			storage.AuthoringStage(authoring.StageShape))
+			storage.SpecStageSpark,
+			storage.SpecStageShape)
 		require.NoError(t, err)
 
 		updated, err := store.GetSpec(ctx, "stage-hash")
@@ -636,15 +635,15 @@ func TestAuthoring(t *testing.T) {
 
 		// Advance to shape so we can amend back to spark.
 		err = store.TransitionStage(ctx, "amend-hash",
-			storage.AuthoringStage(authoring.StageSpark),
-			storage.AuthoringStage(authoring.StageShape))
+			storage.SpecStageSpark,
+			storage.SpecStageShape)
 		require.NoError(t, err)
 
 		preAmend, err := store.GetSpec(ctx, "amend-hash")
 		require.NoError(t, err)
 
 		_, err = store.AmendSpec(ctx, "amend-hash", "rework needed",
-			storage.AuthoringStage(authoring.StageSpark))
+			storage.SpecStageSpark)
 		require.NoError(t, err)
 
 		updated, err := store.GetSpec(ctx, "amend-hash")

--- a/internal/storage/scoper.go
+++ b/internal/storage/scoper.go
@@ -20,6 +20,8 @@ type ScopedBackend interface {
 	SyncBackend
 	ProjectBackend
 	SliceBackend
+	ConversationBackend
+	ChangeLogBackend
 }
 
 // Scoper creates project-scoped storage instances.


### PR DESCRIPTION
## Summary

Wave 1 of the comprehensive codebase review ([spgr-dec epic](docs/reviews/2026-03-27-comprehensive-go-codebase-review.md)). All P0 security issues + foundational type consolidation.

**Security fixes (P0):**
- Sanitize error messages across all handlers — no internal details leak to clients (dec.2)
- Add auth middleware to `/api/projects` endpoint (dec.3)
- Add HTTP request body size limits (4MB) and server timeouts (dec.4)
- Add security headers middleware: `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` (dec.8)

**Foundation improvements:**
- Consolidate 3 stage types to single canonical `SpecStage` (dec.9)
- Add `ConversationBackend` and `ChangeLogBackend` to `ScopedBackend` (dec.7)
- Fix timing side-channel in API key comparison via HMAC-SHA256 (dec.15)
- Use `cmd.Context()` for graceful cancellation in all CLI commands (dec.11)

## Test plan
- [x] `go test -short -race ./...` passes
- [ ] `task pr-prep` (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> **Stack:** PR 1 of 3. Merge this first, then wave 2, then wave 3.