### PR TITLE
fix(ci): git-cliff action output is 'version' not 'tag'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check if version bumped
         id: check
         run: |
-          TAG="${{ steps.cliff.outputs.tag }}"
+          TAG="${{ steps.cliff.outputs.version }}"
           if [ -z "$TAG" ]; then
             echo "No releasable commits since last tag. Exiting."
             echo "new_tag=" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The release workflow has been broken since the git-cliff-action v4 upgrade. The action's output field is `version`, not `tag`. The workflow referenced `steps.cliff.outputs.tag` which is always empty, causing every manual release to exit with "No releasable commits since last tag."

**Fix:** `steps.cliff.outputs.tag` → `steps.cliff.outputs.version`

## Test plan

- [ ] Trigger manual release after merge — should detect `feat:` commits since v0.2.1 and bump to v0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)