### PR TITLE
fix(ci): cap version bumps at 0.x while pre-1.0

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -56,3 +56,8 @@ protect_breaking_commits = true
 filter_commits = false
 tag_pattern = "v[0-9].*"
 sort_commits = "newest"
+
+[bump]
+# While pre-1.0, breaking changes bump minor instead of major.
+# Remove this section when ready to release v1.0.0.
+breaking_always_bump_major = false


### PR DESCRIPTION
## Summary

The `feat(storage)!:` breaking change commit from the slice epic triggers a major version bump via git-cliff's `--bump`. This would release v1.0.0 — we're not ready for that.

**Fix:** Add `[bump]` config to `cliff.toml` with `breaking_always_bump_major = false`. Breaking changes will bump minor (0.2.1 → 0.3.0) instead of major while we're pre-1.0.

Remove the `[bump]` section when ready to release v1.0.0.

## Test plan

- [ ] After merge + the branch protection fix, trigger manual release → should produce v0.3.0 (not v1.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)