### PR TITLE
fix(ci): use GitHub App token for release workflow pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+      - name: Generate release app token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - name: Install git-cliff
         uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72 # v4
         id: cliff
@@ -30,7 +36,7 @@ jobs:
       - name: Check if version bumped
         id: check
         run: |
-          TAG="${{ steps.cliff.outputs.tag }}"
+          TAG="${{ steps.cliff.outputs.version }}"
           if [ -z "$TAG" ]; then
             echo "No releasable commits since last tag. Exiting."
             echo "new_tag=" >> "$GITHUB_OUTPUT"
@@ -42,11 +48,14 @@ jobs:
       - name: Commit changelog
         if: steps.check.outputs.new_tag != ''
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "specgraph-release-bot[bot]"
+          git config user.email "specgraph-release-bot[bot]@users.noreply.github.com"
           git add CHANGELOG.md
           git commit -m "chore(release): ${{ steps.check.outputs.new_tag }}"
           git push
+        env:
+          # App token bypasses branch protection for this push only.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Create and push tag
         if: steps.check.outputs.new_tag != ''
         run: |
@@ -54,6 +63,8 @@ jobs:
           git push origin "$TAG"
         env:
           TAG: ${{ steps.check.outputs.new_tag }}
+          # App token for tag push as well.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Create GitHub release
         if: steps.check.outputs.new_tag != ''
         run: |


### PR DESCRIPTION
## Summary

The release workflow pushes a changelog commit and tag directly to `main`, which is blocked by branch protection rules. This PR uses the new `specgraph-release-bot` GitHub App to generate a scoped token that can bypass branch protection.

**Changes:**
- Added `actions/create-github-app-token@v2` step (SHA-pinned) to generate an installation token
- Changelog commit push uses the app token via `GITHUB_TOKEN` env var (scoped to that step only)
- Tag push also uses the app token
- Git author set to `specgraph-release-bot[bot]` for audit trail
- GitHub Release creation still uses `secrets.GITHUB_TOKEN` (doesn't need bypass)
- Also includes the `steps.cliff.outputs.version` fix from PR #780

**Security model:**
- App has only `contents: write` permission on `specgraph/specgraph`
- Token is generated per-run and expires after 1 hour
- Token is only passed to the two `git push` steps, not the entire job
- Workflow only runs on `workflow_dispatch` (manual trigger)

**Secrets required:** `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY` (already configured)

## Test plan

- [ ] Merge this + PR #781 (bump cap), then trigger manual release → should push changelog, create tag v0.3.0, goreleaser builds artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)