### PR TITLE
fix(ci): use app token via git remote URL for branch protection bypass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,26 +45,23 @@ jobs:
           VERSION="${TAG#v}"
           echo "new_tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-      - name: Commit changelog
+      - name: Commit changelog and push
         if: steps.check.outputs.new_tag != ''
         run: |
+          # Override the remote URL to use the app token for authentication.
+          # actions/checkout bakes the default GITHUB_TOKEN into git credentials;
+          # we must replace it with the app token to bypass branch protection.
+          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
           git config user.name "specgraph-release-bot[bot]"
           git config user.email "specgraph-release-bot[bot]@users.noreply.github.com"
           git add CHANGELOG.md
-          git commit -m "chore(release): ${{ steps.check.outputs.new_tag }}"
+          git commit -m "chore(release): ${TAG}"
           git push
+          git tag "${TAG}"
+          git push origin "${TAG}"
         env:
-          # App token bypasses branch protection for this push only.
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-      - name: Create and push tag
-        if: steps.check.outputs.new_tag != ''
-        run: |
-          git tag "$TAG"
-          git push origin "$TAG"
-        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ steps.check.outputs.new_tag }}
-          # App token for tag push as well.
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Create GitHub release
         if: steps.check.outputs.new_tag != ''
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #782. The app token was passed as `GITHUB_TOKEN` env var, but `git push` uses the credentials baked in by `actions/checkout` (which uses the default `GITHUB_TOKEN`). The env var alone doesn't change what credentials git uses for the push.

**Fix:** Set the remote URL to include the app token directly: `git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/..."`. This ensures `git push` authenticates as the app, which has bypass permission in the ruleset.

Also combines the changelog commit + tag push into a single step to keep the token scope minimal.

## Test plan

- [ ] After merge, trigger manual release → should push changelog commit + v0.3.0 tag to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)