### PR TITLE
fix(ci): disable persist-credentials so app token works for push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Generate release app token
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2


### PR DESCRIPTION
## Summary

Follow-up to #783. `actions/checkout` persists credentials via a git `extraheader` config that takes precedence over the URL-embedded token. Even though we set the remote URL with the app token, git was still using the checkout-baked credentials (the default `GITHUB_TOKEN` which can't bypass branch protection).

**Fix:** `persist-credentials: false` on the checkout step prevents it from baking credentials. The `git remote set-url` with the app token is then the only credential available for push.

## Test plan

- [ ] After merge, trigger manual release → v0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)