### PR TITLE
fix(ci): use cliff action output for release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,14 +66,14 @@ jobs:
       - name: Create GitHub release
         if: steps.check.outputs.new_tag != ''
         run: |
-          git cliff --latest --strip header > /tmp/release-notes.md
           gh release create "$TAG" \
             --title "$TAG" \
-            --notes-file /tmp/release-notes.md \
+            --notes "$NOTES" \
             --verify-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.check.outputs.new_tag }}
+          NOTES: ${{ steps.cliff.outputs.content }}
   goreleaser:
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

The release workflow failed at the "Create GitHub release" step because `git cliff` isn't on PATH — the `orhun/git-cliff-action` runs as a Docker action and doesn't install the binary globally.

**Fix:** Use `steps.cliff.outputs.content` (the changelog content already generated by the action) instead of re-running `git cliff --latest`.

Note: v0.3.0 tag and changelog commit pushed successfully — only the GitHub Release creation failed. After merging this, manually create the release or re-trigger.

## Test plan

- [ ] After merge, trigger manual release → GitHub Release should be created with proper notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)