### PR TITLE
fix(ci): specify pnpm version in goreleaser release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,7 @@ jobs:
           node-version: "22"
       - uses: pnpm/action-setup@02f6c237bd2518259fed6c71566509edfb3f2b74 # v4
         with:
+          version: 10
           run_install: false
       - name: Build web UI
         working-directory: web


### PR DESCRIPTION
## Summary

The goreleaser job in the release workflow fails because `pnpm/action-setup` requires an explicit pnpm version. There's no `packageManager` field in `package.json` and the action no longer auto-detects.

**Fix:** Add `version: 10` to the `pnpm/action-setup` step.

Note: v0.3.0 release and tag were created successfully — only goreleaser (binary builds, Docker image, Homebrew) failed. After merging, delete the v0.3.0 tag + release and re-trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)