### PR TITLE
fix(ci): skip changelog commit when nothing changed (idempotent re-runs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,11 @@ jobs:
           git config user.name "specgraph-release-bot[bot]"
           git config user.email "specgraph-release-bot[bot]@users.noreply.github.com"
           git add CHANGELOG.md
-          git commit -m "chore(release): ${TAG}"
-          git push
+          # Commit only if changelog actually changed (idempotent re-runs).
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(release): ${TAG}"
+            git push
+          fi
           git tag "${TAG}"
           git push origin "${TAG}"
         env:


### PR DESCRIPTION
## Summary

The release workflow fails on re-runs because the `chore(release): v0.3.0` changelog commit already exists on main. `git commit` fails with "nothing to commit, working tree clean".

**Fix:** Check `git diff --cached --quiet` before committing. If CHANGELOG.md hasn't changed (because the changelog commit already exists), skip the commit+push and proceed to tagging.

This makes the release workflow idempotent — safe to re-run after partial failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)