### PR TITLE
fix(ci): make tag and release creation fully idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,18 +61,24 @@ jobs:
             git commit -m "chore(release): ${TAG}"
             git push
           fi
-          git tag "${TAG}"
-          git push origin "${TAG}"
+          # Create tag if it doesn't already exist (idempotent).
+          if ! git rev-parse "${TAG}" >/dev/null 2>&1; then
+            git tag "${TAG}"
+            git push origin "${TAG}"
+          fi
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ steps.check.outputs.new_tag }}
       - name: Create GitHub release
         if: steps.check.outputs.new_tag != ''
         run: |
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --notes "$NOTES" \
-            --verify-tag
+          # Create release if it doesn't already exist (idempotent).
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes "$NOTES" \
+              --verify-tag
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.check.outputs.new_tag }}


### PR DESCRIPTION
## Summary

Makes every step of the release workflow safe to re-run:
- Changelog commit: skip if nothing changed (already merged in #788)
- Tag creation: skip if tag already exists (`git rev-parse`)
- GitHub Release: skip if release already exists (`gh release view`)

This ensures partial failures (tag exists, release exists) don't block re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)