### PR TITLE
fix(security): upgrade Go 1.26.1, add Trivy FS scan to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,14 @@ jobs:
         run: task check
       - name: Go vulnerability check
         run: go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
+      - name: Trivy filesystem scan
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          ignore-unfixed: true
       - name: Verify generated code is up to date
         run: task proto:check
       - name: Unit test coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,9 +134,10 @@ jobs:
       - name: Scan Docker image
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
-          image-ref: "ghcr.io/specgraph/specgraph:${{ needs.release.outputs.version }}"
+          image-ref: "ghcr.io/specgraph/specgraph:${{ needs.release.outputs.version }}-amd64"
           format: table
           exit-code: "1"
+          ignore-unfixed: true
           severity: CRITICAL,HIGH
       - name: Attest binary provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -8,7 +8,7 @@ COPY web/ .
 RUN pnpm build
 
 # Stage 2: Build Go binary with embedded UI
-FROM golang:1.25-alpine@sha256:8e02eb337d9e0ea459e041f1ee5eece41cbb61f1d83e7d883a3e2fb4862063fa AS go-builder
+FROM golang:1.26-alpine@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039 AS go-builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/specgraph/specgraph
 
-go 1.25.0
+go 1.26.1
 
 require (
 	connectrpc.com/connect v1.19.1


### PR DESCRIPTION
## Summary

Trivy scan during v0.3.3 release found 1 CRITICAL + 5 HIGH vulnerabilities in Go stdlib (Go 1.25.0). Alpine zlib CVE is unfixed upstream.

**Changes:**
- `go.mod`: Go 1.25.0 → 1.26.1 (fixes CVE-2025-68121 crypto/tls CRITICAL + 4 HIGH stdlib CVEs)
- `ci.yml`: Added Trivy filesystem scan to build-and-test job (catches vulns at PR time, not just release)
- `release.yml`: Trivy image scan now uses `ignore-unfixed: true` (Alpine zlib fix not yet available) and scans the `-amd64` image tag

**CVEs resolved by Go upgrade:**
- CVE-2025-68121 (CRITICAL) — crypto/tls session resumption
- CVE-2025-58183 (HIGH) — archive/tar unbounded allocation
- CVE-2025-61726 (HIGH) — net/url memory exhaustion
- CVE-2025-61728 (HIGH) — archive/zip excessive CPU
- CVE-2025-61729 (HIGH) — crypto/x509 denial of service
- CVE-2026-25679 (HIGH) — net/url IPv6 parsing

**Unfixed (Alpine upstream):**
- CVE-2026-22184 (HIGH) — zlib buffer overflow (waiting for Alpine 3.23 patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)