### PR TITLE
fix(ci): skip release on no-op re-runs, switch to dockers_v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     runs-on: namespace-profile-linux-amd64-4x8
     outputs:
-      new_tag: ${{ steps.check.outputs.new_tag }}
+      new_tag: ${{ steps.push.outputs.new_tag || steps.check.outputs.new_tag }}
       version: ${{ steps.check.outputs.version }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -47,6 +47,7 @@ jobs:
           echo "new_tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Commit changelog and push
+        id: push
         if: steps.check.outputs.new_tag != ''
         run: |
           # Override the remote URL to use the app token for authentication.
@@ -56,22 +57,36 @@ jobs:
           git config user.name "specgraph-release-bot[bot]"
           git config user.email "specgraph-release-bot[bot]@users.noreply.github.com"
           git add CHANGELOG.md
-          # Commit only if changelog actually changed — makes re-runs safe
-          # after partial failures (e.g., tag push blocked).
+
+          CHANGED=false
+
+          # Commit only if changelog actually changed.
           if ! git diff --cached --quiet; then
             git commit -m "chore(release): ${TAG}"
             git push
+            CHANGED=true
           fi
-          # Create tag if it doesn't already exist (idempotent).
+
+          # Create tag if it doesn't already exist.
           if ! git rev-parse "${TAG}" >/dev/null 2>&1; then
             git tag "${TAG}"
             git push origin "${TAG}"
+            CHANGED=true
+          fi
+
+          # If nothing changed, this is a no-op re-run. Clear the tag so
+          # downstream steps (release creation, goreleaser) are skipped.
+          if [ "$CHANGED" = "false" ]; then
+            echo "Tag ${TAG} and changelog already exist. Nothing to do."
+            echo "new_tag=" >> "$GITHUB_OUTPUT"
+          else
+            echo "new_tag=${TAG}" >> "$GITHUB_OUTPUT"
           fi
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ steps.check.outputs.new_tag }}
       - name: Create GitHub release
-        if: steps.check.outputs.new_tag != ''
+        if: steps.push.outputs.new_tag != ''
         run: |
           # Create release if it doesn't already exist (idempotent).
           if ! gh release view "$TAG" >/dev/null 2>&1; then
@@ -82,7 +97,7 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.check.outputs.new_tag }}
+          TAG: ${{ steps.push.outputs.new_tag }}
           NOTES: ${{ steps.cliff.outputs.content }}
   goreleaser:
     permissions:
@@ -134,7 +149,7 @@ jobs:
       - name: Scan Docker image
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
-          image-ref: "ghcr.io/specgraph/specgraph:${{ needs.release.outputs.version }}-amd64"
+          image-ref: "ghcr.io/specgraph/specgraph:${{ needs.release.outputs.version }}"
           format: table
           exit-code: "1"
           ignore-unfixed: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,42 +37,21 @@ homebrew_casks:
     homepage: https://specgraph.io
     description: Live spec-driven development framework
     license: MIT
-dockers:
-  - id: docker-amd64
-    ids: [specgraph]
-    goos: linux
-    goarch: amd64
-    image_templates:
-      - "ghcr.io/specgraph/specgraph:{{ .Version }}-amd64"
+dockers_v2:
+  - ids: [specgraph]
+    images:
+      - "ghcr.io/specgraph/specgraph"
+    tags:
+      - "{{ .Version }}"
+      - latest
+    platforms:
+      - linux/amd64
+      - linux/arm64
     dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.source=https://github.com/specgraph/specgraph"
-  - id: docker-arm64
-    ids: [specgraph]
-    goos: linux
-    goarch: arm64
-    image_templates:
-      - "ghcr.io/specgraph/specgraph:{{ .Version }}-arm64"
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.source=https://github.com/specgraph/specgraph"
-docker_manifests:
-  - name_template: "ghcr.io/specgraph/specgraph:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/specgraph/specgraph:{{ .Version }}-amd64"
-      - "ghcr.io/specgraph/specgraph:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/specgraph/specgraph:latest"
-    image_templates:
-      - "ghcr.io/specgraph/specgraph:{{ .Version }}-amd64"
-      - "ghcr.io/specgraph/specgraph:{{ .Version }}-arm64"
+    labels:
+      "org.opencontainers.image.title": "{{ .ProjectName }}"
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.source": "https://github.com/specgraph/specgraph"
 source:
   enabled: true
   name_template: "{{ .ProjectName }}.src"


### PR DESCRIPTION
## Summary

Three fixes:

1. **No-op re-run guard**: If the changelog commit and tag already exist (e.g., re-triggering after a partial failure that's since been fixed), the workflow now detects "nothing changed" and skips the GitHub Release creation and goreleaser job entirely. The `push` step tracks whether anything was actually pushed and clears `new_tag` if not.

2. **Switch to `dockers_v2`**: Replaces deprecated `dockers` + `docker_manifests` with `dockers_v2` (goreleaser v2's buildx-native multi-arch format). Eliminates the deprecation warnings in goreleaser output.

3. **Trivy image ref**: Updated to match `dockers_v2` tag format (`<version>` instead of `<version>-amd64`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)