### PR TITLE
refactor(server): remove redundant ConversationBackend type assertions

### DIFF
--- a/internal/server/authoring_handler.go
+++ b/internal/server/authoring_handler.go
@@ -540,11 +540,6 @@ func (h *AuthoringHandler) RecordConversation(
 	if err != nil {
 		return nil, err
 	}
-	convBackend, ok := store.(storage.ConversationBackend)
-	if !ok {
-		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("storage backend does not support conversation logs"))
-	}
-
 	exchanges, exErr := conversationExchangesFromProto(req.Msg.Exchanges)
 	if exErr != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, exErr)
@@ -556,7 +551,7 @@ func (h *AuthoringHandler) RecordConversation(
 		ExchangeCount: int32(len(req.Msg.Exchanges)), //nolint:gosec // bounded by maxElements (100) validation above
 	}
 
-	result, recErr := convBackend.RecordConversation(ctx, slug, entry)
+	result, recErr := store.RecordConversation(ctx, slug, entry)
 	if recErr != nil {
 		return nil, h.stageError(recErr)
 	}
@@ -580,12 +575,7 @@ func (h *AuthoringHandler) ListConversations(
 	if err != nil {
 		return nil, err
 	}
-	convBackend, ok := store.(storage.ConversationBackend)
-	if !ok {
-		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("storage backend does not support conversation logs"))
-	}
-
-	entries, listErr := convBackend.ListConversations(ctx, slug, req.Msg.Stage)
+	entries, listErr := store.ListConversations(ctx, slug, req.Msg.Stage)
 	if listErr != nil {
 		return nil, h.stageError(listErr)
 	}


### PR DESCRIPTION
## Summary
- Remove redundant `store.(storage.ConversationBackend)` runtime type assertions in `authoring_handler.go`
- `ConversationBackend` is already composed into `ScopedBackend`, so these assertions always succeed
- Call `store.RecordConversation`/`store.ListConversations` directly

## Context
Closed 8 `spgr-dec` beads from the comprehensive code review — 7 were already fixed in wave 1-3 PRs. This PR contains the only remaining code change (dec.7).

Closes #713

## Test plan
- [x] `go build ./internal/server/...` passes
- [x] All conversation handler tests pass (`TestAuthoringHandler_RecordConversation*`, `TestAuthoringHandler_ListConversations*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>