### PR TITLE
fix: remove redundant .specgraph subdir in EnsureComposeFile path (spgr-2p5)

### DIFF
--- a/e2e/docker/serve_test.go
+++ b/e2e/docker/serve_test.go
@@ -100,8 +100,8 @@ var _ = Describe("Docker mode serve", Ordered, func() {
 		}()
 
 		// Wait for the compose file to appear (docker compose up may take a while).
-		// EnsureComposeFile writes to xdg.DataHome()/.specgraph/docker-compose.yaml.
-		composePath := filepath.Join(dataDir, "specgraph", ".specgraph", "docker-compose.yaml")
+		// EnsureComposeFile writes to xdg.DataHome()/docker-compose.yaml.
+		composePath := filepath.Join(dataDir, "specgraph", "docker-compose.yaml")
 		Eventually(func() bool {
 			_, err := os.Stat(composePath)
 			return err == nil

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -37,13 +37,12 @@ func ComposeDown(composeFile string) error {
 }
 
 // EnsureComposeFile writes a default docker-compose.yaml for the given backend
-// into projectDir/.specgraph/ if one does not already exist.
+// into projectDir if one does not already exist.
 func EnsureComposeFile(projectDir, backend string) (string, error) {
-	sgDir := filepath.Join(projectDir, ".specgraph")
-	if err := os.MkdirAll(sgDir, 0o750); err != nil {
-		return "", fmt.Errorf("create .specgraph dir: %w", err)
+	if err := os.MkdirAll(projectDir, 0o750); err != nil {
+		return "", fmt.Errorf("create data dir: %w", err)
 	}
-	dest := filepath.Join(sgDir, "docker-compose.yaml")
+	dest := filepath.Join(projectDir, "docker-compose.yaml")
 	if _, err := os.Stat(dest); err == nil {
 		return dest, nil
 	}


### PR DESCRIPTION
## Summary
- `EnsureComposeFile` wrote to `xdg.DataHome()/.specgraph/docker-compose.yaml`, but `DataHome()` already returns `~/.local/share/specgraph` — the `.specgraph` subdir was redundant
- Now writes directly to `xdg.DataHome()/docker-compose.yaml`, consistent with `down.go` which already used the correct path
- Updated e2e test path expectation accordingly

Closes #483

## Test plan
- [x] `task check` passes (fmt, lint, build, unit tests)
- [ ] `task pr-prep` (integration + e2e — CI will cover this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>