### PR TITLE
fix: dev:reset removes stale compose file, fix XDG data paths

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,12 +21,13 @@ tasks:
         # Stop launchd service if installed
         launchctl bootout gui/$(id -u)/com.specgraph.server 2>/dev/null || true
         # Stop Docker containers from specgraph serve/up
-        docker compose -f "${XDG_DATA_HOME:-$HOME/.local/share}/specgraph/.specgraph/docker-compose.yaml" down 2>/dev/null || true
+        docker compose -f "${XDG_DATA_HOME:-$HOME/.local/share}/specgraph/docker-compose.yaml" down 2>/dev/null || true
   dev:reset:
-    desc: Stop server, drop data volumes, clean artifacts, rebuild
+    desc: Stop server, drop data volumes, remove stale compose file, rebuild
     cmds:
       - task: dev:stop
-      - docker compose -f "${XDG_DATA_HOME:-$HOME/.local/share}/specgraph/.specgraph/docker-compose.yaml" down -v 2>/dev/null || true
+      - docker compose -f "${XDG_DATA_HOME:-$HOME/.local/share}/specgraph/docker-compose.yaml" down -v 2>/dev/null || true
+      - rm -f "${XDG_DATA_HOME:-$HOME/.local/share}/specgraph/docker-compose.yaml"
       - task: clean
       - task: build
   # Code Generation

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -5,6 +5,7 @@
 package docker
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -43,8 +44,12 @@ func EnsureComposeFile(projectDir string) (string, error) {
 		return "", fmt.Errorf("create data dir: %w", err)
 	}
 	dest := filepath.Join(projectDir, "docker-compose.yaml")
-	if _, err := os.Stat(dest); err == nil {
-		return dest, nil
+	if data, err := os.ReadFile(dest); err == nil {
+		// Regenerate if the existing file is a stale Memgraph compose template.
+		if !bytes.Contains(data, []byte("memgraph")) {
+			return dest, nil
+		}
+		// Fall through to overwrite with Postgres template.
 	}
 	template := postgresComposeTemplate()
 	if err := os.WriteFile(dest, []byte(template), 0o600); err != nil {


### PR DESCRIPTION
## Summary

- `task dev:reset` now removes the stale `docker-compose.yaml` so `EnsureComposeFile` regenerates it with the Postgres template
- Fixed XDG data paths in `dev:stop` and `dev:reset` — had an extra `.specgraph/` subdirectory that didn't match the actual path used by `xdg.DataHome()`

Without this, users who ran SpecGraph before the Postgres migration get a stale Memgraph compose file that starts Memgraph instead of Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>