### PR TITLE
fix(storage): handle duplicate slug constraint in CreateDecision and CreateSpec (spgr-dn7)

### DIFF
--- a/internal/storage/postgres/decision_test.go
+++ b/internal/storage/postgres/decision_test.go
@@ -73,6 +73,20 @@ func TestCreateDecision_MinimalFields(t *testing.T) {
 	require.Empty(t, dec.OriginStage)
 }
 
+func TestCreateDecision_DuplicateSlug(t *testing.T) {
+	store := newStore(t)
+	clearDatabase(t, store)
+	ctx := context.Background()
+
+	_, err := store.CreateDecision(ctx, "dup-dec", "Title", "Body", "Rationale",
+		"", nil, "", nil, "", "", "")
+	require.NoError(t, err)
+
+	_, err = store.CreateDecision(ctx, "dup-dec", "Title2", "Body2", "Rationale2",
+		"", nil, "", nil, "", "", "")
+	require.ErrorIs(t, err, storage.ErrDecisionAlreadyExists)
+}
+
 func TestGetDecision_NotFound(t *testing.T) {
 	store := newStore(t)
 	clearDatabase(t, store)

--- a/internal/storage/postgres/spec.go
+++ b/internal/storage/postgres/spec.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/specgraph/specgraph/internal/storage/contenthash"
@@ -59,6 +60,10 @@ func (s *Store) CreateSpec(ctx context.Context, slug, intent, priority, complexi
 
 		spec, err := scanSpec(row)
 		if err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				return fmt.Errorf("slug %q: %w", slug, storage.ErrSpecAlreadyExists)
+			}
 			return fmt.Errorf("postgres: create spec: scan: %w", err)
 		}
 


### PR DESCRIPTION
## Summary

- `CreateDecision`: PG unique constraint violation (23505) now returns `ErrDecisionAlreadyExists` (409 AlreadyExists) instead of bubbling up as 500 Internal Error
- `CreateSpec`: Added same PG 23505 safety net for the TOCTOU race between the pre-check SELECT and INSERT
- Added `TestCreateDecision_DuplicateSlug` integration test

Found during PR #824 — Playwright UI e2e tests called `seedDecision` which expected 409 on retry but got 500.

## Test plan

- [x] `TestCreateDecision_DuplicateSlug` passes
- [x] `go build ./internal/storage/postgres/...`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>