### PR TITLE
fix(auth): always show admin token path on dev server startup

### DIFF
--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -153,8 +153,10 @@ func runServe(cmd *cobra.Command, _ []string) error {
 				return fmt.Errorf("reload auth after bootstrap: %w", err)
 			}
 		}
-	} else if mode == "local" && authStore.HasKeys() {
-		fmt.Fprintf(os.Stderr, "  Auth: using credentials from %s\n", credPath)
+	} else if mode == "local" {
+		if _, statErr := os.Stat(credPath); statErr == nil {
+			fmt.Fprintf(os.Stderr, "  Auth: using credentials from %s\n", credPath)
+		}
 	}
 
 	if warning := auth.CheckCredentialPermissions(credPath); warning != "" {


### PR DESCRIPTION
## Summary
- Always print the bootstrap API key on first generation (removed `stderrIsTerminal` guard that swallowed the key when run via `task dev`)
- On subsequent runs in local mode, print the credentials file path so the token is discoverable
- Removed unused `stderrIsTerminal` helper

## Test plan
- [ ] Run `task dev:reset && task dev` — verify key is printed on first startup
- [ ] Stop and re-run `task dev` — verify credentials path is shown
- [ ] `cat` the credentials file to confirm key is retrievable

🤖 Generated with [Claude Code](https://claude.com/claude-code)