### PR TITLE
fix(auth): add missing permission mappings for conversation RPCs

### DIFF
--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -39,7 +39,7 @@ func NewAuthInterceptor(store IdentityStore) connect.UnaryInterceptorFunc {
 				slog.Error("auth: unconfigured RPC permission",
 					"procedure", procedure,
 				)
-				return nil, connect.NewError(connect.CodeInternal, nil)
+				return nil, connect.NewError(connect.CodeInternal, errors.New("unconfigured RPC permission"))
 			}
 
 			if !HasPermission(id.Permissions, required) {

--- a/internal/auth/permissions.go
+++ b/internal/auth/permissions.go
@@ -45,7 +45,9 @@ var rpcPermissions = map[string]string{
 	specgraphv1connect.AuthoringServiceDecomposeProcedure:  "authoring:write",
 	specgraphv1connect.AuthoringServiceApproveProcedure:    "authoring:write",
 	specgraphv1connect.AuthoringServiceAmendProcedure:      "authoring:write",
-	specgraphv1connect.AuthoringServiceSupersedeProcedure:  "authoring:write",
+	specgraphv1connect.AuthoringServiceSupersedeProcedure:          "authoring:write",
+	specgraphv1connect.AuthoringServiceRecordConversationProcedure: "authoring:write",
+	specgraphv1connect.AuthoringServiceListConversationsProcedure:  "authoring:read",
 	// ExecutionService
 	specgraphv1connect.ExecutionServiceGenerateBundleProcedure:     "execution:read",
 	specgraphv1connect.ExecutionServiceGetPrimeProcedure:           "execution:read",

--- a/internal/auth/permissions_test.go
+++ b/internal/auth/permissions_test.go
@@ -49,6 +49,8 @@ var allProcedures = []string{
 	specgraphv1connect.AuthoringServiceAmendProcedure,
 	specgraphv1connect.AuthoringServiceSupersedeProcedure,
 	specgraphv1connect.AuthoringServiceGetPromptsProcedure,
+	specgraphv1connect.AuthoringServiceRecordConversationProcedure,
+	specgraphv1connect.AuthoringServiceListConversationsProcedure,
 	// ExecutionService
 	specgraphv1connect.ExecutionServiceGenerateBundleProcedure,
 	specgraphv1connect.ExecutionServiceGetPrimeProcedure,

--- a/plugin/specgraph/skills/specgraph-approve/SKILL.md
+++ b/plugin/specgraph/skills/specgraph-approve/SKILL.md
@@ -166,11 +166,18 @@ confirmed each one:
    record on hold/decline — approvals are self-evident.
 
    ```bash
-   cat > /tmp/conv-<slug>.json << 'CONV_EOF'
-   { "exchanges": [ ... review discussion + rejection rationale ... ] }
+   CONV_TMP="$(mktemp /tmp/conv-XXXXXX.json)"
+   trap 'rm -f "$CONV_TMP"' EXIT
+   cat > "$CONV_TMP" << 'CONV_EOF'
+   {
+     "exchanges": [
+       {"role": "probe", "content": "...", "stage": "approve", "sequence": 1},
+       {"role": "response", "content": "...", "stage": "approve", "sequence": 1},
+       ...
+     ]
+   }
    CONV_EOF
-   specgraph conversation record <slug> --stage approve --json-file /tmp/conv-<slug>.json
-   rm /tmp/conv-<slug>.json
+   specgraph conversation record <slug> --stage approve --json-file "$CONV_TMP"
    ```
 
 2. Record the hold reason, suggest which stage to revisit, and do NOT re-offer

--- a/plugin/specgraph/skills/specgraph-decompose/SKILL.md
+++ b/plugin/specgraph/skills/specgraph-decompose/SKILL.md
@@ -129,11 +129,18 @@ specgraph decompose <slug> --json-file <tmpfile>
 5. **Record the conversation:** See `references/conversation-recording.md` for the exchange format.
 
    ```bash
-   cat > /tmp/conv-<slug>.json << 'CONV_EOF'
-   { "exchanges": [ ... accumulated probe/response exchanges ... ] }
+   CONV_TMP="$(mktemp /tmp/conv-XXXXXX.json)"
+   trap 'rm -f "$CONV_TMP"' EXIT
+   cat > "$CONV_TMP" << 'CONV_EOF'
+   {
+     "exchanges": [
+       {"role": "probe", "content": "...", "stage": "decompose", "sequence": 1},
+       {"role": "response", "content": "...", "stage": "decompose", "sequence": 1},
+       ...
+     ]
+   }
    CONV_EOF
-   specgraph conversation record <slug> --stage decompose --json-file /tmp/conv-<slug>.json
-   rm /tmp/conv-<slug>.json
+   specgraph conversation record <slug> --stage decompose --json-file "$CONV_TMP"
    ```
 
 6. Confirm: "Saved. Spec is now at Decompose."

--- a/plugin/specgraph/skills/specgraph-shape/SKILL.md
+++ b/plugin/specgraph/skills/specgraph-shape/SKILL.md
@@ -251,11 +251,18 @@ When the shaping conversation is complete:
 5. **Record the conversation:** See `references/conversation-recording.md` for the exchange format.
 
    ```bash
-   cat > /tmp/conv-<slug>.json << 'CONV_EOF'
-   { "exchanges": [ ... accumulated probe/response exchanges ... ] }
+   CONV_TMP="$(mktemp /tmp/conv-XXXXXX.json)"
+   trap 'rm -f "$CONV_TMP"' EXIT
+   cat > "$CONV_TMP" << 'CONV_EOF'
+   {
+     "exchanges": [
+       {"role": "probe", "content": "...", "stage": "shape", "sequence": 1},
+       {"role": "response", "content": "...", "stage": "shape", "sequence": 1},
+       ...
+     ]
+   }
    CONV_EOF
-   specgraph conversation record <slug> --stage shape --json-file /tmp/conv-<slug>.json
-   rm /tmp/conv-<slug>.json
+   specgraph conversation record <slug> --stage shape --json-file "$CONV_TMP"
    ```
 
 6. **Confirm:** "Saved. Spec is now at Specify stage."

--- a/plugin/specgraph/skills/specgraph-spark/SKILL.md
+++ b/plugin/specgraph/skills/specgraph-spark/SKILL.md
@@ -134,11 +134,18 @@ specgraph spark <slug> --seed "<seed>"
 2. Record the conversation (see `references/conversation-recording.md`):
 
    ```bash
-   cat > /tmp/conv-<slug>.json << 'CONV_EOF'
-   { "exchanges": [ ... accumulated probe/response exchanges ... ] }
+   CONV_TMP="$(mktemp /tmp/conv-XXXXXX.json)"
+   trap 'rm -f "$CONV_TMP"' EXIT
+   cat > "$CONV_TMP" << 'CONV_EOF'
+   {
+     "exchanges": [
+       {"role": "probe", "content": "...", "stage": "spark", "sequence": 1},
+       {"role": "response", "content": "...", "stage": "spark", "sequence": 1},
+       ...
+     ]
+   }
    CONV_EOF
-   specgraph conversation record <slug> --stage spark --json-file /tmp/conv-<slug>.json
-   rm /tmp/conv-<slug>.json
+   specgraph conversation record <slug> --stage spark --json-file "$CONV_TMP"
    ```
 
 3. Show the user what was saved.

--- a/plugin/specgraph/skills/specgraph-specify/SKILL.md
+++ b/plugin/specgraph/skills/specgraph-specify/SKILL.md
@@ -231,11 +231,18 @@ When the specify conversation is complete:
 5. **Record the conversation:** See `references/conversation-recording.md` for the exchange format.
 
    ```bash
-   cat > /tmp/conv-<slug>.json << 'CONV_EOF'
-   { "exchanges": [ ... accumulated probe/response exchanges ... ] }
+   CONV_TMP="$(mktemp /tmp/conv-XXXXXX.json)"
+   trap 'rm -f "$CONV_TMP"' EXIT
+   cat > "$CONV_TMP" << 'CONV_EOF'
+   {
+     "exchanges": [
+       {"role": "probe", "content": "...", "stage": "specify", "sequence": 1},
+       {"role": "response", "content": "...", "stage": "specify", "sequence": 1},
+       ...
+     ]
+   }
    CONV_EOF
-   specgraph conversation record <slug> --stage specify --json-file /tmp/conv-<slug>.json
-   rm /tmp/conv-<slug>.json
+   specgraph conversation record <slug> --stage specify --json-file "$CONV_TMP"
    ```
 
 6. **Confirm:** "Saved. Spec is now at Decompose stage."


### PR DESCRIPTION
## Summary
- Add `RecordConversation` (`authoring:write`) and `ListConversations` (`authoring:read`) to the auth permission table — both were missing, causing all conversation recording to fail with an opaque `"internal"` error
- Improve error message for unconfigured RPC permissions from `nil` to `"unconfigured RPC permission"` so the client can see what went wrong
- Update conversation recording snippets in all 5 authoring skill templates (spark, shape, specify, decompose, approve) to use `mktemp`/`trap` cleanup pattern and show the correct JSON field names

## Test plan
- [x] `TestPermissionTable_Completeness` passes (verifies all procedures are mapped)
- [x] `go test ./internal/auth/` — all tests pass
- [x] `go build ./cmd/specgraph` — builds clean
- [x] Manual verification: `specgraph conversation record` succeeds after server restart with new binary
- [x] `task check` passes (pre-existing failures in `cmd/specgraph/` conversation_test.go and decision_test.go are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)