### PR TITLE
chore: add adaptive thinking and token config to claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,8 @@
 {
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
+    "MAX_THINKING_TOKENS": "128000"
   },
   "hooks": {
     "PostToolUse": [


### PR DESCRIPTION
## Summary

- Disables adaptive thinking (`CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1`) for faster, more interactive responses during coding sessions
- Sets `MAX_THINKING_TOKENS=128000` as an explicit cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)