### PR TITLE
fix(skills): make conversation recording structurally inseparable from stage persistence

### DIFF
--- a/plugin/specgraph/skills/specgraph-decompose/SKILL.md
+++ b/plugin/specgraph/skills/specgraph-decompose/SKILL.md
@@ -140,15 +140,14 @@ If the spec is already at or past Decompose:
    - `slices` — array of objects with `id`, `intent`, `verify`, `touches`, `dependsOn`
 2. Show the user: "Here's the decomposition I'm going to save: [summary]. Look right?"
 3. User confirms or tweaks.
-4. Write temp file, call CLI:
-
-```bash
-specgraph decompose <slug> --json-file <tmpfile>
-```
-
-5. **Record the conversation:** See `references/conversation-recording.md` for the exchange format.
+4. Write temp file and persist, then record the conversation in the same step.
+   Run both commands before moving on — conversation recording is not optional.
 
    ```bash
+   # Persist to the graph
+   specgraph decompose <slug> --json-file <tmpfile>
+
+   # Record the conversation (REQUIRED — see references/conversation-recording.md)
    CONV_TMP="$(mktemp /tmp/conv-XXXXXX.json)"
    trap 'rm -f "$CONV_TMP"' EXIT
    cat > "$CONV_TMP" << 'CONV_EOF'

--- a/plugin/specgraph/skills/specgraph-decompose/SKILL.md
+++ b/plugin/specgraph/skills/specgraph-decompose/SKILL.md
@@ -147,7 +147,7 @@ If the spec is already at or past Decompose:
    # Persist to the graph
    specgraph decompose <slug> --json-file <tmpfile>
 
-   # Record the conversation (REQUIRED — see references/conversation-recording.md)
+   # Record the conversation (REQUIRED — retry once on failure; abort if both attempts fail)
    CONV_TMP="$(mktemp /tmp/conv-XXXXXX.json)"
    trap 'rm -f "$CONV_TMP"' EXIT
    cat > "$CONV_TMP" << 'CONV_EOF'
@@ -159,7 +159,9 @@ If the spec is already at or past Decompose:
      ]
    }
    CONV_EOF
-   specgraph conversation record <slug> --stage decompose --json-file "$CONV_TMP"
+   specgraph conversation record <slug> --stage decompose --json-file "$CONV_TMP" || \
+     specgraph conversation record <slug> --stage decompose --json-file "$CONV_TMP" || \
+     { echo "ERROR: conversation recording failed after retry — do not advance to the next stage until this is resolved"; exit 1; }
    ```
 
 ### Analytical Passes

--- a/plugin/specgraph/skills/specgraph-shape/SKILL.md
+++ b/plugin/specgraph/skills/specgraph-shape/SKILL.md
@@ -218,8 +218,10 @@ When the shaping conversation is complete:
 3. **Wait for confirmation.** User confirms or requests changes. Iterate until
    they approve.
 
-4. **Write and persist:** Read `references/shape-output-format.md` for the
-   exact JSON schema. Use only ASCII characters — no em dashes or Unicode.
+4. **Persist and record — both commands, same step:** Read
+   `references/shape-output-format.md` for the exact JSON schema. Use only
+   ASCII characters — no em dashes or Unicode. Run both commands before moving
+   on. Conversation recording is part of this step, not an optional follow-up.
 
    ```bash
    # Write synthesized output to temp file (see references/shape-output-format.md for schema)
@@ -229,11 +231,8 @@ When the shaping conversation is complete:
 
    # Persist to the graph
    specgraph shape <slug> --json-file /tmp/shape-<slug>.json
-   ```
 
-5. **Record the conversation:** See `references/conversation-recording.md` for the exchange format.
-
-   ```bash
+   # Record the conversation (REQUIRED — see references/conversation-recording.md)
    CONV_TMP="$(mktemp /tmp/conv-XXXXXX.json)"
    trap 'rm -f "$CONV_TMP"' EXIT
    cat > "$CONV_TMP" << 'CONV_EOF'

--- a/plugin/specgraph/skills/specgraph-shape/SKILL.md
+++ b/plugin/specgraph/skills/specgraph-shape/SKILL.md
@@ -232,7 +232,7 @@ When the shaping conversation is complete:
    # Persist to the graph
    specgraph shape <slug> --json-file /tmp/shape-<slug>.json
 
-   # Record the conversation (REQUIRED — see references/conversation-recording.md)
+   # Record the conversation (REQUIRED — retry once on failure; abort if both attempts fail)
    CONV_TMP="$(mktemp /tmp/conv-XXXXXX.json)"
    trap 'rm -f "$CONV_TMP"' EXIT
    cat > "$CONV_TMP" << 'CONV_EOF'
@@ -244,7 +244,9 @@ When the shaping conversation is complete:
      ]
    }
    CONV_EOF
-   specgraph conversation record <slug> --stage shape --json-file "$CONV_TMP"
+   specgraph conversation record <slug> --stage shape --json-file "$CONV_TMP" || \
+     specgraph conversation record <slug> --stage shape --json-file "$CONV_TMP" || \
+     { echo "ERROR: conversation recording failed after retry — do not advance to the next stage until this is resolved"; exit 1; }
    ```
 
 ### Analytical Passes

--- a/plugin/specgraph/skills/specgraph-specify/SKILL.md
+++ b/plugin/specgraph/skills/specgraph-specify/SKILL.md
@@ -215,7 +215,7 @@ When the specify conversation is complete:
    # Persist to the graph
    specgraph specify <slug> --json-file /tmp/specify-<slug>.json
 
-   # Record the conversation (REQUIRED — see references/conversation-recording.md)
+   # Record the conversation (REQUIRED — retry once on failure; abort if both attempts fail)
    CONV_TMP="$(mktemp /tmp/conv-XXXXXX.json)"
    trap 'rm -f "$CONV_TMP"' EXIT
    cat > "$CONV_TMP" << 'CONV_EOF'
@@ -227,7 +227,9 @@ When the specify conversation is complete:
      ]
    }
    CONV_EOF
-   specgraph conversation record <slug> --stage specify --json-file "$CONV_TMP"
+   specgraph conversation record <slug> --stage specify --json-file "$CONV_TMP" || \
+     specgraph conversation record <slug> --stage specify --json-file "$CONV_TMP" || \
+     { echo "ERROR: conversation recording failed after retry — do not advance to the next stage until this is resolved"; exit 1; }
    ```
 
 ### Analytical Passes

--- a/plugin/specgraph/skills/specgraph-specify/SKILL.md
+++ b/plugin/specgraph/skills/specgraph-specify/SKILL.md
@@ -202,7 +202,9 @@ When the specify conversation is complete:
 3. **Wait for confirmation.** User confirms or requests changes. Iterate until
    they approve.
 
-4. **Write and persist:**
+4. **Persist and record — both commands, same step:** Run both commands before
+   moving on. Conversation recording is part of this step, not an optional
+   follow-up.
 
    ```bash
    # Write synthesized output to temp file
@@ -212,11 +214,8 @@ When the specify conversation is complete:
 
    # Persist to the graph
    specgraph specify <slug> --json-file /tmp/specify-<slug>.json
-   ```
 
-5. **Record the conversation:** See `references/conversation-recording.md` for the exchange format.
-
-   ```bash
+   # Record the conversation (REQUIRED — see references/conversation-recording.md)
    CONV_TMP="$(mktemp /tmp/conv-XXXXXX.json)"
    trap 'rm -f "$CONV_TMP"' EXIT
    cat > "$CONV_TMP" << 'CONV_EOF'

--- a/plugin/specgraph/skills/specgraph/conversation-recording.md
+++ b/plugin/specgraph/skills/specgraph/conversation-recording.md
@@ -78,4 +78,4 @@ Only record on rejection (hold/decline). The approval flow's discussion is worth
 
 ## Error Handling
 
-Conversation recording is required. If the CLI call fails with a transient error, retry once. If it still fails, log the error — but do not skip the attempt. The structured stage output is the primary artifact, but the conversation log is part of the same persistence step, not an optional follow-up.
+Conversation recording is required. If the CLI call fails with a transient error, retry once automatically (the stage SKILL.md snippets include this retry). If the retry also fails, treat it as a fatal error for the persistence step: surface the error to the user and do not advance to the next stage. The structured stage output and the conversation log are a single atomic persistence operation — both must succeed before the stage is considered complete.

--- a/plugin/specgraph/skills/specgraph/conversation-recording.md
+++ b/plugin/specgraph/skills/specgraph/conversation-recording.md
@@ -78,4 +78,4 @@ Only record on rejection (hold/decline). The approval flow's discussion is worth
 
 ## Error Handling
 
-Conversation recording is non-critical. If the CLI call fails, log the error but do NOT abort the stage persistence. The structured stage output is the primary artifact.
+Conversation recording is required. If the CLI call fails with a transient error, retry once. If it still fails, log the error — but do not skip the attempt. The structured stage output is the primary artifact, but the conversation log is part of the same persistence step, not an optional follow-up.


### PR DESCRIPTION
## Summary

- Merges conversation recording into the same numbered step and bash block as the stage persist command (shape, specify, decompose)
- Removes the two-step structure that let agents treat recording as an optional follow-up
- Updates `conversation-recording.md` to remove the "non-critical" framing that gave agents permission to skip

## Root cause

The previous structure had step 4 (persist) and step 5 (record conversation) as separate steps in separate bash blocks. Under context pressure, agents would complete step 4 and not proceed to step 5. The fix makes them structurally one step with explicit "REQUIRED" and "not optional" language.

## Test plan

- [ ] Run through shape/specify/decompose authoring flow with Sonnet — verify conversation is recorded at each stage
- [ ] Confirm `specgraph conversation list <slug>` shows exchanges after a full funnel pass

Closes spgr-c2i

🤖 Generated with [Claude Code](https://claude.com/claude-code)