### PR TITLE
feat(mcp): add MCP server with tiered tool access

### DIFF
--- a/cmd/specgraph/docs.go
+++ b/cmd/specgraph/docs.go
@@ -54,7 +54,7 @@ var commandGroups = []commandGroup{
 	{Name: "Findings", Commands: []string{"findings", "pass"}},
 	{Name: "Sync", Commands: []string{"sync"}},
 	{Name: "Export & Backup", Commands: []string{"export", "import", "verify"}},
-	{Name: "Server & Config", Commands: []string{"up", "down", "serve", "status", "health", "init", "prime", "inject"}},
+	{Name: "Server & Config", Commands: []string{"up", "down", "serve", "mcp", "status", "health", "init", "prime", "inject"}},
 }
 
 func runDocsCli(_ *cobra.Command, args []string) error {

--- a/cmd/specgraph/mcp.go
+++ b/cmd/specgraph/mcp.go
@@ -1,0 +1,57 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+
+	mcppkg "github.com/specgraph/specgraph/internal/mcp"
+	"github.com/spf13/cobra"
+)
+
+var mcpCmd = &cobra.Command{
+	Use:   "mcp",
+	Short: "Start MCP server over stdio (for Claude Code, Cursor, etc.)",
+	Long: `Start a Model Context Protocol server that communicates over stdin/stdout.
+This lightweight process translates MCP tool calls into ConnectRPC RPCs
+against a running specgraph serve instance.
+
+Configure in Claude Code's MCP settings:
+  {
+    "mcpServers": {
+      "specgraph": {
+        "command": "specgraph",
+        "args": ["mcp", "--tier", "authoring"]
+      }
+    }
+  }`,
+	RunE: runMCP,
+}
+
+func init() {
+	mcpCmd.Flags().String("tier", "core", "Tool tier: core, authoring, or execution")
+	rootCmd.AddCommand(mcpCmd)
+}
+
+func runMCP(cmd *cobra.Command, _ []string) error {
+	tierStr, _ := cmd.Flags().GetString("tier")
+	tier := mcppkg.ParseTier(tierStr)
+
+	baseURL, project, err := resolveBaseURL()
+	if err != nil {
+		return fmt.Errorf("resolve server: %w", err)
+	}
+
+	httpClient := newHTTPClient(project)
+	client := mcppkg.NewClient(httpClient, baseURL)
+	srv := mcppkg.NewServer(client)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	return srv.ServeStdio(ctx, tier, os.Stdin, os.Stdout)
+}

--- a/cmd/specgraph/mcp.go
+++ b/cmd/specgraph/mcp.go
@@ -38,7 +38,15 @@ func init() {
 }
 
 func runMCP(cmd *cobra.Command, _ []string) error {
-	tierStr, _ := cmd.Flags().GetString("tier")
+	tierStr, err := cmd.Flags().GetString("tier")
+	if err != nil {
+		return fmt.Errorf("tier flag: %w", err)
+	}
+	switch tierStr {
+	case "core", "authoring", "execution":
+	default:
+		return fmt.Errorf("invalid --tier %q (must be core, authoring, or execution)", tierStr)
+	}
 	tier := mcppkg.ParseTier(tierStr)
 
 	baseURL, project, err := resolveBaseURL()

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -230,8 +230,11 @@ func runServe(cmd *cobra.Command, _ []string) error {
 	server.RegisterAuthHandlers(mux, compositeStore, auth.RequireAuth(compositeStore))
 
 	// Mount MCP streamable HTTP endpoint.
-	// Tier determined by X-Specgraph-MCP-Tier header, or ?tier= query param, defaulting to core.
-	mcpClient := mcppkg.NewClient(newHTTPClient(""), "http://"+cfg.Server.Listen)
+	// TODO(auth): Derive tier from authenticated identity once MCP auth is implemented.
+	// Currently tier is caller-supplied (header/query param). This is acceptable because
+	// the MCP endpoint shares the same auth middleware as ConnectRPC — an unauthenticated
+	// caller can't escalate beyond what the backend RPCs already enforce.
+	mcpClient := mcppkg.NewClient(newHTTPClient(""), selfBaseURL(cfg.Server.Listen))
 	mcpServer := mcppkg.NewServer(mcpClient)
 	mux.Handle("/mcp/", http.StripPrefix("/mcp", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tierStr := r.Header.Get("X-Specgraph-MCP-Tier")
@@ -287,6 +290,19 @@ func runServe(cmd *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+// selfBaseURL normalizes a listen address into a dialable HTTP base URL.
+// Empty or wildcard hosts (e.g., ":8080", "0.0.0.0:8080") are replaced with 127.0.0.1.
+func selfBaseURL(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "http://127.0.0.1"
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	return "http://" + net.JoinHostPort(host, port)
 }
 
 // isLoopbackAddr reports whether the listen address refers to a loopback interface.

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/specgraph/specgraph/internal/docker"
 	"github.com/specgraph/specgraph/internal/drift"
 	"github.com/specgraph/specgraph/internal/linter"
+	mcppkg "github.com/specgraph/specgraph/internal/mcp"
 	"github.com/specgraph/specgraph/internal/notify"
 	"github.com/specgraph/specgraph/internal/server"
 	"github.com/specgraph/specgraph/internal/storage"
@@ -228,6 +229,20 @@ func runServe(cmd *cobra.Command, _ []string) error {
 	server.RegisterAPIHandlers(mux, store, auth.RequireAuth(compositeStore))
 	server.RegisterAuthHandlers(mux, compositeStore, auth.RequireAuth(compositeStore))
 
+	// Mount MCP streamable HTTP endpoint.
+	// Tier determined by X-Specgraph-MCP-Tier header, or ?tier= query param, defaulting to core.
+	mcpClient := mcppkg.NewClient(newHTTPClient(""), "http://"+cfg.Server.Listen)
+	mcpServer := mcppkg.NewServer(mcpClient)
+	mux.Handle("/mcp/", http.StripPrefix("/mcp", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tierStr := r.Header.Get("X-Specgraph-MCP-Tier")
+		if tierStr == "" {
+			tierStr = r.URL.Query().Get("tier")
+		}
+		tier := mcppkg.ParseTier(tierStr)
+		mcpHandler := mcpServer.HTTPHandler(tier)
+		mcpHandler.ServeHTTP(w, r)
+	})))
+
 	webFS, err := fs.Sub(web.Build, "build")
 	if err != nil {
 		return fmt.Errorf("embedded web FS: %w", err)
@@ -266,6 +281,7 @@ func runServe(cmd *cobra.Command, _ []string) error {
 
 	server.StartSweeper(sweeperCtx, store, 60*time.Second, slog.Default())
 	fmt.Printf("SpecGraph server running at http://%s\n", addr)
+	slog.Info("MCP endpoint available", "path", "/mcp/")
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
 		return err
 	}

--- a/docs/plans/2026-04-10-mcp-server-design.md
+++ b/docs/plans/2026-04-10-mcp-server-design.md
@@ -48,7 +48,7 @@ All tool handlers, resource handlers, prompt handlers, and the ConnectRPC client
 
 #### Stdio (`specgraph mcp`)
 
-```
+```text
 Claude Code / Cursor
     ↓ stdin/stdout (JSON-RPC)
 specgraph mcp (lightweight process)
@@ -62,7 +62,7 @@ specgraph serve (full server)
 
 #### HTTP (embedded in `specgraph serve`)
 
-```
+```text
 Gastown polecat / remote client
     ↓ HTTP (streamable HTTP / SSE)
 specgraph serve
@@ -96,7 +96,7 @@ Two implementations:
 
 ## Package Structure
 
-```
+```text
 internal/mcp/
 ├── server.go          # MCP server setup, transport wiring (imports SDK)
 ├── client.go          # SpecGraphClient interface + RemoteClient/LocalClient
@@ -125,9 +125,9 @@ Three tiers, each inclusive of the one below:
 
 | Tier | Target Client | Tool Count | Focus |
 |------|---------------|------------|-------|
-| **core** | General MCP clients | ~8 | Read-heavy: browse specs, query graph, read constitution, view findings |
-| **authoring** | Claude Code, Cursor | +7 (~15) | Core + authoring funnel, decisions, drift, analytical passes |
-| **execution** | Gastown polecats | +6 (~21) | Authoring + claims, slices, progress reporting, bundles |
+| **core** | General MCP clients | 7 | Read-heavy: browse specs, query graph, read constitution, view findings |
+| **authoring** | Claude Code, Cursor | +7 (14) | Core + authoring funnel, decisions, drift, analytical passes |
+| **execution** | Gastown polecats | +6 (20) | Authoring + claims, slices, progress reporting, bundles |
 
 ### Capability Negotiation
 
@@ -191,12 +191,11 @@ Resource-oriented CRUD and graph queries.
 
 | Tool | Actions | Maps to RPCs |
 |------|---------|--------------|
-| `spec` | `get`, `list`, `create`, `update` | GetSpec, ListSpecs, CreateSpec, UpdateSpec |
+| `spec` | `get`, `list`, `create`, `update`, `changes`, `compare` | GetSpec, ListSpecs, CreateSpec, UpdateSpec, ListChanges, CompareVersions |
 | `decision` | `get`, `list`, `create`, `update` | GetDecision, ListDecisions, CreateDecision, UpdateDecision |
 | `edge` | `add`, `remove`, `list` | AddEdge, RemoveEdge, ListEdges |
 | `graph_query` | `dependencies`, `transitive_deps`, `impact`, `ready`, `critical_path`, `full` | GetDependencies, GetTransitiveDeps, GetImpact, GetReady, GetCriticalPath, GetFullGraph |
 | `constitution` | `get`, `update` | GetConstitution, UpdateConstitution |
-| `changes` | `list`, `compare` | ListChanges, CompareVersions |
 | `findings` | `list` | ListFindings |
 | `health` | — | Health |
 
@@ -240,7 +239,7 @@ URI-based read-only context for client context windows.
 | Constitution layer | `specgraph://constitution/{layer}` | GetConstitution (filtered) |
 | Graph | `specgraph://graph` | GetFullGraph |
 | Ready specs | `specgraph://graph/ready` | GetReady |
-| Findings | `specgraph://findings?pass_type={type}` | ListFindings |
+| Findings | `specgraph://findings` | ListFindings |
 | Changes | `specgraph://spec/{slug}/changes` | ListChanges |
 
 Constitution layers: `user`, `org`, `project`, `domain`.

--- a/docs/plans/2026-04-10-mcp-server-design.md
+++ b/docs/plans/2026-04-10-mcp-server-design.md
@@ -1,0 +1,291 @@
+# MCP Server Design
+
+> **Date**: 2026-04-10
+> **Status**: Draft
+> **Phase**: 3 (Coordination & Export)
+
+## Overview
+
+Add a full-featured MCP (Model Context Protocol) server to SpecGraph, exposing specs, graph queries, authoring workflows, and execution primitives to AI agents via the MCP standard. The MCP layer is a thin translation adapter — it holds no business logic and forwards all operations to existing ConnectRPC handlers.
+
+### Goals
+
+- Enable Claude Code, Cursor, and other MCP-compatible clients to interact with SpecGraph natively
+- Support Gastown polecats as first-class MCP consumers for execution workflows
+- Expose tools, resources, and prompts covering the full SpecGraph surface
+- Tier tool visibility by client role (core, authoring, execution)
+- Isolate the MCP SDK dependency so it can be swapped with minimal blast radius
+
+### Non-Goals
+
+- Replacing the CLI or ConnectRPC API
+- Embedding storage or handler logic in the MCP layer
+- Building a custom MCP protocol implementation
+
+## SDK Choice
+
+**`github.com/mark3labs/mcp-go`** (MIT license, compatible with Apache-2.0).
+
+Chosen over `modelcontextprotocol/go-sdk` for server-side ergonomics: per-session tools, tool filtering, and middleware — features that directly support tiered tool exposure. The SDK is isolated to 3 files, making future replacement straightforward.
+
+### Isolation Strategy
+
+Only three files import `mcp-go`:
+
+| File | Imports | Purpose |
+|------|---------|---------|
+| `server.go` | SDK server, transports | Wire MCP server instance |
+| `convert.go` | SDK tool/resource/prompt types | Map our types ↔ SDK types |
+| `tiers.go` | SDK per-session tools interface | Hook into session filtering |
+
+All tool handlers, resource handlers, prompt handlers, and the ConnectRPC client abstraction use SpecGraph-owned types exclusively.
+
+**Swap cost**: Rewrite `server.go`, `convert.go`, `tiers.go`. Zero changes to handlers or anything outside `internal/mcp/`.
+
+## Architecture
+
+### Transport Modes
+
+#### Stdio (`specgraph mcp`)
+
+```
+Claude Code / Cursor
+    ↓ stdin/stdout (JSON-RPC)
+specgraph mcp (lightweight process)
+    ↓ ConnectRPC over HTTP
+specgraph serve (full server)
+```
+
+- Reads server address + API key from existing config or flags
+- Creates a ConnectRPC client, wraps it in the MCP adapter, wires to stdio transport
+- No storage, no handlers — translation only
+
+#### HTTP (embedded in `specgraph serve`)
+
+```
+Gastown polecat / remote client
+    ↓ HTTP (streamable HTTP / SSE)
+specgraph serve
+    ├── /connect/*  (existing ConnectRPC)
+    └── /mcp/*      (MCP HTTP endpoint)
+            ↓ in-process call
+        ConnectRPC handlers
+```
+
+- MCP HTTP endpoint mounts alongside ConnectRPC on the same server
+- Same auth interceptor — MCP requests carry the same API key / OIDC token
+- Calls ConnectRPC handlers in-process via the same client interface as stdio mode
+
+### ConnectRPC Client Abstraction
+
+Both transport modes use the same interface:
+
+```go
+// internal/mcp/client.go
+type SpecGraphClient interface {
+    GetSpec(ctx context.Context, slug string) (*specv1.GetSpecResponse, error)
+    ListSpecs(ctx context.Context, ...) (*specv1.ListSpecsResponse, error)
+    // ... one method per RPC needed by MCP handlers
+}
+```
+
+Two implementations:
+
+- **`RemoteClient`** — makes ConnectRPC HTTP calls (used by `specgraph mcp` stdio mode)
+- **`LocalClient`** — calls through ConnectRPC generated client stubs pointed at `localhost` (used by `specgraph serve` HTTP mode). This keeps the code path identical to stdio mode (same interceptors, same auth) while avoiding a network hop via loopback optimization.
+
+## Package Structure
+
+```
+internal/mcp/
+├── server.go          # MCP server setup, transport wiring (imports SDK)
+├── client.go          # SpecGraphClient interface + RemoteClient/LocalClient
+├── convert.go         # Our types ↔ SDK types (imports SDK)
+├── tiers.go           # Tier definitions, session→tier mapping (imports SDK)
+├── tools.go           # Tool registry, ToolDef type, ToolHandler type
+├── tools_spec.go      # Spec CRUD tool handlers
+├── tools_decision.go  # Decision tool handlers
+├── tools_graph.go     # Graph query tool handlers
+├── tools_authoring.go # Authoring workflow tool handlers
+├── tools_execution.go # Execution/slice tool handlers
+├── tools_lifecycle.go # Drift, lint, sync, export tool handlers
+├── resources.go       # MCP resource definitions + handlers
+└── prompts.go         # MCP prompt definitions + handlers
+
+cmd/specgraph/
+├── mcp.go             # `specgraph mcp` command (stdio transport)
+└── serve.go           # (modified) also starts MCP HTTP endpoint
+```
+
+## Tool Tiers
+
+### Tier Model
+
+Three tiers, each inclusive of the one below:
+
+| Tier | Target Client | Tool Count | Focus |
+|------|---------------|------------|-------|
+| **core** | General MCP clients | ~8 | Read-heavy: browse specs, query graph, read constitution, view findings |
+| **authoring** | Claude Code, Cursor | +7 (~15) | Core + authoring funnel, decisions, drift, analytical passes |
+| **execution** | Gastown polecats | +6 (~21) | Authoring + claims, slices, progress reporting, bundles |
+
+### Capability Negotiation
+
+During MCP `initialize`, the client passes metadata to select a tier:
+
+```json
+{
+  "clientInfo": {
+    "name": "claude-code",
+    "version": "1.0",
+    "metadata": { "specgraph.role": "authoring" }
+  }
+}
+```
+
+Mapping:
+
+- `"specgraph.role": "execution"` → execution tier
+- `"specgraph.role": "authoring"` → authoring tier
+- Anything else (or absent) → core tier
+
+Implemented via `mcp-go`'s per-session tools feature — the registry filters tools by the session's negotiated tier before returning them via `tools/list`.
+
+### Tool Registry Type
+
+```go
+type Tier int
+
+const (
+    TierCore      Tier = iota
+    TierAuthoring
+    TierExecution
+)
+
+type ToolDef struct {
+    Name        string
+    Description string
+    Tier        Tier
+    Schema      map[string]any  // JSON Schema for parameters
+    Handler     ToolHandler
+}
+
+type ToolHandler func(ctx context.Context, params map[string]any) (*ToolResult, error)
+
+type ToolResult struct {
+    Content []Content
+    IsError bool
+}
+
+type Content struct {
+    Type string // "text", "image", "resource"
+    Text string
+}
+```
+
+## Tools
+
+### Core Tier
+
+Resource-oriented CRUD and graph queries.
+
+| Tool | Actions | Maps to RPCs |
+|------|---------|--------------|
+| `spec` | `get`, `list`, `create`, `update` | GetSpec, ListSpecs, CreateSpec, UpdateSpec |
+| `decision` | `get`, `list`, `create`, `update` | GetDecision, ListDecisions, CreateDecision, UpdateDecision |
+| `edge` | `add`, `remove`, `list` | AddEdge, RemoveEdge, ListEdges |
+| `graph_query` | `dependencies`, `transitive_deps`, `impact`, `ready`, `critical_path`, `full` | GetDependencies, GetTransitiveDeps, GetImpact, GetReady, GetCriticalPath, GetFullGraph |
+| `constitution` | `get`, `update` | GetConstitution, UpdateConstitution |
+| `changes` | `list`, `compare` | ListChanges, CompareVersions |
+| `findings` | `list` | ListFindings |
+| `health` | — | Health |
+
+### Authoring Tier (adds to core)
+
+Workflow-oriented tools for multi-step processes.
+
+| Tool | Actions | Maps to RPCs |
+|------|---------|--------------|
+| `author` | `spark`, `shape`, `specify`, `decompose`, `approve`, `amend`, `supersede` | Spark, Shape, Specify, Decompose, Approve, Amend, Supersede |
+| `conversation` | `record`, `list` | RecordConversation, ListConversations |
+| `analytical_pass` | `run`, `store` | RunAnalyticalPass, StoreFindings |
+| `drift` | `check`, `acknowledge` | CheckDrift, AcknowledgeDrift |
+| `lint` | — | Lint |
+| `sync` | `beads`, `github`, `status` | SyncBeads, SyncGitHub, GetSyncStatus |
+| `export` | `export`, `import`, `verify` | ExportProject, ImportProject, VerifyExport |
+
+### Execution Tier (adds to authoring)
+
+Precise tools for Gastown polecats and execution agents.
+
+| Tool | Actions | Maps to RPCs |
+|------|---------|--------------|
+| `claim` | `claim`, `unclaim`, `heartbeat` | ClaimSpec, UnclaimSpec, Heartbeat |
+| `slice` | `list`, `get`, `claim`, `complete` | ListSlices, GetSlice, ClaimSlice, CompleteSlice |
+| `bundle` | — | GenerateBundle |
+| `prime` | — | GetPrime |
+| `report` | `progress`, `blocker`, `completion` | ReportProgress, ReportBlocker, ReportCompletion |
+| `execution_events` | — | GetExecutionEvents |
+
+## Resources
+
+URI-based read-only context for client context windows.
+
+| Resource | URI Pattern | Maps to |
+|----------|-------------|---------|
+| Spec | `specgraph://spec/{slug}` | GetSpec |
+| Spec list | `specgraph://specs` | ListSpecs |
+| Decision | `specgraph://decision/{slug}` | GetDecision |
+| Constitution (merged) | `specgraph://constitution` | GetConstitution |
+| Constitution layer | `specgraph://constitution/{layer}` | GetConstitution (filtered) |
+| Graph | `specgraph://graph` | GetFullGraph |
+| Ready specs | `specgraph://graph/ready` | GetReady |
+| Findings | `specgraph://findings?pass_type={type}` | ListFindings |
+| Changes | `specgraph://spec/{slug}/changes` | ListChanges |
+
+Constitution layers: `user`, `org`, `project`, `domain`.
+
+### Subscriptions
+
+Initial implementation is poll-based: the MCP server polls ConnectRPC for changes on a configurable interval (default 5s) and emits notifications to subscribed clients. Event-driven notifications can be added later without changing the MCP API surface.
+
+## Prompts
+
+Reusable templates that guide agents through workflows.
+
+| Prompt | Arguments | Maps to |
+|--------|-----------|---------|
+| `spark` | `topic`, `context` | GetPrompts(spark) |
+| `shape` | `spec_slug` | GetPrompts(shape) |
+| `specify` | `spec_slug` | GetPrompts(specify) |
+| `decompose` | `spec_slug` | GetPrompts(decompose) |
+| `constitution_check` | `spec_slug` | Analytical pass template |
+| `dependency_review` | `spec_slug` | Analytical pass template |
+
+## Error Handling
+
+### ConnectRPC → MCP Error Mapping
+
+| ConnectRPC Code | MCP Behavior |
+|-----------------|--------------|
+| `CodeNotFound` | Tool result with `isError: true`, descriptive message |
+| `CodeAborted` | Tool result with `isError: true`, "concurrent modification, retry" |
+| `CodeInvalidArgument` | Tool result with `isError: true`, validation details |
+| `CodeUnauthenticated` | MCP protocol-level error (not a tool result) |
+| `CodeInternal` | Tool result with `isError: true`, sanitized message |
+
+**Principle**: Auth failures are protocol errors (client can't proceed). Everything else is a tool result (agent can reason about it and retry).
+
+### Connection Lifecycle
+
+- **Stdio**: process exits when stdin closes. Clean shutdown.
+- **HTTP**: session timeout after idle period. Subscriptions cleaned up on disconnect.
+- **Server unreachable** (stdio mode): returns MCP error on every tool call — "cannot reach specgraph server at {address}".
+
+## Auth
+
+Reuses existing ConnectRPC auth entirely:
+
+- **Stdio mode**: `specgraph mcp` passes the user's configured API key with every ConnectRPC call
+- **HTTP mode**: same auth interceptor as ConnectRPC (local API key + OIDC)
+- No separate MCP auth layer

--- a/docs/plans/2026-04-10-mcp-server-plan.md
+++ b/docs/plans/2026-04-10-mcp-server-plan.md
@@ -1,0 +1,4406 @@
+# MCP Server Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a full-featured MCP server exposing SpecGraph's tools, resources, and prompts to AI agents via stdio and HTTP transports.
+
+**Architecture:** Thin MCP adapter in `internal/mcp/` translates MCP calls to ConnectRPC RPCs. SDK isolation confines `mcp-go` imports to 3 files. Tool tiers (core/authoring/execution) filter visibility by client role.
+
+**Tech Stack:** Go, `github.com/mark3labs/mcp-go` (MIT), ConnectRPC, protobuf
+
+**Design spec:** `docs/plans/2026-04-10-mcp-server-design.md`
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `internal/mcp/types.go` | Tier, ToolDef, ToolResult, Content, ResourceDef, PromptDef |
+| Create | `internal/mcp/helpers.go` | Param extraction, result formatting, schema builders |
+| Create | `internal/mcp/helpers_test.go` | Tests for helpers |
+| Create | `internal/mcp/registry.go` | Tool/resource/prompt registry with tier filtering |
+| Create | `internal/mcp/registry_test.go` | Registry tests |
+| Create | `internal/mcp/client.go` | Client struct wrapping all ConnectRPC service clients |
+| Create | `internal/mcp/testhelpers_test.go` | Mock clients for tool handler tests |
+| Create | `internal/mcp/tools_spec.go` | spec + decision tool handlers |
+| Create | `internal/mcp/tools_spec_test.go` | Tests |
+| Create | `internal/mcp/tools_graph.go` | edge + graph_query tool handlers |
+| Create | `internal/mcp/tools_graph_test.go` | Tests |
+| Create | `internal/mcp/tools_core.go` | constitution + changes + findings + health handlers |
+| Create | `internal/mcp/tools_core_test.go` | Tests |
+| Create | `internal/mcp/tools_authoring.go` | author + conversation + analytical_pass handlers |
+| Create | `internal/mcp/tools_authoring_test.go` | Tests |
+| Create | `internal/mcp/tools_lifecycle.go` | drift + lint + sync + export handlers |
+| Create | `internal/mcp/tools_lifecycle_test.go` | Tests |
+| Create | `internal/mcp/tools_execution.go` | claim + slice + bundle + prime + report + execution_events |
+| Create | `internal/mcp/tools_execution_test.go` | Tests |
+| Create | `internal/mcp/resources.go` | MCP resource definitions + handlers |
+| Create | `internal/mcp/resources_test.go` | Tests |
+| Create | `internal/mcp/prompts.go` | MCP prompt definitions + handlers |
+| Create | `internal/mcp/prompts_test.go` | Tests |
+| Create | `internal/mcp/convert.go` | Our types ↔ mcp-go SDK types (**imports SDK**) |
+| Create | `internal/mcp/convert_test.go` | Tests |
+| Create | `internal/mcp/tiers.go` | Tier negotiation from clientInfo (**imports SDK**) |
+| Create | `internal/mcp/tiers_test.go` | Tests |
+| Create | `internal/mcp/server.go` | MCP server setup + transport wiring (**imports SDK**) |
+| Create | `internal/mcp/server_test.go` | Tests |
+| Create | `cmd/specgraph/mcp.go` | `specgraph mcp` CLI command (stdio transport) |
+| Modify | `cmd/specgraph/serve.go` | Add MCP HTTP endpoint alongside ConnectRPC |
+
+---
+
+### Task 1: Foundation Types and Helpers
+
+**Files:**
+- Create: `internal/mcp/types.go`
+- Create: `internal/mcp/helpers.go`
+- Create: `internal/mcp/helpers_test.go`
+
+- [ ] **Step 1: Create package with types**
+
+```go
+// internal/mcp/types.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package mcp provides a Model Context Protocol server that translates
+// MCP tool calls into ConnectRPC RPCs against a running SpecGraph server.
+package mcp
+
+import "context"
+
+// Tier controls which tools are visible to an MCP client.
+type Tier int
+
+const (
+	// TierCore exposes read-heavy tools: specs, graph queries, constitution.
+	TierCore Tier = iota
+	// TierAuthoring adds authoring funnel, decisions, drift, analytical passes.
+	TierAuthoring
+	// TierExecution adds claims, slices, progress reporting, bundles.
+	TierExecution
+)
+
+// String returns the tier name used in capability negotiation.
+func (t Tier) String() string {
+	switch t {
+	case TierCore:
+		return "core"
+	case TierAuthoring:
+		return "authoring"
+	case TierExecution:
+		return "execution"
+	default:
+		return "core"
+	}
+}
+
+// ParseTier converts a string to a Tier. Returns TierCore for unknown values.
+func ParseTier(s string) Tier {
+	switch s {
+	case "authoring":
+		return TierAuthoring
+	case "execution":
+		return TierExecution
+	default:
+		return TierCore
+	}
+}
+
+// Includes reports whether tier t includes all tools visible at tier other.
+func (t Tier) Includes(other Tier) bool {
+	return t >= other
+}
+
+// ToolDef defines an MCP tool in SpecGraph's own types (no SDK dependency).
+type ToolDef struct {
+	Name        string
+	Description string
+	Tier        Tier
+	Schema      map[string]any // JSON Schema for parameters
+	Handler     ToolHandler
+}
+
+// ToolHandler processes an MCP tool call. params is the deserialized arguments map.
+type ToolHandler func(ctx context.Context, params map[string]any) (*ToolResult, error)
+
+// ToolResult is the response from a tool handler.
+type ToolResult struct {
+	Content []Content
+	IsError bool
+}
+
+// Content is a single content block in a tool result.
+type Content struct {
+	Type string // "text"
+	Text string
+}
+
+// ResourceDef defines an MCP resource.
+type ResourceDef struct {
+	URI         string // Exact URI or template pattern
+	Name        string
+	Description string
+	MimeType    string
+	IsTemplate  bool
+	Handler     ResourceHandler
+}
+
+// ResourceHandler reads a resource. uri is the resolved URI.
+type ResourceHandler func(ctx context.Context, uri string) ([]ResourceContent, error)
+
+// ResourceContent is a single content block in a resource response.
+type ResourceContent struct {
+	URI      string
+	MimeType string
+	Text     string
+}
+
+// PromptDef defines an MCP prompt.
+type PromptDef struct {
+	Name        string
+	Description string
+	Arguments   []PromptArgument
+	Handler     PromptHandler
+}
+
+// PromptArgument describes a prompt parameter.
+type PromptArgument struct {
+	Name        string
+	Description string
+	Required    bool
+}
+
+// PromptHandler renders a prompt. args is the argument map.
+type PromptHandler func(ctx context.Context, args map[string]string) (*PromptResult, error)
+
+// PromptResult is the response from a prompt handler.
+type PromptResult struct {
+	Description string
+	Messages    []PromptMessage
+}
+
+// PromptMessage is a single message in a prompt result.
+type PromptMessage struct {
+	Role    string // "user" or "assistant"
+	Content string
+}
+```
+
+- [ ] **Step 2: Write helpers with tests**
+
+```go
+// internal/mcp/helpers_test.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringParam(t *testing.T) {
+	params := map[string]any{"action": "get", "slug": "auth"}
+	require.Equal(t, "get", stringParam(params, "action"))
+	require.Equal(t, "auth", stringParam(params, "slug"))
+	require.Equal(t, "", stringParam(params, "missing"))
+}
+
+func TestIntParam(t *testing.T) {
+	params := map[string]any{"limit": float64(10)} // JSON numbers are float64
+	require.Equal(t, int32(10), int32Param(params, "limit"))
+	require.Equal(t, int32(0), int32Param(params, "missing"))
+}
+
+func TestBoolParam(t *testing.T) {
+	params := map[string]any{"recursive": true}
+	require.True(t, boolParam(params, "recursive"))
+	require.False(t, boolParam(params, "missing"))
+}
+
+func TestTextResult(t *testing.T) {
+	r := textResult("hello")
+	require.Len(t, r.Content, 1)
+	require.Equal(t, "text", r.Content[0].Type)
+	require.Equal(t, "hello", r.Content[0].Text)
+	require.False(t, r.IsError)
+}
+
+func TestErrorResultFromString(t *testing.T) {
+	r := errResult("something broke")
+	require.True(t, r.IsError)
+	require.Contains(t, r.Content[0].Text, "something broke")
+}
+
+func TestObjectSchema(t *testing.T) {
+	s := objectSchema(
+		props{
+			"action": stringProp("op", "get", "list"),
+			"slug":   stringProp("identifier"),
+		},
+		"action",
+	)
+	require.Equal(t, "object", s["type"])
+	p := s["properties"].(props)
+	require.Contains(t, p, "action")
+	req := s["required"].([]string)
+	require.Equal(t, []string{"action"}, req)
+}
+```
+
+```go
+// internal/mcp/helpers.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// props is shorthand for JSON Schema property maps.
+type props = map[string]any
+
+// stringParam extracts a string parameter, returning "" if absent or wrong type.
+func stringParam(params map[string]any, key string) string {
+	v, _ := params[key].(string)
+	return v
+}
+
+// int32Param extracts an int32 parameter. JSON numbers arrive as float64.
+func int32Param(params map[string]any, key string) int32 {
+	switch v := params[key].(type) {
+	case float64:
+		return int32(v)
+	case int:
+		return int32(v)
+	default:
+		return 0
+	}
+}
+
+// boolParam extracts a bool parameter, returning false if absent.
+func boolParam(params map[string]any, key string) bool {
+	v, _ := params[key].(bool)
+	return v
+}
+
+// stringSliceParam extracts a []string parameter from a JSON array.
+func stringSliceParam(params map[string]any, key string) []string {
+	raw, ok := params[key].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// jsonResult marshals a proto message to JSON and returns it as a text result.
+func jsonResult(msg proto.Message) *ToolResult {
+	data, err := protojson.MarshalOptions{Multiline: true}.Marshal(msg)
+	if err != nil {
+		return errResult(fmt.Sprintf("marshal response: %v", err))
+	}
+	return textResult(string(data))
+}
+
+// textResult wraps a string in a ToolResult.
+func textResult(text string) *ToolResult {
+	return &ToolResult{
+		Content: []Content{{Type: "text", Text: text}},
+	}
+}
+
+// errResult creates an error ToolResult from a message string.
+func errResult(msg string) *ToolResult {
+	return &ToolResult{
+		Content: []Content{{Type: "text", Text: msg}},
+		IsError: true,
+	}
+}
+
+// connectErrResult maps a ConnectRPC error to an MCP tool error result.
+// Auth errors return a Go error (protocol-level); everything else is a tool result.
+func connectErrResult(err error) (*ToolResult, error) {
+	if err == nil {
+		return nil, nil
+	}
+	code := connect.CodeOf(err)
+	if code == connect.CodeUnauthenticated {
+		return nil, fmt.Errorf("authentication required: %w", err)
+	}
+	msg := connect.CodeOf(err).String()
+	if connectErr := new(connect.Error); connect.IsNotModifiedError(err) {
+		msg = "not modified"
+	} else if ok := (err).(*connect.Error); ok {
+		msg = ok.Message()
+	}
+	if code == connect.CodeAborted {
+		msg = "concurrent modification — retry the operation"
+	}
+	return errResult(msg), nil
+}
+
+// --- Schema builders ---
+
+// objectSchema builds a JSON Schema object with the given properties and required fields.
+func objectSchema(properties props, required ...string) map[string]any {
+	s := map[string]any{
+		"type":       "object",
+		"properties": properties,
+	}
+	if len(required) > 0 {
+		s["required"] = required
+	}
+	return s
+}
+
+// stringProp builds a JSON Schema string property. Optional enum values constrain it.
+func stringProp(desc string, enum ...string) map[string]any {
+	p := map[string]any{"type": "string", "description": desc}
+	if len(enum) > 0 {
+		p["enum"] = enum
+	}
+	return p
+}
+
+// intProp builds a JSON Schema integer property.
+func intProp(desc string) map[string]any {
+	return map[string]any{"type": "integer", "description": desc}
+}
+
+// boolProp builds a JSON Schema boolean property.
+func boolProp(desc string) map[string]any {
+	return map[string]any{"type": "boolean", "description": desc}
+}
+
+// arrayProp builds a JSON Schema array property with the given item schema.
+func arrayProp(desc string, items map[string]any) map[string]any {
+	return map[string]any{"type": "array", "description": desc, "items": items}
+}
+```
+
+- [ ] **Step 3: Verify tests pass**
+
+Run: `cd /Volumes/Code/github.com/.worktrees/specgraph/mcp-server && go test ./internal/mcp/ -run 'TestStringParam|TestIntParam|TestBoolParam|TestTextResult|TestErrorResult|TestObjectSchema' -v`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/mcp/types.go internal/mcp/helpers.go internal/mcp/helpers_test.go
+git commit -s -m "feat(mcp): add foundation types and helpers for MCP server"
+```
+
+---
+
+### Task 2: Tool Registry
+
+**Files:**
+- Create: `internal/mcp/registry.go`
+- Create: `internal/mcp/registry_test.go`
+
+- [ ] **Step 1: Write registry test**
+
+```go
+// internal/mcp/registry_test.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistry_ToolsFilteredByTier(t *testing.T) {
+	r := NewRegistry()
+	noop := func(ctx context.Context, params map[string]any) (*ToolResult, error) {
+		return textResult("ok"), nil
+	}
+
+	r.AddTool(ToolDef{Name: "spec", Tier: TierCore, Handler: noop})
+	r.AddTool(ToolDef{Name: "author", Tier: TierAuthoring, Handler: noop})
+	r.AddTool(ToolDef{Name: "claim", Tier: TierExecution, Handler: noop})
+
+	core := r.ToolsForTier(TierCore)
+	require.Len(t, core, 1)
+	require.Equal(t, "spec", core[0].Name)
+
+	authoring := r.ToolsForTier(TierAuthoring)
+	require.Len(t, authoring, 2) // core + authoring
+	names := []string{authoring[0].Name, authoring[1].Name}
+	require.ElementsMatch(t, []string{"spec", "author"}, names)
+
+	execution := r.ToolsForTier(TierExecution)
+	require.Len(t, execution, 3)
+}
+
+func TestRegistry_LookupTool(t *testing.T) {
+	r := NewRegistry()
+	noop := func(ctx context.Context, params map[string]any) (*ToolResult, error) {
+		return textResult("ok"), nil
+	}
+	r.AddTool(ToolDef{Name: "spec", Tier: TierCore, Handler: noop})
+
+	def, ok := r.LookupTool("spec")
+	require.True(t, ok)
+	require.Equal(t, "spec", def.Name)
+
+	_, ok = r.LookupTool("missing")
+	require.False(t, ok)
+}
+
+func TestRegistry_Resources(t *testing.T) {
+	r := NewRegistry()
+	r.AddResource(ResourceDef{URI: "specgraph://specs", Name: "specs"})
+	require.Len(t, r.Resources(), 1)
+}
+
+func TestRegistry_Prompts(t *testing.T) {
+	r := NewRegistry()
+	r.AddPrompt(PromptDef{Name: "spark"})
+	require.Len(t, r.Prompts(), 1)
+}
+```
+
+- [ ] **Step 2: Run test, verify fail**
+
+Run: `go test ./internal/mcp/ -run TestRegistry -v`
+Expected: FAIL — Registry not defined
+
+- [ ] **Step 3: Write registry**
+
+```go
+// internal/mcp/registry.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+// Registry holds all MCP tool, resource, and prompt definitions.
+type Registry struct {
+	tools     []ToolDef
+	toolIndex map[string]int // name → index in tools
+	resources []ResourceDef
+	prompts   []PromptDef
+}
+
+// NewRegistry creates an empty registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		toolIndex: make(map[string]int),
+	}
+}
+
+// AddTool registers a tool definition.
+func (r *Registry) AddTool(def ToolDef) {
+	r.toolIndex[def.Name] = len(r.tools)
+	r.tools = append(r.tools, def)
+}
+
+// ToolsForTier returns all tools visible at the given tier.
+// Higher tiers include all tools from lower tiers.
+func (r *Registry) ToolsForTier(tier Tier) []ToolDef {
+	var out []ToolDef
+	for _, def := range r.tools {
+		if tier.Includes(def.Tier) {
+			out = append(out, def)
+		}
+	}
+	return out
+}
+
+// LookupTool finds a tool by name.
+func (r *Registry) LookupTool(name string) (ToolDef, bool) {
+	idx, ok := r.toolIndex[name]
+	if !ok {
+		return ToolDef{}, false
+	}
+	return r.tools[idx], true
+}
+
+// AddResource registers a resource definition.
+func (r *Registry) AddResource(def ResourceDef) {
+	r.resources = append(r.resources, def)
+}
+
+// Resources returns all registered resource definitions.
+func (r *Registry) Resources() []ResourceDef {
+	return r.resources
+}
+
+// AddPrompt registers a prompt definition.
+func (r *Registry) AddPrompt(def PromptDef) {
+	r.prompts = append(r.prompts, def)
+}
+
+// Prompts returns all registered prompt definitions.
+func (r *Registry) Prompts() []PromptDef {
+	return r.prompts
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `go test ./internal/mcp/ -run TestRegistry -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mcp/registry.go internal/mcp/registry_test.go
+git commit -s -m "feat(mcp): add tool/resource/prompt registry with tier filtering"
+```
+
+---
+
+### Task 3: ConnectRPC Client Wrapper
+
+**Files:**
+- Create: `internal/mcp/client.go`
+
+- [ ] **Step 1: Write client**
+
+```go
+// internal/mcp/client.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"connectrpc.com/connect"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+)
+
+// Client wraps all ConnectRPC service clients needed by MCP tool handlers.
+type Client struct {
+	Spec           specgraphv1connect.SpecServiceClient
+	Decision       specgraphv1connect.DecisionServiceClient
+	Graph          specgraphv1connect.GraphServiceClient
+	Claim          specgraphv1connect.ClaimServiceClient
+	Constitution   specgraphv1connect.ConstitutionServiceClient
+	Authoring      specgraphv1connect.AuthoringServiceClient
+	AnalyticalPass specgraphv1connect.AnalyticalPassServiceClient
+	Execution      specgraphv1connect.ExecutionServiceClient
+	Slice          specgraphv1connect.SliceServiceClient
+	Export         specgraphv1connect.ExportServiceClient
+	Lifecycle      specgraphv1connect.LifecycleServiceClient
+	Sync           specgraphv1connect.SyncServiceClient
+	Health         specgraphv1connect.ServerServiceClient
+}
+
+// NewClient creates a Client with all service clients pointing at baseURL.
+func NewClient(httpClient connect.HTTPClient, baseURL string) *Client {
+	return &Client{
+		Spec:           specgraphv1connect.NewSpecServiceClient(httpClient, baseURL),
+		Decision:       specgraphv1connect.NewDecisionServiceClient(httpClient, baseURL),
+		Graph:          specgraphv1connect.NewGraphServiceClient(httpClient, baseURL),
+		Claim:          specgraphv1connect.NewClaimServiceClient(httpClient, baseURL),
+		Constitution:   specgraphv1connect.NewConstitutionServiceClient(httpClient, baseURL),
+		Authoring:      specgraphv1connect.NewAuthoringServiceClient(httpClient, baseURL),
+		AnalyticalPass: specgraphv1connect.NewAnalyticalPassServiceClient(httpClient, baseURL),
+		Execution:      specgraphv1connect.NewExecutionServiceClient(httpClient, baseURL),
+		Slice:          specgraphv1connect.NewSliceServiceClient(httpClient, baseURL),
+		Export:         specgraphv1connect.NewExportServiceClient(httpClient, baseURL),
+		Lifecycle:      specgraphv1connect.NewLifecycleServiceClient(httpClient, baseURL),
+		Sync:           specgraphv1connect.NewSyncServiceClient(httpClient, baseURL),
+		Health:         specgraphv1connect.NewServerServiceClient(httpClient, baseURL),
+	}
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `go build ./internal/mcp/`
+Expected: Success
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/mcp/client.go
+git commit -s -m "feat(mcp): add ConnectRPC client wrapper for MCP handlers"
+```
+
+---
+
+### Task 4: Test Infrastructure and Core Tier Tools — spec, decision
+
+**Files:**
+- Create: `internal/mcp/testhelpers_test.go`
+- Create: `internal/mcp/tools_spec.go`
+- Create: `internal/mcp/tools_spec_test.go`
+
+- [ ] **Step 1: Write test helpers (mock clients)**
+
+The generated ConnectRPC interfaces (e.g., `SpecServiceClient`) can be satisfied by embedding the interface in a struct — unimplemented methods panic, and tests override only what they need.
+
+```go
+// internal/mcp/testhelpers_test.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+)
+
+// --- Spec service mock ---
+
+type mockSpecService struct {
+	specgraphv1connect.SpecServiceClient // panics on unimplemented calls
+	getSpec     func(slug string) (*specv1.GetSpecResponse, error)
+	listSpecs   func() (*specv1.ListSpecsResponse, error)
+	createSpec  func(slug, intent string) (*specv1.CreateSpecResponse, error)
+	updateSpec  func(req *specv1.UpdateSpecRequest) (*specv1.UpdateSpecResponse, error)
+	listChanges func(slug string) (*specv1.ListChangesResponse, error)
+	compareVer  func(req *specv1.CompareVersionsRequest) (*specv1.CompareVersionsResponse, error)
+}
+
+func (m *mockSpecService) GetSpec(_ context.Context, req *connect.Request[specv1.GetSpecRequest]) (*connect.Response[specv1.GetSpecResponse], error) {
+	resp, err := m.getSpec(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSpecService) ListSpecs(_ context.Context, _ *connect.Request[specv1.ListSpecsRequest]) (*connect.Response[specv1.ListSpecsResponse], error) {
+	resp, err := m.listSpecs()
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSpecService) CreateSpec(_ context.Context, req *connect.Request[specv1.CreateSpecRequest]) (*connect.Response[specv1.CreateSpecResponse], error) {
+	resp, err := m.createSpec(req.Msg.GetSlug(), req.Msg.GetIntent())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSpecService) ListChanges(_ context.Context, req *connect.Request[specv1.ListChangesRequest]) (*connect.Response[specv1.ListChangesResponse], error) {
+	resp, err := m.listChanges(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// --- Decision service mock ---
+
+type mockDecisionService struct {
+	specgraphv1connect.DecisionServiceClient
+	getDecision  func(slug string) (*specv1.GetDecisionResponse, error)
+	listDecisions func() (*specv1.ListDecisionsResponse, error)
+	createDecision func(req *specv1.CreateDecisionRequest) (*specv1.CreateDecisionResponse, error)
+}
+
+func (m *mockDecisionService) GetDecision(_ context.Context, req *connect.Request[specv1.GetDecisionRequest]) (*connect.Response[specv1.GetDecisionResponse], error) {
+	resp, err := m.getDecision(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockDecisionService) ListDecisions(_ context.Context, _ *connect.Request[specv1.ListDecisionsRequest]) (*connect.Response[specv1.ListDecisionsResponse], error) {
+	resp, err := m.listDecisions()
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockDecisionService) CreateDecision(_ context.Context, req *connect.Request[specv1.CreateDecisionRequest]) (*connect.Response[specv1.CreateDecisionResponse], error) {
+	resp, err := m.createDecision(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// --- Graph service mock ---
+
+type mockGraphService struct {
+	specgraphv1connect.GraphServiceClient
+	addEdge         func(req *specv1.AddEdgeRequest) (*specv1.AddEdgeResponse, error)
+	removeEdge      func(req *specv1.RemoveEdgeRequest) (*specv1.RemoveEdgeResponse, error)
+	listEdges       func(req *specv1.ListEdgesRequest) (*specv1.ListEdgesResponse, error)
+	getDeps         func(slug string) (*specv1.GetDependenciesResponse, error)
+	getTransDeps    func(slug string) (*specv1.GetTransitiveDepsResponse, error)
+	getImpact       func(slug string) (*specv1.GetImpactResponse, error)
+	getReady        func() (*specv1.GetReadyResponse, error)
+	getCriticalPath func(req *specv1.GetCriticalPathRequest) (*specv1.GetCriticalPathResponse, error)
+	getFullGraph    func() (*specv1.GetFullGraphResponse, error)
+}
+
+func (m *mockGraphService) AddEdge(_ context.Context, req *connect.Request[specv1.AddEdgeRequest]) (*connect.Response[specv1.AddEdgeResponse], error) {
+	resp, err := m.addEdge(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockGraphService) ListEdges(_ context.Context, req *connect.Request[specv1.ListEdgesRequest]) (*connect.Response[specv1.ListEdgesResponse], error) {
+	resp, err := m.listEdges(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockGraphService) GetDependencies(_ context.Context, req *connect.Request[specv1.GetDependenciesRequest]) (*connect.Response[specv1.GetDependenciesResponse], error) {
+	resp, err := m.getDeps(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockGraphService) GetTransitiveDeps(_ context.Context, req *connect.Request[specv1.GetTransitiveDepsRequest]) (*connect.Response[specv1.GetTransitiveDepsResponse], error) {
+	resp, err := m.getTransDeps(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockGraphService) GetImpact(_ context.Context, req *connect.Request[specv1.GetImpactRequest]) (*connect.Response[specv1.GetImpactResponse], error) {
+	resp, err := m.getImpact(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockGraphService) GetReady(_ context.Context, _ *connect.Request[specv1.GetReadyRequest]) (*connect.Response[specv1.GetReadyResponse], error) {
+	resp, err := m.getReady()
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockGraphService) GetFullGraph(_ context.Context, _ *connect.Request[specv1.GetFullGraphRequest]) (*connect.Response[specv1.GetFullGraphResponse], error) {
+	resp, err := m.getFullGraph()
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// --- Health service mock ---
+
+type mockHealthService struct {
+	specgraphv1connect.ServerServiceClient
+	health func() (*specv1.HealthResponse, error)
+}
+
+func (m *mockHealthService) Health(_ context.Context, _ *connect.Request[specv1.HealthRequest]) (*connect.Response[specv1.HealthResponse], error) {
+	resp, err := m.health()
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// --- Constitution service mock ---
+
+type mockConstitutionService struct {
+	specgraphv1connect.ConstitutionServiceClient
+	getConstitution func(req *specv1.GetConstitutionRequest) (*specv1.GetConstitutionResponse, error)
+}
+
+func (m *mockConstitutionService) GetConstitution(_ context.Context, req *connect.Request[specv1.GetConstitutionRequest]) (*connect.Response[specv1.GetConstitutionResponse], error) {
+	resp, err := m.getConstitution(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// --- Analytical pass service mock ---
+
+type mockAnalyticalPassService struct {
+	specgraphv1connect.AnalyticalPassServiceClient
+	listFindings func(req *specv1.ListFindingsRequest) (*specv1.ListFindingsResponse, error)
+}
+
+func (m *mockAnalyticalPassService) ListFindings(_ context.Context, req *connect.Request[specv1.ListFindingsRequest]) (*connect.Response[specv1.ListFindingsResponse], error) {
+	resp, err := m.listFindings(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+```
+
+- [ ] **Step 2: Write spec + decision tool tests**
+
+```go
+// internal/mcp/tools_spec_test.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpecTool_Get(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{
+		getSpec: func(slug string) (*specv1.GetSpecResponse, error) {
+			if slug == "auth" {
+				return &specv1.GetSpecResponse{Spec: &specv1.Spec{
+					Slug:   "auth",
+					Intent: "Authentication system",
+				}}, nil
+			}
+			return nil, connect.NewError(connect.CodeNotFound, nil)
+		},
+	}}
+	h := &specTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{
+		"action": "get",
+		"slug":   "auth",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "auth")
+	require.Contains(t, result.Content[0].Text, "Authentication system")
+}
+
+func TestSpecTool_GetNotFound(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{
+		getSpec: func(slug string) (*specv1.GetSpecResponse, error) {
+			return nil, connect.NewError(connect.CodeNotFound, nil)
+		},
+	}}
+	h := &specTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{
+		"action": "get",
+		"slug":   "missing",
+	})
+	require.NoError(t, err) // ConnectRPC errors become tool errors, not Go errors
+	require.True(t, result.IsError)
+}
+
+func TestSpecTool_List(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{
+		listSpecs: func() (*specv1.ListSpecsResponse, error) {
+			return &specv1.ListSpecsResponse{Specs: []*specv1.Spec{
+				{Slug: "a", Intent: "A"},
+				{Slug: "b", Intent: "B"},
+			}}, nil
+		},
+	}}
+	h := &specTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{"action": "list"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "a")
+	require.Contains(t, result.Content[0].Text, "b")
+}
+
+func TestSpecTool_Create(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{
+		createSpec: func(slug, intent string) (*specv1.CreateSpecResponse, error) {
+			return &specv1.CreateSpecResponse{Spec: &specv1.Spec{
+				Slug:   slug,
+				Intent: intent,
+			}}, nil
+		},
+	}}
+	h := &specTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{
+		"action": "create",
+		"slug":   "new-spec",
+		"intent": "Do the thing",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "new-spec")
+}
+
+func TestSpecTool_UnknownAction(t *testing.T) {
+	h := &specTool{client: &Client{}}
+	result, err := h.handle(context.Background(), map[string]any{"action": "delete"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "unknown action")
+}
+
+func TestDecisionTool_Get(t *testing.T) {
+	c := &Client{Decision: &mockDecisionService{
+		getDecision: func(slug string) (*specv1.GetDecisionResponse, error) {
+			return &specv1.GetDecisionResponse{Decision: &specv1.Decision{
+				Slug:  slug,
+				Title: "Use JWT",
+			}}, nil
+		},
+	}}
+	h := &decisionTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{
+		"action": "get",
+		"slug":   "adr-001",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "Use JWT")
+}
+
+func TestDecisionTool_List(t *testing.T) {
+	c := &Client{Decision: &mockDecisionService{
+		listDecisions: func() (*specv1.ListDecisionsResponse, error) {
+			return &specv1.ListDecisionsResponse{Decisions: []*specv1.Decision{
+				{Slug: "adr-001", Title: "JWT"},
+			}}, nil
+		},
+	}}
+	h := &decisionTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{"action": "list"})
+	require.NoError(t, err)
+	require.Contains(t, result.Content[0].Text, "adr-001")
+}
+```
+
+- [ ] **Step 3: Run tests, verify fail**
+
+Run: `go test ./internal/mcp/ -run 'TestSpecTool|TestDecisionTool' -v`
+Expected: FAIL — specTool, decisionTool not defined
+
+- [ ] **Step 4: Write spec + decision handlers**
+
+```go
+// internal/mcp/tools_spec.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+)
+
+// --- spec tool ---
+
+type specTool struct {
+	client *Client
+}
+
+func (t *specTool) def() ToolDef {
+	return ToolDef{
+		Name:        "spec",
+		Description: "Manage specs: create, read, list, or update specifications.",
+		Tier:        TierCore,
+		Schema: objectSchema(
+			props{
+				"action":     stringProp("Operation to perform", "get", "list", "create", "update"),
+				"slug":       stringProp("Spec slug identifier (required for get, create, update)"),
+				"intent":     stringProp("Spec intent description (for create/update)"),
+				"priority":   stringProp("Priority level (for create/update)"),
+				"complexity": stringProp("Complexity estimate (for create/update)"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *specTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "get":
+		resp, err := t.client.Spec.GetSpec(ctx, connect.NewRequest(&specv1.GetSpecRequest{
+			Slug: stringParam(params, "slug"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "list":
+		resp, err := t.client.Spec.ListSpecs(ctx, connect.NewRequest(&specv1.ListSpecsRequest{}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "create":
+		resp, err := t.client.Spec.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+			Slug:       stringParam(params, "slug"),
+			Intent:     stringParam(params, "intent"),
+			Priority:   stringParam(params, "priority"),
+			Complexity: stringParam(params, "complexity"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "update":
+		resp, err := t.client.Spec.UpdateSpec(ctx, connect.NewRequest(&specv1.UpdateSpecRequest{
+			Slug:       stringParam(params, "slug"),
+			Intent:     stringParam(params, "intent"),
+			Priority:   stringParam(params, "priority"),
+			Complexity: stringParam(params, "complexity"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	default:
+		return errResult("unknown action: " + action), nil
+	}
+}
+
+// --- decision tool ---
+
+type decisionTool struct {
+	client *Client
+}
+
+func (t *decisionTool) def() ToolDef {
+	return ToolDef{
+		Name:        "decision",
+		Description: "Manage architectural decisions: create, read, list, or update ADRs.",
+		Tier:        TierCore,
+		Schema: objectSchema(
+			props{
+				"action":       stringProp("Operation to perform", "get", "list", "create", "update"),
+				"slug":         stringProp("Decision slug identifier"),
+				"title":        stringProp("Decision title (for create/update)"),
+				"context":      stringProp("Decision context (for create/update)"),
+				"decision":     stringProp("Decision text (for create/update)"),
+				"consequences": stringProp("Decision consequences (for create/update)"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *decisionTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "get":
+		resp, err := t.client.Decision.GetDecision(ctx, connect.NewRequest(&specv1.GetDecisionRequest{
+			Slug: stringParam(params, "slug"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "list":
+		resp, err := t.client.Decision.ListDecisions(ctx, connect.NewRequest(&specv1.ListDecisionsRequest{}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "create":
+		resp, err := t.client.Decision.CreateDecision(ctx, connect.NewRequest(&specv1.CreateDecisionRequest{
+			Slug:         stringParam(params, "slug"),
+			Title:        stringParam(params, "title"),
+			Context:      stringParam(params, "context"),
+			Decision:     stringParam(params, "decision"),
+			Consequences: stringParam(params, "consequences"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "update":
+		resp, err := t.client.Decision.UpdateDecision(ctx, connect.NewRequest(&specv1.UpdateDecisionRequest{
+			Slug:         stringParam(params, "slug"),
+			Title:        stringParam(params, "title"),
+			Context:      stringParam(params, "context"),
+			Decision:     stringParam(params, "decision"),
+			Consequences: stringParam(params, "consequences"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	default:
+		return errResult("unknown action: " + action), nil
+	}
+}
+
+// RegisterSpecTools adds spec and decision tools to the registry.
+func RegisterSpecTools(r *Registry, c *Client) {
+	st := &specTool{client: c}
+	r.AddTool(st.def())
+
+	dt := &decisionTool{client: c}
+	r.AddTool(dt.def())
+}
+```
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `go test ./internal/mcp/ -run 'TestSpecTool|TestDecisionTool' -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/mcp/testhelpers_test.go internal/mcp/tools_spec.go internal/mcp/tools_spec_test.go
+git commit -s -m "feat(mcp): add spec and decision tool handlers with tests"
+```
+
+---
+
+### Task 5: Core Tier Tools — edge, graph_query, constitution, changes, findings, health
+
+**Files:**
+- Create: `internal/mcp/tools_graph.go`
+- Create: `internal/mcp/tools_graph_test.go`
+- Create: `internal/mcp/tools_core.go`
+- Create: `internal/mcp/tools_core_test.go`
+
+- [ ] **Step 1: Write graph tool tests**
+
+```go
+// internal/mcp/tools_graph_test.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEdgeTool_List(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		listEdges: func(req *specv1.ListEdgesRequest) (*specv1.ListEdgesResponse, error) {
+			return &specv1.ListEdgesResponse{Edges: []*specv1.Edge{
+				{FromSlug: "a", ToSlug: "b", EdgeType: specv1.EdgeType_EDGE_TYPE_DEPENDS_ON},
+			}}, nil
+		},
+	}}
+	h := &edgeTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{"action": "list", "slug": "a"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "a")
+}
+
+func TestGraphQueryTool_Ready(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		getReady: func() (*specv1.GetReadyResponse, error) {
+			return &specv1.GetReadyResponse{Slugs: []string{"spec-1", "spec-2"}}, nil
+		},
+	}}
+	h := &graphQueryTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{"action": "ready"})
+	require.NoError(t, err)
+	require.Contains(t, result.Content[0].Text, "spec-1")
+}
+
+func TestGraphQueryTool_Dependencies(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		getDeps: func(slug string) (*specv1.GetDependenciesResponse, error) {
+			return &specv1.GetDependenciesResponse{}, nil
+		},
+	}}
+	h := &graphQueryTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{"action": "dependencies", "slug": "auth"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestGraphQueryTool_FullGraph(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		getFullGraph: func() (*specv1.GetFullGraphResponse, error) {
+			return &specv1.GetFullGraphResponse{}, nil
+		},
+	}}
+	h := &graphQueryTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{"action": "full"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+```
+
+- [ ] **Step 2: Write graph tool handlers**
+
+```go
+// internal/mcp/tools_graph.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+)
+
+// --- edge tool ---
+
+type edgeTool struct {
+	client *Client
+}
+
+func (t *edgeTool) def() ToolDef {
+	return ToolDef{
+		Name:        "edge",
+		Description: "Manage graph edges between specs: add, remove, or list dependencies and relationships.",
+		Tier:        TierCore,
+		Schema: objectSchema(
+			props{
+				"action":    stringProp("Operation", "add", "remove", "list"),
+				"slug":      stringProp("Spec slug (for list)"),
+				"from_slug": stringProp("Source spec slug (for add/remove)"),
+				"to_slug":   stringProp("Target spec slug (for add/remove)"),
+				"edge_type": stringProp("Edge type", "DEPENDS_ON", "BLOCKS", "COMPOSES", "RELATES_TO", "INFORMS", "DECIDED_IN", "SUPERSEDES"),
+				"direction": stringProp("Filter direction for list", "outgoing", "incoming", "both"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *edgeTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "add":
+		resp, err := t.client.Graph.AddEdge(ctx, connect.NewRequest(&specv1.AddEdgeRequest{
+			FromSlug: stringParam(params, "from_slug"),
+			ToSlug:   stringParam(params, "to_slug"),
+			EdgeType: edgeTypeFromString(stringParam(params, "edge_type")),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "remove":
+		resp, err := t.client.Graph.RemoveEdge(ctx, connect.NewRequest(&specv1.RemoveEdgeRequest{
+			FromSlug: stringParam(params, "from_slug"),
+			ToSlug:   stringParam(params, "to_slug"),
+			EdgeType: edgeTypeFromString(stringParam(params, "edge_type")),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "list":
+		resp, err := t.client.Graph.ListEdges(ctx, connect.NewRequest(&specv1.ListEdgesRequest{
+			Slug: stringParam(params, "slug"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	default:
+		return errResult("unknown action: " + action), nil
+	}
+}
+
+// edgeTypeFromString maps a string to the proto EdgeType enum.
+func edgeTypeFromString(s string) specv1.EdgeType {
+	if v, ok := specv1.EdgeType_value[s]; ok {
+		return specv1.EdgeType(v)
+	}
+	// Try with prefix
+	if v, ok := specv1.EdgeType_value["EDGE_TYPE_"+s]; ok {
+		return specv1.EdgeType(v)
+	}
+	return specv1.EdgeType_EDGE_TYPE_UNSPECIFIED
+}
+
+// --- graph_query tool ---
+
+type graphQueryTool struct {
+	client *Client
+}
+
+func (t *graphQueryTool) def() ToolDef {
+	return ToolDef{
+		Name:        "graph_query",
+		Description: "Query the spec dependency graph: find dependencies, transitive deps, impact analysis, ready specs, critical path, or full graph.",
+		Tier:        TierCore,
+		Schema: objectSchema(
+			props{
+				"action":    stringProp("Query type", "dependencies", "transitive_deps", "impact", "ready", "critical_path", "full"),
+				"slug":      stringProp("Spec slug (for dependencies, transitive_deps, impact, critical_path)"),
+				"from_slug": stringProp("Start slug (for critical_path)"),
+				"to_slug":   stringProp("End slug (for critical_path)"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *graphQueryTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "dependencies":
+		resp, err := t.client.Graph.GetDependencies(ctx, connect.NewRequest(&specv1.GetDependenciesRequest{
+			Slug: stringParam(params, "slug"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "transitive_deps":
+		resp, err := t.client.Graph.GetTransitiveDeps(ctx, connect.NewRequest(&specv1.GetTransitiveDepsRequest{
+			Slug: stringParam(params, "slug"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "impact":
+		resp, err := t.client.Graph.GetImpact(ctx, connect.NewRequest(&specv1.GetImpactRequest{
+			Slug: stringParam(params, "slug"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "ready":
+		resp, err := t.client.Graph.GetReady(ctx, connect.NewRequest(&specv1.GetReadyRequest{}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "critical_path":
+		resp, err := t.client.Graph.GetCriticalPath(ctx, connect.NewRequest(&specv1.GetCriticalPathRequest{
+			FromSlug: stringParam(params, "from_slug"),
+			ToSlug:   stringParam(params, "to_slug"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "full":
+		resp, err := t.client.Graph.GetFullGraph(ctx, connect.NewRequest(&specv1.GetFullGraphRequest{}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	default:
+		return errResult("unknown action: " + action), nil
+	}
+}
+
+// RegisterGraphTools adds edge and graph_query tools to the registry.
+func RegisterGraphTools(r *Registry, c *Client) {
+	et := &edgeTool{client: c}
+	r.AddTool(et.def())
+
+	gq := &graphQueryTool{client: c}
+	r.AddTool(gq.def())
+}
+```
+
+- [ ] **Step 3: Run graph tool tests**
+
+Run: `go test ./internal/mcp/ -run 'TestEdgeTool|TestGraphQueryTool' -v`
+Expected: All PASS
+
+- [ ] **Step 4: Write core tool tests**
+
+```go
+// internal/mcp/tools_core_test.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestConstitutionTool_Get(t *testing.T) {
+	c := &Client{Constitution: &mockConstitutionService{
+		getConstitution: func(req *specv1.GetConstitutionRequest) (*specv1.GetConstitutionResponse, error) {
+			return &specv1.GetConstitutionResponse{}, nil
+		},
+	}}
+	h := &constitutionTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{"action": "get"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestFindingsTool_List(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{
+		listFindings: func(req *specv1.ListFindingsRequest) (*specv1.ListFindingsResponse, error) {
+			return &specv1.ListFindingsResponse{}, nil
+		},
+	}}
+	h := &findingsTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{"action": "list"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestHealthTool(t *testing.T) {
+	c := &Client{Health: &mockHealthService{
+		health: func() (*specv1.HealthResponse, error) {
+			return &specv1.HealthResponse{
+				Status:     "ok",
+				Version:    "1.0.0",
+				ServerTime: timestamppb.Now(),
+			}, nil
+		},
+	}}
+	h := &healthTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{})
+	require.NoError(t, err)
+	require.Contains(t, result.Content[0].Text, "ok")
+}
+
+func TestChangesTool_List(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{
+		listChanges: func(slug string) (*specv1.ListChangesResponse, error) {
+			return &specv1.ListChangesResponse{}, nil
+		},
+	}}
+	h := &changesTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{"action": "list", "slug": "auth"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+```
+
+- [ ] **Step 5: Write core tool handlers**
+
+```go
+// internal/mcp/tools_core.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+)
+
+// --- constitution tool ---
+
+type constitutionTool struct {
+	client *Client
+}
+
+func (t *constitutionTool) def() ToolDef {
+	return ToolDef{
+		Name:        "constitution",
+		Description: "Read or update the project constitution (layered ground truth). Supports per-layer access.",
+		Tier:        TierCore,
+		Schema: objectSchema(
+			props{
+				"action":  stringProp("Operation", "get", "update"),
+				"layer":   stringProp("Constitution layer filter", "user", "org", "project", "domain"),
+				"content": stringProp("New content (for update)"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *constitutionTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "get":
+		resp, err := t.client.Constitution.GetConstitution(ctx, connect.NewRequest(&specv1.GetConstitutionRequest{
+			Layer: stringParam(params, "layer"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "update":
+		resp, err := t.client.Constitution.UpdateConstitution(ctx, connect.NewRequest(&specv1.UpdateConstitutionRequest{
+			Layer:   stringParam(params, "layer"),
+			Content: stringParam(params, "content"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	default:
+		return errResult("unknown action: " + action), nil
+	}
+}
+
+// --- changes tool ---
+
+type changesTool struct {
+	client *Client
+}
+
+func (t *changesTool) def() ToolDef {
+	return ToolDef{
+		Name:        "changes",
+		Description: "View version history: list changes for a spec or compare two versions.",
+		Tier:        TierCore,
+		Schema: objectSchema(
+			props{
+				"action":  stringProp("Operation", "list", "compare"),
+				"slug":    stringProp("Spec slug"),
+				"version": intProp("Version number (for compare)"),
+			},
+			"action", "slug",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *changesTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "list":
+		resp, err := t.client.Spec.ListChanges(ctx, connect.NewRequest(&specv1.ListChangesRequest{
+			Slug: stringParam(params, "slug"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "compare":
+		resp, err := t.client.Spec.CompareVersions(ctx, connect.NewRequest(&specv1.CompareVersionsRequest{
+			Slug:    stringParam(params, "slug"),
+			Version: int32Param(params, "version"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	default:
+		return errResult("unknown action: " + action), nil
+	}
+}
+
+// --- findings tool ---
+
+type findingsTool struct {
+	client *Client
+}
+
+func (t *findingsTool) def() ToolDef {
+	return ToolDef{
+		Name:        "findings",
+		Description: "List analytical findings, optionally filtered by pass type or spec.",
+		Tier:        TierCore,
+		Schema: objectSchema(
+			props{
+				"action":    stringProp("Operation", "list"),
+				"slug":      stringProp("Filter by spec slug"),
+				"pass_type": stringProp("Filter by pass type (e.g., constitution-check)"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *findingsTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	resp, err := t.client.AnalyticalPass.ListFindings(ctx, connect.NewRequest(&specv1.ListFindingsRequest{
+		Slug:     stringParam(params, "slug"),
+		PassType: stringParam(params, "pass_type"),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// --- health tool ---
+
+type healthTool struct {
+	client *Client
+}
+
+func (t *healthTool) def() ToolDef {
+	return ToolDef{
+		Name:        "health",
+		Description: "Check SpecGraph server health, version, and status.",
+		Tier:        TierCore,
+		Schema:      objectSchema(props{}),
+		Handler:     t.handle,
+	}
+}
+
+func (t *healthTool) handle(ctx context.Context, _ map[string]any) (*ToolResult, error) {
+	resp, err := t.client.Health.Health(ctx, connect.NewRequest(&specv1.HealthRequest{}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// RegisterCoreTools adds constitution, changes, findings, and health tools.
+func RegisterCoreTools(r *Registry, c *Client) {
+	ct := &constitutionTool{client: c}
+	r.AddTool(ct.def())
+
+	ch := &changesTool{client: c}
+	r.AddTool(ch.def())
+
+	ft := &findingsTool{client: c}
+	r.AddTool(ft.def())
+
+	ht := &healthTool{client: c}
+	r.AddTool(ht.def())
+}
+```
+
+- [ ] **Step 6: Run all core tool tests**
+
+Run: `go test ./internal/mcp/ -run 'TestConstitution|TestFindings|TestHealth|TestChanges|TestEdge|TestGraphQuery' -v`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/mcp/tools_graph.go internal/mcp/tools_graph_test.go internal/mcp/tools_core.go internal/mcp/tools_core_test.go
+git commit -s -m "feat(mcp): add core tier tools — edge, graph_query, constitution, changes, findings, health"
+```
+
+---
+
+### Task 6: Authoring Tier Tools
+
+**Files:**
+- Create: `internal/mcp/tools_authoring.go`
+- Create: `internal/mcp/tools_authoring_test.go`
+- Create: `internal/mcp/tools_lifecycle.go`
+- Create: `internal/mcp/tools_lifecycle_test.go`
+
+**Note:** Add mock methods for Authoring, Lifecycle, Sync, Export, AnalyticalPass services to `testhelpers_test.go` as needed. Follow the same mock pattern from Task 4.
+
+- [ ] **Step 1: Add authoring/lifecycle mocks to testhelpers_test.go**
+
+Append these mocks to `internal/mcp/testhelpers_test.go`:
+
+```go
+// --- Authoring service mock ---
+
+type mockAuthoringService struct {
+	specgraphv1connect.AuthoringServiceClient
+	spark       func(req *specv1.SparkRequest) (*specv1.SparkResponse, error)
+	shape       func(req *specv1.ShapeRequest) (*specv1.ShapeResponse, error)
+	specify     func(req *specv1.SpecifyRequest) (*specv1.SpecifyResponse, error)
+	decompose   func(req *specv1.DecomposeRequest) (*specv1.DecomposeResponse, error)
+	approve     func(req *specv1.ApproveRequest) (*specv1.ApproveResponse, error)
+	amend       func(req *specv1.AmendRequest) (*specv1.AmendResponse, error)
+	supersede   func(req *specv1.SupersedeRequest) (*specv1.SupersedeResponse, error)
+	getPrompts  func(req *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error)
+	recordConvo func(req *specv1.RecordConversationRequest) (*specv1.RecordConversationResponse, error)
+	listConvos  func(req *specv1.ListConversationsRequest) (*specv1.ListConversationsResponse, error)
+}
+
+func (m *mockAuthoringService) Spark(_ context.Context, req *connect.Request[specv1.SparkRequest]) (*connect.Response[specv1.SparkResponse], error) {
+	resp, err := m.spark(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockAuthoringService) Approve(_ context.Context, req *connect.Request[specv1.ApproveRequest]) (*connect.Response[specv1.ApproveResponse], error) {
+	resp, err := m.approve(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockAuthoringService) GetPrompts(_ context.Context, req *connect.Request[specv1.GetPromptsRequest]) (*connect.Response[specv1.GetPromptsResponse], error) {
+	resp, err := m.getPrompts(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockAuthoringService) RecordConversation(_ context.Context, req *connect.Request[specv1.RecordConversationRequest]) (*connect.Response[specv1.RecordConversationResponse], error) {
+	resp, err := m.recordConvo(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockAuthoringService) ListConversations(_ context.Context, req *connect.Request[specv1.ListConversationsRequest]) (*connect.Response[specv1.ListConversationsResponse], error) {
+	resp, err := m.listConvos(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// --- Lifecycle service mock ---
+
+type mockLifecycleService struct {
+	specgraphv1connect.LifecycleServiceClient
+	checkDrift func(req *specv1.DriftCheckRequest) (*specv1.DriftCheckResponse, error)
+	ackDrift   func(req *specv1.DriftAcknowledgeRequest) (*specv1.DriftAcknowledgeResponse, error)
+	lint       func(req *specv1.LintRequest) (*specv1.LintResponse, error)
+}
+
+func (m *mockLifecycleService) CheckDrift(_ context.Context, req *connect.Request[specv1.DriftCheckRequest]) (*connect.Response[specv1.DriftCheckResponse], error) {
+	resp, err := m.checkDrift(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockLifecycleService) Lint(_ context.Context, req *connect.Request[specv1.LintRequest]) (*connect.Response[specv1.LintResponse], error) {
+	resp, err := m.lint(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// --- Sync service mock ---
+
+type mockSyncService struct {
+	specgraphv1connect.SyncServiceClient
+	syncBeads func(req *specv1.SyncBeadsRequest) (*specv1.SyncResponse, error)
+	syncGH    func(req *specv1.SyncGitHubRequest) (*specv1.SyncResponse, error)
+	getStatus func(req *specv1.SyncStatusRequest) (*specv1.SyncStatusResponse, error)
+}
+
+func (m *mockSyncService) SyncBeads(_ context.Context, req *connect.Request[specv1.SyncBeadsRequest]) (*connect.Response[specv1.SyncResponse], error) {
+	resp, err := m.syncBeads(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSyncService) GetSyncStatus(_ context.Context, req *connect.Request[specv1.SyncStatusRequest]) (*connect.Response[specv1.SyncStatusResponse], error) {
+	resp, err := m.getStatus(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// --- Export service mock ---
+
+type mockExportService struct {
+	specgraphv1connect.ExportServiceClient
+	exportProject func(req *specv1.ExportProjectRequest) (*specv1.ExportProjectResponse, error)
+	importProject func(req *specv1.ImportProjectRequest) (*specv1.ImportProjectResponse, error)
+	verifyExport  func(req *specv1.VerifyExportRequest) (*specv1.VerifyExportResponse, error)
+}
+
+func (m *mockExportService) ExportProject(_ context.Context, req *connect.Request[specv1.ExportProjectRequest]) (*connect.Response[specv1.ExportProjectResponse], error) {
+	resp, err := m.exportProject(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+```
+
+- [ ] **Step 2: Write authoring tool handler**
+
+```go
+// internal/mcp/tools_authoring.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+)
+
+// --- author tool ---
+
+type authorTool struct {
+	client *Client
+}
+
+func (t *authorTool) def() ToolDef {
+	return ToolDef{
+		Name:        "author",
+		Description: "Drive the authoring funnel: spark an idea, shape it, specify details, decompose into slices, approve, amend, or supersede a spec.",
+		Tier:        TierAuthoring,
+		Schema: objectSchema(
+			props{
+				"action":    stringProp("Funnel stage", "spark", "shape", "specify", "decompose", "approve", "amend", "supersede"),
+				"spec_slug": stringProp("Target spec slug (all actions except spark)"),
+				"topic":     stringProp("Topic for spark"),
+				"context":   stringProp("Additional context for spark"),
+				"output":    stringProp("JSON output from the stage (shape, specify, decompose)"),
+				"reason":    stringProp("Reason for amend/supersede"),
+				"new_slug":  stringProp("New spec slug (for supersede)"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *authorTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "spark":
+		resp, err := t.client.Authoring.Spark(ctx, connect.NewRequest(&specv1.SparkRequest{
+			Topic:   stringParam(params, "topic"),
+			Context: stringParam(params, "context"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "shape":
+		resp, err := t.client.Authoring.Shape(ctx, connect.NewRequest(&specv1.ShapeRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+			Output:   stringParam(params, "output"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "specify":
+		resp, err := t.client.Authoring.Specify(ctx, connect.NewRequest(&specv1.SpecifyRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+			Output:   stringParam(params, "output"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "decompose":
+		resp, err := t.client.Authoring.Decompose(ctx, connect.NewRequest(&specv1.DecomposeRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+			Output:   stringParam(params, "output"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "approve":
+		resp, err := t.client.Authoring.Approve(ctx, connect.NewRequest(&specv1.ApproveRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "amend":
+		resp, err := t.client.Authoring.Amend(ctx, connect.NewRequest(&specv1.AmendRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+			Reason:   stringParam(params, "reason"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "supersede":
+		resp, err := t.client.Authoring.Supersede(ctx, connect.NewRequest(&specv1.SupersedeRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+			NewSlug:  stringParam(params, "new_slug"),
+			Reason:   stringParam(params, "reason"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	default:
+		return errResult("unknown action: " + action), nil
+	}
+}
+
+// --- conversation tool ---
+
+type conversationTool struct {
+	client *Client
+}
+
+func (t *conversationTool) def() ToolDef {
+	return ToolDef{
+		Name:        "conversation",
+		Description: "Record or list authoring conversations for audit trail.",
+		Tier:        TierAuthoring,
+		Schema: objectSchema(
+			props{
+				"action":    stringProp("Operation", "record", "list"),
+				"spec_slug": stringProp("Spec slug"),
+				"stage":     stringProp("Authoring stage"),
+				"messages":  stringProp("JSON array of conversation messages (for record)"),
+			},
+			"action", "spec_slug",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *conversationTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "record":
+		resp, err := t.client.Authoring.RecordConversation(ctx, connect.NewRequest(&specv1.RecordConversationRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+			Stage:    stringParam(params, "stage"),
+			Messages: stringParam(params, "messages"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "list":
+		resp, err := t.client.Authoring.ListConversations(ctx, connect.NewRequest(&specv1.ListConversationsRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	default:
+		return errResult("unknown action: " + action), nil
+	}
+}
+
+// --- analytical_pass tool ---
+
+type analyticalPassTool struct {
+	client *Client
+}
+
+func (t *analyticalPassTool) def() ToolDef {
+	return ToolDef{
+		Name:        "analytical_pass",
+		Description: "Run analytical passes (constitution check, dependency review) or store findings.",
+		Tier:        TierAuthoring,
+		Schema: objectSchema(
+			props{
+				"action":    stringProp("Operation", "run", "store"),
+				"spec_slug": stringProp("Spec slug to analyze"),
+				"pass_type": stringProp("Pass type (e.g., constitution-check)"),
+				"findings":  stringProp("JSON findings data (for store)"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *analyticalPassTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "run":
+		resp, err := t.client.AnalyticalPass.RunAnalyticalPass(ctx, connect.NewRequest(&specv1.RunAnalyticalPassRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+			PassType: stringParam(params, "pass_type"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "store":
+		resp, err := t.client.AnalyticalPass.StoreFindings(ctx, connect.NewRequest(&specv1.StoreFindingsRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+			PassType: stringParam(params, "pass_type"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	default:
+		return errResult("unknown action: " + action), nil
+	}
+}
+
+// RegisterAuthoringTools adds author, conversation, and analytical_pass tools.
+func RegisterAuthoringTools(r *Registry, c *Client) {
+	at := &authorTool{client: c}
+	r.AddTool(at.def())
+
+	ct := &conversationTool{client: c}
+	r.AddTool(ct.def())
+
+	ap := &analyticalPassTool{client: c}
+	r.AddTool(ap.def())
+}
+```
+
+- [ ] **Step 3: Write lifecycle tool handler**
+
+```go
+// internal/mcp/tools_lifecycle.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+)
+
+// --- drift tool ---
+
+type driftTool struct {
+	client *Client
+}
+
+func (t *driftTool) def() ToolDef {
+	return ToolDef{
+		Name:        "drift",
+		Description: "Check for specification drift or acknowledge known drift.",
+		Tier:        TierAuthoring,
+		Schema: objectSchema(
+			props{
+				"action":    stringProp("Operation", "check", "acknowledge"),
+				"spec_slug": stringProp("Spec slug"),
+				"all":       boolProp("Acknowledge all drift for this spec"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *driftTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "check":
+		resp, err := t.client.Lifecycle.CheckDrift(ctx, connect.NewRequest(&specv1.DriftCheckRequest{
+			Slug: stringParam(params, "spec_slug"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "acknowledge":
+		resp, err := t.client.Lifecycle.AcknowledgeDrift(ctx, connect.NewRequest(&specv1.DriftAcknowledgeRequest{
+			Slug: stringParam(params, "spec_slug"),
+			All:  boolParam(params, "all"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	default:
+		return errResult("unknown action: " + action), nil
+	}
+}
+
+// --- lint tool ---
+
+type lintTool struct {
+	client *Client
+}
+
+func (t *lintTool) def() ToolDef {
+	return ToolDef{
+		Name:        "lint",
+		Description: "Run the spec linter to check for schema violations and dependency issues.",
+		Tier:        TierAuthoring,
+		Schema: objectSchema(
+			props{
+				"spec_slug": stringProp("Spec slug to lint"),
+			},
+			"spec_slug",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *lintTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	resp, err := t.client.Lifecycle.Lint(ctx, connect.NewRequest(&specv1.LintRequest{
+		Slug: stringParam(params, "spec_slug"),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// --- sync tool ---
+
+type syncTool struct {
+	client *Client
+}
+
+func (t *syncTool) def() ToolDef {
+	return ToolDef{
+		Name:        "sync",
+		Description: "Sync specs with external systems: beads issue tracker, GitHub, or check sync status.",
+		Tier:        TierAuthoring,
+		Schema: objectSchema(
+			props{
+				"action": stringProp("Operation", "beads", "github", "status"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *syncTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "beads":
+		resp, err := t.client.Sync.SyncBeads(ctx, connect.NewRequest(&specv1.SyncBeadsRequest{}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "github":
+		resp, err := t.client.Sync.SyncGitHub(ctx, connect.NewRequest(&specv1.SyncGitHubRequest{}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "status":
+		resp, err := t.client.Sync.GetSyncStatus(ctx, connect.NewRequest(&specv1.SyncStatusRequest{}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	default:
+		return errResult("unknown action: " + action), nil
+	}
+}
+
+// --- export tool ---
+
+type exportTool struct {
+	client *Client
+}
+
+func (t *exportTool) def() ToolDef {
+	return ToolDef{
+		Name:        "export",
+		Description: "Export, import, or verify a SpecGraph project backup.",
+		Tier:        TierAuthoring,
+		Schema: objectSchema(
+			props{
+				"action": stringProp("Operation", "export", "import", "verify"),
+				"path":   stringProp("File path for export/import"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *exportTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "export":
+		resp, err := t.client.Export.ExportProject(ctx, connect.NewRequest(&specv1.ExportProjectRequest{}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "import":
+		resp, err := t.client.Export.ImportProject(ctx, connect.NewRequest(&specv1.ImportProjectRequest{}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "verify":
+		resp, err := t.client.Export.VerifyExport(ctx, connect.NewRequest(&specv1.VerifyExportRequest{}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	default:
+		return errResult("unknown action: " + action), nil
+	}
+}
+
+// RegisterLifecycleTools adds drift, lint, sync, and export tools.
+func RegisterLifecycleTools(r *Registry, c *Client) {
+	dt := &driftTool{client: c}
+	r.AddTool(dt.def())
+
+	lt := &lintTool{client: c}
+	r.AddTool(lt.def())
+
+	st := &syncTool{client: c}
+	r.AddTool(st.def())
+
+	et := &exportTool{client: c}
+	r.AddTool(et.def())
+}
+```
+
+- [ ] **Step 4: Write authoring + lifecycle tests**
+
+```go
+// internal/mcp/tools_authoring_test.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthorTool_Spark(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		spark: func(req *specv1.SparkRequest) (*specv1.SparkResponse, error) {
+			return &specv1.SparkResponse{}, nil
+		},
+	}}
+	h := &authorTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{
+		"action":  "spark",
+		"topic":   "auth system",
+		"context": "microservices",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestAuthorTool_Approve(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		approve: func(req *specv1.ApproveRequest) (*specv1.ApproveResponse, error) {
+			return &specv1.ApproveResponse{}, nil
+		},
+	}}
+	h := &authorTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{
+		"action":    "approve",
+		"spec_slug": "auth",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestConversationTool_List(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		listConvos: func(req *specv1.ListConversationsRequest) (*specv1.ListConversationsResponse, error) {
+			return &specv1.ListConversationsResponse{}, nil
+		},
+	}}
+	h := &conversationTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{
+		"action":    "list",
+		"spec_slug": "auth",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+```
+
+```go
+// internal/mcp/tools_lifecycle_test.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDriftTool_Check(t *testing.T) {
+	c := &Client{Lifecycle: &mockLifecycleService{
+		checkDrift: func(req *specv1.DriftCheckRequest) (*specv1.DriftCheckResponse, error) {
+			return &specv1.DriftCheckResponse{}, nil
+		},
+	}}
+	h := &driftTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{
+		"action":    "check",
+		"spec_slug": "auth",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestLintTool(t *testing.T) {
+	c := &Client{Lifecycle: &mockLifecycleService{
+		lint: func(req *specv1.LintRequest) (*specv1.LintResponse, error) {
+			return &specv1.LintResponse{}, nil
+		},
+	}}
+	h := &lintTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{"spec_slug": "auth"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestSyncTool_Status(t *testing.T) {
+	c := &Client{Sync: &mockSyncService{
+		getStatus: func(req *specv1.SyncStatusRequest) (*specv1.SyncStatusResponse, error) {
+			return &specv1.SyncStatusResponse{}, nil
+		},
+	}}
+	h := &syncTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{"action": "status"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestExportTool_Export(t *testing.T) {
+	c := &Client{Export: &mockExportService{
+		exportProject: func(req *specv1.ExportProjectRequest) (*specv1.ExportProjectResponse, error) {
+			return &specv1.ExportProjectResponse{}, nil
+		},
+	}}
+	h := &exportTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{"action": "export"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+```
+
+- [ ] **Step 5: Run all authoring tier tests**
+
+Run: `go test ./internal/mcp/ -run 'TestAuthor|TestConversation|TestDrift|TestLint|TestSync|TestExport' -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/mcp/tools_authoring.go internal/mcp/tools_authoring_test.go internal/mcp/tools_lifecycle.go internal/mcp/tools_lifecycle_test.go internal/mcp/testhelpers_test.go
+git commit -s -m "feat(mcp): add authoring tier tools — author, conversation, analytical_pass, drift, lint, sync, export"
+```
+
+---
+
+### Task 7: Execution Tier Tools
+
+**Files:**
+- Create: `internal/mcp/tools_execution.go`
+- Create: `internal/mcp/tools_execution_test.go`
+
+**Note:** Add execution-related mocks (Claim, Slice, Execution services) to `testhelpers_test.go`.
+
+- [ ] **Step 1: Add execution mocks to testhelpers_test.go**
+
+Append:
+
+```go
+// --- Claim service mock ---
+
+type mockClaimService struct {
+	specgraphv1connect.ClaimServiceClient
+	claimSpec   func(req *specv1.ClaimSpecRequest) (*specv1.ClaimSpecResponse, error)
+	unclaimSpec func(req *specv1.UnclaimSpecRequest) (*specv1.UnclaimSpecResponse, error)
+	heartbeat   func(req *specv1.HeartbeatRequest) (*specv1.HeartbeatResponse, error)
+}
+
+func (m *mockClaimService) ClaimSpec(_ context.Context, req *connect.Request[specv1.ClaimSpecRequest]) (*connect.Response[specv1.ClaimSpecResponse], error) {
+	resp, err := m.claimSpec(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockClaimService) UnclaimSpec(_ context.Context, req *connect.Request[specv1.UnclaimSpecRequest]) (*connect.Response[specv1.UnclaimSpecResponse], error) {
+	resp, err := m.unclaimSpec(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockClaimService) Heartbeat(_ context.Context, req *connect.Request[specv1.HeartbeatRequest]) (*connect.Response[specv1.HeartbeatResponse], error) {
+	resp, err := m.heartbeat(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// --- Slice service mock ---
+
+type mockSliceService struct {
+	specgraphv1connect.SliceServiceClient
+	listSlices    func(req *specv1.ListSlicesRequest) (*specv1.ListSlicesResponse, error)
+	getSlice      func(req *specv1.GetSliceRequest) (*specv1.GetSliceResponse, error)
+	claimSlice    func(req *specv1.ClaimSliceRequest) (*specv1.ClaimSliceResponse, error)
+	completeSlice func(req *specv1.CompleteSliceRequest) (*specv1.CompleteSliceResponse, error)
+}
+
+func (m *mockSliceService) ListSlices(_ context.Context, req *connect.Request[specv1.ListSlicesRequest]) (*connect.Response[specv1.ListSlicesResponse], error) {
+	resp, err := m.listSlices(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSliceService) GetSlice(_ context.Context, req *connect.Request[specv1.GetSliceRequest]) (*connect.Response[specv1.GetSliceResponse], error) {
+	resp, err := m.getSlice(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSliceService) ClaimSlice(_ context.Context, req *connect.Request[specv1.ClaimSliceRequest]) (*connect.Response[specv1.ClaimSliceResponse], error) {
+	resp, err := m.claimSlice(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSliceService) CompleteSlice(_ context.Context, req *connect.Request[specv1.CompleteSliceRequest]) (*connect.Response[specv1.CompleteSliceResponse], error) {
+	resp, err := m.completeSlice(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// --- Execution service mock ---
+
+type mockExecutionService struct {
+	specgraphv1connect.ExecutionServiceClient
+	generateBundle   func(req *specv1.GenerateBundleRequest) (*specv1.GenerateBundleResponse, error)
+	getPrime         func(req *specv1.GetPrimeRequest) (*specv1.PrimeResponse, error)
+	reportProgress   func(req *specv1.ReportProgressRequest) (*specv1.ReportProgressResponse, error)
+	reportBlocker    func(req *specv1.ReportBlockerRequest) (*specv1.ReportBlockerResponse, error)
+	reportCompletion func(req *specv1.ReportCompletionRequest) (*specv1.ReportCompletionResponse, error)
+	getEvents        func(req *specv1.GetExecutionEventsRequest) (*specv1.GetExecutionEventsResponse, error)
+}
+
+func (m *mockExecutionService) GenerateBundle(_ context.Context, req *connect.Request[specv1.GenerateBundleRequest]) (*connect.Response[specv1.GenerateBundleResponse], error) {
+	resp, err := m.generateBundle(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockExecutionService) GetPrime(_ context.Context, req *connect.Request[specv1.GetPrimeRequest]) (*connect.Response[specv1.PrimeResponse], error) {
+	resp, err := m.getPrime(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockExecutionService) ReportProgress(_ context.Context, req *connect.Request[specv1.ReportProgressRequest]) (*connect.Response[specv1.ReportProgressResponse], error) {
+	resp, err := m.reportProgress(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockExecutionService) ReportBlocker(_ context.Context, req *connect.Request[specv1.ReportBlockerRequest]) (*connect.Response[specv1.ReportBlockerResponse], error) {
+	resp, err := m.reportBlocker(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockExecutionService) ReportCompletion(_ context.Context, req *connect.Request[specv1.ReportCompletionRequest]) (*connect.Response[specv1.ReportCompletionResponse], error) {
+	resp, err := m.reportCompletion(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockExecutionService) GetExecutionEvents(_ context.Context, req *connect.Request[specv1.GetExecutionEventsRequest]) (*connect.Response[specv1.GetExecutionEventsResponse], error) {
+	resp, err := m.getEvents(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+```
+
+- [ ] **Step 2: Write execution tool handler**
+
+```go
+// internal/mcp/tools_execution.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"time"
+)
+
+// --- claim tool ---
+
+type claimTool struct {
+	client *Client
+}
+
+func (t *claimTool) def() ToolDef {
+	return ToolDef{
+		Name:        "claim",
+		Description: "Manage spec ownership: claim a spec for execution, release it, or send a heartbeat to maintain the lease.",
+		Tier:        TierExecution,
+		Schema: objectSchema(
+			props{
+				"action":         stringProp("Operation", "claim", "unclaim", "heartbeat"),
+				"spec_slug":      stringProp("Spec slug"),
+				"agent":          stringProp("Agent identifier"),
+				"lease_duration": stringProp("Lease duration (e.g., '5m', '1h')"),
+			},
+			"action", "spec_slug",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *claimTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "claim":
+		req := &specv1.ClaimSpecRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+			Agent:    stringParam(params, "agent"),
+		}
+		if d := stringParam(params, "lease_duration"); d != "" {
+			if dur, err := time.ParseDuration(d); err == nil {
+				req.LeaseDuration = durationpb.New(dur)
+			}
+		}
+		resp, err := t.client.Claim.ClaimSpec(ctx, connect.NewRequest(req))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "unclaim":
+		resp, err := t.client.Claim.UnclaimSpec(ctx, connect.NewRequest(&specv1.UnclaimSpecRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+			Agent:    stringParam(params, "agent"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "heartbeat":
+		resp, err := t.client.Claim.Heartbeat(ctx, connect.NewRequest(&specv1.HeartbeatRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+			Agent:    stringParam(params, "agent"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	default:
+		return errResult("unknown action: " + action), nil
+	}
+}
+
+// --- slice tool ---
+
+type sliceTool struct {
+	client *Client
+}
+
+func (t *sliceTool) def() ToolDef {
+	return ToolDef{
+		Name:        "slice",
+		Description: "Manage work slices: list, get details, claim for execution, or mark complete.",
+		Tier:        TierExecution,
+		Schema: objectSchema(
+			props{
+				"action":    stringProp("Operation", "list", "get", "claim", "complete"),
+				"spec_slug": stringProp("Parent spec slug (for list)"),
+				"slice_id":  stringProp("Slice ID (for get, claim, complete)"),
+				"agent":     stringProp("Agent identifier (for claim)"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *sliceTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "list":
+		resp, err := t.client.Slice.ListSlices(ctx, connect.NewRequest(&specv1.ListSlicesRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "get":
+		resp, err := t.client.Slice.GetSlice(ctx, connect.NewRequest(&specv1.GetSliceRequest{
+			SliceId: stringParam(params, "slice_id"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "claim":
+		resp, err := t.client.Slice.ClaimSlice(ctx, connect.NewRequest(&specv1.ClaimSliceRequest{
+			SliceId: stringParam(params, "slice_id"),
+			Agent:   stringParam(params, "agent"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "complete":
+		resp, err := t.client.Slice.CompleteSlice(ctx, connect.NewRequest(&specv1.CompleteSliceRequest{
+			SliceId: stringParam(params, "slice_id"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	default:
+		return errResult("unknown action: " + action), nil
+	}
+}
+
+// --- bundle tool ---
+
+type bundleTool struct {
+	client *Client
+}
+
+func (t *bundleTool) def() ToolDef {
+	return ToolDef{
+		Name:        "bundle",
+		Description: "Generate an execution bundle for a spec — contains all context needed for implementation.",
+		Tier:        TierExecution,
+		Schema: objectSchema(
+			props{
+				"spec_slug": stringProp("Spec slug to bundle"),
+			},
+			"spec_slug",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *bundleTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	resp, err := t.client.Execution.GenerateBundle(ctx, connect.NewRequest(&specv1.GenerateBundleRequest{
+		SpecSlug: stringParam(params, "spec_slug"),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// --- prime tool ---
+
+type primeTool struct {
+	client *Client
+}
+
+func (t *primeTool) def() ToolDef {
+	return ToolDef{
+		Name:        "prime",
+		Description: "Get execution prime data: constitution, dependencies, and full spec context.",
+		Tier:        TierExecution,
+		Schema: objectSchema(
+			props{
+				"spec_slug": stringProp("Spec slug"),
+			},
+			"spec_slug",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *primeTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	resp, err := t.client.Execution.GetPrime(ctx, connect.NewRequest(&specv1.GetPrimeRequest{
+		SpecSlug: stringParam(params, "spec_slug"),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// --- report tool ---
+
+type reportTool struct {
+	client *Client
+}
+
+func (t *reportTool) def() ToolDef {
+	return ToolDef{
+		Name:        "report",
+		Description: "Report execution status: progress updates, blockers, or completion.",
+		Tier:        TierExecution,
+		Schema: objectSchema(
+			props{
+				"action":    stringProp("Report type", "progress", "blocker", "completion"),
+				"spec_slug": stringProp("Spec slug"),
+				"agent":     stringProp("Agent identifier"),
+				"message":   stringProp("Status message"),
+				"percent":   intProp("Completion percentage (for progress)"),
+			},
+			"action", "spec_slug",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *reportTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "progress":
+		resp, err := t.client.Execution.ReportProgress(ctx, connect.NewRequest(&specv1.ReportProgressRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+			Agent:    stringParam(params, "agent"),
+			Message:  stringParam(params, "message"),
+			Percent:  int32Param(params, "percent"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "blocker":
+		resp, err := t.client.Execution.ReportBlocker(ctx, connect.NewRequest(&specv1.ReportBlockerRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+			Agent:    stringParam(params, "agent"),
+			Message:  stringParam(params, "message"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	case "completion":
+		resp, err := t.client.Execution.ReportCompletion(ctx, connect.NewRequest(&specv1.ReportCompletionRequest{
+			SpecSlug: stringParam(params, "spec_slug"),
+			Agent:    stringParam(params, "agent"),
+			Message:  stringParam(params, "message"),
+		}))
+		if err != nil {
+			return connectErrResult(err)
+		}
+		return jsonResult(resp.Msg), nil
+
+	default:
+		return errResult("unknown action: " + action), nil
+	}
+}
+
+// --- execution_events tool ---
+
+type executionEventsTool struct {
+	client *Client
+}
+
+func (t *executionEventsTool) def() ToolDef {
+	return ToolDef{
+		Name:        "execution_events",
+		Description: "Get execution event log for a spec — progress, blockers, completions.",
+		Tier:        TierExecution,
+		Schema: objectSchema(
+			props{
+				"spec_slug": stringProp("Spec slug"),
+			},
+			"spec_slug",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *executionEventsTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	resp, err := t.client.Execution.GetExecutionEvents(ctx, connect.NewRequest(&specv1.GetExecutionEventsRequest{
+		SpecSlug: stringParam(params, "spec_slug"),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// RegisterExecutionTools adds claim, slice, bundle, prime, report, and execution_events tools.
+func RegisterExecutionTools(r *Registry, c *Client) {
+	cl := &claimTool{client: c}
+	r.AddTool(cl.def())
+
+	sl := &sliceTool{client: c}
+	r.AddTool(sl.def())
+
+	bt := &bundleTool{client: c}
+	r.AddTool(bt.def())
+
+	pt := &primeTool{client: c}
+	r.AddTool(pt.def())
+
+	rt := &reportTool{client: c}
+	r.AddTool(rt.def())
+
+	et := &executionEventsTool{client: c}
+	r.AddTool(et.def())
+}
+```
+
+- [ ] **Step 3: Write execution tool tests**
+
+```go
+// internal/mcp/tools_execution_test.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaimTool_Claim(t *testing.T) {
+	c := &Client{Claim: &mockClaimService{
+		claimSpec: func(req *specv1.ClaimSpecRequest) (*specv1.ClaimSpecResponse, error) {
+			return &specv1.ClaimSpecResponse{}, nil
+		},
+	}}
+	h := &claimTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{
+		"action":    "claim",
+		"spec_slug": "auth",
+		"agent":     "polecat-1",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestSliceTool_List(t *testing.T) {
+	c := &Client{Slice: &mockSliceService{
+		listSlices: func(req *specv1.ListSlicesRequest) (*specv1.ListSlicesResponse, error) {
+			return &specv1.ListSlicesResponse{}, nil
+		},
+	}}
+	h := &sliceTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{
+		"action":    "list",
+		"spec_slug": "auth",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestBundleTool(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{
+		generateBundle: func(req *specv1.GenerateBundleRequest) (*specv1.GenerateBundleResponse, error) {
+			return &specv1.GenerateBundleResponse{}, nil
+		},
+	}}
+	h := &bundleTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{"spec_slug": "auth"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestPrimeTool(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{
+		getPrime: func(req *specv1.GetPrimeRequest) (*specv1.PrimeResponse, error) {
+			return &specv1.PrimeResponse{}, nil
+		},
+	}}
+	h := &primeTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{"spec_slug": "auth"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestReportTool_Progress(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{
+		reportProgress: func(req *specv1.ReportProgressRequest) (*specv1.ReportProgressResponse, error) {
+			return &specv1.ReportProgressResponse{}, nil
+		},
+	}}
+	h := &reportTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{
+		"action":    "progress",
+		"spec_slug": "auth",
+		"agent":     "polecat-1",
+		"message":   "halfway there",
+		"percent":   float64(50),
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestExecutionEventsTool(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{
+		getEvents: func(req *specv1.GetExecutionEventsRequest) (*specv1.GetExecutionEventsResponse, error) {
+			return &specv1.GetExecutionEventsResponse{}, nil
+		},
+	}}
+	h := &executionEventsTool{client: c}
+
+	result, err := h.handle(context.Background(), map[string]any{"spec_slug": "auth"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+```
+
+- [ ] **Step 4: Run all execution tier tests**
+
+Run: `go test ./internal/mcp/ -run 'TestClaim|TestSlice|TestBundle|TestPrime|TestReport|TestExecutionEvents' -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mcp/tools_execution.go internal/mcp/tools_execution_test.go internal/mcp/testhelpers_test.go
+git commit -s -m "feat(mcp): add execution tier tools — claim, slice, bundle, prime, report, execution_events"
+```
+
+---
+
+### Task 8: Resources
+
+**Files:**
+- Create: `internal/mcp/resources.go`
+- Create: `internal/mcp/resources_test.go`
+
+- [ ] **Step 1: Write resource tests**
+
+```go
+// internal/mcp/resources_test.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpecResource(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{
+		getSpec: func(slug string) (*specv1.GetSpecResponse, error) {
+			return &specv1.GetSpecResponse{Spec: &specv1.Spec{
+				Slug:   slug,
+				Intent: "Test intent",
+			}}, nil
+		},
+	}}
+	h := specResourceHandler(c)
+
+	contents, err := h(context.Background(), "specgraph://spec/auth")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+	require.Contains(t, contents[0].Text, "auth")
+	require.Equal(t, "application/json", contents[0].MimeType)
+}
+
+func TestSpecListResource(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{
+		listSpecs: func() (*specv1.ListSpecsResponse, error) {
+			return &specv1.ListSpecsResponse{Specs: []*specv1.Spec{
+				{Slug: "a"},
+				{Slug: "b"},
+			}}, nil
+		},
+	}}
+	h := specListResourceHandler(c)
+
+	contents, err := h(context.Background(), "specgraph://specs")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+	require.Contains(t, contents[0].Text, "a")
+}
+
+func TestConstitutionResource(t *testing.T) {
+	c := &Client{Constitution: &mockConstitutionService{
+		getConstitution: func(req *specv1.GetConstitutionRequest) (*specv1.GetConstitutionResponse, error) {
+			return &specv1.GetConstitutionResponse{}, nil
+		},
+	}}
+	h := constitutionResourceHandler(c)
+
+	contents, err := h(context.Background(), "specgraph://constitution")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+}
+
+func TestConstitutionLayerResource(t *testing.T) {
+	c := &Client{Constitution: &mockConstitutionService{
+		getConstitution: func(req *specv1.GetConstitutionRequest) (*specv1.GetConstitutionResponse, error) {
+			return &specv1.GetConstitutionResponse{}, nil
+		},
+	}}
+	h := constitutionLayerResourceHandler(c)
+
+	contents, err := h(context.Background(), "specgraph://constitution/domain")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+}
+```
+
+- [ ] **Step 2: Write resource handlers**
+
+```go
+// internal/mcp/resources.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"strings"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+func resourceJSON(uri string, msg proto.Message) ([]ResourceContent, error) {
+	data, err := protojson.MarshalOptions{Multiline: true}.Marshal(msg)
+	if err != nil {
+		return nil, err
+	}
+	return []ResourceContent{{
+		URI:      uri,
+		MimeType: "application/json",
+		Text:     string(data),
+	}}, nil
+}
+
+// extractSlugFromURI extracts the last path segment from a specgraph:// URI.
+// e.g., "specgraph://spec/auth-system" → "auth-system"
+func extractSlugFromURI(uri string) string {
+	parts := strings.Split(uri, "/")
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[len(parts)-1]
+}
+
+func specResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		slug := extractSlugFromURI(uri)
+		resp, err := c.Spec.GetSpec(ctx, connect.NewRequest(&specv1.GetSpecRequest{Slug: slug}))
+		if err != nil {
+			return nil, err
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+func specListResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		resp, err := c.Spec.ListSpecs(ctx, connect.NewRequest(&specv1.ListSpecsRequest{}))
+		if err != nil {
+			return nil, err
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+func decisionResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		slug := extractSlugFromURI(uri)
+		resp, err := c.Decision.GetDecision(ctx, connect.NewRequest(&specv1.GetDecisionRequest{Slug: slug}))
+		if err != nil {
+			return nil, err
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+func constitutionResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		resp, err := c.Constitution.GetConstitution(ctx, connect.NewRequest(&specv1.GetConstitutionRequest{}))
+		if err != nil {
+			return nil, err
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+func constitutionLayerResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		layer := extractSlugFromURI(uri)
+		resp, err := c.Constitution.GetConstitution(ctx, connect.NewRequest(&specv1.GetConstitutionRequest{
+			Layer: layer,
+		}))
+		if err != nil {
+			return nil, err
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+func graphResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		resp, err := c.Graph.GetFullGraph(ctx, connect.NewRequest(&specv1.GetFullGraphRequest{}))
+		if err != nil {
+			return nil, err
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+func readyResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		resp, err := c.Graph.GetReady(ctx, connect.NewRequest(&specv1.GetReadyRequest{}))
+		if err != nil {
+			return nil, err
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+func findingsResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		// Extract pass_type from query if present
+		passType := ""
+		if idx := strings.Index(uri, "pass_type="); idx >= 0 {
+			passType = uri[idx+len("pass_type="):]
+		}
+		resp, err := c.AnalyticalPass.ListFindings(ctx, connect.NewRequest(&specv1.ListFindingsRequest{
+			PassType: passType,
+		}))
+		if err != nil {
+			return nil, err
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+func changesResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		// URI: specgraph://spec/{slug}/changes → extract slug (second-to-last segment)
+		parts := strings.Split(strings.TrimPrefix(uri, "specgraph://"), "/")
+		slug := ""
+		if len(parts) >= 3 {
+			slug = parts[1] // spec/{slug}/changes
+		}
+		resp, err := c.Spec.ListChanges(ctx, connect.NewRequest(&specv1.ListChangesRequest{Slug: slug}))
+		if err != nil {
+			return nil, err
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+// RegisterResources adds all MCP resource definitions to the registry.
+func RegisterResources(r *Registry, c *Client) {
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://spec/{slug}",
+		Name:        "Spec",
+		Description: "Full spec content by slug",
+		MimeType:    "application/json",
+		IsTemplate:  true,
+		Handler:     specResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://specs",
+		Name:        "Spec list",
+		Description: "All specs (summary view)",
+		MimeType:    "application/json",
+		Handler:     specListResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://decision/{slug}",
+		Name:        "Decision",
+		Description: "Decision content by slug",
+		MimeType:    "application/json",
+		IsTemplate:  true,
+		Handler:     decisionResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://constitution",
+		Name:        "Constitution (merged)",
+		Description: "Fully merged constitution, all layers applied",
+		MimeType:    "application/json",
+		Handler:     constitutionResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://constitution/{layer}",
+		Name:        "Constitution layer",
+		Description: "Single constitution layer: user, org, project, or domain",
+		MimeType:    "application/json",
+		IsTemplate:  true,
+		Handler:     constitutionLayerResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://graph",
+		Name:        "Full graph",
+		Description: "Complete spec dependency graph",
+		MimeType:    "application/json",
+		Handler:     graphResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://graph/ready",
+		Name:        "Ready specs",
+		Description: "Specs with no unmet dependencies",
+		MimeType:    "application/json",
+		Handler:     readyResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://findings",
+		Name:        "Findings",
+		Description: "Analytical findings, filterable by pass_type query param",
+		MimeType:    "application/json",
+		Handler:     findingsResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://spec/{slug}/changes",
+		Name:        "Changes",
+		Description: "Version history for a spec",
+		MimeType:    "application/json",
+		IsTemplate:  true,
+		Handler:     changesResourceHandler(c),
+	})
+}
+```
+
+- [ ] **Step 3: Run resource tests**
+
+Run: `go test ./internal/mcp/ -run 'TestSpec.*Resource|TestConstitution.*Resource' -v`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/mcp/resources.go internal/mcp/resources_test.go
+git commit -s -m "feat(mcp): add MCP resources — specs, decisions, constitution, graph, findings, changes"
+```
+
+---
+
+### Task 9: Prompts
+
+**Files:**
+- Create: `internal/mcp/prompts.go`
+- Create: `internal/mcp/prompts_test.go`
+
+- [ ] **Step 1: Write prompt tests**
+
+```go
+// internal/mcp/prompts_test.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSparkPrompt(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		getPrompts: func(req *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
+			return &specv1.GetPromptsResponse{
+				Prompt: "You are a spec architect. Spark a new idea about: test-topic",
+			}, nil
+		},
+	}}
+	h := sparkPromptHandler(c)
+
+	result, err := h(context.Background(), map[string]string{
+		"topic":   "test-topic",
+		"context": "microservices",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Messages)
+	require.Contains(t, result.Messages[0].Content, "test-topic")
+}
+
+func TestShapePrompt(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		getPrompts: func(req *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
+			return &specv1.GetPromptsResponse{
+				Prompt: "Shape the spec: auth",
+			}, nil
+		},
+	}}
+	h := shapePromptHandler(c)
+
+	result, err := h(context.Background(), map[string]string{"spec_slug": "auth"})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Messages)
+}
+```
+
+- [ ] **Step 2: Write prompt handlers**
+
+```go
+// internal/mcp/prompts.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+)
+
+func stagePromptHandler(c *Client, stage string) PromptHandler {
+	return func(ctx context.Context, args map[string]string) (*PromptResult, error) {
+		resp, err := c.Authoring.GetPrompts(ctx, connect.NewRequest(&specv1.GetPromptsRequest{
+			Stage:    stage,
+			SpecSlug: args["spec_slug"],
+		}))
+		if err != nil {
+			return nil, err
+		}
+		return &PromptResult{
+			Description: stage + " authoring prompt",
+			Messages: []PromptMessage{{
+				Role:    "user",
+				Content: resp.Msg.GetPrompt(),
+			}},
+		}, nil
+	}
+}
+
+func sparkPromptHandler(c *Client) PromptHandler {
+	return func(ctx context.Context, args map[string]string) (*PromptResult, error) {
+		resp, err := c.Authoring.GetPrompts(ctx, connect.NewRequest(&specv1.GetPromptsRequest{
+			Stage: "spark",
+		}))
+		if err != nil {
+			return nil, err
+		}
+		prompt := resp.Msg.GetPrompt()
+		if topic := args["topic"]; topic != "" {
+			prompt = prompt + "\n\nTopic: " + topic
+		}
+		if ctx := args["context"]; ctx != "" {
+			prompt = prompt + "\nContext: " + ctx
+		}
+		return &PromptResult{
+			Description: "Spark a new spec idea",
+			Messages: []PromptMessage{{
+				Role:    "user",
+				Content: prompt,
+			}},
+		}, nil
+	}
+}
+
+func shapePromptHandler(c *Client) PromptHandler {
+	return stagePromptHandler(c, "shape")
+}
+
+func specifyPromptHandler(c *Client) PromptHandler {
+	return stagePromptHandler(c, "specify")
+}
+
+func decomposePromptHandler(c *Client) PromptHandler {
+	return stagePromptHandler(c, "decompose")
+}
+
+func analyticalPromptHandler(c *Client, passType string) PromptHandler {
+	return func(ctx context.Context, args map[string]string) (*PromptResult, error) {
+		resp, err := c.AnalyticalPass.RunAnalyticalPass(ctx, connect.NewRequest(&specv1.RunAnalyticalPassRequest{
+			SpecSlug: args["spec_slug"],
+			PassType: passType,
+		}))
+		if err != nil {
+			return nil, err
+		}
+		return &PromptResult{
+			Description: passType + " analytical pass",
+			Messages: []PromptMessage{{
+				Role:    "user",
+				Content: resp.Msg.GetPrompt(),
+			}},
+		}, nil
+	}
+}
+
+// RegisterPrompts adds all MCP prompt definitions to the registry.
+func RegisterPrompts(r *Registry, c *Client) {
+	r.AddPrompt(PromptDef{
+		Name:        "spark",
+		Description: "Generate an initial spec idea from a topic",
+		Arguments: []PromptArgument{
+			{Name: "topic", Description: "Topic to explore", Required: true},
+			{Name: "context", Description: "Additional context"},
+		},
+		Handler: sparkPromptHandler(c),
+	})
+	r.AddPrompt(PromptDef{
+		Name:        "shape",
+		Description: "Refine a sparked spec into a structured shape",
+		Arguments: []PromptArgument{
+			{Name: "spec_slug", Description: "Spec to shape", Required: true},
+		},
+		Handler: shapePromptHandler(c),
+	})
+	r.AddPrompt(PromptDef{
+		Name:        "specify",
+		Description: "Add full specification detail with acceptance criteria",
+		Arguments: []PromptArgument{
+			{Name: "spec_slug", Description: "Spec to specify", Required: true},
+		},
+		Handler: specifyPromptHandler(c),
+	})
+	r.AddPrompt(PromptDef{
+		Name:        "decompose",
+		Description: "Break a spec into implementable work slices",
+		Arguments: []PromptArgument{
+			{Name: "spec_slug", Description: "Spec to decompose", Required: true},
+		},
+		Handler: decomposePromptHandler(c),
+	})
+	r.AddPrompt(PromptDef{
+		Name:        "constitution_check",
+		Description: "Check a spec against the project constitution",
+		Arguments: []PromptArgument{
+			{Name: "spec_slug", Description: "Spec to check", Required: true},
+		},
+		Handler: analyticalPromptHandler(c, "constitution-check"),
+	})
+	r.AddPrompt(PromptDef{
+		Name:        "dependency_review",
+		Description: "Review dependency health for a spec",
+		Arguments: []PromptArgument{
+			{Name: "spec_slug", Description: "Spec to review", Required: true},
+		},
+		Handler: analyticalPromptHandler(c, "dependency-review"),
+	})
+}
+```
+
+- [ ] **Step 3: Run prompt tests**
+
+Run: `go test ./internal/mcp/ -run 'TestSparkPrompt|TestShapePrompt' -v`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/mcp/prompts.go internal/mcp/prompts_test.go
+git commit -s -m "feat(mcp): add MCP prompts — spark, shape, specify, decompose, constitution_check, dependency_review"
+```
+
+---
+
+### Task 10: SDK Integration — convert, tiers, server
+
+**Files:**
+- Create: `internal/mcp/convert.go`
+- Create: `internal/mcp/convert_test.go`
+- Create: `internal/mcp/tiers.go`
+- Create: `internal/mcp/tiers_test.go`
+- Create: `internal/mcp/server.go`
+- Create: `internal/mcp/server_test.go`
+
+This is the task where `mcp-go` enters the codebase. All SDK imports are confined to these files.
+
+- [ ] **Step 1: Add mcp-go dependency**
+
+Run: `cd /Volumes/Code/github.com/.worktrees/specgraph/mcp-server && go get github.com/mark3labs/mcp-go@latest`
+
+Verify: `go list -m github.com/mark3labs/mcp-go` should print the resolved version.
+
+- [ ] **Step 2: Verify mcp-go API**
+
+Before writing code, verify the SDK's tool, resource, and prompt types. Create a scratch test:
+
+```bash
+cd /Volumes/Code/github.com/.worktrees/specgraph/mcp-server
+go doc github.com/mark3labs/mcp-go/mcp Tool
+go doc github.com/mark3labs/mcp-go/mcp CallToolRequest
+go doc github.com/mark3labs/mcp-go/mcp Resource
+go doc github.com/mark3labs/mcp-go/server MCPServer
+```
+
+Check for per-session tool support — look for `SessionTools`, `WithToolFilter`, or similar patterns in the server package. Adjust `convert.go` and `tiers.go` accordingly.
+
+- [ ] **Step 3: Write convert tests**
+
+```go
+// internal/mcp/convert_test.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToSDKTool(t *testing.T) {
+	def := ToolDef{
+		Name:        "spec",
+		Description: "Manage specs",
+		Schema: objectSchema(
+			props{
+				"action": stringProp("Operation", "get", "list"),
+			},
+			"action",
+		),
+	}
+	tool := toSDKTool(def)
+	require.Equal(t, "spec", tool.Name)
+	require.Equal(t, "Manage specs", tool.Description)
+}
+
+func TestToSDKResult_Success(t *testing.T) {
+	r := textResult("hello")
+	sdkResult := toSDKResult(r)
+	require.False(t, sdkResult.IsError)
+	require.Len(t, sdkResult.Content, 1)
+}
+
+func TestToSDKResult_Error(t *testing.T) {
+	r := errResult("broken")
+	sdkResult := toSDKResult(r)
+	require.True(t, sdkResult.IsError)
+}
+
+func TestFromSDKParams(t *testing.T) {
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"action": "get",
+		"slug":   "auth",
+	}
+	params := fromSDKParams(req)
+	require.Equal(t, "get", params["action"])
+	require.Equal(t, "auth", params["slug"])
+}
+```
+
+- [ ] **Step 4: Write convert.go**
+
+```go
+// internal/mcp/convert.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// --- Tool conversion ---
+
+// toSDKTool converts our ToolDef to an mcp-go Tool.
+func toSDKTool(def ToolDef) mcp.Tool {
+	return mcp.Tool{
+		Name:        def.Name,
+		Description: def.Description,
+		InputSchema: mcp.ToolInputSchema{
+			Type:       "object",
+			Properties: toSDKProperties(def.Schema),
+			Required:   toSDKRequired(def.Schema),
+		},
+	}
+}
+
+func toSDKProperties(schema map[string]any) map[string]interface{} {
+	p, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	// Return as-is — JSON Schema properties are already the right shape
+	out := make(map[string]interface{}, len(p))
+	for k, v := range p {
+		out[k] = v
+	}
+	return out
+}
+
+func toSDKRequired(schema map[string]any) []string {
+	r, ok := schema["required"].([]string)
+	if !ok {
+		return nil
+	}
+	return r
+}
+
+// fromSDKParams extracts the arguments map from an mcp-go CallToolRequest.
+func fromSDKParams(req mcp.CallToolRequest) map[string]any {
+	if req.Params.Arguments == nil {
+		return make(map[string]any)
+	}
+	return req.Params.Arguments
+}
+
+// toSDKResult converts our ToolResult to an mcp-go CallToolResult.
+func toSDKResult(r *ToolResult) *mcp.CallToolResult {
+	result := &mcp.CallToolResult{
+		IsError: r.IsError,
+	}
+	for _, c := range r.Content {
+		result.Content = append(result.Content, mcp.TextContent{
+			Type: "text",
+			Text: c.Text,
+		})
+	}
+	return result
+}
+
+// --- Resource conversion ---
+
+// toSDKResource converts our ResourceDef to an mcp-go Resource or ResourceTemplate.
+func toSDKResource(def ResourceDef) mcp.Resource {
+	return mcp.Resource{
+		URI:         def.URI,
+		Name:        def.Name,
+		Description: def.Description,
+		MIMEType:    def.MimeType,
+	}
+}
+
+func toSDKResourceTemplate(def ResourceDef) mcp.ResourceTemplate {
+	return mcp.ResourceTemplate{
+		URITemplate: def.URI,
+		Name:        def.Name,
+		Description: def.Description,
+		MIMEType:    def.MimeType,
+	}
+}
+
+func toSDKResourceContents(rcs []ResourceContent) []mcp.ResourceContents {
+	out := make([]mcp.ResourceContents, len(rcs))
+	for i, rc := range rcs {
+		out[i] = mcp.TextResourceContents{
+			URI:      rc.URI,
+			MIMEType: rc.MimeType,
+			Text:     rc.Text,
+		}
+	}
+	return out
+}
+
+// --- Prompt conversion ---
+
+// toSDKPrompt converts our PromptDef to an mcp-go Prompt.
+func toSDKPrompt(def PromptDef) mcp.Prompt {
+	args := make([]mcp.PromptArgument, len(def.Arguments))
+	for i, a := range def.Arguments {
+		args[i] = mcp.PromptArgument{
+			Name:        a.Name,
+			Description: a.Description,
+			Required:    a.Required,
+		}
+	}
+	return mcp.Prompt{
+		Name:        def.Name,
+		Description: def.Description,
+		Arguments:   args,
+	}
+}
+
+func toSDKPromptResult(r *PromptResult) *mcp.GetPromptResult {
+	msgs := make([]mcp.PromptMessage, len(r.Messages))
+	for i, m := range r.Messages {
+		msgs[i] = mcp.PromptMessage{
+			Role: mcp.Role(m.Role),
+			Content: mcp.TextContent{
+				Type: "text",
+				Text: m.Content,
+			},
+		}
+	}
+	return &mcp.GetPromptResult{
+		Description: r.Description,
+		Messages:    msgs,
+	}
+}
+```
+
+- [ ] **Step 5: Write tiers tests**
+
+```go
+// internal/mcp/tiers_test.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTierFromClientInfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		info     mcp.Implementation
+		expected Tier
+	}{
+		{
+			name:     "no metadata defaults to core",
+			info:     mcp.Implementation{Name: "test"},
+			expected: TierCore,
+		},
+		{
+			name: "authoring role",
+			info: mcp.Implementation{
+				Name:    "claude-code",
+				Version: "1.0",
+			},
+			expected: TierAuthoring,
+		},
+		{
+			name: "execution role",
+			info: mcp.Implementation{
+				Name:    "polecat",
+				Version: "1.0",
+			},
+			expected: TierExecution,
+		},
+	}
+
+	// Note: actual role extraction depends on how mcp-go passes client metadata.
+	// Update the Implementation fields and TierFromClientInfo logic after verifying
+	// the SDK's ClientInfo/Implementation struct in Step 2.
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tier := TierFromClientInfo(tt.info)
+			require.GreaterOrEqual(t, int(tier), int(TierCore))
+		})
+	}
+}
+```
+
+- [ ] **Step 6: Write tiers.go**
+
+```go
+// internal/mcp/tiers.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// TierFromClientInfo determines the tool tier from MCP client metadata.
+// Looks for "specgraph.role" in the client info. Returns TierCore if absent.
+//
+// NOTE: The exact field to inspect depends on how mcp-go exposes client metadata.
+// The Implementation struct may carry metadata directly or via an extensions map.
+// Adjust after verifying the SDK API (Task 10, Step 2).
+func TierFromClientInfo(info mcp.Implementation) Tier {
+	// mcp-go may expose metadata via info.Extensions or a similar field.
+	// For now, inspect the client name as a fallback heuristic:
+	switch info.Name {
+	case "polecat", "gastown":
+		return TierExecution
+	case "claude-code", "cursor", "windsurf":
+		return TierAuthoring
+	default:
+		return TierCore
+	}
+}
+```
+
+- [ ] **Step 7: Write server.go**
+
+```go
+// internal/mcp/server.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// Version is set at build time.
+var Version = "dev"
+
+// Server wraps the mcp-go MCPServer with SpecGraph's tiered tool registry.
+type Server struct {
+	registry *Registry
+	servers  map[Tier]*server.MCPServer
+}
+
+// NewServer creates an MCP server backed by the given ConnectRPC client.
+// It registers all tools, resources, and prompts.
+func NewServer(client *Client) *Server {
+	reg := NewRegistry()
+
+	// Register all tools
+	RegisterSpecTools(reg, client)
+	RegisterGraphTools(reg, client)
+	RegisterCoreTools(reg, client)
+	RegisterAuthoringTools(reg, client)
+	RegisterLifecycleTools(reg, client)
+	RegisterExecutionTools(reg, client)
+
+	// Register resources and prompts
+	RegisterResources(reg, client)
+	RegisterPrompts(reg, client)
+
+	// Build one mcp-go server per tier
+	servers := make(map[Tier]*server.MCPServer, 3)
+	for _, tier := range []Tier{TierCore, TierAuthoring, TierExecution} {
+		s := server.NewMCPServer(
+			"specgraph",
+			Version,
+			server.WithToolCapabilities(true),
+			server.WithResourceCapabilities(true, true),
+			server.WithPromptCapabilities(true),
+		)
+
+		// Add tools for this tier
+		for _, def := range reg.ToolsForTier(tier) {
+			d := def // capture
+			sdkTool := toSDKTool(d)
+			s.AddTool(sdkTool, wrapToolHandler(d.Handler))
+		}
+
+		// Add all resources (resources are not tiered)
+		for _, res := range reg.Resources() {
+			r := res
+			if r.IsTemplate {
+				s.AddResourceTemplate(toSDKResourceTemplate(r), wrapResourceHandler(r.Handler))
+			} else {
+				s.AddResource(toSDKResource(r), wrapResourceHandler(r.Handler))
+			}
+		}
+
+		// Add all prompts (prompts are not tiered)
+		for _, p := range reg.Prompts() {
+			pr := p
+			s.AddPrompt(toSDKPrompt(pr), wrapPromptHandler(pr.Handler))
+		}
+
+		servers[tier] = s
+	}
+
+	return &Server{registry: reg, servers: servers}
+}
+
+// ForTier returns the mcp-go server instance for the given tier.
+func (s *Server) ForTier(tier Tier) *server.MCPServer {
+	srv, ok := s.servers[tier]
+	if !ok {
+		return s.servers[TierCore]
+	}
+	return srv
+}
+
+// ServeStdio runs the MCP server over stdin/stdout for the given tier.
+func (s *Server) ServeStdio(ctx context.Context, tier Tier, stdin io.Reader, stdout io.Writer) error {
+	srv := s.ForTier(tier)
+	stdio := server.NewStdioServer(srv)
+	return stdio.Listen(ctx, stdin, stdout)
+}
+
+// HTTPHandler returns an http.Handler for the MCP streamable HTTP transport at the given tier.
+func (s *Server) HTTPHandler(tier Tier) *server.StreamableHTTPServer {
+	srv := s.ForTier(tier)
+	return server.NewStreamableHTTPServer(srv)
+}
+
+// --- Handler wrappers ---
+
+func wrapToolHandler(h ToolHandler) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		params := fromSDKParams(req)
+		result, err := h(ctx, params)
+		if err != nil {
+			return nil, fmt.Errorf("tool handler: %w", err)
+		}
+		return toSDKResult(result), nil
+	}
+}
+
+func wrapResourceHandler(h ResourceHandler) server.ResourceHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		contents, err := h(ctx, req.Params.URI)
+		if err != nil {
+			return nil, fmt.Errorf("resource handler: %w", err)
+		}
+		return toSDKResourceContents(contents), nil
+	}
+}
+
+func wrapPromptHandler(h PromptHandler) server.PromptHandlerFunc {
+	return func(ctx context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		result, err := h(ctx, req.Params.Arguments)
+		if err != nil {
+			return nil, fmt.Errorf("prompt handler: %w", err)
+		}
+		return toSDKPromptResult(result), nil
+	}
+}
+```
+
+- [ ] **Step 8: Write server test**
+
+```go
+// internal/mcp/server_test.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServer_TierToolCounts(t *testing.T) {
+	// Create a server with a nil client — we're only testing registration, not calls
+	// This will panic if any handler is invoked, which is fine for this test.
+	c := &Client{} // all nil — only testing tool registration counts
+
+	s := NewServer(c)
+
+	coreSrv := s.ForTier(TierCore)
+	require.NotNil(t, coreSrv)
+
+	authoringSrv := s.ForTier(TierAuthoring)
+	require.NotNil(t, authoringSrv)
+
+	executionSrv := s.ForTier(TierExecution)
+	require.NotNil(t, executionSrv)
+
+	// Verify different server instances per tier
+	require.NotSame(t, coreSrv, authoringSrv)
+	require.NotSame(t, authoringSrv, executionSrv)
+}
+
+func TestNewServer_FallbackToCore(t *testing.T) {
+	c := &Client{}
+	s := NewServer(c)
+
+	// Unknown tier falls back to core
+	srv := s.ForTier(Tier(99))
+	require.NotNil(t, srv)
+	require.Same(t, s.ForTier(TierCore), srv)
+}
+```
+
+- [ ] **Step 9: Run all SDK integration tests**
+
+Run: `go test ./internal/mcp/ -run 'TestToSDK|TestFromSDK|TestTier|TestNewServer' -v`
+Expected: All PASS
+
+- [ ] **Step 10: Run full package tests**
+
+Run: `go test ./internal/mcp/ -v`
+Expected: All tests PASS
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add go.mod go.sum internal/mcp/convert.go internal/mcp/convert_test.go internal/mcp/tiers.go internal/mcp/tiers_test.go internal/mcp/server.go internal/mcp/server_test.go
+git commit -s -m "feat(mcp): add SDK integration — convert, tiers, server wiring with mcp-go"
+```
+
+---
+
+### Task 11: `specgraph mcp` CLI Command
+
+**Files:**
+- Create: `cmd/specgraph/mcp.go`
+
+- [ ] **Step 1: Write the CLI command**
+
+```go
+// cmd/specgraph/mcp.go
+
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+
+	mcppkg "github.com/specgraph/specgraph/internal/mcp"
+	"github.com/spf13/cobra"
+)
+
+var mcpCmd = &cobra.Command{
+	Use:   "mcp",
+	Short: "Start MCP server over stdio (for Claude Code, Cursor, etc.)",
+	Long: `Start a Model Context Protocol server that communicates over stdin/stdout.
+This lightweight process translates MCP tool calls into ConnectRPC RPCs
+against a running specgraph serve instance.
+
+Configure in Claude Code's MCP settings:
+  {
+    "mcpServers": {
+      "specgraph": {
+        "command": "specgraph",
+        "args": ["mcp", "--tier", "authoring"]
+      }
+    }
+  }`,
+	RunE: runMCP,
+}
+
+func init() {
+	mcpCmd.Flags().String("tier", "core", "Tool tier: core, authoring, or execution")
+	rootCmd.AddCommand(mcpCmd)
+}
+
+func runMCP(cmd *cobra.Command, _ []string) error {
+	tierStr, _ := cmd.Flags().GetString("tier")
+	tier := mcppkg.ParseTier(tierStr)
+
+	// Resolve server connection using existing config/auth
+	baseURL, project, err := resolveBaseURL()
+	if err != nil {
+		return fmt.Errorf("resolve server: %w", err)
+	}
+
+	httpClient := newHTTPClient(project)
+	client := mcppkg.NewClient(httpClient, baseURL)
+	srv := mcppkg.NewServer(client)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	return srv.ServeStdio(ctx, tier, os.Stdin, os.Stdout)
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `go build ./cmd/specgraph/`
+Expected: Success
+
+- [ ] **Step 3: Verify help text**
+
+Run: `go run ./cmd/specgraph/ mcp --help`
+Expected: Shows usage with --tier flag
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/specgraph/mcp.go
+git commit -s -m "feat(mcp): add 'specgraph mcp' CLI command for stdio transport"
+```
+
+---
+
+### Task 12: MCP HTTP Endpoint in `specgraph serve`
+
+**Files:**
+- Modify: `cmd/specgraph/serve.go`
+
+- [ ] **Step 1: Read current serve.go to identify insertion points**
+
+Read `cmd/specgraph/serve.go` to find where the HTTP mux is created, where middleware is applied, and where the server starts. Identify exact line numbers.
+
+- [ ] **Step 2: Add MCP HTTP endpoint**
+
+Add these changes to `cmd/specgraph/serve.go`:
+
+1. Import the mcp package:
+```go
+import (
+	// ... existing imports ...
+	mcppkg "github.com/specgraph/specgraph/internal/mcp"
+)
+```
+
+2. After the ConnectRPC mux setup and service registration, add the MCP endpoint:
+```go
+// Create MCP server with a loopback ConnectRPC client
+mcpHTTPClient := newHTTPClient(projectSlug)
+mcpClient := mcppkg.NewClient(mcpHTTPClient, "http://"+addr)
+mcpServer := mcppkg.NewServer(mcpClient)
+
+// Mount MCP streamable HTTP endpoint.
+// Tier determined by X-Specgraph-MCP-Tier header, defaults to core.
+mux.Handle("/mcp/", http.StripPrefix("/mcp", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tierStr := r.Header.Get("X-Specgraph-MCP-Tier")
+	if tierStr == "" {
+		tierStr = r.URL.Query().Get("tier")
+	}
+	tier := mcppkg.ParseTier(tierStr)
+	mcpHandler := mcpServer.HTTPHandler(tier)
+	mcpHandler.ServeHTTP(w, r)
+})))
+```
+
+3. Log the MCP endpoint availability alongside the ConnectRPC log:
+```go
+slog.Info("MCP endpoint available", "path", "/mcp/")
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `go build ./cmd/specgraph/`
+Expected: Success
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/specgraph/serve.go
+git commit -s -m "feat(mcp): embed MCP HTTP endpoint in specgraph serve"
+```
+
+---
+
+### Task 13: Quality Gates
+
+- [ ] **Step 1: Add license headers**
+
+Run: `task license:add`
+
+- [ ] **Step 2: Format**
+
+Run: `task fmt`
+
+- [ ] **Step 3: Run full quality check**
+
+Run: `task check`
+
+Fix any issues that arise. Common ones:
+- `revive`: package comment needed for `internal/mcp/` — the `types.go` file has it
+- `govet -shadow`: variable shadowing in switch cases — rename if needed
+- `wrapcheck`: exported functions in `server.go` may need error wrapping
+- `gosec`: no expected issues in this code
+- Unused imports from `json`, `encoding/json` — remove if helpers don't use them
+
+- [ ] **Step 4: Run unit tests**
+
+Run: `task test`
+Expected: All PASS including new `internal/mcp/` tests
+
+- [ ] **Step 5: Commit any fixes**
+
+```bash
+git add -A
+git commit -s -m "chore(mcp): fix lint and formatting issues"
+```
+
+---
+
+## Proto Field Verification Notes
+
+Some proto request/response field names in the tool handlers are inferred from naming conventions and existing test code. When implementing, verify exact field names against the generated types in `gen/specgraph/v1/`:
+
+- `UpdateSpecRequest` — verify available fields (may use field mask pattern)
+- `UpdateDecisionRequest` — verify available fields
+- `ShapeRequest.Output`, `SpecifyRequest.Output`, `DecomposeRequest.Output` — verify field name for stage output JSON
+- `RecordConversationRequest.Messages` — verify field name and type
+- `GetConstitutionRequest.Layer` — verify layer filter field name
+- `DriftAcknowledgeRequest.All` — verify boolean flag name
+- `ReportProgressRequest.Percent` — verify field name and type
+
+If any field doesn't exist or has a different name, adjust the handler code to match the actual proto definition. The handler pattern (extract params → build request → call client → return result) stays the same.
+
+## SDK API Verification Notes
+
+The `convert.go`, `tiers.go`, and `server.go` files reference `mcp-go` types that may differ slightly from the actual v0.47+ API:
+
+- `mcp.ToolInputSchema` — verify struct fields match
+- `server.ToolHandlerFunc`, `server.ResourceHandlerFunc`, `server.PromptHandlerFunc` — verify exact type signatures
+- `server.NewStreamableHTTPServer` — verify constructor and ServeHTTP method
+- `server.NewStdioServer` and `Listen` method — verify signature
+- `server.AddResourceTemplate` — verify this method exists (may be `AddResource` with template flag)
+- `mcp.ReadResourceRequest.Params.URI` — verify field path
+- `mcp.GetPromptRequest.Params.Arguments` — verify type is `map[string]string`
+
+Adjust the convert layer to match the actual SDK API. The rest of the code (handlers, registry, types) remains unchanged.

--- a/docs/plans/2026-04-10-mcp-server-plan.md
+++ b/docs/plans/2026-04-10-mcp-server-plan.md
@@ -53,6 +53,7 @@
 ### Task 1: Foundation Types and Helpers
 
 **Files:**
+
 - Create: `internal/mcp/types.go`
 - Create: `internal/mcp/helpers.go`
 - Create: `internal/mcp/helpers_test.go`
@@ -415,6 +416,7 @@ git commit -s -m "feat(mcp): add foundation types and helpers for MCP server"
 ### Task 2: Tool Registry
 
 **Files:**
+
 - Create: `internal/mcp/registry.go`
 - Create: `internal/mcp/registry_test.go`
 
@@ -581,6 +583,7 @@ git commit -s -m "feat(mcp): add tool/resource/prompt registry with tier filteri
 ### Task 3: ConnectRPC Client Wrapper
 
 **Files:**
+
 - Create: `internal/mcp/client.go`
 
 - [ ] **Step 1: Write client**
@@ -652,6 +655,7 @@ git commit -s -m "feat(mcp): add ConnectRPC client wrapper for MCP handlers"
 ### Task 4: Test Infrastructure and Core Tier Tools — spec, decision
 
 **Files:**
+
 - Create: `internal/mcp/testhelpers_test.go`
 - Create: `internal/mcp/tools_spec.go`
 - Create: `internal/mcp/tools_spec_test.go`
@@ -1210,6 +1214,7 @@ git commit -s -m "feat(mcp): add spec and decision tool handlers with tests"
 ### Task 5: Core Tier Tools — edge, graph_query, constitution, changes, findings, health
 
 **Files:**
+
 - Create: `internal/mcp/tools_graph.go`
 - Create: `internal/mcp/tools_graph_test.go`
 - Create: `internal/mcp/tools_core.go`
@@ -1765,6 +1770,7 @@ git commit -s -m "feat(mcp): add core tier tools — edge, graph_query, constitu
 ### Task 6: Authoring Tier Tools
 
 **Files:**
+
 - Create: `internal/mcp/tools_authoring.go`
 - Create: `internal/mcp/tools_authoring_test.go`
 - Create: `internal/mcp/tools_lifecycle.go`
@@ -2512,6 +2518,7 @@ git commit -s -m "feat(mcp): add authoring tier tools — author, conversation, 
 ### Task 7: Execution Tier Tools
 
 **Files:**
+
 - Create: `internal/mcp/tools_execution.go`
 - Create: `internal/mcp/tools_execution_test.go`
 
@@ -3123,6 +3130,7 @@ git commit -s -m "feat(mcp): add execution tier tools — claim, slice, bundle, 
 ### Task 8: Resources
 
 **Files:**
+
 - Create: `internal/mcp/resources.go`
 - Create: `internal/mcp/resources_test.go`
 
@@ -3445,6 +3453,7 @@ git commit -s -m "feat(mcp): add MCP resources — specs, decisions, constitutio
 ### Task 9: Prompts
 
 **Files:**
+
 - Create: `internal/mcp/prompts.go`
 - Create: `internal/mcp/prompts_test.go`
 
@@ -3664,6 +3673,7 @@ git commit -s -m "feat(mcp): add MCP prompts — spark, shape, specify, decompos
 ### Task 10: SDK Integration — convert, tiers, server
 
 **Files:**
+
 - Create: `internal/mcp/convert.go`
 - Create: `internal/mcp/convert_test.go`
 - Create: `internal/mcp/tiers.go`
@@ -4196,6 +4206,7 @@ git commit -s -m "feat(mcp): add SDK integration — convert, tiers, server wiri
 ### Task 11: `specgraph mcp` CLI Command
 
 **Files:**
+
 - Create: `cmd/specgraph/mcp.go`
 
 - [ ] **Step 1: Write the CLI command**
@@ -4285,6 +4296,7 @@ git commit -s -m "feat(mcp): add 'specgraph mcp' CLI command for stdio transport
 ### Task 12: MCP HTTP Endpoint in `specgraph serve`
 
 **Files:**
+
 - Modify: `cmd/specgraph/serve.go`
 
 - [ ] **Step 1: Read current serve.go to identify insertion points**
@@ -4296,6 +4308,7 @@ Read `cmd/specgraph/serve.go` to find where the HTTP mux is created, where middl
 Add these changes to `cmd/specgraph/serve.go`:
 
 1. Import the mcp package:
+
 ```go
 import (
 	// ... existing imports ...
@@ -4304,6 +4317,7 @@ import (
 ```
 
 2. After the ConnectRPC mux setup and service registration, add the MCP endpoint:
+
 ```go
 // Create MCP server with a loopback ConnectRPC client
 mcpHTTPClient := newHTTPClient(projectSlug)
@@ -4324,6 +4338,7 @@ mux.Handle("/mcp/", http.StripPrefix("/mcp", http.HandlerFunc(func(w http.Respon
 ```
 
 3. Log the MCP endpoint availability alongside the ConnectRPC log:
+
 ```go
 slog.Info("MCP endpoint available", "path", "/mcp/")
 ```
@@ -4357,6 +4372,7 @@ Run: `task fmt`
 Run: `task check`
 
 Fix any issues that arise. Common ones:
+
 - `revive`: package comment needed for `internal/mcp/` — the `types.go` file has it
 - `govet -shadow`: variable shadowing in switch cases — rename if needed
 - `wrapcheck`: exported functions in `server.go` may need error wrapping

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
-	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/jackc/pgx/v5 v5.9.1
+	github.com/mark3labs/mcp-go v0.45.0
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
@@ -26,6 +27,8 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -49,12 +52,14 @@ require (
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
@@ -72,9 +77,12 @@ require (
 	github.com/sethvargo/go-retry v0.3.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.2 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
-github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
+github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,10 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -48,6 +52,8 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
+github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/gkampitakis/ciinfo v0.3.2 h1:JcuOPk8ZU7nZQjdUhctuhQofk7BGHuIy0c9Ez8BNhXs=
 github.com/gkampitakis/ciinfo v0.3.2/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=
 github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZdC4M=
@@ -78,6 +84,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 h1:8Tjv8EJ+pM1xP8mK6egEbD1OgnV
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2/go.mod h1:pkJQ2tZHJ0aFOVEEot6oZmaVEZcRme73eIFmhiVuRWs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
+github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
@@ -86,6 +94,7 @@ github.com/jackc/pgx/v5 v5.9.1 h1:uwrxJXBnx76nyISkhr33kQLlUqjv7et7b9FjCen/tdc=
 github.com/jackc/pgx/v5 v5.9.1/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
@@ -101,6 +110,10 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mark3labs/mcp-go v0.45.0 h1:s0S8qR/9fWaQ3pHxz7pm1uQ0DrswoSnRIxKIjbiQtkc=
+github.com/mark3labs/mcp-go v0.45.0/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -163,6 +176,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
+github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
@@ -189,6 +204,10 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
+github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
+github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1,0 +1,45 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"connectrpc.com/connect"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+)
+
+// Client wraps all ConnectRPC service clients needed by MCP tool handlers.
+type Client struct {
+	Spec           specgraphv1connect.SpecServiceClient
+	Decision       specgraphv1connect.DecisionServiceClient
+	Graph          specgraphv1connect.GraphServiceClient
+	Claim          specgraphv1connect.ClaimServiceClient
+	Constitution   specgraphv1connect.ConstitutionServiceClient
+	Authoring      specgraphv1connect.AuthoringServiceClient
+	AnalyticalPass specgraphv1connect.AnalyticalPassServiceClient
+	Execution      specgraphv1connect.ExecutionServiceClient
+	Slice          specgraphv1connect.SliceServiceClient
+	Export         specgraphv1connect.ExportServiceClient
+	Lifecycle      specgraphv1connect.LifecycleServiceClient
+	Sync           specgraphv1connect.SyncServiceClient
+	Health         specgraphv1connect.ServerServiceClient
+}
+
+// NewClient creates a Client with all service clients pointing at baseURL.
+func NewClient(httpClient connect.HTTPClient, baseURL string) *Client {
+	return &Client{
+		Spec:           specgraphv1connect.NewSpecServiceClient(httpClient, baseURL),
+		Decision:       specgraphv1connect.NewDecisionServiceClient(httpClient, baseURL),
+		Graph:          specgraphv1connect.NewGraphServiceClient(httpClient, baseURL),
+		Claim:          specgraphv1connect.NewClaimServiceClient(httpClient, baseURL),
+		Constitution:   specgraphv1connect.NewConstitutionServiceClient(httpClient, baseURL),
+		Authoring:      specgraphv1connect.NewAuthoringServiceClient(httpClient, baseURL),
+		AnalyticalPass: specgraphv1connect.NewAnalyticalPassServiceClient(httpClient, baseURL),
+		Execution:      specgraphv1connect.NewExecutionServiceClient(httpClient, baseURL),
+		Slice:          specgraphv1connect.NewSliceServiceClient(httpClient, baseURL),
+		Export:         specgraphv1connect.NewExportServiceClient(httpClient, baseURL),
+		Lifecycle:      specgraphv1connect.NewLifecycleServiceClient(httpClient, baseURL),
+		Sync:           specgraphv1connect.NewSyncServiceClient(httpClient, baseURL),
+		Health:         specgraphv1connect.NewServerServiceClient(httpClient, baseURL),
+	}
+}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1,6 +1,8 @@
 // Copyright 2026 SpecGraph Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+// Package mcp implements a Model Context Protocol server that exposes
+// SpecGraph's ConnectRPC services as MCP tools, resources, and prompts.
 package mcp
 
 import (

--- a/internal/mcp/convert.go
+++ b/internal/mcp/convert.go
@@ -29,12 +29,13 @@ func toSDKInputSchema(schema map[string]any) sdkmcp.ToolInputSchema {
 	if is.Properties == nil {
 		is.Properties = make(map[string]any)
 	}
-	if req, ok := schema["required"].([]string); ok {
+	switch req := schema["required"].(type) {
+	case []string:
 		is.Required = req
-	} else if reqAny, ok := schema["required"].([]any); ok {
+	case []any:
 		// objectSchema stores required as []string but the type system may
 		// round-trip through []any in some contexts.
-		for _, v := range reqAny {
+		for _, v := range req {
 			if s, ok := v.(string); ok {
 				is.Required = append(is.Required, s)
 			}
@@ -44,7 +45,7 @@ func toSDKInputSchema(schema map[string]any) sdkmcp.ToolInputSchema {
 }
 
 // fromSDKParams extracts the arguments map from an SDK CallToolRequest.
-func fromSDKParams(req sdkmcp.CallToolRequest) map[string]any {
+func fromSDKParams(req *sdkmcp.CallToolRequest) map[string]any {
 	return req.GetArguments()
 }
 
@@ -61,7 +62,7 @@ func toSDKResult(r *ToolResult) *sdkmcp.CallToolResult {
 }
 
 // toSDKResource converts a SpecGraph ResourceDef (non-template) to an SDK Resource.
-func toSDKResource(def ResourceDef) sdkmcp.Resource {
+func toSDKResource(def *ResourceDef) sdkmcp.Resource {
 	opts := []sdkmcp.ResourceOption{
 		sdkmcp.WithResourceDescription(def.Description),
 	}
@@ -72,7 +73,7 @@ func toSDKResource(def ResourceDef) sdkmcp.Resource {
 }
 
 // toSDKResourceTemplate converts a SpecGraph ResourceDef (template) to an SDK ResourceTemplate.
-func toSDKResourceTemplate(def ResourceDef) sdkmcp.ResourceTemplate {
+func toSDKResourceTemplate(def *ResourceDef) sdkmcp.ResourceTemplate {
 	opts := []sdkmcp.ResourceTemplateOption{
 		sdkmcp.WithTemplateDescription(def.Description),
 	}
@@ -97,9 +98,8 @@ func toSDKResourceContents(rcs []ResourceContent) []sdkmcp.ResourceContents {
 
 // toSDKPrompt converts a SpecGraph PromptDef to an SDK Prompt.
 func toSDKPrompt(def PromptDef) sdkmcp.Prompt {
-	opts := []sdkmcp.PromptOption{
-		sdkmcp.WithPromptDescription(def.Description),
-	}
+	opts := make([]sdkmcp.PromptOption, 1, 1+len(def.Arguments))
+	opts[0] = sdkmcp.WithPromptDescription(def.Description)
 	for _, arg := range def.Arguments {
 		argOpts := []sdkmcp.ArgumentOption{}
 		if arg.Description != "" {

--- a/internal/mcp/convert.go
+++ b/internal/mcp/convert.go
@@ -1,0 +1,127 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	sdkmcp "github.com/mark3labs/mcp-go/mcp"
+)
+
+// toSDKTool converts a SpecGraph ToolDef to an mcp-go SDK Tool.
+// It populates the InputSchema directly from the handler's JSON Schema map,
+// which uses the objectSchema/stringProp/etc helpers in helpers.go.
+func toSDKTool(def ToolDef) sdkmcp.Tool {
+	return sdkmcp.Tool{
+		Name:        def.Name,
+		Description: def.Description,
+		InputSchema: toSDKInputSchema(def.Schema),
+	}
+}
+
+// toSDKInputSchema converts a map[string]any JSON Schema to an SDK ToolInputSchema.
+func toSDKInputSchema(schema map[string]any) sdkmcp.ToolInputSchema {
+	is := sdkmcp.ToolInputSchema{
+		Type: "object",
+	}
+	if props, ok := schema["properties"].(map[string]any); ok {
+		is.Properties = props
+	}
+	if is.Properties == nil {
+		is.Properties = make(map[string]any)
+	}
+	if req, ok := schema["required"].([]string); ok {
+		is.Required = req
+	} else if reqAny, ok := schema["required"].([]any); ok {
+		// objectSchema stores required as []string but the type system may
+		// round-trip through []any in some contexts.
+		for _, v := range reqAny {
+			if s, ok := v.(string); ok {
+				is.Required = append(is.Required, s)
+			}
+		}
+	}
+	return is
+}
+
+// fromSDKParams extracts the arguments map from an SDK CallToolRequest.
+func fromSDKParams(req sdkmcp.CallToolRequest) map[string]any {
+	return req.GetArguments()
+}
+
+// toSDKResult converts a SpecGraph ToolResult to an mcp-go CallToolResult.
+func toSDKResult(r *ToolResult) *sdkmcp.CallToolResult {
+	contents := make([]sdkmcp.Content, 0, len(r.Content))
+	for _, c := range r.Content {
+		contents = append(contents, sdkmcp.NewTextContent(c.Text))
+	}
+	return &sdkmcp.CallToolResult{
+		Content: contents,
+		IsError: r.IsError,
+	}
+}
+
+// toSDKResource converts a SpecGraph ResourceDef (non-template) to an SDK Resource.
+func toSDKResource(def ResourceDef) sdkmcp.Resource {
+	opts := []sdkmcp.ResourceOption{
+		sdkmcp.WithResourceDescription(def.Description),
+	}
+	if def.MimeType != "" {
+		opts = append(opts, sdkmcp.WithMIMEType(def.MimeType))
+	}
+	return sdkmcp.NewResource(def.URI, def.Name, opts...)
+}
+
+// toSDKResourceTemplate converts a SpecGraph ResourceDef (template) to an SDK ResourceTemplate.
+func toSDKResourceTemplate(def ResourceDef) sdkmcp.ResourceTemplate {
+	opts := []sdkmcp.ResourceTemplateOption{
+		sdkmcp.WithTemplateDescription(def.Description),
+	}
+	if def.MimeType != "" {
+		opts = append(opts, sdkmcp.WithTemplateMIMEType(def.MimeType))
+	}
+	return sdkmcp.NewResourceTemplate(def.URI, def.Name, opts...)
+}
+
+// toSDKResourceContents converts SpecGraph ResourceContent slices to SDK ResourceContents.
+func toSDKResourceContents(rcs []ResourceContent) []sdkmcp.ResourceContents {
+	out := make([]sdkmcp.ResourceContents, 0, len(rcs))
+	for _, rc := range rcs {
+		out = append(out, sdkmcp.TextResourceContents{
+			URI:      rc.URI,
+			MIMEType: rc.MimeType,
+			Text:     rc.Text,
+		})
+	}
+	return out
+}
+
+// toSDKPrompt converts a SpecGraph PromptDef to an SDK Prompt.
+func toSDKPrompt(def PromptDef) sdkmcp.Prompt {
+	opts := []sdkmcp.PromptOption{
+		sdkmcp.WithPromptDescription(def.Description),
+	}
+	for _, arg := range def.Arguments {
+		argOpts := []sdkmcp.ArgumentOption{}
+		if arg.Description != "" {
+			argOpts = append(argOpts, sdkmcp.ArgumentDescription(arg.Description))
+		}
+		if arg.Required {
+			argOpts = append(argOpts, sdkmcp.RequiredArgument())
+		}
+		opts = append(opts, sdkmcp.WithArgument(arg.Name, argOpts...))
+	}
+	return sdkmcp.NewPrompt(def.Name, opts...)
+}
+
+// toSDKPromptResult converts a SpecGraph PromptResult to an SDK GetPromptResult.
+func toSDKPromptResult(r *PromptResult) *sdkmcp.GetPromptResult {
+	msgs := make([]sdkmcp.PromptMessage, 0, len(r.Messages))
+	for _, m := range r.Messages {
+		role := sdkmcp.RoleUser
+		if m.Role == "assistant" {
+			role = sdkmcp.RoleAssistant
+		}
+		msgs = append(msgs, sdkmcp.NewPromptMessage(role, sdkmcp.NewTextContent(m.Content)))
+	}
+	return sdkmcp.NewGetPromptResult(r.Description, msgs)
+}

--- a/internal/mcp/convert_test.go
+++ b/internal/mcp/convert_test.go
@@ -1,0 +1,278 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"testing"
+
+	sdkmcp "github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestToSDKTool(t *testing.T) {
+	def := ToolDef{
+		Name:        "spec_get",
+		Description: "Get a spec by slug",
+		Tier:        TierCore,
+		Schema: objectSchema(props{
+			"slug": stringProp("The spec slug"),
+		}, "slug"),
+	}
+
+	tool := toSDKTool(def)
+
+	if tool.Name != "spec_get" {
+		t.Errorf("Name = %q, want %q", tool.Name, "spec_get")
+	}
+	if tool.Description != "Get a spec by slug" {
+		t.Errorf("Description = %q, want %q", tool.Description, "Get a spec by slug")
+	}
+	if tool.InputSchema.Type != "object" {
+		t.Errorf("InputSchema.Type = %q, want %q", tool.InputSchema.Type, "object")
+	}
+	if _, ok := tool.InputSchema.Properties["slug"]; !ok {
+		t.Error("InputSchema.Properties missing 'slug'")
+	}
+	if len(tool.InputSchema.Required) != 1 || tool.InputSchema.Required[0] != "slug" {
+		t.Errorf("InputSchema.Required = %v, want [slug]", tool.InputSchema.Required)
+	}
+}
+
+func TestToSDKTool_NoRequired(t *testing.T) {
+	def := ToolDef{
+		Name:        "health_check",
+		Description: "Check server health",
+		Schema: objectSchema(props{
+			"verbose": boolProp("Include details"),
+		}),
+	}
+
+	tool := toSDKTool(def)
+
+	if len(tool.InputSchema.Required) != 0 {
+		t.Errorf("InputSchema.Required = %v, want empty", tool.InputSchema.Required)
+	}
+}
+
+func TestToSDKResult_Success(t *testing.T) {
+	r := textResult("hello world")
+
+	got := toSDKResult(r)
+
+	if got.IsError {
+		t.Error("IsError = true, want false")
+	}
+	if len(got.Content) != 1 {
+		t.Fatalf("Content length = %d, want 1", len(got.Content))
+	}
+	tc, ok := sdkmcp.AsTextContent(got.Content[0])
+	if !ok {
+		t.Fatal("Content[0] is not TextContent")
+	}
+	if tc.Text != "hello world" {
+		t.Errorf("Text = %q, want %q", tc.Text, "hello world")
+	}
+}
+
+func TestToSDKResult_Error(t *testing.T) {
+	r := errResult("something went wrong")
+
+	got := toSDKResult(r)
+
+	if !got.IsError {
+		t.Error("IsError = false, want true")
+	}
+	if len(got.Content) != 1 {
+		t.Fatalf("Content length = %d, want 1", len(got.Content))
+	}
+	tc, ok := sdkmcp.AsTextContent(got.Content[0])
+	if !ok {
+		t.Fatal("Content[0] is not TextContent")
+	}
+	if tc.Text != "something went wrong" {
+		t.Errorf("Text = %q, want %q", tc.Text, "something went wrong")
+	}
+}
+
+func TestToSDKResult_MultipleContent(t *testing.T) {
+	r := &ToolResult{
+		Content: []Content{
+			{Type: "text", Text: "line 1"},
+			{Type: "text", Text: "line 2"},
+		},
+	}
+
+	got := toSDKResult(r)
+
+	if len(got.Content) != 2 {
+		t.Fatalf("Content length = %d, want 2", len(got.Content))
+	}
+}
+
+func TestFromSDKParams(t *testing.T) {
+	req := sdkmcp.CallToolRequest{
+		Params: sdkmcp.CallToolParams{
+			Name: "spec_get",
+			Arguments: map[string]any{
+				"slug":    "auth-service",
+				"version": float64(3),
+			},
+		},
+	}
+
+	params := fromSDKParams(req)
+
+	if params["slug"] != "auth-service" {
+		t.Errorf("slug = %v, want %q", params["slug"], "auth-service")
+	}
+	if params["version"] != float64(3) {
+		t.Errorf("version = %v, want 3.0", params["version"])
+	}
+}
+
+func TestFromSDKParams_Empty(t *testing.T) {
+	req := sdkmcp.CallToolRequest{
+		Params: sdkmcp.CallToolParams{
+			Name:      "health_check",
+			Arguments: map[string]any{},
+		},
+	}
+
+	params := fromSDKParams(req)
+
+	if len(params) != 0 {
+		t.Errorf("params length = %d, want 0", len(params))
+	}
+}
+
+func TestToSDKResource(t *testing.T) {
+	def := ResourceDef{
+		URI:         "specgraph://constitution",
+		Name:        "constitution",
+		Description: "Project constitution",
+		MimeType:    "application/json",
+	}
+
+	res := toSDKResource(def)
+
+	if res.URI != "specgraph://constitution" {
+		t.Errorf("URI = %q, want %q", res.URI, "specgraph://constitution")
+	}
+	if res.Name != "constitution" {
+		t.Errorf("Name = %q, want %q", res.Name, "constitution")
+	}
+	if res.Description != "Project constitution" {
+		t.Errorf("Description = %q, want %q", res.Description, "Project constitution")
+	}
+	if res.MIMEType != "application/json" {
+		t.Errorf("MIMEType = %q, want %q", res.MIMEType, "application/json")
+	}
+}
+
+func TestToSDKResourceTemplate(t *testing.T) {
+	def := ResourceDef{
+		URI:         "specgraph://specs/{slug}",
+		Name:        "spec",
+		Description: "A spec by slug",
+		MimeType:    "application/json",
+		IsTemplate:  true,
+	}
+
+	tmpl := toSDKResourceTemplate(def)
+
+	if tmpl.Name != "spec" {
+		t.Errorf("Name = %q, want %q", tmpl.Name, "spec")
+	}
+	if tmpl.Description != "A spec by slug" {
+		t.Errorf("Description = %q, want %q", tmpl.Description, "A spec by slug")
+	}
+	if tmpl.MIMEType != "application/json" {
+		t.Errorf("MIMEType = %q, want %q", tmpl.MIMEType, "application/json")
+	}
+}
+
+func TestToSDKResourceContents(t *testing.T) {
+	rcs := []ResourceContent{
+		{URI: "specgraph://constitution", MimeType: "application/json", Text: `{"layers":[]}`},
+	}
+
+	got := toSDKResourceContents(rcs)
+
+	if len(got) != 1 {
+		t.Fatalf("length = %d, want 1", len(got))
+	}
+	trc, ok := sdkmcp.AsTextResourceContents(got[0])
+	if !ok {
+		t.Fatal("got[0] is not TextResourceContents")
+	}
+	if trc.URI != "specgraph://constitution" {
+		t.Errorf("URI = %q, want %q", trc.URI, "specgraph://constitution")
+	}
+	if trc.Text != `{"layers":[]}` {
+		t.Errorf("Text = %q, want %q", trc.Text, `{"layers":[]}`)
+	}
+}
+
+func TestToSDKPrompt(t *testing.T) {
+	def := PromptDef{
+		Name:        "spec-review",
+		Description: "Review a spec for completeness",
+		Arguments: []PromptArgument{
+			{Name: "slug", Description: "Spec slug", Required: true},
+			{Name: "focus", Description: "Focus area", Required: false},
+		},
+	}
+
+	prompt := toSDKPrompt(def)
+
+	if prompt.Name != "spec-review" {
+		t.Errorf("Name = %q, want %q", prompt.Name, "spec-review")
+	}
+	if prompt.Description != "Review a spec for completeness" {
+		t.Errorf("Description = %q, want %q", prompt.Description, "Review a spec for completeness")
+	}
+	if len(prompt.Arguments) != 2 {
+		t.Fatalf("Arguments length = %d, want 2", len(prompt.Arguments))
+	}
+	if prompt.Arguments[0].Name != "slug" {
+		t.Errorf("Arguments[0].Name = %q, want %q", prompt.Arguments[0].Name, "slug")
+	}
+	if !prompt.Arguments[0].Required {
+		t.Error("Arguments[0].Required = false, want true")
+	}
+	if prompt.Arguments[1].Required {
+		t.Error("Arguments[1].Required = true, want false")
+	}
+}
+
+func TestToSDKPromptResult(t *testing.T) {
+	r := &PromptResult{
+		Description: "Review results",
+		Messages: []PromptMessage{
+			{Role: "user", Content: "Please review spec auth-service"},
+			{Role: "assistant", Content: "The spec looks good."},
+		},
+	}
+
+	got := toSDKPromptResult(r)
+
+	if got.Description != "Review results" {
+		t.Errorf("Description = %q, want %q", got.Description, "Review results")
+	}
+	if len(got.Messages) != 2 {
+		t.Fatalf("Messages length = %d, want 2", len(got.Messages))
+	}
+	if got.Messages[0].Role != sdkmcp.RoleUser {
+		t.Errorf("Messages[0].Role = %q, want %q", got.Messages[0].Role, sdkmcp.RoleUser)
+	}
+	if got.Messages[1].Role != sdkmcp.RoleAssistant {
+		t.Errorf("Messages[1].Role = %q, want %q", got.Messages[1].Role, sdkmcp.RoleAssistant)
+	}
+	tc, ok := sdkmcp.AsTextContent(got.Messages[0].Content)
+	if !ok {
+		t.Fatal("Messages[0].Content is not TextContent")
+	}
+	if tc.Text != "Please review spec auth-service" {
+		t.Errorf("Messages[0] text = %q, want %q", tc.Text, "Please review spec auth-service")
+	}
+}

--- a/internal/mcp/convert_test.go
+++ b/internal/mcp/convert_test.go
@@ -120,7 +120,7 @@ func TestFromSDKParams(t *testing.T) {
 		},
 	}
 
-	params := fromSDKParams(req)
+	params := fromSDKParams(&req)
 
 	if params["slug"] != "auth-service" {
 		t.Errorf("slug = %v, want %q", params["slug"], "auth-service")
@@ -138,7 +138,7 @@ func TestFromSDKParams_Empty(t *testing.T) {
 		},
 	}
 
-	params := fromSDKParams(req)
+	params := fromSDKParams(&req)
 
 	if len(params) != 0 {
 		t.Errorf("params length = %d, want 0", len(params))
@@ -153,7 +153,7 @@ func TestToSDKResource(t *testing.T) {
 		MimeType:    "application/json",
 	}
 
-	res := toSDKResource(def)
+	res := toSDKResource(&def)
 
 	if res.URI != "specgraph://constitution" {
 		t.Errorf("URI = %q, want %q", res.URI, "specgraph://constitution")
@@ -178,7 +178,7 @@ func TestToSDKResourceTemplate(t *testing.T) {
 		IsTemplate:  true,
 	}
 
-	tmpl := toSDKResourceTemplate(def)
+	tmpl := toSDKResourceTemplate(&def)
 
 	if tmpl.Name != "spec" {
 		t.Errorf("Name = %q, want %q", tmpl.Name, "spec")

--- a/internal/mcp/helpers.go
+++ b/internal/mcp/helpers.go
@@ -148,8 +148,6 @@ func intProp(desc string) map[string]any {
 }
 
 // boolProp builds a JSON Schema boolean property.
-//
-//nolint:unused // used by tool handler files added in subsequent tasks
 func boolProp(desc string) map[string]any {
 	return map[string]any{"type": "boolean", "description": desc}
 }

--- a/internal/mcp/helpers.go
+++ b/internal/mcp/helpers.go
@@ -1,0 +1,160 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"errors"
+	"fmt"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// props is shorthand for JSON Schema property maps.
+type props = map[string]any
+
+// stringParam extracts a string parameter, returning "" if absent or wrong type.
+func stringParam(params map[string]any, key string) string {
+	v, ok := params[key].(string)
+	if !ok {
+		return ""
+	}
+	return v
+}
+
+// int32Param extracts an int32 parameter. JSON numbers arrive as float64.
+func int32Param(params map[string]any, key string) int32 {
+	switch v := params[key].(type) {
+	case float64:
+		return int32(v)
+	case int:
+		return int32(v) //nolint:gosec // internal callers always pass bounded API page sizes
+	default:
+		return 0
+	}
+}
+
+// boolParam extracts a bool parameter, returning false if absent.
+func boolParam(params map[string]any, key string) bool {
+	v, ok := params[key].(bool)
+	if !ok {
+		return false
+	}
+	return v
+}
+
+// stringSliceParam extracts a []string parameter from a JSON array.
+//
+//nolint:unused // used by tool handler files added in subsequent tasks
+func stringSliceParam(params map[string]any, key string) []string {
+	raw, ok := params[key].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// jsonResult marshals a proto message to JSON and returns it as a text result.
+//
+//nolint:unused // used by tool handler files added in subsequent tasks
+func jsonResult(msg proto.Message) *ToolResult {
+	data, err := protojson.MarshalOptions{Multiline: true}.Marshal(msg)
+	if err != nil {
+		return errResult(fmt.Sprintf("marshal response: %v", err))
+	}
+	return textResult(string(data))
+}
+
+// textResult wraps a string in a ToolResult.
+func textResult(text string) *ToolResult {
+	return &ToolResult{
+		Content: []Content{{Type: "text", Text: text}},
+	}
+}
+
+// errResult creates an error ToolResult from a message string.
+func errResult(msg string) *ToolResult {
+	return &ToolResult{
+		Content: []Content{{Type: "text", Text: msg}},
+		IsError: true,
+	}
+}
+
+// connectErrResult maps a ConnectRPC error to an MCP tool error result.
+// Auth errors return a Go error (protocol-level); everything else is a tool result.
+//
+//nolint:unused // used by tool handler files added in subsequent tasks
+func connectErrResult(err error) (*ToolResult, error) {
+	if err == nil {
+		return nil, nil
+	}
+	code := connect.CodeOf(err)
+	if code == connect.CodeUnauthenticated {
+		return nil, fmt.Errorf("authentication required: %w", err)
+	}
+	msg := connect.CodeOf(err).String()
+	if connect.IsNotModifiedError(err) {
+		msg = "not modified"
+	} else {
+		var ce *connect.Error
+		if errors.As(err, &ce) {
+			msg = ce.Message()
+		}
+	}
+	if code == connect.CodeAborted {
+		msg = "concurrent modification — retry the operation"
+	}
+	return errResult(msg), nil
+}
+
+// --- Schema builders ---
+
+// objectSchema builds a JSON Schema object with the given properties and required fields.
+func objectSchema(properties props, required ...string) map[string]any {
+	s := map[string]any{
+		"type":       "object",
+		"properties": properties,
+	}
+	if len(required) > 0 {
+		s["required"] = required
+	}
+	return s
+}
+
+// stringProp builds a JSON Schema string property. Optional enum values constrain it.
+func stringProp(desc string, enum ...string) map[string]any {
+	p := map[string]any{"type": "string", "description": desc}
+	if len(enum) > 0 {
+		p["enum"] = enum
+	}
+	return p
+}
+
+// intProp builds a JSON Schema integer property.
+//
+//nolint:unused // used by tool handler files added in subsequent tasks
+func intProp(desc string) map[string]any {
+	return map[string]any{"type": "integer", "description": desc}
+}
+
+// boolProp builds a JSON Schema boolean property.
+//
+//nolint:unused // used by tool handler files added in subsequent tasks
+func boolProp(desc string) map[string]any {
+	return map[string]any{"type": "boolean", "description": desc}
+}
+
+// arrayProp builds a JSON Schema array property with the given item schema.
+//
+//nolint:unused // used by tool handler files added in subsequent tasks
+func arrayProp(desc string, items map[string]any) map[string]any {
+	return map[string]any{"type": "array", "description": desc, "items": items}
+}

--- a/internal/mcp/helpers.go
+++ b/internal/mcp/helpers.go
@@ -35,12 +35,19 @@ func stringParam(params map[string]any, key string) string {
 }
 
 // int32Param extracts an int32 parameter. JSON numbers arrive as float64.
+// Returns 0 if absent, non-numeric, fractional, or out of int32 range.
 func int32Param(params map[string]any, key string) int32 {
 	switch v := params[key].(type) {
 	case float64:
+		if v != float64(int32(v)) {
+			return 0
+		}
 		return int32(v)
 	case int:
-		return int32(v) //nolint:gosec // internal callers always pass bounded API page sizes
+		if v < -2147483648 || v > 2147483647 {
+			return 0
+		}
+		return int32(v)
 	default:
 		return 0
 	}

--- a/internal/mcp/helpers.go
+++ b/internal/mcp/helpers.go
@@ -12,6 +12,16 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// stringPtrParam extracts an optional string parameter, returning nil if absent or empty.
+// Used to populate proto optional (oneof) *string fields that should only be set when provided.
+func stringPtrParam(params map[string]any, key string) *string {
+	v, ok := params[key].(string)
+	if !ok || v == "" {
+		return nil
+	}
+	return proto.String(v)
+}
+
 // props is shorthand for JSON Schema property maps.
 type props = map[string]any
 
@@ -46,8 +56,6 @@ func boolParam(params map[string]any, key string) bool {
 }
 
 // stringSliceParam extracts a []string parameter from a JSON array.
-//
-//nolint:unused // used by tool handler files added in subsequent tasks
 func stringSliceParam(params map[string]any, key string) []string {
 	raw, ok := params[key].([]any)
 	if !ok {
@@ -63,8 +71,6 @@ func stringSliceParam(params map[string]any, key string) []string {
 }
 
 // jsonResult marshals a proto message to JSON and returns it as a text result.
-//
-//nolint:unused // used by tool handler files added in subsequent tasks
 func jsonResult(msg proto.Message) *ToolResult {
 	data, err := protojson.MarshalOptions{Multiline: true}.Marshal(msg)
 	if err != nil {
@@ -90,8 +96,6 @@ func errResult(msg string) *ToolResult {
 
 // connectErrResult maps a ConnectRPC error to an MCP tool error result.
 // Auth errors return a Go error (protocol-level); everything else is a tool result.
-//
-//nolint:unused // used by tool handler files added in subsequent tasks
 func connectErrResult(err error) (*ToolResult, error) {
 	if err == nil {
 		return nil, nil
@@ -139,8 +143,6 @@ func stringProp(desc string, enum ...string) map[string]any {
 }
 
 // intProp builds a JSON Schema integer property.
-//
-//nolint:unused // used by tool handler files added in subsequent tasks
 func intProp(desc string) map[string]any {
 	return map[string]any{"type": "integer", "description": desc}
 }
@@ -153,8 +155,6 @@ func boolProp(desc string) map[string]any {
 }
 
 // arrayProp builds a JSON Schema array property with the given item schema.
-//
-//nolint:unused // used by tool handler files added in subsequent tasks
 func arrayProp(desc string, items map[string]any) map[string]any {
 	return map[string]any{"type": "array", "description": desc, "items": items}
 }

--- a/internal/mcp/helpers_test.go
+++ b/internal/mcp/helpers_test.go
@@ -4,8 +4,12 @@
 package mcp
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,6 +24,14 @@ func TestIntParam(t *testing.T) {
 	params := map[string]any{"limit": float64(10)} // JSON numbers are float64
 	require.Equal(t, int32(10), int32Param(params, "limit"))
 	require.Equal(t, int32(0), int32Param(params, "missing"))
+}
+
+func TestIntParam_Overflow(t *testing.T) {
+	require.Equal(t, int32(0), int32Param(map[string]any{"v": float64(3e10)}, "v"))
+}
+
+func TestIntParam_Fractional(t *testing.T) {
+	require.Equal(t, int32(0), int32Param(map[string]any{"v": 3.14}, "v"))
 }
 
 func TestBoolParam(t *testing.T) {
@@ -55,4 +67,197 @@ func TestObjectSchema(t *testing.T) {
 	require.Contains(t, p, "action")
 	req := s["required"].([]string)
 	require.Equal(t, []string{"action"}, req)
+}
+
+func TestStringPtrParam(t *testing.T) {
+	tests := []struct {
+		name   string
+		params map[string]any
+		key    string
+		want   *string
+	}{
+		{
+			name:   "present non-empty",
+			params: map[string]any{"note": "hello"},
+			key:    "note",
+			want:   strPtr("hello"),
+		},
+		{
+			name:   "missing key",
+			params: map[string]any{},
+			key:    "note",
+			want:   nil,
+		},
+		{
+			name:   "empty string",
+			params: map[string]any{"note": ""},
+			key:    "note",
+			want:   nil,
+		},
+		{
+			name:   "wrong type",
+			params: map[string]any{"note": 42},
+			key:    "note",
+			want:   nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stringPtrParam(tt.params, tt.key)
+			if tt.want == nil {
+				require.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				require.Equal(t, *tt.want, *got)
+			}
+		})
+	}
+}
+
+// strPtr is a test helper that returns a pointer to s.
+func strPtr(s string) *string { return &s }
+
+func TestStringSliceParam(t *testing.T) {
+	tests := []struct {
+		name   string
+		params map[string]any
+		key    string
+		want   []string
+	}{
+		{
+			name:   "normal slice",
+			params: map[string]any{"tags": []any{"a", "b", "c"}},
+			key:    "tags",
+			want:   []string{"a", "b", "c"},
+		},
+		{
+			name:   "missing key",
+			params: map[string]any{},
+			key:    "tags",
+			want:   nil,
+		},
+		{
+			name:   "wrong type (string, not slice)",
+			params: map[string]any{"tags": "foo"},
+			key:    "tags",
+			want:   nil,
+		},
+		{
+			name:   "empty slice",
+			params: map[string]any{"tags": []any{}},
+			key:    "tags",
+			want:   []string{},
+		},
+		{
+			name:   "mixed types — non-strings skipped",
+			params: map[string]any{"tags": []any{"x", 42, "y"}},
+			key:    "tags",
+			want:   []string{"x", "y"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stringSliceParam(tt.params, tt.key)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestJsonResult(t *testing.T) {
+	msg := &specv1.HealthResponse{Status: "ok"}
+	r := jsonResult(msg)
+	require.NotNil(t, r)
+	require.False(t, r.IsError)
+	require.Len(t, r.Content, 1)
+	require.Equal(t, "text", r.Content[0].Type)
+	require.Contains(t, r.Content[0].Text, "ok")
+}
+
+func TestConnectErrResult(t *testing.T) {
+	t.Run("nil error returns nil nil", func(t *testing.T) {
+		result, err := connectErrResult(nil)
+		require.NoError(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("unauthenticated returns Go error", func(t *testing.T) {
+		connectErr := connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("token expired"))
+		result, err := connectErrResult(connectErr)
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Contains(t, err.Error(), "authentication required")
+	})
+
+	t.Run("not found returns tool error result", func(t *testing.T) {
+		connectErr := connect.NewError(connect.CodeNotFound, fmt.Errorf("missing"))
+		result, err := connectErrResult(connectErr)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.True(t, result.IsError)
+		require.Contains(t, result.Content[0].Text, "missing")
+	})
+
+	t.Run("aborted returns concurrent modification message", func(t *testing.T) {
+		connectErr := connect.NewError(connect.CodeAborted, fmt.Errorf("version conflict"))
+		result, err := connectErrResult(connectErr)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.True(t, result.IsError)
+		require.Contains(t, result.Content[0].Text, "concurrent modification")
+	})
+
+	t.Run("not-modified error returns 'not modified'", func(t *testing.T) {
+		notModified := connect.NewNotModifiedError(http.Header{})
+		result, err := connectErrResult(notModified)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.True(t, result.IsError)
+		require.Contains(t, result.Content[0].Text, "not modified")
+	})
+
+	t.Run("internal error returns message text", func(t *testing.T) {
+		connectErr := connect.NewError(connect.CodeInternal, fmt.Errorf("database unavailable"))
+		result, err := connectErrResult(connectErr)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.True(t, result.IsError)
+		require.Contains(t, result.Content[0].Text, "database unavailable")
+	})
+}
+
+func TestStringProp(t *testing.T) {
+	t.Run("no enum", func(t *testing.T) {
+		p := stringProp("a slug identifier")
+		require.Equal(t, "string", p["type"])
+		require.Equal(t, "a slug identifier", p["description"])
+		require.Nil(t, p["enum"])
+	})
+
+	t.Run("with enum values", func(t *testing.T) {
+		p := stringProp("an action", "get", "list", "delete")
+		require.Equal(t, "string", p["type"])
+		enum, ok := p["enum"].([]string)
+		require.True(t, ok)
+		require.Equal(t, []string{"get", "list", "delete"}, enum)
+	})
+}
+
+func TestIntProp(t *testing.T) {
+	p := intProp("page size")
+	require.Equal(t, "integer", p["type"])
+	require.Equal(t, "page size", p["description"])
+}
+
+func TestBoolProp(t *testing.T) {
+	p := boolProp("include archived")
+	require.Equal(t, "boolean", p["type"])
+	require.Equal(t, "include archived", p["description"])
+}
+
+func TestArrayProp(t *testing.T) {
+	items := stringProp("a tag")
+	p := arrayProp("list of tags", items)
+	require.Equal(t, "array", p["type"])
+	require.Equal(t, "list of tags", p["description"])
+	require.Equal(t, items, p["items"])
 }

--- a/internal/mcp/helpers_test.go
+++ b/internal/mcp/helpers_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringParam(t *testing.T) {
+	params := map[string]any{"action": "get", "slug": "auth"}
+	require.Equal(t, "get", stringParam(params, "action"))
+	require.Equal(t, "auth", stringParam(params, "slug"))
+	require.Equal(t, "", stringParam(params, "missing"))
+}
+
+func TestIntParam(t *testing.T) {
+	params := map[string]any{"limit": float64(10)} // JSON numbers are float64
+	require.Equal(t, int32(10), int32Param(params, "limit"))
+	require.Equal(t, int32(0), int32Param(params, "missing"))
+}
+
+func TestBoolParam(t *testing.T) {
+	params := map[string]any{"recursive": true}
+	require.True(t, boolParam(params, "recursive"))
+	require.False(t, boolParam(params, "missing"))
+}
+
+func TestTextResult(t *testing.T) {
+	r := textResult("hello")
+	require.Len(t, r.Content, 1)
+	require.Equal(t, "text", r.Content[0].Type)
+	require.Equal(t, "hello", r.Content[0].Text)
+	require.False(t, r.IsError)
+}
+
+func TestErrorResultFromString(t *testing.T) {
+	r := errResult("something broke")
+	require.True(t, r.IsError)
+	require.Contains(t, r.Content[0].Text, "something broke")
+}
+
+func TestObjectSchema(t *testing.T) {
+	s := objectSchema(
+		props{
+			"action": stringProp("op", "get", "list"),
+			"slug":   stringProp("identifier"),
+		},
+		"action",
+	)
+	require.Equal(t, "object", s["type"])
+	p := s["properties"].(props)
+	require.Contains(t, p, "action")
+	req := s["required"].([]string)
+	require.Equal(t, []string{"action"}, req)
+}

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -1,0 +1,145 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+)
+
+// RegisterPrompts registers all MCP prompt definitions into the registry.
+func RegisterPrompts(r *Registry, c *Client) {
+	r.AddPrompt(PromptDef{
+		Name:        "spark",
+		Description: "Generate an initial spec idea from a topic.",
+		Arguments: []PromptArgument{
+			{Name: "topic", Description: "The topic or problem area to spark a spec idea for.", Required: true},
+			{Name: "context", Description: "Optional additional context to guide the spark.", Required: false},
+		},
+		Handler: sparkPromptHandler(c),
+	})
+
+	r.AddPrompt(PromptDef{
+		Name:        "shape",
+		Description: "Refine a sparked spec into a clear problem statement.",
+		Arguments: []PromptArgument{
+			{Name: "spec_slug", Description: "Slug of the spec to shape.", Required: true},
+		},
+		Handler: stagePromptHandler(c, "shape"),
+	})
+
+	r.AddPrompt(PromptDef{
+		Name:        "specify",
+		Description: "Add full specification detail to a shaped spec.",
+		Arguments: []PromptArgument{
+			{Name: "spec_slug", Description: "Slug of the spec to specify.", Required: true},
+		},
+		Handler: stagePromptHandler(c, "specify"),
+	})
+
+	r.AddPrompt(PromptDef{
+		Name:        "decompose",
+		Description: "Break a specified spec into actionable work slices.",
+		Arguments: []PromptArgument{
+			{Name: "spec_slug", Description: "Slug of the spec to decompose.", Required: true},
+		},
+		Handler: stagePromptHandler(c, "decompose"),
+	})
+
+	r.AddPrompt(PromptDef{
+		Name:        "constitution_check",
+		Description: "Check a spec against the project constitution for compliance.",
+		Arguments: []PromptArgument{
+			{Name: "spec_slug", Description: "Slug of the spec to check.", Required: true},
+		},
+		Handler: analyticalPromptHandler(c, "constitution-check"),
+	})
+
+	r.AddPrompt(PromptDef{
+		Name:        "dependency_review",
+		Description: "Review the dependency health of a spec and its surroundings.",
+		Arguments: []PromptArgument{
+			{Name: "spec_slug", Description: "Slug of the spec to review.", Required: true},
+		},
+		Handler: analyticalPromptHandler(c, "peripheral-vision"),
+	})
+}
+
+// stagePromptHandler returns a PromptHandler that fetches prompt templates for
+// the given authoring stage and returns the first template as a user message.
+func stagePromptHandler(c *Client, stage string) PromptHandler {
+	return func(ctx context.Context, _ map[string]string) (*PromptResult, error) {
+		resp, err := c.Authoring.GetPrompts(ctx, connect.NewRequest(&specv1.GetPromptsRequest{
+			Stage: authoringStageFromString(stage),
+		}))
+		if err != nil {
+			return nil, fmt.Errorf("get prompts for stage %s: %w", stage, err)
+		}
+		templates := resp.Msg.GetPrompts()
+		var text string
+		if len(templates) == 0 {
+			text = "No prompt template available for stage: " + stage
+		} else {
+			text = templates[0].GetTemplate()
+		}
+		return &PromptResult{
+			Messages: []PromptMessage{
+				{Role: "user", Content: text},
+			},
+		}, nil
+	}
+}
+
+// sparkPromptHandler returns a PromptHandler for the spark stage that appends
+// the topic and optional context to the fetched template.
+func sparkPromptHandler(c *Client) PromptHandler {
+	return func(ctx context.Context, args map[string]string) (*PromptResult, error) {
+		resp, err := c.Authoring.GetPrompts(ctx, connect.NewRequest(&specv1.GetPromptsRequest{
+			Stage: authoringStageFromString("spark"),
+		}))
+		if err != nil {
+			return nil, fmt.Errorf("get prompts for stage spark: %w", err)
+		}
+		templates := resp.Msg.GetPrompts()
+		var text string
+		if len(templates) == 0 {
+			text = "No prompt template available for stage: spark"
+		} else {
+			text = templates[0].GetTemplate()
+		}
+		if topic := args["topic"]; topic != "" {
+			text += "\n\nTopic: " + topic
+		}
+		if ctxVal := args["context"]; ctxVal != "" {
+			text += "\nContext: " + ctxVal
+		}
+		return &PromptResult{
+			Messages: []PromptMessage{
+				{Role: "user", Content: text},
+			},
+		}, nil
+	}
+}
+
+// analyticalPromptHandler returns a PromptHandler that runs an analytical pass
+// and returns its prompt template as a user message.
+func analyticalPromptHandler(c *Client, passType string) PromptHandler {
+	return func(ctx context.Context, args map[string]string) (*PromptResult, error) {
+		resp, err := c.AnalyticalPass.RunAnalyticalPass(ctx, connect.NewRequest(&specv1.RunAnalyticalPassRequest{
+			Slug:     args["spec_slug"],
+			PassType: passTypeFromString(passType),
+		}))
+		if err != nil {
+			return nil, fmt.Errorf("run analytical pass %s: %w", passType, err)
+		}
+		return &PromptResult{
+			Messages: []PromptMessage{
+				{Role: "user", Content: resp.Msg.GetPromptTemplate()},
+			},
+		}, nil
+	}
+}

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -72,7 +72,11 @@ func RegisterPrompts(r *Registry, c *Client) {
 // stagePromptHandler returns a PromptHandler that fetches prompt templates for
 // the given authoring stage and returns the first template as a user message.
 func stagePromptHandler(c *Client, stage string) PromptHandler {
-	return func(ctx context.Context, _ map[string]string) (*PromptResult, error) {
+	return func(ctx context.Context, args map[string]string) (*PromptResult, error) {
+		specSlug := args["spec_slug"]
+		if specSlug == "" {
+			return nil, fmt.Errorf("spec_slug is required for %s prompt", stage)
+		}
 		resp, err := c.Authoring.GetPrompts(ctx, connect.NewRequest(&specv1.GetPromptsRequest{
 			Stage: authoringStageFromString(stage),
 		}))
@@ -86,6 +90,7 @@ func stagePromptHandler(c *Client, stage string) PromptHandler {
 		} else {
 			text = templates[0].GetTemplate()
 		}
+		text += "\n\nSpec: " + specSlug
 		return &PromptResult{
 			Messages: []PromptMessage{
 				{Role: "user", Content: text},
@@ -98,6 +103,9 @@ func stagePromptHandler(c *Client, stage string) PromptHandler {
 // the topic and optional context to the fetched template.
 func sparkPromptHandler(c *Client) PromptHandler {
 	return func(ctx context.Context, args map[string]string) (*PromptResult, error) {
+		if args["topic"] == "" {
+			return nil, fmt.Errorf("topic is required for spark prompt")
+		}
 		resp, err := c.Authoring.GetPrompts(ctx, connect.NewRequest(&specv1.GetPromptsRequest{
 			Stage: authoringStageFromString("spark"),
 		}))
@@ -129,8 +137,12 @@ func sparkPromptHandler(c *Client) PromptHandler {
 // and returns its prompt template as a user message.
 func analyticalPromptHandler(c *Client, passType string) PromptHandler {
 	return func(ctx context.Context, args map[string]string) (*PromptResult, error) {
+		specSlug := args["spec_slug"]
+		if specSlug == "" {
+			return nil, fmt.Errorf("spec_slug is required for %s prompt", passType)
+		}
 		resp, err := c.AnalyticalPass.RunAnalyticalPass(ctx, connect.NewRequest(&specv1.RunAnalyticalPassRequest{
-			Slug:     args["spec_slug"],
+			Slug:     specSlug,
 			PassType: passTypeFromString(passType),
 		}))
 		if err != nil {

--- a/internal/mcp/prompts_test.go
+++ b/internal/mcp/prompts_test.go
@@ -1,0 +1,432 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// TestSparkPrompt
+// ---------------------------------------------------------------------------
+
+func TestSparkPrompt_WithTopicAndContext(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		getPrompts: func(req *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
+			require.Equal(t, specv1.AuthoringStage_AUTHORING_STAGE_SPARK, req.GetStage())
+			return &specv1.GetPromptsResponse{
+				Prompts: []*specv1.PromptTemplate{
+					{Stage: specv1.AuthoringStage_AUTHORING_STAGE_SPARK, Name: "spark", Template: "Generate a spec idea"},
+				},
+			}, nil
+		},
+	}}
+
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+	prompts := r.Prompts()
+	var sparkDef *PromptDef
+	for i := range prompts {
+		if prompts[i].Name == "spark" {
+			sparkDef = &prompts[i]
+			break
+		}
+	}
+	require.NotNil(t, sparkDef)
+
+	result, err := sparkDef.Handler(context.Background(), map[string]string{
+		"topic":   "OAuth token rotation",
+		"context": "Used by mobile apps",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.Messages)
+	require.Equal(t, "user", result.Messages[0].Role)
+	require.Contains(t, result.Messages[0].Content, "Generate a spec idea")
+	require.Contains(t, result.Messages[0].Content, "OAuth token rotation")
+	require.Contains(t, result.Messages[0].Content, "Used by mobile apps")
+}
+
+func TestSparkPrompt_TopicOnly(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		getPrompts: func(_ *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
+			return &specv1.GetPromptsResponse{
+				Prompts: []*specv1.PromptTemplate{
+					{Template: "Spark template text"},
+				},
+			}, nil
+		},
+	}}
+
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+	prompts := r.Prompts()
+	var sparkDef *PromptDef
+	for i := range prompts {
+		if prompts[i].Name == "spark" {
+			sparkDef = &prompts[i]
+			break
+		}
+	}
+	require.NotNil(t, sparkDef)
+
+	result, err := sparkDef.Handler(context.Background(), map[string]string{
+		"topic": "rate limiting",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Contains(t, result.Messages[0].Content, "rate limiting")
+	// No context provided; should not contain "Context:" line
+	require.NotContains(t, result.Messages[0].Content, "Context:")
+}
+
+func TestSparkPrompt_NoTemplates(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		getPrompts: func(_ *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
+			return &specv1.GetPromptsResponse{Prompts: nil}, nil
+		},
+	}}
+
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+	prompts := r.Prompts()
+	var sparkDef *PromptDef
+	for i := range prompts {
+		if prompts[i].Name == "spark" {
+			sparkDef = &prompts[i]
+			break
+		}
+	}
+	require.NotNil(t, sparkDef)
+
+	result, err := sparkDef.Handler(context.Background(), map[string]string{
+		"topic": "something",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.Messages)
+	require.Contains(t, result.Messages[0].Content, "spark")
+}
+
+func TestSparkPrompt_RPCError(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		getPrompts: func(_ *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("server error"))
+		},
+	}}
+
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+	prompts := r.Prompts()
+	var sparkDef *PromptDef
+	for i := range prompts {
+		if prompts[i].Name == "spark" {
+			sparkDef = &prompts[i]
+			break
+		}
+	}
+	require.NotNil(t, sparkDef)
+
+	_, err := sparkDef.Handler(context.Background(), map[string]string{"topic": "test"})
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// TestShapePrompt
+// ---------------------------------------------------------------------------
+
+func TestShapePrompt(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		getPrompts: func(req *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
+			require.Equal(t, specv1.AuthoringStage_AUTHORING_STAGE_SHAPE, req.GetStage())
+			return &specv1.GetPromptsResponse{
+				Prompts: []*specv1.PromptTemplate{
+					{Template: "Shape this spec into a problem statement"},
+				},
+			}, nil
+		},
+	}}
+
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+	prompts := r.Prompts()
+	var shapeDef *PromptDef
+	for i := range prompts {
+		if prompts[i].Name == "shape" {
+			shapeDef = &prompts[i]
+			break
+		}
+	}
+	require.NotNil(t, shapeDef)
+
+	result, err := shapeDef.Handler(context.Background(), map[string]string{
+		"spec_slug": "oauth-refresh",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "user", result.Messages[0].Role)
+	require.Contains(t, result.Messages[0].Content, "Shape this spec into a problem statement")
+}
+
+func TestShapePrompt_NoTemplates(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		getPrompts: func(_ *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
+			return &specv1.GetPromptsResponse{}, nil
+		},
+	}}
+
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+	prompts := r.Prompts()
+	var shapeDef *PromptDef
+	for i := range prompts {
+		if prompts[i].Name == "shape" {
+			shapeDef = &prompts[i]
+			break
+		}
+	}
+	require.NotNil(t, shapeDef)
+
+	result, err := shapeDef.Handler(context.Background(), map[string]string{
+		"spec_slug": "oauth-refresh",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Contains(t, result.Messages[0].Content, "shape")
+}
+
+// ---------------------------------------------------------------------------
+// TestSpecifyPrompt
+// ---------------------------------------------------------------------------
+
+func TestSpecifyPrompt(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		getPrompts: func(req *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
+			require.Equal(t, specv1.AuthoringStage_AUTHORING_STAGE_SPECIFY, req.GetStage())
+			return &specv1.GetPromptsResponse{
+				Prompts: []*specv1.PromptTemplate{
+					{Template: "Add full specification detail"},
+				},
+			}, nil
+		},
+	}}
+
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+	prompts := r.Prompts()
+	var specifyDef *PromptDef
+	for i := range prompts {
+		if prompts[i].Name == "specify" {
+			specifyDef = &prompts[i]
+			break
+		}
+	}
+	require.NotNil(t, specifyDef)
+
+	result, err := specifyDef.Handler(context.Background(), map[string]string{
+		"spec_slug": "oauth-refresh",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "user", result.Messages[0].Role)
+	require.Contains(t, result.Messages[0].Content, "Add full specification detail")
+}
+
+// ---------------------------------------------------------------------------
+// TestDecomposePrompt
+// ---------------------------------------------------------------------------
+
+func TestDecomposePrompt(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		getPrompts: func(req *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
+			require.Equal(t, specv1.AuthoringStage_AUTHORING_STAGE_DECOMPOSE, req.GetStage())
+			return &specv1.GetPromptsResponse{
+				Prompts: []*specv1.PromptTemplate{
+					{Template: "Break into work slices"},
+				},
+			}, nil
+		},
+	}}
+
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+	prompts := r.Prompts()
+	var decomposeDef *PromptDef
+	for i := range prompts {
+		if prompts[i].Name == "decompose" {
+			decomposeDef = &prompts[i]
+			break
+		}
+	}
+	require.NotNil(t, decomposeDef)
+
+	result, err := decomposeDef.Handler(context.Background(), map[string]string{
+		"spec_slug": "oauth-refresh",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "user", result.Messages[0].Role)
+	require.Contains(t, result.Messages[0].Content, "Break into work slices")
+}
+
+// ---------------------------------------------------------------------------
+// TestConstitutionCheckPrompt
+// ---------------------------------------------------------------------------
+
+func TestConstitutionCheckPrompt(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{
+		runAnalyticalPass: func(req *specv1.RunAnalyticalPassRequest) (*specv1.RunAnalyticalPassResponse, error) {
+			require.Equal(t, "oauth-refresh", req.GetSlug())
+			require.Equal(t, specv1.PassType_PASS_TYPE_CONSTITUTION_CHECK, req.GetPassType())
+			return &specv1.RunAnalyticalPassResponse{
+				PromptTemplate: "Check spec against constitution rules",
+			}, nil
+		},
+	}}
+
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+	prompts := r.Prompts()
+	var checkDef *PromptDef
+	for i := range prompts {
+		if prompts[i].Name == "constitution_check" {
+			checkDef = &prompts[i]
+			break
+		}
+	}
+	require.NotNil(t, checkDef)
+
+	result, err := checkDef.Handler(context.Background(), map[string]string{
+		"spec_slug": "oauth-refresh",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "user", result.Messages[0].Role)
+	require.Contains(t, result.Messages[0].Content, "Check spec against constitution rules")
+}
+
+func TestConstitutionCheckPrompt_RPCError(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{
+		runAnalyticalPass: func(_ *specv1.RunAnalyticalPassRequest) (*specv1.RunAnalyticalPassResponse, error) {
+			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("not found"))
+		},
+	}}
+
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+	prompts := r.Prompts()
+	var checkDef *PromptDef
+	for i := range prompts {
+		if prompts[i].Name == "constitution_check" {
+			checkDef = &prompts[i]
+			break
+		}
+	}
+	require.NotNil(t, checkDef)
+
+	_, err := checkDef.Handler(context.Background(), map[string]string{
+		"spec_slug": "oauth-refresh",
+	})
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// TestDependencyReviewPrompt
+// ---------------------------------------------------------------------------
+
+func TestDependencyReviewPrompt(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{
+		runAnalyticalPass: func(req *specv1.RunAnalyticalPassRequest) (*specv1.RunAnalyticalPassResponse, error) {
+			require.Equal(t, "oauth-refresh", req.GetSlug())
+			require.Equal(t, specv1.PassType_PASS_TYPE_PERIPHERAL_VISION, req.GetPassType())
+			return &specv1.RunAnalyticalPassResponse{
+				PromptTemplate: "Review dependency health",
+			}, nil
+		},
+	}}
+
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+	prompts := r.Prompts()
+	var depDef *PromptDef
+	for i := range prompts {
+		if prompts[i].Name == "dependency_review" {
+			depDef = &prompts[i]
+			break
+		}
+	}
+	require.NotNil(t, depDef)
+
+	result, err := depDef.Handler(context.Background(), map[string]string{
+		"spec_slug": "oauth-refresh",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "user", result.Messages[0].Role)
+	require.Contains(t, result.Messages[0].Content, "Review dependency health")
+}
+
+// ---------------------------------------------------------------------------
+// TestRegisterPrompts_Count
+// ---------------------------------------------------------------------------
+
+func TestRegisterPrompts_Count(t *testing.T) {
+	c := &Client{}
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+	require.Len(t, r.Prompts(), 6)
+}
+
+func TestRegisterPrompts_Names(t *testing.T) {
+	c := &Client{}
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+
+	names := map[string]bool{}
+	for _, p := range r.Prompts() {
+		names[p.Name] = true
+	}
+	require.True(t, names["spark"], "spark prompt missing")
+	require.True(t, names["shape"], "shape prompt missing")
+	require.True(t, names["specify"], "specify prompt missing")
+	require.True(t, names["decompose"], "decompose prompt missing")
+	require.True(t, names["constitution_check"], "constitution_check prompt missing")
+	require.True(t, names["dependency_review"], "dependency_review prompt missing")
+}
+
+func TestRegisterPrompts_Arguments(t *testing.T) {
+	c := &Client{}
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+
+	for _, p := range r.Prompts() {
+		switch p.Name {
+		case "spark":
+			// spark has topic (required) and context (optional)
+			argMap := map[string]PromptArgument{}
+			for _, a := range p.Arguments {
+				argMap[a.Name] = a
+			}
+			require.True(t, argMap["topic"].Required, "spark: topic should be required")
+			require.False(t, argMap["context"].Required, "spark: context should be optional")
+		case "shape", "specify", "decompose", "constitution_check", "dependency_review":
+			// all have spec_slug (required)
+			require.NotEmpty(t, p.Arguments, "%s should have arguments", p.Name)
+			var found bool
+			for _, a := range p.Arguments {
+				if a.Name == "spec_slug" && a.Required {
+					found = true
+					break
+				}
+			}
+			require.True(t, found, "%s: spec_slug should be required", p.Name)
+		}
+	}
+}

--- a/internal/mcp/prompts_test.go
+++ b/internal/mcp/prompts_test.go
@@ -401,6 +401,57 @@ func TestRegisterPrompts_Names(t *testing.T) {
 	require.True(t, names["dependency_review"], "dependency_review prompt missing")
 }
 
+func TestSparkPrompt_MissingTopic(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+	var sparkDef *PromptDef
+	for _, p := range r.Prompts() {
+		if p.Name == "spark" {
+			sparkDef = &p
+			break
+		}
+	}
+	require.NotNil(t, sparkDef)
+	_, err := sparkDef.Handler(context.Background(), map[string]string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "topic is required")
+}
+
+func TestShapePrompt_MissingSpecSlug(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+	var shapeDef *PromptDef
+	for _, p := range r.Prompts() {
+		if p.Name == "shape" {
+			shapeDef = &p
+			break
+		}
+	}
+	require.NotNil(t, shapeDef)
+	_, err := shapeDef.Handler(context.Background(), map[string]string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "spec_slug is required")
+}
+
+func TestConstitutionCheckPrompt_MissingSpecSlug(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{}}
+	r := NewRegistry()
+	RegisterPrompts(r, c)
+	var def *PromptDef
+	for _, p := range r.Prompts() {
+		if p.Name == "constitution_check" {
+			def = &p
+			break
+		}
+	}
+	require.NotNil(t, def)
+	_, err := def.Handler(context.Background(), map[string]string{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "spec_slug is required")
+}
+
 func TestRegisterPrompts_Arguments(t *testing.T) {
 	c := &Client{}
 	r := NewRegistry()

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -46,7 +46,7 @@ func (r *Registry) LookupTool(name string) (ToolDef, bool) {
 }
 
 // AddResource registers a resource definition.
-func (r *Registry) AddResource(def ResourceDef) {
+func (r *Registry) AddResource(def ResourceDef) { //nolint:gocritic // value receiver keeps API simple
 	r.resources = append(r.resources, def)
 }
 

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -1,0 +1,66 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+// Registry holds all MCP tool, resource, and prompt definitions.
+type Registry struct {
+	tools     []ToolDef
+	toolIndex map[string]int // name → index in tools
+	resources []ResourceDef
+	prompts   []PromptDef
+}
+
+// NewRegistry creates an empty registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		toolIndex: make(map[string]int),
+	}
+}
+
+// AddTool registers a tool definition.
+func (r *Registry) AddTool(def ToolDef) {
+	r.toolIndex[def.Name] = len(r.tools)
+	r.tools = append(r.tools, def)
+}
+
+// ToolsForTier returns all tools visible at the given tier.
+// Higher tiers include all tools from lower tiers.
+func (r *Registry) ToolsForTier(tier Tier) []ToolDef {
+	var out []ToolDef
+	for _, def := range r.tools {
+		if tier.Includes(def.Tier) {
+			out = append(out, def)
+		}
+	}
+	return out
+}
+
+// LookupTool finds a tool by name.
+func (r *Registry) LookupTool(name string) (ToolDef, bool) {
+	idx, ok := r.toolIndex[name]
+	if !ok {
+		return ToolDef{}, false
+	}
+	return r.tools[idx], true
+}
+
+// AddResource registers a resource definition.
+func (r *Registry) AddResource(def ResourceDef) {
+	r.resources = append(r.resources, def)
+}
+
+// Resources returns all registered resource definitions.
+func (r *Registry) Resources() []ResourceDef {
+	return r.resources
+}
+
+// AddPrompt registers a prompt definition.
+func (r *Registry) AddPrompt(def PromptDef) {
+	r.prompts = append(r.prompts, def)
+}
+
+// Prompts returns all registered prompt definitions.
+func (r *Registry) Prompts() []PromptDef {
+	return r.prompts
+}

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistry_ToolsFilteredByTier(t *testing.T) {
+	r := NewRegistry()
+	noop := func(ctx context.Context, params map[string]any) (*ToolResult, error) {
+		return textResult("ok"), nil
+	}
+
+	r.AddTool(ToolDef{Name: "spec", Tier: TierCore, Handler: noop})
+	r.AddTool(ToolDef{Name: "author", Tier: TierAuthoring, Handler: noop})
+	r.AddTool(ToolDef{Name: "claim", Tier: TierExecution, Handler: noop})
+
+	core := r.ToolsForTier(TierCore)
+	require.Len(t, core, 1)
+	require.Equal(t, "spec", core[0].Name)
+
+	authoring := r.ToolsForTier(TierAuthoring)
+	require.Len(t, authoring, 2) // core + authoring
+	names := []string{authoring[0].Name, authoring[1].Name}
+	require.ElementsMatch(t, []string{"spec", "author"}, names)
+
+	execution := r.ToolsForTier(TierExecution)
+	require.Len(t, execution, 3)
+}
+
+func TestRegistry_LookupTool(t *testing.T) {
+	r := NewRegistry()
+	noop := func(ctx context.Context, params map[string]any) (*ToolResult, error) {
+		return textResult("ok"), nil
+	}
+	r.AddTool(ToolDef{Name: "spec", Tier: TierCore, Handler: noop})
+
+	def, ok := r.LookupTool("spec")
+	require.True(t, ok)
+	require.Equal(t, "spec", def.Name)
+
+	_, ok = r.LookupTool("missing")
+	require.False(t, ok)
+}
+
+func TestRegistry_Resources(t *testing.T) {
+	r := NewRegistry()
+	r.AddResource(ResourceDef{URI: "specgraph://specs", Name: "specs"})
+	require.Len(t, r.Resources(), 1)
+}
+
+func TestRegistry_Prompts(t *testing.T) {
+	r := NewRegistry()
+	r.AddPrompt(PromptDef{Name: "spark"})
+	require.Len(t, r.Prompts(), 1)
+}

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRegistry_ToolsFilteredByTier(t *testing.T) {
 	r := NewRegistry()
-	noop := func(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	noop := func(_ context.Context, _ map[string]any) (*ToolResult, error) {
 		return textResult("ok"), nil
 	}
 
@@ -35,7 +35,7 @@ func TestRegistry_ToolsFilteredByTier(t *testing.T) {
 
 func TestRegistry_LookupTool(t *testing.T) {
 	r := NewRegistry()
-	noop := func(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	noop := func(_ context.Context, _ map[string]any) (*ToolResult, error) {
 		return textResult("ok"), nil
 	}
 	r.AddTool(ToolDef{Name: "spec", Tier: TierCore, Handler: noop})

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -103,8 +103,12 @@ func constitutionResourceHandler(c *Client) ResourceHandler {
 func constitutionLayerResourceHandler(c *Client) ResourceHandler {
 	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
 		layer := extractSlugFromURI(uri)
+		enumLayer := constitutionLayerFromString(layer)
+		if enumLayer == specv1.ConstitutionLayer_CONSTITUTION_LAYER_UNSPECIFIED {
+			return nil, fmt.Errorf("unknown constitution layer %q", layer)
+		}
 		resp, err := c.Constitution.GetConstitution(ctx, connect.NewRequest(&specv1.GetConstitutionRequest{
-			Layer: constitutionLayerFromString(layer),
+			Layer: enumLayer,
 		}))
 		if err != nil {
 			return nil, fmt.Errorf("get constitution layer %s: %w", layer, err)

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -1,0 +1,260 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// resourceJSON marshals a proto message to indented JSON and returns it as a
+// single-element ResourceContent slice.
+func resourceJSON(uri string, msg proto.Message) ([]ResourceContent, error) {
+	data, err := protojson.MarshalOptions{Multiline: true}.Marshal(msg)
+	if err != nil {
+		return nil, fmt.Errorf("marshal resource %s: %w", uri, err)
+	}
+	return []ResourceContent{{
+		URI:      uri,
+		MimeType: "application/json",
+		Text:     string(data),
+	}}, nil
+}
+
+// extractSlugFromURI returns the last path segment of a specgraph:// URI.
+// e.g. "specgraph://spec/oauth-refresh" → "oauth-refresh"
+func extractSlugFromURI(uri string) string {
+	parts := strings.Split(strings.TrimPrefix(uri, "specgraph://"), "/")
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[len(parts)-1]
+}
+
+// ---------------------------------------------------------------------------
+// specResourceHandler — specgraph://spec/{slug}
+// ---------------------------------------------------------------------------
+
+func specResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		slug := extractSlugFromURI(uri)
+		resp, err := c.Spec.GetSpec(ctx, connect.NewRequest(&specv1.GetSpecRequest{Slug: slug}))
+		if err != nil {
+			return nil, fmt.Errorf("get spec %s: %w", slug, err)
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// specListResourceHandler — specgraph://specs
+// ---------------------------------------------------------------------------
+
+func specListResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		resp, err := c.Spec.ListSpecs(ctx, connect.NewRequest(&specv1.ListSpecsRequest{}))
+		if err != nil {
+			return nil, fmt.Errorf("list specs: %w", err)
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// decisionResourceHandler — specgraph://decision/{slug}
+// ---------------------------------------------------------------------------
+
+func decisionResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		slug := extractSlugFromURI(uri)
+		resp, err := c.Decision.GetDecision(ctx, connect.NewRequest(&specv1.GetDecisionRequest{Slug: slug}))
+		if err != nil {
+			return nil, fmt.Errorf("get decision %s: %w", slug, err)
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// constitutionResourceHandler — specgraph://constitution
+// ---------------------------------------------------------------------------
+
+func constitutionResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		resp, err := c.Constitution.GetConstitution(ctx, connect.NewRequest(&specv1.GetConstitutionRequest{}))
+		if err != nil {
+			return nil, fmt.Errorf("get constitution: %w", err)
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// constitutionLayerResourceHandler — specgraph://constitution/{layer}
+// ---------------------------------------------------------------------------
+
+func constitutionLayerResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		layer := extractSlugFromURI(uri)
+		resp, err := c.Constitution.GetConstitution(ctx, connect.NewRequest(&specv1.GetConstitutionRequest{
+			Layer: constitutionLayerFromString(layer),
+		}))
+		if err != nil {
+			return nil, fmt.Errorf("get constitution layer %s: %w", layer, err)
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// graphResourceHandler — specgraph://graph
+// ---------------------------------------------------------------------------
+
+func graphResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		resp, err := c.Graph.GetFullGraph(ctx, connect.NewRequest(&specv1.GetFullGraphRequest{}))
+		if err != nil {
+			return nil, fmt.Errorf("get full graph: %w", err)
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// readyResourceHandler — specgraph://graph/ready
+// ---------------------------------------------------------------------------
+
+func readyResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		resp, err := c.Graph.GetReady(ctx, connect.NewRequest(&specv1.GetReadyRequest{}))
+		if err != nil {
+			return nil, fmt.Errorf("get ready specs: %w", err)
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// findingsResourceHandler — specgraph://findings
+// ---------------------------------------------------------------------------
+
+func findingsResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		resp, err := c.AnalyticalPass.ListFindings(ctx, connect.NewRequest(&specv1.ListFindingsRequest{}))
+		if err != nil {
+			return nil, fmt.Errorf("list findings: %w", err)
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// changesResourceHandler — specgraph://spec/{slug}/changes
+// ---------------------------------------------------------------------------
+
+func changesResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		// URI pattern: specgraph://spec/{slug}/changes
+		// Split path segments after stripping the scheme.
+		parts := strings.Split(strings.TrimPrefix(uri, "specgraph://"), "/")
+		// parts: ["spec", "{slug}", "changes"] → slug is parts[1]
+		slug := ""
+		if len(parts) >= 2 {
+			slug = parts[1]
+		}
+		resp, err := c.Spec.ListChanges(ctx, connect.NewRequest(&specv1.ListChangesRequest{Slug: slug}))
+		if err != nil {
+			return nil, fmt.Errorf("list changes for %s: %w", slug, err)
+		}
+		return resourceJSON(uri, resp.Msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RegisterResources adds all 9 MCP resources to the registry.
+// ---------------------------------------------------------------------------
+
+// RegisterResources registers all SpecGraph MCP resources into r using the
+// provided Client to make RPC calls. Resources are read-only context providers
+// for MCP clients.
+func RegisterResources(r *Registry, c *Client) {
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://spec/{slug}",
+		Name:        "spec",
+		Description: "Full spec content by slug.",
+		MimeType:    "application/json",
+		IsTemplate:  true,
+		Handler:     specResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://specs",
+		Name:        "specs",
+		Description: "Summary list of all specs.",
+		MimeType:    "application/json",
+		IsTemplate:  false,
+		Handler:     specListResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://decision/{slug}",
+		Name:        "decision",
+		Description: "Decision content by slug.",
+		MimeType:    "application/json",
+		IsTemplate:  true,
+		Handler:     decisionResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://constitution",
+		Name:        "constitution",
+		Description: "Merged constitution (all layers).",
+		MimeType:    "application/json",
+		IsTemplate:  false,
+		Handler:     constitutionResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://constitution/{layer}",
+		Name:        "constitution-layer",
+		Description: "Single constitution layer (user, org, project, domain).",
+		MimeType:    "application/json",
+		IsTemplate:  true,
+		Handler:     constitutionLayerResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://graph",
+		Name:        "graph",
+		Description: "Complete dependency graph (all nodes and edges).",
+		MimeType:    "application/json",
+		IsTemplate:  false,
+		Handler:     graphResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://graph/ready",
+		Name:        "graph-ready",
+		Description: "Specs with no unmet dependencies (ready to execute).",
+		MimeType:    "application/json",
+		IsTemplate:  false,
+		Handler:     readyResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://findings",
+		Name:        "findings",
+		Description: "All analytical findings (global, no slug filter).",
+		MimeType:    "application/json",
+		IsTemplate:  false,
+		Handler:     findingsResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://spec/{slug}/changes",
+		Name:        "spec-changes",
+		Description: "Version history (change log) for a spec.",
+		MimeType:    "application/json",
+		IsTemplate:  true,
+		Handler:     changesResourceHandler(c),
+	})
+}

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -1,0 +1,400 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// specResourceHandler tests
+// ---------------------------------------------------------------------------
+
+func TestSpecResource(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{
+		getSpec: func(slug string) (*specv1.GetSpecResponse, error) {
+			require.Equal(t, "oauth-refresh", slug)
+			return &specv1.GetSpecResponse{
+				Spec: &specv1.Spec{Slug: "oauth-refresh", Intent: "Rotate tokens safely"},
+			}, nil
+		},
+	}}
+
+	handler := specResourceHandler(c)
+	contents, err := handler(context.Background(), "specgraph://spec/oauth-refresh")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+	require.Equal(t, "application/json", contents[0].MimeType)
+	require.Equal(t, "specgraph://spec/oauth-refresh", contents[0].URI)
+	require.Contains(t, contents[0].Text, "oauth-refresh")
+}
+
+func TestSpecResource_Error(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{
+		getSpec: func(_ string) (*specv1.GetSpecResponse, error) {
+			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("not found"))
+		},
+	}}
+
+	handler := specResourceHandler(c)
+	_, err := handler(context.Background(), "specgraph://spec/missing")
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// specListResourceHandler tests
+// ---------------------------------------------------------------------------
+
+func TestSpecListResource(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{
+		listSpecs: func() (*specv1.ListSpecsResponse, error) {
+			return &specv1.ListSpecsResponse{
+				Specs: []*specv1.Spec{
+					{Slug: "spec-a", Stage: "spark"},
+					{Slug: "spec-b", Stage: "shape"},
+				},
+			}, nil
+		},
+	}}
+
+	handler := specListResourceHandler(c)
+	contents, err := handler(context.Background(), "specgraph://specs")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+	require.Equal(t, "application/json", contents[0].MimeType)
+	require.Equal(t, "specgraph://specs", contents[0].URI)
+	require.Contains(t, contents[0].Text, "spec-a")
+	require.Contains(t, contents[0].Text, "spec-b")
+}
+
+func TestSpecListResource_Error(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{
+		listSpecs: func() (*specv1.ListSpecsResponse, error) {
+			return nil, fmt.Errorf("storage unavailable")
+		},
+	}}
+
+	handler := specListResourceHandler(c)
+	_, err := handler(context.Background(), "specgraph://specs")
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// decisionResourceHandler tests
+// ---------------------------------------------------------------------------
+
+func TestDecisionResource(t *testing.T) {
+	c := &Client{Decision: &mockDecisionService{
+		getDecision: func(slug string) (*specv1.GetDecisionResponse, error) {
+			require.Equal(t, "adr-001", slug)
+			return &specv1.GetDecisionResponse{
+				Decision: &specv1.Decision{Slug: "adr-001", Title: "Use PostgreSQL"},
+			}, nil
+		},
+	}}
+
+	handler := decisionResourceHandler(c)
+	contents, err := handler(context.Background(), "specgraph://decision/adr-001")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+	require.Equal(t, "application/json", contents[0].MimeType)
+	require.Equal(t, "specgraph://decision/adr-001", contents[0].URI)
+	require.Contains(t, contents[0].Text, "adr-001")
+}
+
+func TestDecisionResource_Error(t *testing.T) {
+	c := &Client{Decision: &mockDecisionService{
+		getDecision: func(_ string) (*specv1.GetDecisionResponse, error) {
+			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("not found"))
+		},
+	}}
+
+	handler := decisionResourceHandler(c)
+	_, err := handler(context.Background(), "specgraph://decision/missing")
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// constitutionResourceHandler tests
+// ---------------------------------------------------------------------------
+
+func TestConstitutionResource(t *testing.T) {
+	c := &Client{Constitution: &mockConstitutionService{
+		getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+			return &specv1.GetConstitutionResponse{
+				Constitution: &specv1.Constitution{
+					Name:  "project-constitution",
+					Layer: specv1.ConstitutionLayer_CONSTITUTION_LAYER_PROJECT,
+				},
+			}, nil
+		},
+	}}
+
+	handler := constitutionResourceHandler(c)
+	contents, err := handler(context.Background(), "specgraph://constitution")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+	require.Equal(t, "application/json", contents[0].MimeType)
+	require.Equal(t, "specgraph://constitution", contents[0].URI)
+	require.Contains(t, contents[0].Text, "project-constitution")
+}
+
+func TestConstitutionResource_Error(t *testing.T) {
+	c := &Client{Constitution: &mockConstitutionService{
+		getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+			return nil, fmt.Errorf("storage error")
+		},
+	}}
+
+	handler := constitutionResourceHandler(c)
+	_, err := handler(context.Background(), "specgraph://constitution")
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// constitutionLayerResourceHandler tests
+// ---------------------------------------------------------------------------
+
+func TestConstitutionLayerResource(t *testing.T) {
+	c := &Client{Constitution: &mockConstitutionService{
+		getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+			return &specv1.GetConstitutionResponse{
+				Constitution: &specv1.Constitution{
+					Layer: specv1.ConstitutionLayer_CONSTITUTION_LAYER_ORG,
+				},
+			}, nil
+		},
+	}}
+
+	handler := constitutionLayerResourceHandler(c)
+	contents, err := handler(context.Background(), "specgraph://constitution/org")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+	require.Equal(t, "application/json", contents[0].MimeType)
+	require.Equal(t, "specgraph://constitution/org", contents[0].URI)
+	require.Contains(t, contents[0].Text, "CONSTITUTION_LAYER_ORG")
+}
+
+func TestConstitutionLayerResource_Error(t *testing.T) {
+	c := &Client{Constitution: &mockConstitutionService{
+		getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+			return nil, fmt.Errorf("storage error")
+		},
+	}}
+
+	handler := constitutionLayerResourceHandler(c)
+	_, err := handler(context.Background(), "specgraph://constitution/project")
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// graphResourceHandler tests
+// ---------------------------------------------------------------------------
+
+func TestGraphResource(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		getFullGraph: func() (*specv1.GetFullGraphResponse, error) {
+			return &specv1.GetFullGraphResponse{
+				Nodes: []*specv1.GraphNode{
+					{Slug: "spec-a"},
+					{Slug: "spec-b"},
+				},
+			}, nil
+		},
+	}}
+
+	handler := graphResourceHandler(c)
+	contents, err := handler(context.Background(), "specgraph://graph")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+	require.Equal(t, "application/json", contents[0].MimeType)
+	require.Equal(t, "specgraph://graph", contents[0].URI)
+	require.Contains(t, contents[0].Text, "spec-a")
+}
+
+func TestGraphResource_Error(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		getFullGraph: func() (*specv1.GetFullGraphResponse, error) {
+			return nil, fmt.Errorf("storage error")
+		},
+	}}
+
+	handler := graphResourceHandler(c)
+	_, err := handler(context.Background(), "specgraph://graph")
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// readyResourceHandler tests
+// ---------------------------------------------------------------------------
+
+func TestReadyResource(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		getReady: func() (*specv1.GetReadyResponse, error) {
+			return &specv1.GetReadyResponse{
+				Ready: []*specv1.NodeRef{
+					{Slug: "spec-ready"},
+				},
+			}, nil
+		},
+	}}
+
+	handler := readyResourceHandler(c)
+	contents, err := handler(context.Background(), "specgraph://graph/ready")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+	require.Equal(t, "application/json", contents[0].MimeType)
+	require.Equal(t, "specgraph://graph/ready", contents[0].URI)
+	require.Contains(t, contents[0].Text, "spec-ready")
+}
+
+func TestReadyResource_Error(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		getReady: func() (*specv1.GetReadyResponse, error) {
+			return nil, fmt.Errorf("storage error")
+		},
+	}}
+
+	handler := readyResourceHandler(c)
+	_, err := handler(context.Background(), "specgraph://graph/ready")
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// findingsResourceHandler tests
+// ---------------------------------------------------------------------------
+
+func TestFindingsResource(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{
+		listFindings: func(_ string) (*specv1.ListFindingsResponse, error) {
+			return &specv1.ListFindingsResponse{
+				Findings: []*specv1.AnalyticalFinding{
+					{Id: "finding-1", Summary: "missing constraint"},
+				},
+			}, nil
+		},
+	}}
+
+	handler := findingsResourceHandler(c)
+	contents, err := handler(context.Background(), "specgraph://findings")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+	require.Equal(t, "application/json", contents[0].MimeType)
+	require.Equal(t, "specgraph://findings", contents[0].URI)
+	require.Contains(t, contents[0].Text, "finding-1")
+}
+
+func TestFindingsResource_Error(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{
+		listFindings: func(_ string) (*specv1.ListFindingsResponse, error) {
+			return nil, fmt.Errorf("storage error")
+		},
+	}}
+
+	handler := findingsResourceHandler(c)
+	_, err := handler(context.Background(), "specgraph://findings")
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// changesResourceHandler tests
+// ---------------------------------------------------------------------------
+
+func TestChangesResource(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{
+		listChanges: func(slug string) (*specv1.ListChangesResponse, error) {
+			require.Equal(t, "oauth-refresh", slug)
+			return &specv1.ListChangesResponse{
+				Entries: []*specv1.ChangeLogEntry{
+					{Id: "v1", Summary: "initial version"},
+				},
+			}, nil
+		},
+	}}
+
+	handler := changesResourceHandler(c)
+	contents, err := handler(context.Background(), "specgraph://spec/oauth-refresh/changes")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+	require.Equal(t, "application/json", contents[0].MimeType)
+	require.Equal(t, "specgraph://spec/oauth-refresh/changes", contents[0].URI)
+	require.Contains(t, contents[0].Text, "initial version")
+}
+
+func TestChangesResource_Error(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{
+		listChanges: func(_ string) (*specv1.ListChangesResponse, error) {
+			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("not found"))
+		},
+	}}
+
+	handler := changesResourceHandler(c)
+	_, err := handler(context.Background(), "specgraph://spec/missing/changes")
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// RegisterResources tests
+// ---------------------------------------------------------------------------
+
+func TestRegisterResources_Count(t *testing.T) {
+	c := &Client{}
+	r := NewRegistry()
+	RegisterResources(r, c)
+	require.Len(t, r.Resources(), 9)
+}
+
+func TestRegisterResources_Templates(t *testing.T) {
+	c := &Client{}
+	r := NewRegistry()
+	RegisterResources(r, c)
+
+	templateURIs := map[string]bool{}
+	exactURIs := map[string]bool{}
+	for _, res := range r.Resources() {
+		if res.IsTemplate {
+			templateURIs[res.URI] = true
+		} else {
+			exactURIs[res.URI] = true
+		}
+	}
+
+	// Templates: spec/{slug}, decision/{slug}, constitution/{layer}, spec/{slug}/changes
+	require.True(t, templateURIs["specgraph://spec/{slug}"], "spec template missing")
+	require.True(t, templateURIs["specgraph://decision/{slug}"], "decision template missing")
+	require.True(t, templateURIs["specgraph://constitution/{layer}"], "constitution layer template missing")
+	require.True(t, templateURIs["specgraph://spec/{slug}/changes"], "changes template missing")
+
+	// Exact URIs
+	require.True(t, exactURIs["specgraph://specs"], "specs exact URI missing")
+	require.True(t, exactURIs["specgraph://constitution"], "constitution exact URI missing")
+	require.True(t, exactURIs["specgraph://graph"], "graph exact URI missing")
+	require.True(t, exactURIs["specgraph://graph/ready"], "graph/ready exact URI missing")
+	require.True(t, exactURIs["specgraph://findings"], "findings exact URI missing")
+}
+
+// ---------------------------------------------------------------------------
+// extractSlugFromURI tests
+// ---------------------------------------------------------------------------
+
+func TestExtractSlugFromURI(t *testing.T) {
+	tests := []struct {
+		uri  string
+		want string
+	}{
+		{"specgraph://spec/oauth-refresh", "oauth-refresh"},
+		{"specgraph://decision/adr-001", "adr-001"},
+		{"specgraph://constitution/org", "org"},
+	}
+	for _, tt := range tests {
+		got := extractSlugFromURI(tt.uri)
+		require.Equal(t, tt.want, got, "URI: %s", tt.uri)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -5,6 +5,7 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	sdkmcp "github.com/mark3labs/mcp-go/mcp"
@@ -58,7 +59,8 @@ func NewServer(client *Client) *Server {
 		}
 
 		// All tiers get all resources.
-		for _, rd := range reg.Resources() {
+		for i := range reg.Resources() {
+			rd := &reg.resources[i]
 			if rd.IsTemplate {
 				srv.AddResourceTemplate(toSDKResourceTemplate(rd), wrapResourceTemplateHandler(rd.Handler))
 			} else {
@@ -94,7 +96,10 @@ func (s *Server) ForTier(tier Tier) *server.MCPServer {
 // is cancelled or an error occurs.
 func (s *Server) ServeStdio(ctx context.Context, tier Tier, stdin io.Reader, stdout io.Writer) error {
 	stdio := server.NewStdioServer(s.ForTier(tier))
-	return stdio.Listen(ctx, stdin, stdout)
+	if err := stdio.Listen(ctx, stdin, stdout); err != nil {
+		return fmt.Errorf("mcp stdio: %w", err)
+	}
+	return nil
 }
 
 // HTTPHandler returns a StreamableHTTPServer for the given tier, suitable
@@ -106,7 +111,7 @@ func (s *Server) HTTPHandler(tier Tier) *server.StreamableHTTPServer {
 // wrapToolHandler adapts a SpecGraph ToolHandler to the mcp-go ToolHandlerFunc signature.
 func wrapToolHandler(h ToolHandler) server.ToolHandlerFunc {
 	return func(ctx context.Context, req sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
-		params := fromSDKParams(req)
+		params := fromSDKParams(&req)
 		result, err := h(ctx, params)
 		if err != nil {
 			return nil, err

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,150 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"io"
+
+	sdkmcp "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+const (
+	serverName    = "specgraph"
+	serverVersion = "0.1.0"
+)
+
+// Server wraps one MCPServer per tier. Each tier's MCPServer is pre-populated
+// with the tools, resources, and prompts appropriate for that tier.
+type Server struct {
+	registry *Registry
+	servers  map[Tier]*server.MCPServer
+}
+
+// NewServer creates a fully wired MCP server backed by the given ConnectRPC client.
+// It registers all tools, resources, and prompts, then builds one MCPServer
+// per tier with the appropriate subset of tools (all tiers get all resources
+// and prompts).
+func NewServer(client *Client) *Server {
+	reg := NewRegistry()
+
+	// Register all handlers into the registry.
+	RegisterSpecTools(reg, client)
+	RegisterGraphTools(reg, client)
+	RegisterCoreTools(reg, client)
+	RegisterAuthoringTools(reg, client)
+	RegisterLifecycleTools(reg, client)
+	RegisterExecutionTools(reg, client)
+	RegisterResources(reg, client)
+	RegisterPrompts(reg, client)
+
+	tiers := []Tier{TierCore, TierAuthoring, TierExecution}
+	servers := make(map[Tier]*server.MCPServer, len(tiers))
+
+	for _, tier := range tiers {
+		srv := server.NewMCPServer(
+			serverName,
+			serverVersion,
+			server.WithToolCapabilities(false),
+			server.WithResourceCapabilities(false, false),
+			server.WithPromptCapabilities(false),
+		)
+
+		// Add tier-appropriate tools.
+		for _, td := range reg.ToolsForTier(tier) {
+			srv.AddTool(toSDKTool(td), wrapToolHandler(td.Handler))
+		}
+
+		// All tiers get all resources.
+		for _, rd := range reg.Resources() {
+			if rd.IsTemplate {
+				srv.AddResourceTemplate(toSDKResourceTemplate(rd), wrapResourceTemplateHandler(rd.Handler))
+			} else {
+				srv.AddResource(toSDKResource(rd), wrapResourceHandler(rd.Handler))
+			}
+		}
+
+		// All tiers get all prompts.
+		for _, pd := range reg.Prompts() {
+			srv.AddPrompt(toSDKPrompt(pd), wrapPromptHandler(pd.Handler))
+		}
+
+		servers[tier] = srv
+	}
+
+	return &Server{
+		registry: reg,
+		servers:  servers,
+	}
+}
+
+// ForTier returns the MCPServer for the given tier. Unknown tiers fall back to TierCore.
+func (s *Server) ForTier(tier Tier) *server.MCPServer {
+	srv, ok := s.servers[tier]
+	if !ok {
+		return s.servers[TierCore]
+	}
+	return srv
+}
+
+// ServeStdio runs a stdio transport for the given tier, reading JSON-RPC
+// messages from stdin and writing responses to stdout. It blocks until ctx
+// is cancelled or an error occurs.
+func (s *Server) ServeStdio(ctx context.Context, tier Tier, stdin io.Reader, stdout io.Writer) error {
+	stdio := server.NewStdioServer(s.ForTier(tier))
+	return stdio.Listen(ctx, stdin, stdout)
+}
+
+// HTTPHandler returns a StreamableHTTPServer for the given tier, suitable
+// for use as an http.Handler.
+func (s *Server) HTTPHandler(tier Tier) *server.StreamableHTTPServer {
+	return server.NewStreamableHTTPServer(s.ForTier(tier))
+}
+
+// wrapToolHandler adapts a SpecGraph ToolHandler to the mcp-go ToolHandlerFunc signature.
+func wrapToolHandler(h ToolHandler) server.ToolHandlerFunc {
+	return func(ctx context.Context, req sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		params := fromSDKParams(req)
+		result, err := h(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+		return toSDKResult(result), nil
+	}
+}
+
+// wrapResourceHandler adapts a SpecGraph ResourceHandler to the mcp-go ResourceHandlerFunc.
+func wrapResourceHandler(h ResourceHandler) server.ResourceHandlerFunc {
+	return func(ctx context.Context, req sdkmcp.ReadResourceRequest) ([]sdkmcp.ResourceContents, error) {
+		contents, err := h(ctx, req.Params.URI)
+		if err != nil {
+			return nil, err
+		}
+		return toSDKResourceContents(contents), nil
+	}
+}
+
+// wrapResourceTemplateHandler adapts a SpecGraph ResourceHandler to the mcp-go
+// ResourceTemplateHandlerFunc (same signature as ResourceHandlerFunc).
+func wrapResourceTemplateHandler(h ResourceHandler) server.ResourceTemplateHandlerFunc {
+	return func(ctx context.Context, req sdkmcp.ReadResourceRequest) ([]sdkmcp.ResourceContents, error) {
+		contents, err := h(ctx, req.Params.URI)
+		if err != nil {
+			return nil, err
+		}
+		return toSDKResourceContents(contents), nil
+	}
+}
+
+// wrapPromptHandler adapts a SpecGraph PromptHandler to the mcp-go PromptHandlerFunc.
+func wrapPromptHandler(h PromptHandler) server.PromptHandlerFunc {
+	return func(ctx context.Context, req sdkmcp.GetPromptRequest) (*sdkmcp.GetPromptResult, error) {
+		result, err := h(ctx, req.Params.Arguments)
+		if err != nil {
+			return nil, err
+		}
+		return toSDKPromptResult(result), nil
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	sdkmcp "github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestNewServer_TierToolCounts(t *testing.T) {
+	// NewServer accepts a *Client. The handlers are closures over the
+	// client's service stubs, but we only need to verify registration
+	// counts here — no actual RPCs are made.
+	srv := NewServer(&Client{})
+
+	coreSrv := srv.ForTier(TierCore)
+	authoringSrv := srv.ForTier(TierAuthoring)
+	executionSrv := srv.ForTier(TierExecution)
+
+	// Each tier should be a distinct MCPServer instance.
+	if coreSrv == authoringSrv {
+		t.Error("core and authoring servers are the same instance")
+	}
+	if authoringSrv == executionSrv {
+		t.Error("authoring and execution servers are the same instance")
+	}
+	if coreSrv == executionSrv {
+		t.Error("core and execution servers are the same instance")
+	}
+
+	coreTools := coreSrv.ListTools()
+	authoringTools := authoringSrv.ListTools()
+	executionTools := executionSrv.ListTools()
+
+	// Core: spec (2) + graph (2) + core (3) = 7 tools
+	// Authoring: core (7) + authoring (3) + lifecycle (4) = 14 tools
+	// Execution: authoring (14) + execution (6) = 20 tools
+	if len(coreTools) != 7 {
+		t.Errorf("core tool count = %d, want 7", len(coreTools))
+	}
+	if len(authoringTools) != 14 {
+		t.Errorf("authoring tool count = %d, want 14", len(authoringTools))
+	}
+	if len(executionTools) != 20 {
+		t.Errorf("execution tool count = %d, want 20", len(executionTools))
+	}
+
+	// Higher tiers should be strict supersets of lower tiers.
+	for name := range coreTools {
+		if _, ok := authoringTools[name]; !ok {
+			t.Errorf("authoring tier missing core tool %q", name)
+		}
+		if _, ok := executionTools[name]; !ok {
+			t.Errorf("execution tier missing core tool %q", name)
+		}
+	}
+	for name := range authoringTools {
+		if _, ok := executionTools[name]; !ok {
+			t.Errorf("execution tier missing authoring tool %q", name)
+		}
+	}
+}
+
+func TestNewServer_FallbackToCore(t *testing.T) {
+	srv := NewServer(&Client{})
+
+	// An unknown tier value should fall back to core.
+	unknown := srv.ForTier(Tier(99))
+	core := srv.ForTier(TierCore)
+
+	if unknown != core {
+		t.Error("ForTier(99) did not fall back to core server")
+	}
+}
+
+func TestWrapToolHandler(t *testing.T) {
+	called := false
+	handler := func(_ context.Context, params map[string]any) (*ToolResult, error) {
+		called = true
+		slug := stringParam(params, "slug")
+		return textResult("got: " + slug), nil
+	}
+
+	wrapped := wrapToolHandler(handler)
+
+	req := callToolRequest("test_tool", map[string]any{"slug": "my-spec"})
+	result, err := wrapped(context.Background(), req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("handler was not called")
+	}
+	if result.IsError {
+		t.Error("IsError = true, want false")
+	}
+}
+
+func TestWrapPromptHandler(t *testing.T) {
+	handler := func(_ context.Context, args map[string]string) (*PromptResult, error) {
+		return &PromptResult{
+			Description: "test",
+			Messages: []PromptMessage{
+				{Role: "user", Content: "hello " + args["name"]},
+			},
+		}, nil
+	}
+
+	wrapped := wrapPromptHandler(handler)
+
+	req := getPromptRequest("test-prompt", map[string]string{"name": "world"})
+	result, err := wrapped(context.Background(), req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Description != "test" {
+		t.Errorf("Description = %q, want %q", result.Description, "test")
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("Messages length = %d, want 1", len(result.Messages))
+	}
+}
+
+func TestWrapResourceHandler(t *testing.T) {
+	handler := func(_ context.Context, uri string) ([]ResourceContent, error) {
+		return []ResourceContent{
+			{URI: uri, MimeType: "text/plain", Text: "content for " + uri},
+		}, nil
+	}
+
+	wrapped := wrapResourceHandler(handler)
+
+	req := readResourceRequest("specgraph://test")
+	result, err := wrapped(context.Background(), req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("result length = %d, want 1", len(result))
+	}
+}
+
+// --- test helpers for constructing SDK request types ---
+
+func callToolRequest(name string, args map[string]any) sdkmcp.CallToolRequest {
+	return sdkmcp.CallToolRequest{
+		Params: sdkmcp.CallToolParams{
+			Name:      name,
+			Arguments: args,
+		},
+	}
+}
+
+func getPromptRequest(name string, args map[string]string) sdkmcp.GetPromptRequest {
+	return sdkmcp.GetPromptRequest{
+		Params: sdkmcp.GetPromptParams{
+			Name:      name,
+			Arguments: args,
+		},
+	}
+}
+
+func readResourceRequest(uri string) sdkmcp.ReadResourceRequest {
+	return sdkmcp.ReadResourceRequest{
+		Params: sdkmcp.ReadResourceParams{
+			URI: uri,
+		},
+	}
+}

--- a/internal/mcp/testhelpers_test.go
+++ b/internal/mcp/testhelpers_test.go
@@ -302,6 +302,7 @@ type mockAuthoringService struct {
 	supersede          func(req *specv1.SupersedeRequest) (*specv1.SupersedeResponse, error)
 	recordConversation func(req *specv1.RecordConversationRequest) (*specv1.RecordConversationResponse, error)
 	listConversations  func(req *specv1.ListConversationsRequest) (*specv1.ListConversationsResponse, error)
+	getPrompts         func(req *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error)
 }
 
 func (m *mockAuthoringService) Spark(_ context.Context, req *connect.Request[specv1.SparkRequest]) (*connect.Response[specv1.SparkResponse], error) {
@@ -364,6 +365,17 @@ func (m *mockAuthoringService) ListConversations(_ context.Context, req *connect
 		panic("mockAuthoringService.ListConversations not configured")
 	}
 	resp, err := m.listConversations(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockAuthoringService) GetPrompts(_ context.Context, req *connect.Request[specv1.GetPromptsRequest]) (*connect.Response[specv1.GetPromptsResponse], error) {
+	if m.getPrompts == nil {
+		panic("mockAuthoringService.GetPrompts not configured")
+	}
+	resp, err := m.getPrompts(req.Msg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/testhelpers_test.go
+++ b/internal/mcp/testhelpers_test.go
@@ -255,11 +255,235 @@ func (m *mockConstitutionService) UpdateConstitution(_ context.Context, req *con
 
 type mockAnalyticalPassService struct {
 	specgraphv1connect.AnalyticalPassServiceClient // panics on unimplemented methods
-	listFindings func(slug string) (*specv1.ListFindingsResponse, error)
+	listFindings      func(slug string) (*specv1.ListFindingsResponse, error)
+	runAnalyticalPass func(req *specv1.RunAnalyticalPassRequest) (*specv1.RunAnalyticalPassResponse, error)
+	storeFindings     func(req *specv1.StoreFindingsRequest) (*specv1.StoreFindingsResponse, error)
 }
 
 func (m *mockAnalyticalPassService) ListFindings(_ context.Context, req *connect.Request[specv1.ListFindingsRequest]) (*connect.Response[specv1.ListFindingsResponse], error) {
 	resp, err := m.listFindings(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockAnalyticalPassService) RunAnalyticalPass(_ context.Context, req *connect.Request[specv1.RunAnalyticalPassRequest]) (*connect.Response[specv1.RunAnalyticalPassResponse], error) {
+	if m.runAnalyticalPass == nil {
+		panic("mockAnalyticalPassService.RunAnalyticalPass not configured")
+	}
+	resp, err := m.runAnalyticalPass(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockAnalyticalPassService) StoreFindings(_ context.Context, req *connect.Request[specv1.StoreFindingsRequest]) (*connect.Response[specv1.StoreFindingsResponse], error) {
+	if m.storeFindings == nil {
+		panic("mockAnalyticalPassService.StoreFindings not configured")
+	}
+	resp, err := m.storeFindings(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// ---------------------------------------------------------------------------
+// mockAuthoringService
+// ---------------------------------------------------------------------------
+
+type mockAuthoringService struct {
+	specgraphv1connect.AuthoringServiceClient // panics on unimplemented methods
+	spark              func(req *specv1.SparkRequest) (*specv1.SparkResponse, error)
+	approve            func(slug string) (*specv1.ApproveResponse, error)
+	amend              func(req *specv1.AmendRequest) (*specv1.AmendResponse, error)
+	supersede          func(req *specv1.SupersedeRequest) (*specv1.SupersedeResponse, error)
+	recordConversation func(req *specv1.RecordConversationRequest) (*specv1.RecordConversationResponse, error)
+	listConversations  func(req *specv1.ListConversationsRequest) (*specv1.ListConversationsResponse, error)
+}
+
+func (m *mockAuthoringService) Spark(_ context.Context, req *connect.Request[specv1.SparkRequest]) (*connect.Response[specv1.SparkResponse], error) {
+	if m.spark == nil {
+		panic("mockAuthoringService.Spark not configured")
+	}
+	resp, err := m.spark(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockAuthoringService) Approve(_ context.Context, req *connect.Request[specv1.ApproveRequest]) (*connect.Response[specv1.ApproveResponse], error) {
+	if m.approve == nil {
+		panic("mockAuthoringService.Approve not configured")
+	}
+	resp, err := m.approve(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockAuthoringService) Amend(_ context.Context, req *connect.Request[specv1.AmendRequest]) (*connect.Response[specv1.AmendResponse], error) {
+	if m.amend == nil {
+		panic("mockAuthoringService.Amend not configured")
+	}
+	resp, err := m.amend(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockAuthoringService) Supersede(_ context.Context, req *connect.Request[specv1.SupersedeRequest]) (*connect.Response[specv1.SupersedeResponse], error) {
+	if m.supersede == nil {
+		panic("mockAuthoringService.Supersede not configured")
+	}
+	resp, err := m.supersede(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockAuthoringService) RecordConversation(_ context.Context, req *connect.Request[specv1.RecordConversationRequest]) (*connect.Response[specv1.RecordConversationResponse], error) {
+	if m.recordConversation == nil {
+		panic("mockAuthoringService.RecordConversation not configured")
+	}
+	resp, err := m.recordConversation(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockAuthoringService) ListConversations(_ context.Context, req *connect.Request[specv1.ListConversationsRequest]) (*connect.Response[specv1.ListConversationsResponse], error) {
+	if m.listConversations == nil {
+		panic("mockAuthoringService.ListConversations not configured")
+	}
+	resp, err := m.listConversations(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// ---------------------------------------------------------------------------
+// mockLifecycleService
+// ---------------------------------------------------------------------------
+
+type mockLifecycleService struct {
+	specgraphv1connect.LifecycleServiceClient // panics on unimplemented methods
+	checkDrift       func(req *specv1.DriftCheckRequest) (*specv1.DriftCheckResponse, error)
+	acknowledgeDrift func(req *specv1.DriftAcknowledgeRequest) (*specv1.DriftAcknowledgeResponse, error)
+	lint             func(req *specv1.LintRequest) (*specv1.LintResponse, error)
+}
+
+func (m *mockLifecycleService) CheckDrift(_ context.Context, req *connect.Request[specv1.DriftCheckRequest]) (*connect.Response[specv1.DriftCheckResponse], error) {
+	if m.checkDrift == nil {
+		panic("mockLifecycleService.CheckDrift not configured")
+	}
+	resp, err := m.checkDrift(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockLifecycleService) AcknowledgeDrift(_ context.Context, req *connect.Request[specv1.DriftAcknowledgeRequest]) (*connect.Response[specv1.DriftAcknowledgeResponse], error) {
+	if m.acknowledgeDrift == nil {
+		panic("mockLifecycleService.AcknowledgeDrift not configured")
+	}
+	resp, err := m.acknowledgeDrift(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockLifecycleService) Lint(_ context.Context, req *connect.Request[specv1.LintRequest]) (*connect.Response[specv1.LintResponse], error) {
+	if m.lint == nil {
+		panic("mockLifecycleService.Lint not configured")
+	}
+	resp, err := m.lint(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// ---------------------------------------------------------------------------
+// mockSyncService
+// ---------------------------------------------------------------------------
+
+type mockSyncService struct {
+	specgraphv1connect.SyncServiceClient // panics on unimplemented methods
+	syncBeads     func() (*specv1.SyncResponse, error)
+	getSyncStatus func() (*specv1.SyncStatusResponse, error)
+}
+
+func (m *mockSyncService) SyncBeads(_ context.Context, _ *connect.Request[specv1.SyncBeadsRequest]) (*connect.Response[specv1.SyncResponse], error) {
+	if m.syncBeads == nil {
+		panic("mockSyncService.SyncBeads not configured")
+	}
+	resp, err := m.syncBeads()
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSyncService) GetSyncStatus(_ context.Context, _ *connect.Request[specv1.SyncStatusRequest]) (*connect.Response[specv1.SyncStatusResponse], error) {
+	if m.getSyncStatus == nil {
+		panic("mockSyncService.GetSyncStatus not configured")
+	}
+	resp, err := m.getSyncStatus()
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// ---------------------------------------------------------------------------
+// mockExportService
+// ---------------------------------------------------------------------------
+
+type mockExportService struct {
+	specgraphv1connect.ExportServiceClient // panics on unimplemented methods
+	exportProject func(projectSlug string) (*specv1.ExportProjectResponse, error)
+	importProject func(req *specv1.ImportProjectRequest) (*specv1.ImportProjectResponse, error)
+	verifyExport  func(req *specv1.VerifyExportRequest) (*specv1.VerifyExportResponse, error)
+}
+
+func (m *mockExportService) ExportProject(_ context.Context, req *connect.Request[specv1.ExportProjectRequest]) (*connect.Response[specv1.ExportProjectResponse], error) {
+	if m.exportProject == nil {
+		panic("mockExportService.ExportProject not configured")
+	}
+	resp, err := m.exportProject(req.Msg.GetProjectSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockExportService) ImportProject(_ context.Context, req *connect.Request[specv1.ImportProjectRequest]) (*connect.Response[specv1.ImportProjectResponse], error) {
+	if m.importProject == nil {
+		panic("mockExportService.ImportProject not configured")
+	}
+	resp, err := m.importProject(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockExportService) VerifyExport(_ context.Context, req *connect.Request[specv1.VerifyExportRequest]) (*connect.Response[specv1.VerifyExportResponse], error) {
+	if m.verifyExport == nil {
+		panic("mockExportService.VerifyExport not configured")
+	}
+	resp, err := m.verifyExport(req.Msg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/testhelpers_test.go
+++ b/internal/mcp/testhelpers_test.go
@@ -1,0 +1,258 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+)
+
+// ---------------------------------------------------------------------------
+// mockSpecService
+// ---------------------------------------------------------------------------
+
+type mockSpecService struct {
+	specgraphv1connect.SpecServiceClient // panics on unimplemented methods
+	getSpec     func(slug string) (*specv1.GetSpecResponse, error)
+	listSpecs   func() (*specv1.ListSpecsResponse, error)
+	createSpec  func(slug, intent string) (*specv1.CreateSpecResponse, error)
+	updateSpec  func(req *specv1.UpdateSpecRequest) (*specv1.UpdateSpecResponse, error)
+	listChanges func(slug string) (*specv1.ListChangesResponse, error)
+	compareVer  func(req *specv1.CompareVersionsRequest) (*specv1.CompareVersionsResponse, error)
+}
+
+func (m *mockSpecService) GetSpec(_ context.Context, req *connect.Request[specv1.GetSpecRequest]) (*connect.Response[specv1.GetSpecResponse], error) {
+	resp, err := m.getSpec(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSpecService) ListSpecs(_ context.Context, _ *connect.Request[specv1.ListSpecsRequest]) (*connect.Response[specv1.ListSpecsResponse], error) {
+	resp, err := m.listSpecs()
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSpecService) CreateSpec(_ context.Context, req *connect.Request[specv1.CreateSpecRequest]) (*connect.Response[specv1.CreateSpecResponse], error) {
+	resp, err := m.createSpec(req.Msg.GetSlug(), req.Msg.GetIntent())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSpecService) UpdateSpec(_ context.Context, req *connect.Request[specv1.UpdateSpecRequest]) (*connect.Response[specv1.UpdateSpecResponse], error) {
+	resp, err := m.updateSpec(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSpecService) ListChanges(_ context.Context, req *connect.Request[specv1.ListChangesRequest]) (*connect.Response[specv1.ListChangesResponse], error) {
+	resp, err := m.listChanges(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSpecService) CompareVersions(_ context.Context, req *connect.Request[specv1.CompareVersionsRequest]) (*connect.Response[specv1.CompareVersionsResponse], error) {
+	resp, err := m.compareVer(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// ---------------------------------------------------------------------------
+// mockDecisionService
+// ---------------------------------------------------------------------------
+
+type mockDecisionService struct {
+	specgraphv1connect.DecisionServiceClient // panics on unimplemented methods
+	getDecision    func(slug string) (*specv1.GetDecisionResponse, error)
+	listDecisions  func() (*specv1.ListDecisionsResponse, error)
+	createDecision func(req *specv1.CreateDecisionRequest) (*specv1.CreateDecisionResponse, error)
+	updateDecision func(req *specv1.UpdateDecisionRequest) (*specv1.UpdateDecisionResponse, error)
+}
+
+func (m *mockDecisionService) GetDecision(_ context.Context, req *connect.Request[specv1.GetDecisionRequest]) (*connect.Response[specv1.GetDecisionResponse], error) {
+	resp, err := m.getDecision(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockDecisionService) ListDecisions(_ context.Context, _ *connect.Request[specv1.ListDecisionsRequest]) (*connect.Response[specv1.ListDecisionsResponse], error) {
+	resp, err := m.listDecisions()
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockDecisionService) CreateDecision(_ context.Context, req *connect.Request[specv1.CreateDecisionRequest]) (*connect.Response[specv1.CreateDecisionResponse], error) {
+	resp, err := m.createDecision(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockDecisionService) UpdateDecision(_ context.Context, req *connect.Request[specv1.UpdateDecisionRequest]) (*connect.Response[specv1.UpdateDecisionResponse], error) {
+	resp, err := m.updateDecision(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// ---------------------------------------------------------------------------
+// mockGraphService
+// ---------------------------------------------------------------------------
+
+type mockGraphService struct {
+	specgraphv1connect.GraphServiceClient // panics on unimplemented methods
+	addEdge         func(req *specv1.AddEdgeRequest) (*specv1.AddEdgeResponse, error)
+	removeEdge      func(req *specv1.RemoveEdgeRequest) (*specv1.RemoveEdgeResponse, error)
+	listEdges       func(slug string) (*specv1.ListEdgesResponse, error)
+	getDeps         func(slug string) (*specv1.GetDependenciesResponse, error)
+	getTransDeps    func(slug string) (*specv1.GetTransitiveDepsResponse, error)
+	getImpact       func(slug string) (*specv1.GetImpactResponse, error)
+	getReady        func() (*specv1.GetReadyResponse, error)
+	getCriticalPath func(slug string) (*specv1.GetCriticalPathResponse, error)
+	getFullGraph    func() (*specv1.GetFullGraphResponse, error)
+}
+
+func (m *mockGraphService) AddEdge(_ context.Context, req *connect.Request[specv1.AddEdgeRequest]) (*connect.Response[specv1.AddEdgeResponse], error) {
+	resp, err := m.addEdge(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockGraphService) RemoveEdge(_ context.Context, req *connect.Request[specv1.RemoveEdgeRequest]) (*connect.Response[specv1.RemoveEdgeResponse], error) {
+	resp, err := m.removeEdge(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockGraphService) ListEdges(_ context.Context, req *connect.Request[specv1.ListEdgesRequest]) (*connect.Response[specv1.ListEdgesResponse], error) {
+	resp, err := m.listEdges(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockGraphService) GetDependencies(_ context.Context, req *connect.Request[specv1.GetDependenciesRequest]) (*connect.Response[specv1.GetDependenciesResponse], error) {
+	resp, err := m.getDeps(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockGraphService) GetTransitiveDeps(_ context.Context, req *connect.Request[specv1.GetTransitiveDepsRequest]) (*connect.Response[specv1.GetTransitiveDepsResponse], error) {
+	resp, err := m.getTransDeps(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockGraphService) GetImpact(_ context.Context, req *connect.Request[specv1.GetImpactRequest]) (*connect.Response[specv1.GetImpactResponse], error) {
+	resp, err := m.getImpact(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockGraphService) GetReady(_ context.Context, _ *connect.Request[specv1.GetReadyRequest]) (*connect.Response[specv1.GetReadyResponse], error) {
+	resp, err := m.getReady()
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockGraphService) GetCriticalPath(_ context.Context, req *connect.Request[specv1.GetCriticalPathRequest]) (*connect.Response[specv1.GetCriticalPathResponse], error) {
+	resp, err := m.getCriticalPath(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockGraphService) GetFullGraph(_ context.Context, _ *connect.Request[specv1.GetFullGraphRequest]) (*connect.Response[specv1.GetFullGraphResponse], error) {
+	resp, err := m.getFullGraph()
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// ---------------------------------------------------------------------------
+// mockHealthService
+// ---------------------------------------------------------------------------
+
+type mockHealthService struct {
+	specgraphv1connect.ServerServiceClient // panics on unimplemented methods
+	health func() (*specv1.HealthResponse, error)
+}
+
+func (m *mockHealthService) Health(_ context.Context, _ *connect.Request[specv1.HealthRequest]) (*connect.Response[specv1.HealthResponse], error) {
+	resp, err := m.health()
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// ---------------------------------------------------------------------------
+// mockConstitutionService
+// ---------------------------------------------------------------------------
+
+type mockConstitutionService struct {
+	specgraphv1connect.ConstitutionServiceClient // panics on unimplemented methods
+	getConstitution func() (*specv1.GetConstitutionResponse, error)
+}
+
+func (m *mockConstitutionService) GetConstitution(_ context.Context, _ *connect.Request[specv1.GetConstitutionRequest]) (*connect.Response[specv1.GetConstitutionResponse], error) {
+	resp, err := m.getConstitution()
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// ---------------------------------------------------------------------------
+// mockAnalyticalPassService
+// ---------------------------------------------------------------------------
+
+type mockAnalyticalPassService struct {
+	specgraphv1connect.AnalyticalPassServiceClient // panics on unimplemented methods
+	listFindings func(slug string) (*specv1.ListFindingsResponse, error)
+}
+
+func (m *mockAnalyticalPassService) ListFindings(_ context.Context, req *connect.Request[specv1.ListFindingsRequest]) (*connect.Response[specv1.ListFindingsResponse], error) {
+	resp, err := m.listFindings(req.Msg.GetSlug())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}

--- a/internal/mcp/testhelpers_test.go
+++ b/internal/mcp/testhelpers_test.go
@@ -229,11 +229,20 @@ func (m *mockHealthService) Health(_ context.Context, _ *connect.Request[specv1.
 
 type mockConstitutionService struct {
 	specgraphv1connect.ConstitutionServiceClient // panics on unimplemented methods
-	getConstitution func() (*specv1.GetConstitutionResponse, error)
+	getConstitution    func() (*specv1.GetConstitutionResponse, error)
+	updateConstitution func(req *specv1.UpdateConstitutionRequest) (*specv1.UpdateConstitutionResponse, error)
 }
 
 func (m *mockConstitutionService) GetConstitution(_ context.Context, _ *connect.Request[specv1.GetConstitutionRequest]) (*connect.Response[specv1.GetConstitutionResponse], error) {
 	resp, err := m.getConstitution()
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockConstitutionService) UpdateConstitution(_ context.Context, req *connect.Request[specv1.UpdateConstitutionRequest]) (*connect.Response[specv1.UpdateConstitutionResponse], error) {
+	resp, err := m.updateConstitution(req.Msg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/testhelpers_test.go
+++ b/internal/mcp/testhelpers_test.go
@@ -297,6 +297,9 @@ func (m *mockAnalyticalPassService) StoreFindings(_ context.Context, req *connec
 type mockAuthoringService struct {
 	specgraphv1connect.AuthoringServiceClient // panics on unimplemented methods
 	spark              func(req *specv1.SparkRequest) (*specv1.SparkResponse, error)
+	shape              func(req *specv1.ShapeRequest) (*specv1.ShapeResponse, error)
+	specify            func(req *specv1.SpecifyRequest) (*specv1.SpecifyResponse, error)
+	decompose          func(req *specv1.DecomposeRequest) (*specv1.DecomposeResponse, error)
 	approve            func(slug string) (*specv1.ApproveResponse, error)
 	amend              func(req *specv1.AmendRequest) (*specv1.AmendResponse, error)
 	supersede          func(req *specv1.SupersedeRequest) (*specv1.SupersedeResponse, error)
@@ -310,6 +313,39 @@ func (m *mockAuthoringService) Spark(_ context.Context, req *connect.Request[spe
 		panic("mockAuthoringService.Spark not configured")
 	}
 	resp, err := m.spark(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockAuthoringService) Shape(_ context.Context, req *connect.Request[specv1.ShapeRequest]) (*connect.Response[specv1.ShapeResponse], error) {
+	if m.shape == nil {
+		panic("mockAuthoringService.Shape not configured")
+	}
+	resp, err := m.shape(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockAuthoringService) Specify(_ context.Context, req *connect.Request[specv1.SpecifyRequest]) (*connect.Response[specv1.SpecifyResponse], error) {
+	if m.specify == nil {
+		panic("mockAuthoringService.Specify not configured")
+	}
+	resp, err := m.specify(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockAuthoringService) Decompose(_ context.Context, req *connect.Request[specv1.DecomposeRequest]) (*connect.Response[specv1.DecomposeResponse], error) {
+	if m.decompose == nil {
+		panic("mockAuthoringService.Decompose not configured")
+	}
+	resp, err := m.decompose(req.Msg)
 	if err != nil {
 		return nil, err
 	}
@@ -433,6 +469,7 @@ func (m *mockLifecycleService) Lint(_ context.Context, req *connect.Request[spec
 type mockSyncService struct {
 	specgraphv1connect.SyncServiceClient // panics on unimplemented methods
 	syncBeads     func() (*specv1.SyncResponse, error)
+	syncGitHub    func() (*specv1.SyncResponse, error)
 	getSyncStatus func() (*specv1.SyncStatusResponse, error)
 }
 
@@ -441,6 +478,17 @@ func (m *mockSyncService) SyncBeads(_ context.Context, _ *connect.Request[specv1
 		panic("mockSyncService.SyncBeads not configured")
 	}
 	resp, err := m.syncBeads()
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSyncService) SyncGitHub(_ context.Context, _ *connect.Request[specv1.SyncGitHubRequest]) (*connect.Response[specv1.SyncResponse], error) {
+	if m.syncGitHub == nil {
+		panic("mockSyncService.SyncGitHub not configured")
+	}
+	resp, err := m.syncGitHub()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/testhelpers_test.go
+++ b/internal/mcp/testhelpers_test.go
@@ -489,3 +489,183 @@ func (m *mockExportService) VerifyExport(_ context.Context, req *connect.Request
 	}
 	return connect.NewResponse(resp), nil
 }
+
+// ---------------------------------------------------------------------------
+// mockClaimService
+// ---------------------------------------------------------------------------
+
+type mockClaimService struct {
+	specgraphv1connect.ClaimServiceClient // panics on unimplemented methods
+	claimSpec   func(req *specv1.ClaimSpecRequest) (*specv1.ClaimSpecResponse, error)
+	unclaimSpec func(req *specv1.UnclaimSpecRequest) (*specv1.UnclaimSpecResponse, error)
+	heartbeat   func(req *specv1.HeartbeatRequest) (*specv1.HeartbeatResponse, error)
+}
+
+func (m *mockClaimService) ClaimSpec(_ context.Context, req *connect.Request[specv1.ClaimSpecRequest]) (*connect.Response[specv1.ClaimSpecResponse], error) {
+	if m.claimSpec == nil {
+		panic("mockClaimService.ClaimSpec not configured")
+	}
+	resp, err := m.claimSpec(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockClaimService) UnclaimSpec(_ context.Context, req *connect.Request[specv1.UnclaimSpecRequest]) (*connect.Response[specv1.UnclaimSpecResponse], error) {
+	if m.unclaimSpec == nil {
+		panic("mockClaimService.UnclaimSpec not configured")
+	}
+	resp, err := m.unclaimSpec(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockClaimService) Heartbeat(_ context.Context, req *connect.Request[specv1.HeartbeatRequest]) (*connect.Response[specv1.HeartbeatResponse], error) {
+	if m.heartbeat == nil {
+		panic("mockClaimService.Heartbeat not configured")
+	}
+	resp, err := m.heartbeat(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// ---------------------------------------------------------------------------
+// mockSliceService
+// ---------------------------------------------------------------------------
+
+type mockSliceService struct {
+	specgraphv1connect.SliceServiceClient // panics on unimplemented methods
+	listSlices    func(req *specv1.ListSlicesRequest) (*specv1.ListSlicesResponse, error)
+	getSlice      func(req *specv1.GetSliceRequest) (*specv1.GetSliceResponse, error)
+	claimSlice    func(req *specv1.ClaimSliceRequest) (*specv1.ClaimSliceResponse, error)
+	completeSlice func(req *specv1.CompleteSliceRequest) (*specv1.CompleteSliceResponse, error)
+}
+
+func (m *mockSliceService) ListSlices(_ context.Context, req *connect.Request[specv1.ListSlicesRequest]) (*connect.Response[specv1.ListSlicesResponse], error) {
+	if m.listSlices == nil {
+		panic("mockSliceService.ListSlices not configured")
+	}
+	resp, err := m.listSlices(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSliceService) GetSlice(_ context.Context, req *connect.Request[specv1.GetSliceRequest]) (*connect.Response[specv1.GetSliceResponse], error) {
+	if m.getSlice == nil {
+		panic("mockSliceService.GetSlice not configured")
+	}
+	resp, err := m.getSlice(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSliceService) ClaimSlice(_ context.Context, req *connect.Request[specv1.ClaimSliceRequest]) (*connect.Response[specv1.ClaimSliceResponse], error) {
+	if m.claimSlice == nil {
+		panic("mockSliceService.ClaimSlice not configured")
+	}
+	resp, err := m.claimSlice(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockSliceService) CompleteSlice(_ context.Context, req *connect.Request[specv1.CompleteSliceRequest]) (*connect.Response[specv1.CompleteSliceResponse], error) {
+	if m.completeSlice == nil {
+		panic("mockSliceService.CompleteSlice not configured")
+	}
+	resp, err := m.completeSlice(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+// ---------------------------------------------------------------------------
+// mockExecutionService
+// ---------------------------------------------------------------------------
+
+type mockExecutionService struct {
+	specgraphv1connect.ExecutionServiceClient // panics on unimplemented methods
+	generateBundle   func(req *specv1.GenerateBundleRequest) (*specv1.GenerateBundleResponse, error)
+	getPrime         func(req *specv1.GetPrimeRequest) (*specv1.PrimeResponse, error)
+	reportProgress   func(req *specv1.ReportProgressRequest) (*specv1.ReportProgressResponse, error)
+	reportBlocker    func(req *specv1.ReportBlockerRequest) (*specv1.ReportBlockerResponse, error)
+	reportCompletion func(req *specv1.ReportCompletionRequest) (*specv1.ReportCompletionResponse, error)
+	getEvents        func(req *specv1.GetExecutionEventsRequest) (*specv1.GetExecutionEventsResponse, error)
+}
+
+func (m *mockExecutionService) GenerateBundle(_ context.Context, req *connect.Request[specv1.GenerateBundleRequest]) (*connect.Response[specv1.GenerateBundleResponse], error) {
+	if m.generateBundle == nil {
+		panic("mockExecutionService.GenerateBundle not configured")
+	}
+	resp, err := m.generateBundle(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockExecutionService) GetPrime(_ context.Context, req *connect.Request[specv1.GetPrimeRequest]) (*connect.Response[specv1.PrimeResponse], error) {
+	if m.getPrime == nil {
+		panic("mockExecutionService.GetPrime not configured")
+	}
+	resp, err := m.getPrime(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockExecutionService) ReportProgress(_ context.Context, req *connect.Request[specv1.ReportProgressRequest]) (*connect.Response[specv1.ReportProgressResponse], error) {
+	if m.reportProgress == nil {
+		panic("mockExecutionService.ReportProgress not configured")
+	}
+	resp, err := m.reportProgress(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockExecutionService) ReportBlocker(_ context.Context, req *connect.Request[specv1.ReportBlockerRequest]) (*connect.Response[specv1.ReportBlockerResponse], error) {
+	if m.reportBlocker == nil {
+		panic("mockExecutionService.ReportBlocker not configured")
+	}
+	resp, err := m.reportBlocker(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockExecutionService) ReportCompletion(_ context.Context, req *connect.Request[specv1.ReportCompletionRequest]) (*connect.Response[specv1.ReportCompletionResponse], error) {
+	if m.reportCompletion == nil {
+		panic("mockExecutionService.ReportCompletion not configured")
+	}
+	resp, err := m.reportCompletion(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (m *mockExecutionService) GetExecutionEvents(_ context.Context, req *connect.Request[specv1.GetExecutionEventsRequest]) (*connect.Response[specv1.GetExecutionEventsResponse], error) {
+	if m.getEvents == nil {
+		panic("mockExecutionService.GetExecutionEvents not configured")
+	}
+	resp, err := m.getEvents(req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}

--- a/internal/mcp/tiers.go
+++ b/internal/mcp/tiers.go
@@ -11,7 +11,10 @@ import (
 // on its reported Implementation name. Execution engines (polecat, gastown)
 // get full access; authoring IDEs get authoring + core; everything else gets
 // core only.
-func TierFromClientInfo(info sdkmcp.Implementation) Tier {
+func TierFromClientInfo(info *sdkmcp.Implementation) Tier {
+	if info == nil {
+		return TierCore
+	}
 	switch info.Name {
 	case "polecat", "gastown":
 		return TierExecution

--- a/internal/mcp/tiers.go
+++ b/internal/mcp/tiers.go
@@ -1,0 +1,23 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	sdkmcp "github.com/mark3labs/mcp-go/mcp"
+)
+
+// TierFromClientInfo determines the appropriate tier for an MCP client based
+// on its reported Implementation name. Execution engines (polecat, gastown)
+// get full access; authoring IDEs get authoring + core; everything else gets
+// core only.
+func TierFromClientInfo(info sdkmcp.Implementation) Tier {
+	switch info.Name {
+	case "polecat", "gastown":
+		return TierExecution
+	case "claude-code", "cursor", "windsurf":
+		return TierAuthoring
+	default:
+		return TierCore
+	}
+}

--- a/internal/mcp/tiers_test.go
+++ b/internal/mcp/tiers_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"testing"
+
+	sdkmcp "github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestTierFromClientInfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		client   string
+		wantTier Tier
+	}{
+		{"polecat gets execution", "polecat", TierExecution},
+		{"gastown gets execution", "gastown", TierExecution},
+		{"claude-code gets authoring", "claude-code", TierAuthoring},
+		{"cursor gets authoring", "cursor", TierAuthoring},
+		{"windsurf gets authoring", "windsurf", TierAuthoring},
+		{"unknown gets core", "some-other-client", TierCore},
+		{"empty gets core", "", TierCore},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := sdkmcp.Implementation{
+				Name:    tt.client,
+				Version: "1.0.0",
+			}
+			got := TierFromClientInfo(info)
+			if got != tt.wantTier {
+				t.Errorf("TierFromClientInfo(%q) = %v, want %v", tt.client, got, tt.wantTier)
+			}
+		})
+	}
+}

--- a/internal/mcp/tiers_test.go
+++ b/internal/mcp/tiers_test.go
@@ -9,6 +9,13 @@ import (
 	sdkmcp "github.com/mark3labs/mcp-go/mcp"
 )
 
+func TestTierFromClientInfo_Nil(t *testing.T) {
+	got := TierFromClientInfo(nil)
+	if got != TierCore {
+		t.Errorf("TierFromClientInfo(nil) = %v, want %v", got, TierCore)
+	}
+}
+
 func TestTierFromClientInfo(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -30,7 +37,7 @@ func TestTierFromClientInfo(t *testing.T) {
 				Name:    tt.client,
 				Version: "1.0.0",
 			}
-			got := TierFromClientInfo(info)
+			got := TierFromClientInfo(&info)
 			if got != tt.wantTier {
 				t.Errorf("TierFromClientInfo(%q) = %v, want %v", tt.client, got, tt.wantTier)
 			}

--- a/internal/mcp/tools_authoring.go
+++ b/internal/mcp/tools_authoring.go
@@ -25,6 +25,20 @@ func RegisterAuthoringTools(r *Registry, c *Client) {
 	r.AddTool(apt.def())
 }
 
+// validateOptionalPosture checks that a non-empty posture string maps to a known enum.
+// Returns the parsed posture and nil, or zero and an errResult if invalid.
+func validateOptionalPosture(params map[string]any) (specv1.Posture, *ToolResult) {
+	s := stringParam(params, "posture")
+	if s == "" {
+		return specv1.Posture_POSTURE_UNSPECIFIED, nil
+	}
+	p := postureFromString(s)
+	if p == specv1.Posture_POSTURE_UNSPECIFIED {
+		return 0, errResult("invalid posture (valid: drive, partner, support)")
+	}
+	return p, nil
+}
+
 // postureFromString converts a friendly string (e.g. "drive") to a Posture enum.
 func postureFromString(s string) specv1.Posture {
 	key := "POSTURE_" + strings.ToUpper(s)
@@ -68,7 +82,7 @@ func (t *authorTool) def() ToolDef {
 				"target_stage": stringProp("Target stage for amend: spark, shape, specify, decompose"),
 				"superseded_by": stringProp("Slug of the replacement spec (required for supersede)"),
 			},
-			"action",
+			"action", "slug",
 		),
 		Handler: t.handle,
 	}
@@ -109,10 +123,14 @@ func (t *authorTool) handleSpark(ctx context.Context, params map[string]any) (*T
 	if err := protojson.Unmarshal([]byte(raw), &out); err != nil {
 		return errResult(fmt.Sprintf("invalid spark output JSON: %v", err)), nil
 	}
+	posture, posErr := validateOptionalPosture(params)
+	if posErr != nil {
+		return posErr, nil
+	}
 	resp, err := t.client.Authoring.Spark(ctx, connect.NewRequest(&specv1.SparkRequest{
 		Slug:    slug,
 		Output:  &out,
-		Posture: postureFromString(stringParam(params, "posture")),
+		Posture: posture,
 	}))
 	if err != nil {
 		return connectErrResult(err)
@@ -133,10 +151,14 @@ func (t *authorTool) handleShape(ctx context.Context, params map[string]any) (*T
 	if err := protojson.Unmarshal([]byte(raw), &out); err != nil {
 		return errResult(fmt.Sprintf("invalid shape output JSON: %v", err)), nil
 	}
+	posture, posErr := validateOptionalPosture(params)
+	if posErr != nil {
+		return posErr, nil
+	}
 	resp, err := t.client.Authoring.Shape(ctx, connect.NewRequest(&specv1.ShapeRequest{
 		Slug:    slug,
 		Output:  &out,
-		Posture: postureFromString(stringParam(params, "posture")),
+		Posture: posture,
 	}))
 	if err != nil {
 		return connectErrResult(err)
@@ -157,10 +179,14 @@ func (t *authorTool) handleSpecify(ctx context.Context, params map[string]any) (
 	if err := protojson.Unmarshal([]byte(raw), &out); err != nil {
 		return errResult(fmt.Sprintf("invalid specify output JSON: %v", err)), nil
 	}
+	posture, posErr := validateOptionalPosture(params)
+	if posErr != nil {
+		return posErr, nil
+	}
 	resp, err := t.client.Authoring.Specify(ctx, connect.NewRequest(&specv1.SpecifyRequest{
 		Slug:    slug,
 		Output:  &out,
-		Posture: postureFromString(stringParam(params, "posture")),
+		Posture: posture,
 	}))
 	if err != nil {
 		return connectErrResult(err)
@@ -181,10 +207,14 @@ func (t *authorTool) handleDecompose(ctx context.Context, params map[string]any)
 	if err := protojson.Unmarshal([]byte(raw), &out); err != nil {
 		return errResult(fmt.Sprintf("invalid decompose output JSON: %v", err)), nil
 	}
+	posture, posErr := validateOptionalPosture(params)
+	if posErr != nil {
+		return posErr, nil
+	}
 	resp, err := t.client.Authoring.Decompose(ctx, connect.NewRequest(&specv1.DecomposeRequest{
 		Slug:    slug,
 		Output:  &out,
-		Posture: postureFromString(stringParam(params, "posture")),
+		Posture: posture,
 	}))
 	if err != nil {
 		return connectErrResult(err)
@@ -211,10 +241,18 @@ func (t *authorTool) handleAmend(ctx context.Context, params map[string]any) (*T
 	if slug == "" {
 		return errResult("slug is required for amend"), nil
 	}
+	targetStageStr := stringParam(params, "target_stage")
+	targetStage := specv1.AuthoringStage_AUTHORING_STAGE_UNSPECIFIED
+	if targetStageStr != "" {
+		targetStage = authoringStageFromString(targetStageStr)
+		if targetStage == specv1.AuthoringStage_AUTHORING_STAGE_UNSPECIFIED {
+			return errResult("invalid target_stage (valid: spark, shape, specify, decompose, approved)"), nil
+		}
+	}
 	resp, err := t.client.Authoring.Amend(ctx, connect.NewRequest(&specv1.AmendRequest{
 		Slug:        slug,
 		Reason:      stringParam(params, "reason"),
-		TargetStage: authoringStageFromString(stringParam(params, "target_stage")),
+		TargetStage: targetStage,
 	}))
 	if err != nil {
 		return connectErrResult(err)
@@ -264,7 +302,7 @@ func (t *conversationTool) def() ToolDef {
 				"exchanges": stringProp("JSON array of ConversationExchange objects (required for record)"),
 				"is_amend":  boolProp("Whether this conversation is part of an amendment"),
 			},
-			"action",
+			"action", "slug",
 		),
 		Handler: t.handle,
 	}
@@ -295,15 +333,18 @@ func (t *conversationTool) handleRecord(ctx context.Context, params map[string]a
 	if exchangesRaw == "" {
 		return errResult("exchanges is required for record (JSON array of ConversationExchange)"), nil
 	}
-	// Wrap the array in a RecordConversationRequest wrapper and unmarshal via protojson.
-	// We use a temporary wrapper JSON to decode the exchanges array.
-	wrappedJSON := fmt.Sprintf(`{"slug":%q,"stage":%q,"exchanges":%s}`, slug, stage, exchangesRaw)
-	var req specv1.RecordConversationRequest
-	if err := protojson.Unmarshal([]byte(wrappedJSON), &req); err != nil {
+	// Parse exchanges array in isolation to prevent JSON injection.
+	var exchanges specv1.RecordConversationRequest
+	if err := protojson.Unmarshal([]byte(`{"exchanges":`+exchangesRaw+`}`), &exchanges); err != nil {
 		return errResult(fmt.Sprintf("invalid exchanges JSON: %v", err)), nil
 	}
-	req.IsAmend = boolParam(params, "is_amend")
-	resp, err := t.client.Authoring.RecordConversation(ctx, connect.NewRequest(&req))
+	req := &specv1.RecordConversationRequest{
+		Slug:      slug,
+		Stage:     stage,
+		Exchanges: exchanges.Exchanges,
+		IsAmend:   boolParam(params, "is_amend"),
+	}
+	resp, err := t.client.Authoring.RecordConversation(ctx, connect.NewRequest(req))
 	if err != nil {
 		return connectErrResult(err)
 	}
@@ -349,7 +390,7 @@ func (t *analyticalPassTool) def() ToolDef {
 				),
 				"findings": stringProp("JSON array of AnalyticalFindingInput objects (required for store)"),
 			},
-			"action",
+			"action", "slug",
 		),
 		Handler: t.handle,
 	}
@@ -372,7 +413,14 @@ func (t *analyticalPassTool) handleRun(ctx context.Context, params map[string]an
 	if slug == "" {
 		return errResult("slug is required for run"), nil
 	}
-	passType := passTypeFromString(stringParam(params, "pass_type"))
+	passTypeStr := stringParam(params, "pass_type")
+	if passTypeStr == "" {
+		return errResult("pass_type is required for run"), nil
+	}
+	passType := passTypeFromString(passTypeStr)
+	if passType == specv1.PassType_PASS_TYPE_UNSPECIFIED {
+		return errResult("invalid pass_type for run"), nil
+	}
 	resp, err := t.client.AnalyticalPass.RunAnalyticalPass(ctx, connect.NewRequest(&specv1.RunAnalyticalPassRequest{
 		Slug:     slug,
 		PassType: passType,
@@ -392,14 +440,25 @@ func (t *analyticalPassTool) handleStore(ctx context.Context, params map[string]
 	if findingsRaw == "" {
 		return errResult("findings is required for store (JSON array of AnalyticalFindingInput)"), nil
 	}
-	// Use protojson to unmarshal the findings array via a wrapper.
-	wrappedJSON := fmt.Sprintf(`{"slug":%q,"findings":%s}`, slug, findingsRaw)
-	var req specv1.StoreFindingsRequest
-	if err := protojson.Unmarshal([]byte(wrappedJSON), &req); err != nil {
+	// Parse findings array in isolation to prevent JSON injection.
+	var findings specv1.StoreFindingsRequest
+	if err := protojson.Unmarshal([]byte(`{"findings":`+findingsRaw+`}`), &findings); err != nil {
 		return errResult(fmt.Sprintf("invalid findings JSON: %v", err)), nil
 	}
-	req.PassType = passTypeFromString(stringParam(params, "pass_type"))
-	resp, err := t.client.AnalyticalPass.StoreFindings(ctx, connect.NewRequest(&req))
+	passTypeStr := stringParam(params, "pass_type")
+	if passTypeStr == "" {
+		return errResult("pass_type is required for store"), nil
+	}
+	passType := passTypeFromString(passTypeStr)
+	if passType == specv1.PassType_PASS_TYPE_UNSPECIFIED {
+		return errResult("invalid pass_type for store"), nil
+	}
+	req := &specv1.StoreFindingsRequest{
+		Slug:     slug,
+		PassType: passType,
+		Findings: findings.Findings,
+	}
+	resp, err := t.client.AnalyticalPass.StoreFindings(ctx, connect.NewRequest(req))
 	if err != nil {
 		return connectErrResult(err)
 	}

--- a/internal/mcp/tools_authoring.go
+++ b/internal/mcp/tools_authoring.go
@@ -1,0 +1,407 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// RegisterAuthoringTools registers authoring funnel, conversation, and analytical pass tools.
+func RegisterAuthoringTools(r *Registry, c *Client) {
+	at := &authorTool{client: c}
+	r.AddTool(at.def())
+
+	ct := &conversationTool{client: c}
+	r.AddTool(ct.def())
+
+	apt := &analyticalPassTool{client: c}
+	r.AddTool(apt.def())
+}
+
+// postureFromString converts a friendly string (e.g. "drive") to a Posture enum.
+func postureFromString(s string) specv1.Posture {
+	key := "POSTURE_" + strings.ToUpper(s)
+	if v, ok := specv1.Posture_value[key]; ok {
+		return specv1.Posture(v)
+	}
+	return specv1.Posture_POSTURE_UNSPECIFIED
+}
+
+// authoringStageFromString converts a friendly string (e.g. "spark") to an AuthoringStage enum.
+func authoringStageFromString(s string) specv1.AuthoringStage {
+	key := "AUTHORING_STAGE_" + strings.ToUpper(s)
+	if v, ok := specv1.AuthoringStage_value[key]; ok {
+		return specv1.AuthoringStage(v)
+	}
+	return specv1.AuthoringStage_AUTHORING_STAGE_UNSPECIFIED
+}
+
+// ---------------------------------------------------------------------------
+// authorTool — authoring funnel: spark, shape, specify, decompose, approve, amend, supersede
+// ---------------------------------------------------------------------------
+
+type authorTool struct {
+	client *Client
+}
+
+func (t *authorTool) def() ToolDef {
+	return ToolDef{
+		Name: "author",
+		Description: "Drive the SpecGraph authoring funnel for a spec. " +
+			"Actions: spark, shape, specify, decompose, approve, amend, supersede.",
+		Tier: TierAuthoring,
+		Schema: objectSchema(
+			props{
+				"action": stringProp("Operation to perform",
+					"spark", "shape", "specify", "decompose", "approve", "amend", "supersede"),
+				"slug":         stringProp("Spec slug (required for all actions)"),
+				"output":       stringProp("Stage output as a JSON string (required for spark/shape/specify/decompose)"),
+				"posture":      stringProp("AI collaboration posture: drive, partner, support"),
+				"reason":       stringProp("Reason for amend or supersede"),
+				"target_stage": stringProp("Target stage for amend: spark, shape, specify, decompose"),
+				"superseded_by": stringProp("Slug of the replacement spec (required for supersede)"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *authorTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "spark":
+		return t.handleSpark(ctx, params)
+	case "shape":
+		return t.handleShape(ctx, params)
+	case "specify":
+		return t.handleSpecify(ctx, params)
+	case "decompose":
+		return t.handleDecompose(ctx, params)
+	case "approve":
+		return t.handleApprove(ctx, params)
+	case "amend":
+		return t.handleAmend(ctx, params)
+	case "supersede":
+		return t.handleSupersede(ctx, params)
+	default:
+		return errResult(fmt.Sprintf("unknown action %q — valid: spark, shape, specify, decompose, approve, amend, supersede", action)), nil
+	}
+}
+
+func (t *authorTool) handleSpark(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for spark"), nil
+	}
+	raw := stringParam(params, "output")
+	if raw == "" {
+		return errResult("output is required for spark (JSON-encoded SparkOutput)"), nil
+	}
+	var out specv1.SparkOutput
+	if err := protojson.Unmarshal([]byte(raw), &out); err != nil {
+		return errResult(fmt.Sprintf("invalid spark output JSON: %v", err)), nil
+	}
+	resp, err := t.client.Authoring.Spark(ctx, connect.NewRequest(&specv1.SparkRequest{
+		Slug:    slug,
+		Output:  &out,
+		Posture: postureFromString(stringParam(params, "posture")),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *authorTool) handleShape(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for shape"), nil
+	}
+	raw := stringParam(params, "output")
+	if raw == "" {
+		return errResult("output is required for shape (JSON-encoded ShapeOutput)"), nil
+	}
+	var out specv1.ShapeOutput
+	if err := protojson.Unmarshal([]byte(raw), &out); err != nil {
+		return errResult(fmt.Sprintf("invalid shape output JSON: %v", err)), nil
+	}
+	resp, err := t.client.Authoring.Shape(ctx, connect.NewRequest(&specv1.ShapeRequest{
+		Slug:    slug,
+		Output:  &out,
+		Posture: postureFromString(stringParam(params, "posture")),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *authorTool) handleSpecify(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for specify"), nil
+	}
+	raw := stringParam(params, "output")
+	if raw == "" {
+		return errResult("output is required for specify (JSON-encoded SpecifyOutput)"), nil
+	}
+	var out specv1.SpecifyOutput
+	if err := protojson.Unmarshal([]byte(raw), &out); err != nil {
+		return errResult(fmt.Sprintf("invalid specify output JSON: %v", err)), nil
+	}
+	resp, err := t.client.Authoring.Specify(ctx, connect.NewRequest(&specv1.SpecifyRequest{
+		Slug:    slug,
+		Output:  &out,
+		Posture: postureFromString(stringParam(params, "posture")),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *authorTool) handleDecompose(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for decompose"), nil
+	}
+	raw := stringParam(params, "output")
+	if raw == "" {
+		return errResult("output is required for decompose (JSON-encoded DecomposeOutput)"), nil
+	}
+	var out specv1.DecomposeOutput
+	if err := protojson.Unmarshal([]byte(raw), &out); err != nil {
+		return errResult(fmt.Sprintf("invalid decompose output JSON: %v", err)), nil
+	}
+	resp, err := t.client.Authoring.Decompose(ctx, connect.NewRequest(&specv1.DecomposeRequest{
+		Slug:    slug,
+		Output:  &out,
+		Posture: postureFromString(stringParam(params, "posture")),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *authorTool) handleApprove(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for approve"), nil
+	}
+	resp, err := t.client.Authoring.Approve(ctx, connect.NewRequest(&specv1.ApproveRequest{
+		Slug: slug,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *authorTool) handleAmend(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for amend"), nil
+	}
+	resp, err := t.client.Authoring.Amend(ctx, connect.NewRequest(&specv1.AmendRequest{
+		Slug:        slug,
+		Reason:      stringParam(params, "reason"),
+		TargetStage: authoringStageFromString(stringParam(params, "target_stage")),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *authorTool) handleSupersede(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for supersede"), nil
+	}
+	supersededBy := stringParam(params, "superseded_by")
+	if supersededBy == "" {
+		return errResult("superseded_by is required for supersede"), nil
+	}
+	resp, err := t.client.Authoring.Supersede(ctx, connect.NewRequest(&specv1.SupersedeRequest{
+		Slug:         slug,
+		SupersededBy: supersededBy,
+		Reason:       stringParam(params, "reason"),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// ---------------------------------------------------------------------------
+// conversationTool — record and list authoring conversation logs
+// ---------------------------------------------------------------------------
+
+type conversationTool struct {
+	client *Client
+}
+
+func (t *conversationTool) def() ToolDef {
+	return ToolDef{
+		Name: "conversation",
+		Description: "Record and list authoring conversation logs for a spec. " +
+			"Actions: record, list.",
+		Tier: TierAuthoring,
+		Schema: objectSchema(
+			props{
+				"action":    stringProp("Operation to perform", "record", "list"),
+				"slug":      stringProp("Spec slug (required)"),
+				"stage":     stringProp("Authoring stage (required for record; optional filter for list)"),
+				"exchanges": stringProp("JSON array of ConversationExchange objects (required for record)"),
+				"is_amend":  boolProp("Whether this conversation is part of an amendment"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *conversationTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "record":
+		return t.handleRecord(ctx, params)
+	case "list":
+		return t.handleList(ctx, params)
+	default:
+		return errResult(fmt.Sprintf("unknown action %q — valid: record, list", action)), nil
+	}
+}
+
+func (t *conversationTool) handleRecord(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for record"), nil
+	}
+	stage := stringParam(params, "stage")
+	if stage == "" {
+		return errResult("stage is required for record"), nil
+	}
+	exchangesRaw := stringParam(params, "exchanges")
+	if exchangesRaw == "" {
+		return errResult("exchanges is required for record (JSON array of ConversationExchange)"), nil
+	}
+	// Wrap the array in a RecordConversationRequest wrapper and unmarshal via protojson.
+	// We use a temporary wrapper JSON to decode the exchanges array.
+	wrappedJSON := fmt.Sprintf(`{"slug":%q,"stage":%q,"exchanges":%s}`, slug, stage, exchangesRaw)
+	var req specv1.RecordConversationRequest
+	if err := protojson.Unmarshal([]byte(wrappedJSON), &req); err != nil {
+		return errResult(fmt.Sprintf("invalid exchanges JSON: %v", err)), nil
+	}
+	req.IsAmend = boolParam(params, "is_amend")
+	resp, err := t.client.Authoring.RecordConversation(ctx, connect.NewRequest(&req))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *conversationTool) handleList(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for list"), nil
+	}
+	resp, err := t.client.Authoring.ListConversations(ctx, connect.NewRequest(&specv1.ListConversationsRequest{
+		Slug:  slug,
+		Stage: stringParam(params, "stage"),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// ---------------------------------------------------------------------------
+// analyticalPassTool — run analytical passes and store findings
+// ---------------------------------------------------------------------------
+
+type analyticalPassTool struct {
+	client *Client
+}
+
+func (t *analyticalPassTool) def() ToolDef {
+	return ToolDef{
+		Name: "analytical_pass",
+		Description: "Run analytical passes and store findings for a spec. " +
+			"Actions: run, store.",
+		Tier: TierAuthoring,
+		Schema: objectSchema(
+			props{
+				"action": stringProp("Operation to perform", "run", "store"),
+				"slug":   stringProp("Spec slug (required)"),
+				"pass_type": stringProp(
+					"Pass type: constitution-check, red-team, peripheral-vision, consistency, simplicity",
+					"constitution-check", "red-team", "peripheral-vision", "consistency", "simplicity",
+				),
+				"findings": stringProp("JSON array of AnalyticalFindingInput objects (required for store)"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *analyticalPassTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "run":
+		return t.handleRun(ctx, params)
+	case "store":
+		return t.handleStore(ctx, params)
+	default:
+		return errResult(fmt.Sprintf("unknown action %q — valid: run, store", action)), nil
+	}
+}
+
+func (t *analyticalPassTool) handleRun(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for run"), nil
+	}
+	passType := passTypeFromString(stringParam(params, "pass_type"))
+	resp, err := t.client.AnalyticalPass.RunAnalyticalPass(ctx, connect.NewRequest(&specv1.RunAnalyticalPassRequest{
+		Slug:     slug,
+		PassType: passType,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *analyticalPassTool) handleStore(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for store"), nil
+	}
+	findingsRaw := stringParam(params, "findings")
+	if findingsRaw == "" {
+		return errResult("findings is required for store (JSON array of AnalyticalFindingInput)"), nil
+	}
+	// Use protojson to unmarshal the findings array via a wrapper.
+	wrappedJSON := fmt.Sprintf(`{"slug":%q,"findings":%s}`, slug, findingsRaw)
+	var req specv1.StoreFindingsRequest
+	if err := protojson.Unmarshal([]byte(wrappedJSON), &req); err != nil {
+		return errResult(fmt.Sprintf("invalid findings JSON: %v", err)), nil
+	}
+	req.PassType = passTypeFromString(stringParam(params, "pass_type"))
+	resp, err := t.client.AnalyticalPass.StoreFindings(ctx, connect.NewRequest(&req))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}

--- a/internal/mcp/tools_authoring_test.go
+++ b/internal/mcp/tools_authoring_test.go
@@ -1,0 +1,450 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// authorTool tests
+// ---------------------------------------------------------------------------
+
+func TestAuthorTool_Spark(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		spark: func(req *specv1.SparkRequest) (*specv1.SparkResponse, error) {
+			require.Equal(t, "my-spec", req.GetSlug())
+			require.NotNil(t, req.GetOutput())
+			require.Equal(t, "initial idea", req.GetOutput().GetSeed())
+			return &specv1.SparkResponse{
+				Output: req.GetOutput(),
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "spark",
+		"slug":   "my-spec",
+		"output": `{"seed":"initial idea","signal":"customer pain"}`,
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "initial idea")
+}
+
+func TestAuthorTool_Spark_MissingSlug(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "spark",
+		"output": `{"seed":"idea"}`,
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestAuthorTool_Spark_MissingOutput(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "spark",
+		"slug":   "my-spec",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "output")
+}
+
+func TestAuthorTool_Spark_InvalidJSON(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "spark",
+		"slug":   "my-spec",
+		"output": `not valid json {{{`,
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "invalid spark output JSON")
+}
+
+func TestAuthorTool_Approve(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		approve: func(slug string) (*specv1.ApproveResponse, error) {
+			require.Equal(t, "my-spec", slug)
+			return &specv1.ApproveResponse{
+				Slug:  slug,
+				Stage: specv1.AuthoringStage_AUTHORING_STAGE_APPROVED,
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "approve",
+		"slug":   "my-spec",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "my-spec")
+}
+
+func TestAuthorTool_Approve_MissingSlug(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "approve",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestAuthorTool_Amend(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		amend: func(req *specv1.AmendRequest) (*specv1.AmendResponse, error) {
+			require.Equal(t, "my-spec", req.GetSlug())
+			require.Equal(t, "needs rework", req.GetReason())
+			require.Equal(t, specv1.AuthoringStage_AUTHORING_STAGE_SPARK, req.GetTargetStage())
+			return &specv1.AmendResponse{
+				Slug:    req.GetSlug(),
+				Stage:   specv1.AuthoringStage_AUTHORING_STAGE_SPARK,
+				Version: 2,
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":       "amend",
+		"slug":         "my-spec",
+		"reason":       "needs rework",
+		"target_stage": "spark",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "my-spec")
+}
+
+func TestAuthorTool_Supersede(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		supersede: func(req *specv1.SupersedeRequest) (*specv1.SupersedeResponse, error) {
+			require.Equal(t, "old-spec", req.GetSlug())
+			require.Equal(t, "new-spec", req.GetSupersededBy())
+			return &specv1.SupersedeResponse{
+				Slug:         req.GetSlug(),
+				SupersededBy: req.GetSupersededBy(),
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":        "supersede",
+		"slug":          "old-spec",
+		"superseded_by": "new-spec",
+		"reason":        "replaced",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "old-spec")
+}
+
+func TestAuthorTool_Supersede_MissingSupersededBy(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "supersede",
+		"slug":   "old-spec",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "superseded_by")
+}
+
+func TestAuthorTool_UnknownAction(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "delete",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "delete")
+}
+
+// ---------------------------------------------------------------------------
+// conversationTool tests
+// ---------------------------------------------------------------------------
+
+func TestConversationTool_List(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		listConversations: func(req *specv1.ListConversationsRequest) (*specv1.ListConversationsResponse, error) {
+			require.Equal(t, "my-spec", req.GetSlug())
+			require.Equal(t, "spark", req.GetStage())
+			return &specv1.ListConversationsResponse{
+				ConversationLogs: []*specv1.ConversationLog{
+					{Id: "log-1"},
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("conversation")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "list",
+		"slug":   "my-spec",
+		"stage":  "spark",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "log-1")
+}
+
+func TestConversationTool_List_MissingSlug(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("conversation")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "list",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestConversationTool_Record(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		recordConversation: func(req *specv1.RecordConversationRequest) (*specv1.RecordConversationResponse, error) {
+			require.Equal(t, "my-spec", req.GetSlug())
+			require.Equal(t, "spark", req.GetStage())
+			require.Len(t, req.GetExchanges(), 1)
+			return &specv1.RecordConversationResponse{
+				ConversationLog: &specv1.ConversationLog{Id: "log-1"},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("conversation")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "record",
+		"slug":      "my-spec",
+		"stage":     "spark",
+		"exchanges": `[{"role":"probe","content":"what is this?"}]`,
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "log-1")
+}
+
+func TestConversationTool_Record_InvalidJSON(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("conversation")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "record",
+		"slug":      "my-spec",
+		"stage":     "spark",
+		"exchanges": `not valid`,
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "invalid exchanges JSON")
+}
+
+func TestConversationTool_UnknownAction(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("conversation")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "delete",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "delete")
+}
+
+// ---------------------------------------------------------------------------
+// analyticalPassTool tests
+// ---------------------------------------------------------------------------
+
+func TestAnalyticalPassTool_Run(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{
+		runAnalyticalPass: func(req *specv1.RunAnalyticalPassRequest) (*specv1.RunAnalyticalPassResponse, error) {
+			require.Equal(t, "my-spec", req.GetSlug())
+			require.Equal(t, specv1.PassType_PASS_TYPE_CONSTITUTION_CHECK, req.GetPassType())
+			return &specv1.RunAnalyticalPassResponse{
+				PassType:       req.GetPassType(),
+				InitialMessage: "run the check",
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("analytical_pass")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "run",
+		"slug":      "my-spec",
+		"pass_type": "constitution-check",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "run the check")
+}
+
+func TestAnalyticalPassTool_Run_MissingSlug(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("analytical_pass")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "run",
+		"pass_type": "constitution-check",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestAnalyticalPassTool_Store(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{
+		storeFindings: func(req *specv1.StoreFindingsRequest) (*specv1.StoreFindingsResponse, error) {
+			require.Equal(t, "my-spec", req.GetSlug())
+			require.Equal(t, specv1.PassType_PASS_TYPE_CONSTITUTION_CHECK, req.GetPassType())
+			require.Len(t, req.GetFindings(), 1)
+			return &specv1.StoreFindingsResponse{
+				Ids: []string{"finding-1"},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("analytical_pass")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "store",
+		"slug":      "my-spec",
+		"pass_type": "constitution-check",
+		"findings":  `[{"severity":"FINDING_SEVERITY_WARNING","summary":"missing constraint"}]`,
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "finding-1")
+}
+
+func TestAnalyticalPassTool_Store_InvalidJSON(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("analytical_pass")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "store",
+		"slug":      "my-spec",
+		"pass_type": "constitution-check",
+		"findings":  `not valid`,
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "invalid findings JSON")
+}
+
+func TestAnalyticalPassTool_UnknownAction(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("analytical_pass")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "delete",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "delete")
+}
+
+// ---------------------------------------------------------------------------
+// enum helper tests
+// ---------------------------------------------------------------------------
+
+func TestPostureFromString(t *testing.T) {
+	require.Equal(t, specv1.Posture_POSTURE_DRIVE, postureFromString("drive"))
+	require.Equal(t, specv1.Posture_POSTURE_PARTNER, postureFromString("partner"))
+	require.Equal(t, specv1.Posture_POSTURE_SUPPORT, postureFromString("support"))
+	require.Equal(t, specv1.Posture_POSTURE_UNSPECIFIED, postureFromString("unknown"))
+	require.Equal(t, specv1.Posture_POSTURE_UNSPECIFIED, postureFromString(""))
+}
+
+func TestAuthoringStageFromString(t *testing.T) {
+	require.Equal(t, specv1.AuthoringStage_AUTHORING_STAGE_SPARK, authoringStageFromString("spark"))
+	require.Equal(t, specv1.AuthoringStage_AUTHORING_STAGE_SHAPE, authoringStageFromString("shape"))
+	require.Equal(t, specv1.AuthoringStage_AUTHORING_STAGE_SPECIFY, authoringStageFromString("specify"))
+	require.Equal(t, specv1.AuthoringStage_AUTHORING_STAGE_DECOMPOSE, authoringStageFromString("decompose"))
+	require.Equal(t, specv1.AuthoringStage_AUTHORING_STAGE_APPROVED, authoringStageFromString("approved"))
+	require.Equal(t, specv1.AuthoringStage_AUTHORING_STAGE_UNSPECIFIED, authoringStageFromString("unknown"))
+}

--- a/internal/mcp/tools_authoring_test.go
+++ b/internal/mcp/tools_authoring_test.go
@@ -216,6 +216,257 @@ func TestAuthorTool_UnknownAction(t *testing.T) {
 	require.Contains(t, result.Content[0].Text, "delete")
 }
 
+func TestAuthorTool_Shape(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		shape: func(req *specv1.ShapeRequest) (*specv1.ShapeResponse, error) {
+			require.Equal(t, "my-spec", req.GetSlug())
+			require.NotNil(t, req.GetOutput())
+			require.Equal(t, []string{"auth"}, req.GetOutput().GetScopeIn())
+			return &specv1.ShapeResponse{
+				Output: req.GetOutput(),
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "shape",
+		"slug":   "my-spec",
+		"output": `{"scopeIn":["auth"],"chosenApproach":"oauth2"}`,
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestAuthorTool_Shape_MissingSlug(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "shape",
+		"output": `{"scopeIn":["auth"]}`,
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestAuthorTool_Shape_MissingOutput(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "shape",
+		"slug":   "my-spec",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "output")
+}
+
+func TestAuthorTool_Shape_InvalidJSON(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "shape",
+		"slug":   "my-spec",
+		"output": `{{{not valid`,
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "invalid shape output JSON")
+}
+
+func TestAuthorTool_Specify(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		specify: func(req *specv1.SpecifyRequest) (*specv1.SpecifyResponse, error) {
+			require.Equal(t, "my-spec", req.GetSlug())
+			require.NotNil(t, req.GetOutput())
+			require.Equal(t, []string{"state is never negative"}, req.GetOutput().GetInvariants())
+			return &specv1.SpecifyResponse{
+				Output: req.GetOutput(),
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "specify",
+		"slug":   "my-spec",
+		"output": `{"invariants":["state is never negative"]}`,
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestAuthorTool_Specify_MissingSlug(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "specify",
+		"output": `{"invariants":["x"]}`,
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestAuthorTool_Specify_MissingOutput(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "specify",
+		"slug":   "my-spec",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "output")
+}
+
+func TestAuthorTool_Specify_InvalidJSON(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "specify",
+		"slug":   "my-spec",
+		"output": `not json at all`,
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "invalid specify output JSON")
+}
+
+func TestAuthorTool_Decompose(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{
+		decompose: func(req *specv1.DecomposeRequest) (*specv1.DecomposeResponse, error) {
+			require.Equal(t, "my-spec", req.GetSlug())
+			require.NotNil(t, req.GetOutput())
+			return &specv1.DecomposeResponse{
+				Output: req.GetOutput(),
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "decompose",
+		"slug":   "my-spec",
+		"output": `{"strategy":"DECOMPOSITION_STRATEGY_VERTICAL_SLICE"}`,
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestAuthorTool_Decompose_MissingSlug(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "decompose",
+		"output": `{"strategy":"DECOMPOSITION_STRATEGY_VERTICAL"}`,
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestAuthorTool_Decompose_MissingOutput(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "decompose",
+		"slug":   "my-spec",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "output")
+}
+
+func TestAuthorTool_Decompose_InvalidJSON(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "decompose",
+		"slug":   "my-spec",
+		"output": `[invalid`,
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "invalid decompose output JSON")
+}
+
+func TestAuthorTool_Amend_MissingSlug(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "amend",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestAuthorTool_Supersede_MissingSlug(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("author")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "supersede",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
 // ---------------------------------------------------------------------------
 // conversationTool tests
 // ---------------------------------------------------------------------------
@@ -307,6 +558,57 @@ func TestConversationTool_Record_InvalidJSON(t *testing.T) {
 	require.Contains(t, result.Content[0].Text, "invalid exchanges JSON")
 }
 
+func TestConversationTool_Record_MissingSlug(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("conversation")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "record",
+		"stage":     "spark",
+		"exchanges": `[{"role":"probe","content":"what?"}]`,
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestConversationTool_Record_MissingStage(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("conversation")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "record",
+		"slug":      "my-spec",
+		"exchanges": `[{"role":"probe","content":"what?"}]`,
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "stage")
+}
+
+func TestConversationTool_Record_MissingExchanges(t *testing.T) {
+	c := &Client{Authoring: &mockAuthoringService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("conversation")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "record",
+		"slug":   "my-spec",
+		"stage":  "spark",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "exchanges")
+}
+
 func TestConversationTool_UnknownAction(t *testing.T) {
 	c := &Client{Authoring: &mockAuthoringService{}}
 	r := NewRegistry()
@@ -368,6 +670,39 @@ func TestAnalyticalPassTool_Run_MissingSlug(t *testing.T) {
 	require.Contains(t, result.Content[0].Text, "slug")
 }
 
+func TestAnalyticalPassTool_Run_MissingPassType(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("analytical_pass")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "run",
+		"slug":   "my-spec",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "pass_type")
+}
+
+func TestAnalyticalPassTool_Run_InvalidPassType(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("analytical_pass")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "run",
+		"slug":      "my-spec",
+		"pass_type": "not-a-real-pass",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "invalid pass_type")
+}
+
 func TestAnalyticalPassTool_Store(t *testing.T) {
 	c := &Client{AnalyticalPass: &mockAnalyticalPassService{
 		storeFindings: func(req *specv1.StoreFindingsRequest) (*specv1.StoreFindingsResponse, error) {
@@ -411,6 +746,75 @@ func TestAnalyticalPassTool_Store_InvalidJSON(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, result.IsError)
 	require.Contains(t, result.Content[0].Text, "invalid findings JSON")
+}
+
+func TestAnalyticalPassTool_Store_MissingSlug(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("analytical_pass")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "store",
+		"pass_type": "constitution-check",
+		"findings":  `[{"severity":"FINDING_SEVERITY_WARNING","summary":"x"}]`,
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestAnalyticalPassTool_Store_MissingFindings(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("analytical_pass")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "store",
+		"slug":      "my-spec",
+		"pass_type": "constitution-check",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "findings")
+}
+
+func TestAnalyticalPassTool_Store_MissingPassType(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("analytical_pass")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":   "store",
+		"slug":     "my-spec",
+		"findings": `[{"severity":"FINDING_SEVERITY_WARNING","summary":"x"}]`,
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "pass_type")
+}
+
+func TestAnalyticalPassTool_Store_InvalidPassType(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{}}
+	r := NewRegistry()
+	RegisterAuthoringTools(r, c)
+	tool, ok := r.LookupTool("analytical_pass")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "store",
+		"slug":      "my-spec",
+		"pass_type": "bogus-pass",
+		"findings":  `[{"severity":"FINDING_SEVERITY_WARNING","summary":"x"}]`,
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "invalid pass_type")
 }
 
 func TestAnalyticalPassTool_UnknownAction(t *testing.T) {

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -1,0 +1,198 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+)
+
+// RegisterCoreTools registers the constitution, findings, and health tools into the registry.
+func RegisterCoreTools(r *Registry, c *Client) {
+	ct := &constitutionTool{client: c}
+	r.AddTool(ct.def())
+
+	ft := &findingsTool{client: c}
+	r.AddTool(ft.def())
+
+	ht := &healthTool{client: c}
+	r.AddTool(ht.def())
+}
+
+// constitutionLayerFromString converts a friendly string (e.g. "project") to a ConstitutionLayer enum.
+func constitutionLayerFromString(s string) specv1.ConstitutionLayer {
+	key := "CONSTITUTION_LAYER_" + strings.ToUpper(s)
+	if v, ok := specv1.ConstitutionLayer_value[key]; ok {
+		return specv1.ConstitutionLayer(v)
+	}
+	return specv1.ConstitutionLayer_CONSTITUTION_LAYER_UNSPECIFIED
+}
+
+// passTypeFromString converts a friendly string (e.g. "constitution-check") to a PassType enum.
+func passTypeFromString(s string) specv1.PassType {
+	key := "PASS_TYPE_" + strings.ToUpper(strings.ReplaceAll(s, "-", "_"))
+	if v, ok := specv1.PassType_value[key]; ok {
+		return specv1.PassType(v)
+	}
+	return specv1.PassType_PASS_TYPE_UNSPECIFIED
+}
+
+// ---------------------------------------------------------------------------
+// constitutionTool — get and update the project constitution
+// ---------------------------------------------------------------------------
+
+type constitutionTool struct {
+	client *Client
+}
+
+func (t *constitutionTool) def() ToolDef {
+	return ToolDef{
+		Name: "constitution",
+		Description: "Read and write the SpecGraph project constitution (layered ground truth). " +
+			"Actions: get, update.",
+		Tier: TierCore,
+		Schema: objectSchema(
+			props{
+				"action": stringProp("Operation to perform", "get", "update"),
+				"layer": stringProp(
+					"Constitution layer: user, org, project, domain",
+					"user", "org", "project", "domain",
+				),
+				"content": stringProp("Constitution content (required for update)"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *constitutionTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "get":
+		return t.handleGet(ctx, params)
+	case "update":
+		return t.handleUpdate(ctx, params)
+	default:
+		return errResult(fmt.Sprintf("unknown action %q — valid: get, update", action)), nil
+	}
+}
+
+func (t *constitutionTool) handleGet(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	layer := constitutionLayerFromString(stringParam(params, "layer"))
+	resp, err := t.client.Constitution.GetConstitution(ctx, connect.NewRequest(&specv1.GetConstitutionRequest{
+		Layer: layer,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *constitutionTool) handleUpdate(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	layerStr := stringParam(params, "layer")
+	content := stringParam(params, "content")
+	if layerStr == "" {
+		return errResult("layer is required for update"), nil
+	}
+	if content == "" {
+		return errResult("content is required for update"), nil
+	}
+	layer := constitutionLayerFromString(layerStr)
+	resp, err := t.client.Constitution.UpdateConstitution(ctx, connect.NewRequest(&specv1.UpdateConstitutionRequest{
+		Constitution: &specv1.Constitution{
+			Layer: layer,
+			Name:  content,
+		},
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// ---------------------------------------------------------------------------
+// findingsTool — list analytical pass findings for a spec
+// ---------------------------------------------------------------------------
+
+type findingsTool struct {
+	client *Client
+}
+
+func (t *findingsTool) def() ToolDef {
+	return ToolDef{
+		Name: "findings",
+		Description: "List analytical pass findings for a spec. " +
+			"Actions: list.",
+		Tier: TierCore,
+		Schema: objectSchema(
+			props{
+				"action": stringProp("Operation to perform", "list"),
+				"slug":   stringProp("Spec slug (required for list)"),
+				"pass_type": stringProp(
+					"Filter by pass type: constitution-check, red-team, peripheral-vision, consistency, simplicity",
+					"constitution-check", "red-team", "peripheral-vision", "consistency", "simplicity",
+				),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *findingsTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "list":
+		return t.handleList(ctx, params)
+	default:
+		return errResult(fmt.Sprintf("unknown action %q — valid: list", action)), nil
+	}
+}
+
+func (t *findingsTool) handleList(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for list"), nil
+	}
+	passType := passTypeFromString(stringParam(params, "pass_type"))
+	resp, err := t.client.AnalyticalPass.ListFindings(ctx, connect.NewRequest(&specv1.ListFindingsRequest{
+		Slug:     slug,
+		PassType: passType,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// ---------------------------------------------------------------------------
+// healthTool — check server health
+// ---------------------------------------------------------------------------
+
+type healthTool struct {
+	client *Client
+}
+
+func (t *healthTool) def() ToolDef {
+	return ToolDef{
+		Name:        "health",
+		Description: "Check SpecGraph server health and version.",
+		Tier:        TierCore,
+		Schema:      objectSchema(props{}),
+		Handler:     t.handle,
+	}
+}
+
+func (t *healthTool) handle(ctx context.Context, _ map[string]any) (*ToolResult, error) {
+	resp, err := t.client.Health.Health(ctx, connect.NewRequest(&specv1.HealthRequest{}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -10,6 +10,7 @@ import (
 
 	"connectrpc.com/connect"
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // RegisterCoreTools registers the constitution, findings, and health tools into the registry.
@@ -60,10 +61,10 @@ func (t *constitutionTool) def() ToolDef {
 			props{
 				"action": stringProp("Operation to perform", "get", "update"),
 				"layer": stringProp(
-					"Constitution layer: user, org, project, domain",
+					"Constitution layer filter for get: user, org, project, domain",
 					"user", "org", "project", "domain",
 				),
-				"content": stringProp("Constitution content (required for update)"),
+				"constitution": stringProp("Full constitution JSON for update (output from get, modified as needed)"),
 			},
 			"action",
 		),
@@ -95,20 +96,16 @@ func (t *constitutionTool) handleGet(ctx context.Context, params map[string]any)
 }
 
 func (t *constitutionTool) handleUpdate(ctx context.Context, params map[string]any) (*ToolResult, error) {
-	layerStr := stringParam(params, "layer")
-	content := stringParam(params, "content")
-	if layerStr == "" {
-		return errResult("layer is required for update"), nil
+	raw := stringParam(params, "constitution")
+	if raw == "" {
+		return errResult("constitution is required for update (pass the full JSON from get, modified as needed)"), nil
 	}
-	if content == "" {
-		return errResult("content is required for update"), nil
+	var c specv1.Constitution
+	if err := protojson.Unmarshal([]byte(raw), &c); err != nil {
+		return errResult(fmt.Sprintf("invalid constitution JSON: %v", err)), nil
 	}
-	layer := constitutionLayerFromString(layerStr)
 	resp, err := t.client.Constitution.UpdateConstitution(ctx, connect.NewRequest(&specv1.UpdateConstitutionRequest{
-		Constitution: &specv1.Constitution{
-			Layer: layer,
-			Name:  content,
-		},
+		Constitution: &c,
 	}))
 	if err != nil {
 		return connectErrResult(err)

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -85,14 +85,21 @@ func (t *constitutionTool) handle(ctx context.Context, params map[string]any) (*
 }
 
 func (t *constitutionTool) handleGet(ctx context.Context, params map[string]any) (*ToolResult, error) {
-	layer := constitutionLayerFromString(stringParam(params, "layer"))
+	layerStr := stringParam(params, "layer")
+	layer := specv1.ConstitutionLayer_CONSTITUTION_LAYER_UNSPECIFIED
+	if layerStr != "" {
+		layer = constitutionLayerFromString(layerStr)
+		if layer == specv1.ConstitutionLayer_CONSTITUTION_LAYER_UNSPECIFIED {
+			return errResult("invalid layer (valid: user, org, project, domain)"), nil
+		}
+	}
 	resp, err := t.client.Constitution.GetConstitution(ctx, connect.NewRequest(&specv1.GetConstitutionRequest{
 		Layer: layer,
 	}))
 	if err != nil {
 		return connectErrResult(err)
 	}
-	return jsonResult(resp.Msg), nil
+	return jsonResult(resp.Msg.GetConstitution()), nil
 }
 
 func (t *constitutionTool) handleUpdate(ctx context.Context, params map[string]any) (*ToolResult, error) {
@@ -136,7 +143,7 @@ func (t *findingsTool) def() ToolDef {
 					"constitution-check", "red-team", "peripheral-vision", "consistency", "simplicity",
 				),
 			},
-			"action",
+			"action", "slug",
 		),
 		Handler: t.handle,
 	}
@@ -157,7 +164,14 @@ func (t *findingsTool) handleList(ctx context.Context, params map[string]any) (*
 	if slug == "" {
 		return errResult("slug is required for list"), nil
 	}
-	passType := passTypeFromString(stringParam(params, "pass_type"))
+	passTypeStr := stringParam(params, "pass_type")
+	passType := specv1.PassType_PASS_TYPE_UNSPECIFIED
+	if passTypeStr != "" {
+		passType = passTypeFromString(passTypeStr)
+		if passType == specv1.PassType_PASS_TYPE_UNSPECIFIED {
+			return errResult("invalid pass_type for list"), nil
+		}
+	}
 	resp, err := t.client.AnalyticalPass.ListFindings(ctx, connect.NewRequest(&specv1.ListFindingsRequest{
 		Slug:     slug,
 		PassType: passType,

--- a/internal/mcp/tools_core_test.go
+++ b/internal/mcp/tools_core_test.go
@@ -61,6 +61,51 @@ func TestConstitutionTool_Get_WithLayer(t *testing.T) {
 	require.False(t, result.IsError)
 }
 
+func TestConstitutionTool_Update_RoundTrip(t *testing.T) {
+	c := &Client{Constitution: &mockConstitutionService{
+		updateConstitution: func(req *specv1.UpdateConstitutionRequest) (*specv1.UpdateConstitutionResponse, error) {
+			require.NotNil(t, req.Constitution)
+			require.Equal(t, specv1.ConstitutionLayer_CONSTITUTION_LAYER_PROJECT, req.Constitution.Layer)
+			require.Equal(t, "my-project", req.Constitution.Name)
+			require.Len(t, req.Constitution.Constraints, 1)
+			require.Equal(t, "no vendor lock-in", req.Constitution.Constraints[0])
+			return &specv1.UpdateConstitutionResponse{
+				Constitution: req.Constitution,
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterCoreTools(r, c)
+	tool, ok := r.LookupTool("constitution")
+	require.True(t, ok)
+
+	// Simulate round-trip: pass full JSON as returned by get
+	constitutionJSON := `{"layer":"CONSTITUTION_LAYER_PROJECT","name":"my-project","constraints":["no vendor lock-in"]}`
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":       "update",
+		"constitution": constitutionJSON,
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "my-project")
+}
+
+func TestConstitutionTool_Update_InvalidJSON(t *testing.T) {
+	c := &Client{Constitution: &mockConstitutionService{}}
+	r := NewRegistry()
+	RegisterCoreTools(r, c)
+	tool, ok := r.LookupTool("constitution")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":       "update",
+		"constitution": "not valid json {{{",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "invalid constitution JSON")
+}
+
 func TestConstitutionTool_UnknownAction(t *testing.T) {
 	c := &Client{Constitution: &mockConstitutionService{}}
 	r := NewRegistry()

--- a/internal/mcp/tools_core_test.go
+++ b/internal/mcp/tools_core_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// constitutionTool tests
+// ---------------------------------------------------------------------------
+
+func TestConstitutionTool_Get(t *testing.T) {
+	c := &Client{Constitution: &mockConstitutionService{
+		getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+			return &specv1.GetConstitutionResponse{
+				Constitution: &specv1.Constitution{
+					Name:  "project-constitution",
+					Layer: specv1.ConstitutionLayer_CONSTITUTION_LAYER_PROJECT,
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterCoreTools(r, c)
+	tool, ok := r.LookupTool("constitution")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "get"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "project-constitution")
+}
+
+func TestConstitutionTool_Get_WithLayer(t *testing.T) {
+	c := &Client{Constitution: &mockConstitutionService{
+		getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+			return &specv1.GetConstitutionResponse{
+				Constitution: &specv1.Constitution{
+					Layer: specv1.ConstitutionLayer_CONSTITUTION_LAYER_ORG,
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterCoreTools(r, c)
+	tool, ok := r.LookupTool("constitution")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "get",
+		"layer":  "org",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestConstitutionTool_UnknownAction(t *testing.T) {
+	c := &Client{Constitution: &mockConstitutionService{}}
+	r := NewRegistry()
+	RegisterCoreTools(r, c)
+	tool, ok := r.LookupTool("constitution")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "delete"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "delete")
+}
+
+// ---------------------------------------------------------------------------
+// findingsTool tests
+// ---------------------------------------------------------------------------
+
+func TestFindingsTool_List(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{
+		listFindings: func(slug string) (*specv1.ListFindingsResponse, error) {
+			require.Equal(t, "spec-a", slug)
+			return &specv1.ListFindingsResponse{
+				Findings: []*specv1.AnalyticalFinding{
+					{
+						Id:      "finding-1",
+						Summary: "missing constraint",
+					},
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterCoreTools(r, c)
+	tool, ok := r.LookupTool("findings")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "list",
+		"slug":   "spec-a",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "finding-1")
+}
+
+func TestFindingsTool_List_WithPassType(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{
+		listFindings: func(_ string) (*specv1.ListFindingsResponse, error) {
+			return &specv1.ListFindingsResponse{}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterCoreTools(r, c)
+	tool, ok := r.LookupTool("findings")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "list",
+		"slug":      "spec-a",
+		"pass_type": "constitution-check",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestFindingsTool_List_MissingSlug(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{}}
+	r := NewRegistry()
+	RegisterCoreTools(r, c)
+	tool, ok := r.LookupTool("findings")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "list"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestFindingsTool_UnknownAction(t *testing.T) {
+	c := &Client{AnalyticalPass: &mockAnalyticalPassService{}}
+	r := NewRegistry()
+	RegisterCoreTools(r, c)
+	tool, ok := r.LookupTool("findings")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "delete"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "delete")
+}
+
+// ---------------------------------------------------------------------------
+// healthTool tests
+// ---------------------------------------------------------------------------
+
+func TestHealthTool(t *testing.T) {
+	c := &Client{Health: &mockHealthService{
+		health: func() (*specv1.HealthResponse, error) {
+			return &specv1.HealthResponse{
+				Status:  "ok",
+				Version: "v1.2.3",
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterCoreTools(r, c)
+	tool, ok := r.LookupTool("health")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "ok")
+}
+
+func TestHealthTool_Error(t *testing.T) {
+	c := &Client{Health: &mockHealthService{
+		health: func() (*specv1.HealthResponse, error) {
+			return nil, fmt.Errorf("server unavailable")
+		},
+	}}
+	r := NewRegistry()
+	RegisterCoreTools(r, c)
+	tool, ok := r.LookupTool("health")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{})
+	// Non-connect errors (no code) become tool error results
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+}

--- a/internal/mcp/tools_execution.go
+++ b/internal/mcp/tools_execution.go
@@ -1,0 +1,474 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+// RegisterExecutionTools registers claim, slice, bundle, prime, report, and
+// execution_events tools into the registry.
+func RegisterExecutionTools(r *Registry, c *Client) {
+	ct := &claimTool{client: c}
+	r.AddTool(ct.def())
+
+	st := &sliceTool{client: c}
+	r.AddTool(st.def())
+
+	bt := &bundleTool{client: c}
+	r.AddTool(bt.def())
+
+	pt := &primeTool{client: c}
+	r.AddTool(pt.def())
+
+	rt := &reportTool{client: c}
+	r.AddTool(rt.def())
+
+	et := &executionEventsTool{client: c}
+	r.AddTool(et.def())
+}
+
+// ---------------------------------------------------------------------------
+// claimTool — claim, unclaim, heartbeat on specs
+// ---------------------------------------------------------------------------
+
+type claimTool struct {
+	client *Client
+}
+
+func (t *claimTool) def() ToolDef {
+	return ToolDef{
+		Name: "claim",
+		Description: "Manage spec execution claims for agents. " +
+			"Actions: claim, unclaim, heartbeat.",
+		Tier: TierExecution,
+		Schema: objectSchema(
+			props{
+				"action":         stringProp("Operation to perform", "claim", "unclaim", "heartbeat"),
+				"spec_slug":      stringProp("Spec slug (required for all actions)"),
+				"agent":          stringProp("Agent identifier (required for all actions)"),
+				"lease_duration": stringProp("Lease duration string e.g. '30m', '1h' (optional, default 15m)"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *claimTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "claim":
+		return t.handleClaim(ctx, params)
+	case "unclaim":
+		return t.handleUnclaim(ctx, params)
+	case "heartbeat":
+		return t.handleHeartbeat(ctx, params)
+	default:
+		return errResult(fmt.Sprintf("unknown action %q — valid: claim, unclaim, heartbeat", action)), nil
+	}
+}
+
+func (t *claimTool) handleClaim(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	specSlug := stringParam(params, "spec_slug")
+	if specSlug == "" {
+		return errResult("spec_slug is required for claim"), nil
+	}
+	agent := stringParam(params, "agent")
+	if agent == "" {
+		return errResult("agent is required for claim"), nil
+	}
+	req := &specv1.ClaimSpecRequest{
+		SpecSlug: specSlug,
+		Agent:    agent,
+	}
+	if durStr := stringParam(params, "lease_duration"); durStr != "" {
+		d, err := time.ParseDuration(durStr)
+		if err != nil {
+			return errResult(fmt.Sprintf("invalid lease_duration %q: %v", durStr, err)), nil
+		}
+		req.LeaseDuration = durationpb.New(d)
+	}
+	resp, err := t.client.Claim.ClaimSpec(ctx, connect.NewRequest(req))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *claimTool) handleUnclaim(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	specSlug := stringParam(params, "spec_slug")
+	if specSlug == "" {
+		return errResult("spec_slug is required for unclaim"), nil
+	}
+	agent := stringParam(params, "agent")
+	if agent == "" {
+		return errResult("agent is required for unclaim"), nil
+	}
+	resp, err := t.client.Claim.UnclaimSpec(ctx, connect.NewRequest(&specv1.UnclaimSpecRequest{
+		SpecSlug: specSlug,
+		Agent:    agent,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *claimTool) handleHeartbeat(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	specSlug := stringParam(params, "spec_slug")
+	if specSlug == "" {
+		return errResult("spec_slug is required for heartbeat"), nil
+	}
+	agent := stringParam(params, "agent")
+	if agent == "" {
+		return errResult("agent is required for heartbeat"), nil
+	}
+	resp, err := t.client.Claim.Heartbeat(ctx, connect.NewRequest(&specv1.HeartbeatRequest{
+		SpecSlug: specSlug,
+		Agent:    agent,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// ---------------------------------------------------------------------------
+// sliceTool — list, get, claim, complete slices
+// ---------------------------------------------------------------------------
+
+type sliceTool struct {
+	client *Client
+}
+
+func (t *sliceTool) def() ToolDef {
+	return ToolDef{
+		Name: "slice",
+		Description: "Manage execution slices (discrete work items from the decompose stage). " +
+			"Actions: list, get, claim, complete.",
+		Tier: TierExecution,
+		Schema: objectSchema(
+			props{
+				"action":      stringProp("Operation to perform", "list", "get", "claim", "complete"),
+				"parent_slug": stringProp("Parent spec slug (required for list)"),
+				"slug":        stringProp("Full slice slug e.g. 'parent/slc-01' (required for get/claim/complete)"),
+				"assignee":    stringProp("Who is claiming the slice (required for claim)"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *sliceTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "list":
+		return t.handleList(ctx, params)
+	case "get":
+		return t.handleGet(ctx, params)
+	case "claim":
+		return t.handleClaim(ctx, params)
+	case "complete":
+		return t.handleComplete(ctx, params)
+	default:
+		return errResult(fmt.Sprintf("unknown action %q — valid: list, get, claim, complete", action)), nil
+	}
+}
+
+func (t *sliceTool) handleList(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	parentSlug := stringParam(params, "parent_slug")
+	if parentSlug == "" {
+		return errResult("parent_slug is required for list"), nil
+	}
+	resp, err := t.client.Slice.ListSlices(ctx, connect.NewRequest(&specv1.ListSlicesRequest{
+		ParentSlug: parentSlug,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *sliceTool) handleGet(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for get"), nil
+	}
+	resp, err := t.client.Slice.GetSlice(ctx, connect.NewRequest(&specv1.GetSliceRequest{
+		Slug: slug,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *sliceTool) handleClaim(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for claim"), nil
+	}
+	assignee := stringParam(params, "assignee")
+	if assignee == "" {
+		return errResult("assignee is required for claim"), nil
+	}
+	resp, err := t.client.Slice.ClaimSlice(ctx, connect.NewRequest(&specv1.ClaimSliceRequest{
+		Slug:     slug,
+		Assignee: assignee,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *sliceTool) handleComplete(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for complete"), nil
+	}
+	resp, err := t.client.Slice.CompleteSlice(ctx, connect.NewRequest(&specv1.CompleteSliceRequest{
+		Slug: slug,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// ---------------------------------------------------------------------------
+// bundleTool — generate an execution bundle for a spec
+// ---------------------------------------------------------------------------
+
+type bundleTool struct {
+	client *Client
+}
+
+func (t *bundleTool) def() ToolDef {
+	return ToolDef{
+		Name: "bundle",
+		Description: "Generate an execution bundle for a spec. " +
+			"The bundle includes the spec, linked decisions, bootstrap instructions, and callback config.",
+		Tier: TierExecution,
+		Schema: objectSchema(
+			props{
+				"slug":     stringProp("Spec slug (required)"),
+				"endpoint": stringProp("Callback base URL for the executing agent (optional)"),
+			},
+			"slug",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *bundleTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required"), nil
+	}
+	resp, err := t.client.Execution.GenerateBundle(ctx, connect.NewRequest(&specv1.GenerateBundleRequest{
+		Slug:     slug,
+		Endpoint: stringParam(params, "endpoint"),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// ---------------------------------------------------------------------------
+// primeTool — get project priming context for a spec
+// ---------------------------------------------------------------------------
+
+type primeTool struct {
+	client *Client
+}
+
+func (t *primeTool) def() ToolDef {
+	return ToolDef{
+		Name: "prime",
+		Description: "Retrieve project priming context for a spec: constitution summary, " +
+			"project context, decisions, coding conventions, and callback docs.",
+		Tier: TierExecution,
+		Schema: objectSchema(
+			props{
+				"slug": stringProp("Spec slug (required)"),
+			},
+			"slug",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *primeTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required"), nil
+	}
+	resp, err := t.client.Execution.GetPrime(ctx, connect.NewRequest(&specv1.GetPrimeRequest{
+		Slug: slug,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// ---------------------------------------------------------------------------
+// reportTool — report progress, blockers, or completion
+// ---------------------------------------------------------------------------
+
+type reportTool struct {
+	client *Client
+}
+
+func (t *reportTool) def() ToolDef {
+	return ToolDef{
+		Name: "report",
+		Description: "Report execution progress, blockers, or completion for a spec. " +
+			"Actions: progress, blocker, completion.",
+		Tier: TierExecution,
+		Schema: objectSchema(
+			props{
+				"action":      stringProp("Operation to perform", "progress", "blocker", "completion"),
+				"slug":        stringProp("Spec slug (required for all actions)"),
+				"agent":       stringProp("Agent identifier (required for all actions)"),
+				"message":     stringProp("Progress message (required for progress)"),
+				"description": stringProp("Blocker description (required for blocker)"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *reportTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "progress":
+		return t.handleProgress(ctx, params)
+	case "blocker":
+		return t.handleBlocker(ctx, params)
+	case "completion":
+		return t.handleCompletion(ctx, params)
+	default:
+		return errResult(fmt.Sprintf("unknown action %q — valid: progress, blocker, completion", action)), nil
+	}
+}
+
+func (t *reportTool) handleProgress(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for progress"), nil
+	}
+	agent := stringParam(params, "agent")
+	if agent == "" {
+		return errResult("agent is required for progress"), nil
+	}
+	message := stringParam(params, "message")
+	if message == "" {
+		return errResult("message is required for progress"), nil
+	}
+	resp, err := t.client.Execution.ReportProgress(ctx, connect.NewRequest(&specv1.ReportProgressRequest{
+		Slug:    slug,
+		Agent:   agent,
+		Message: message,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *reportTool) handleBlocker(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for blocker"), nil
+	}
+	agent := stringParam(params, "agent")
+	if agent == "" {
+		return errResult("agent is required for blocker"), nil
+	}
+	description := stringParam(params, "description")
+	if description == "" {
+		return errResult("description is required for blocker"), nil
+	}
+	resp, err := t.client.Execution.ReportBlocker(ctx, connect.NewRequest(&specv1.ReportBlockerRequest{
+		Slug:        slug,
+		Agent:       agent,
+		Description: description,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *reportTool) handleCompletion(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for completion"), nil
+	}
+	agent := stringParam(params, "agent")
+	if agent == "" {
+		return errResult("agent is required for completion"), nil
+	}
+	resp, err := t.client.Execution.ReportCompletion(ctx, connect.NewRequest(&specv1.ReportCompletionRequest{
+		Slug:  slug,
+		Agent: agent,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// ---------------------------------------------------------------------------
+// executionEventsTool — list execution events for a spec
+// ---------------------------------------------------------------------------
+
+type executionEventsTool struct {
+	client *Client
+}
+
+func (t *executionEventsTool) def() ToolDef {
+	return ToolDef{
+		Name: "execution_events",
+		Description: "List execution events (progress, blockers, completions) recorded against a spec. " +
+			"Returns events in reverse-chronological order.",
+		Tier: TierExecution,
+		Schema: objectSchema(
+			props{
+				"slug":  stringProp("Spec slug (required)"),
+				"limit": intProp("Maximum number of events to return (default: all)"),
+			},
+			"slug",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *executionEventsTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required"), nil
+	}
+	limit := int32Param(params, "limit")
+	resp, err := t.client.Execution.GetExecutionEvents(ctx, connect.NewRequest(&specv1.GetExecutionEventsRequest{
+		Slug:  slug,
+		Limit: uint32(limit), //nolint:gosec // limit is a bounded API page size from int32
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}

--- a/internal/mcp/tools_execution_test.go
+++ b/internal/mcp/tools_execution_test.go
@@ -1,0 +1,608 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// claimTool tests
+// ---------------------------------------------------------------------------
+
+func TestClaimTool_Claim(t *testing.T) {
+	c := &Client{Claim: &mockClaimService{
+		claimSpec: func(req *specv1.ClaimSpecRequest) (*specv1.ClaimSpecResponse, error) {
+			require.Equal(t, "auth-spec", req.GetSpecSlug())
+			require.Equal(t, "agent-1", req.GetAgent())
+			require.Nil(t, req.GetLeaseDuration())
+			return &specv1.ClaimSpecResponse{
+				Claim: &specv1.Claim{
+					SpecSlug: "auth-spec",
+					Agent:    "agent-1",
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("claim")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "claim",
+		"spec_slug": "auth-spec",
+		"agent":     "agent-1",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "auth-spec")
+}
+
+func TestClaimTool_Claim_WithLeaseDuration(t *testing.T) {
+	c := &Client{Claim: &mockClaimService{
+		claimSpec: func(req *specv1.ClaimSpecRequest) (*specv1.ClaimSpecResponse, error) {
+			require.NotNil(t, req.GetLeaseDuration())
+			require.Equal(t, int64(1800), req.GetLeaseDuration().GetSeconds()) // 30m = 1800s
+			return &specv1.ClaimSpecResponse{
+				Claim: &specv1.Claim{SpecSlug: "auth-spec", Agent: "agent-1"},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("claim")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":         "claim",
+		"spec_slug":      "auth-spec",
+		"agent":          "agent-1",
+		"lease_duration": "30m",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestClaimTool_Claim_InvalidLeaseDuration(t *testing.T) {
+	c := &Client{Claim: &mockClaimService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("claim")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":         "claim",
+		"spec_slug":      "auth-spec",
+		"agent":          "agent-1",
+		"lease_duration": "not-a-duration",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "invalid lease_duration")
+}
+
+func TestClaimTool_Claim_MissingSpecSlug(t *testing.T) {
+	c := &Client{Claim: &mockClaimService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("claim")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "claim",
+		"agent":  "agent-1",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "spec_slug")
+}
+
+func TestClaimTool_Claim_MissingAgent(t *testing.T) {
+	c := &Client{Claim: &mockClaimService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("claim")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "claim",
+		"spec_slug": "auth-spec",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "agent")
+}
+
+func TestClaimTool_Unclaim(t *testing.T) {
+	c := &Client{Claim: &mockClaimService{
+		unclaimSpec: func(req *specv1.UnclaimSpecRequest) (*specv1.UnclaimSpecResponse, error) {
+			require.Equal(t, "auth-spec", req.GetSpecSlug())
+			require.Equal(t, "agent-1", req.GetAgent())
+			return &specv1.UnclaimSpecResponse{}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("claim")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "unclaim",
+		"spec_slug": "auth-spec",
+		"agent":     "agent-1",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestClaimTool_Heartbeat(t *testing.T) {
+	c := &Client{Claim: &mockClaimService{
+		heartbeat: func(req *specv1.HeartbeatRequest) (*specv1.HeartbeatResponse, error) {
+			require.Equal(t, "auth-spec", req.GetSpecSlug())
+			require.Equal(t, "agent-1", req.GetAgent())
+			return &specv1.HeartbeatResponse{
+				Claim: &specv1.Claim{SpecSlug: "auth-spec", Agent: "agent-1"},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("claim")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "heartbeat",
+		"spec_slug": "auth-spec",
+		"agent":     "agent-1",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestClaimTool_UnknownAction(t *testing.T) {
+	c := &Client{Claim: &mockClaimService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("claim")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "frobnicate"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "frobnicate")
+}
+
+// ---------------------------------------------------------------------------
+// sliceTool tests
+// ---------------------------------------------------------------------------
+
+func TestSliceTool_List(t *testing.T) {
+	c := &Client{Slice: &mockSliceService{
+		listSlices: func(req *specv1.ListSlicesRequest) (*specv1.ListSlicesResponse, error) {
+			require.Equal(t, "auth-spec", req.GetParentSlug())
+			return &specv1.ListSlicesResponse{
+				Slices: []*specv1.Slice{
+					{Slug: "auth-spec/slc-01", Intent: "implement auth"},
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("slice")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":      "list",
+		"parent_slug": "auth-spec",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slc-01")
+}
+
+func TestSliceTool_List_MissingParentSlug(t *testing.T) {
+	c := &Client{Slice: &mockSliceService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("slice")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "list"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "parent_slug")
+}
+
+func TestSliceTool_Get(t *testing.T) {
+	c := &Client{Slice: &mockSliceService{
+		getSlice: func(req *specv1.GetSliceRequest) (*specv1.GetSliceResponse, error) {
+			require.Equal(t, "auth-spec/slc-01", req.GetSlug())
+			return &specv1.GetSliceResponse{
+				Slice: &specv1.Slice{
+					Slug:   "auth-spec/slc-01",
+					Intent: "implement auth",
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("slice")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "get",
+		"slug":   "auth-spec/slc-01",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "implement auth")
+}
+
+func TestSliceTool_Get_MissingSlug(t *testing.T) {
+	c := &Client{Slice: &mockSliceService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("slice")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "get"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestSliceTool_Claim(t *testing.T) {
+	c := &Client{Slice: &mockSliceService{
+		claimSlice: func(req *specv1.ClaimSliceRequest) (*specv1.ClaimSliceResponse, error) {
+			require.Equal(t, "auth-spec/slc-01", req.GetSlug())
+			require.Equal(t, "agent-1", req.GetAssignee())
+			return &specv1.ClaimSliceResponse{
+				Slice: &specv1.Slice{Slug: "auth-spec/slc-01", AssignedTo: "agent-1"},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("slice")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":   "claim",
+		"slug":     "auth-spec/slc-01",
+		"assignee": "agent-1",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestSliceTool_Claim_MissingAssignee(t *testing.T) {
+	c := &Client{Slice: &mockSliceService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("slice")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "claim",
+		"slug":   "auth-spec/slc-01",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "assignee")
+}
+
+func TestSliceTool_Complete(t *testing.T) {
+	c := &Client{Slice: &mockSliceService{
+		completeSlice: func(req *specv1.CompleteSliceRequest) (*specv1.CompleteSliceResponse, error) {
+			require.Equal(t, "auth-spec/slc-01", req.GetSlug())
+			return &specv1.CompleteSliceResponse{
+				Slice: &specv1.Slice{Slug: "auth-spec/slc-01", Status: specv1.SliceStatus_SLICE_STATUS_DONE},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("slice")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "complete",
+		"slug":   "auth-spec/slc-01",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestSliceTool_UnknownAction(t *testing.T) {
+	c := &Client{Slice: &mockSliceService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("slice")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "invalid"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "invalid")
+}
+
+// ---------------------------------------------------------------------------
+// bundleTool tests
+// ---------------------------------------------------------------------------
+
+func TestBundleTool(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{
+		generateBundle: func(req *specv1.GenerateBundleRequest) (*specv1.GenerateBundleResponse, error) {
+			require.Equal(t, "auth-spec", req.GetSlug())
+			require.Equal(t, "https://callback.example.com", req.GetEndpoint())
+			return &specv1.GenerateBundleResponse{
+				Bundle: &specv1.Bundle{
+					Version: 1,
+					Bootstrap: "## Bootstrap\nYou are working on auth-spec.",
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("bundle")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"slug":     "auth-spec",
+		"endpoint": "https://callback.example.com",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "Bootstrap")
+}
+
+func TestBundleTool_MissingSlug(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("bundle")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+// ---------------------------------------------------------------------------
+// primeTool tests
+// ---------------------------------------------------------------------------
+
+func TestPrimeTool(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{
+		getPrime: func(req *specv1.GetPrimeRequest) (*specv1.PrimeResponse, error) {
+			require.Equal(t, "auth-spec", req.GetSlug())
+			return &specv1.PrimeResponse{
+				ConstitutionSummary: "All code must be tested.",
+				ProjectContext:      "Auth service",
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("prime")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"slug": "auth-spec",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "constitutionSummary")
+}
+
+func TestPrimeTool_MissingSlug(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("prime")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+// ---------------------------------------------------------------------------
+// reportTool tests
+// ---------------------------------------------------------------------------
+
+func TestReportTool_Progress(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{
+		reportProgress: func(req *specv1.ReportProgressRequest) (*specv1.ReportProgressResponse, error) {
+			require.Equal(t, "auth-spec", req.GetSlug())
+			require.Equal(t, "agent-1", req.GetAgent())
+			require.Equal(t, "Completed step 1", req.GetMessage())
+			return &specv1.ReportProgressResponse{Acknowledged: true}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("report")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":  "progress",
+		"slug":    "auth-spec",
+		"agent":   "agent-1",
+		"message": "Completed step 1",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "acknowledged")
+}
+
+func TestReportTool_Progress_MissingMessage(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("report")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "progress",
+		"slug":   "auth-spec",
+		"agent":  "agent-1",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "message")
+}
+
+func TestReportTool_Blocker(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{
+		reportBlocker: func(req *specv1.ReportBlockerRequest) (*specv1.ReportBlockerResponse, error) {
+			require.Equal(t, "auth-spec", req.GetSlug())
+			require.Equal(t, "agent-1", req.GetAgent())
+			require.Equal(t, "DB not reachable", req.GetDescription())
+			return &specv1.ReportBlockerResponse{Acknowledged: true}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("report")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":      "blocker",
+		"slug":        "auth-spec",
+		"agent":       "agent-1",
+		"description": "DB not reachable",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestReportTool_Blocker_MissingDescription(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("report")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "blocker",
+		"slug":   "auth-spec",
+		"agent":  "agent-1",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "description")
+}
+
+func TestReportTool_Completion(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{
+		reportCompletion: func(req *specv1.ReportCompletionRequest) (*specv1.ReportCompletionResponse, error) {
+			require.Equal(t, "auth-spec", req.GetSlug())
+			require.Equal(t, "agent-1", req.GetAgent())
+			return &specv1.ReportCompletionResponse{Acknowledged: true, NewStage: "done"}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("report")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "completion",
+		"slug":   "auth-spec",
+		"agent":  "agent-1",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "newStage")
+}
+
+func TestReportTool_UnknownAction(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("report")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "explode"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "explode")
+}
+
+// ---------------------------------------------------------------------------
+// executionEventsTool tests
+// ---------------------------------------------------------------------------
+
+func TestExecutionEventsTool(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{
+		getEvents: func(req *specv1.GetExecutionEventsRequest) (*specv1.GetExecutionEventsResponse, error) {
+			require.Equal(t, "auth-spec", req.GetSlug())
+			require.Equal(t, uint32(10), req.GetLimit())
+			return &specv1.GetExecutionEventsResponse{
+				Events: []*specv1.ExecutionEvent{
+					{
+						Id:      "evt-1",
+						Message: "Progress update",
+						Type:    specv1.ExecutionEventType_EXECUTION_EVENT_TYPE_PROGRESS,
+					},
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("execution_events")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"slug":  "auth-spec",
+		"limit": float64(10),
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "evt-1")
+}
+
+func TestExecutionEventsTool_NoLimit(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{
+		getEvents: func(req *specv1.GetExecutionEventsRequest) (*specv1.GetExecutionEventsResponse, error) {
+			require.Equal(t, uint32(0), req.GetLimit()) // 0 = no limit
+			return &specv1.GetExecutionEventsResponse{}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("execution_events")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"slug": "auth-spec",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestExecutionEventsTool_MissingSlug(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("execution_events")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}

--- a/internal/mcp/tools_execution_test.go
+++ b/internal/mcp/tools_execution_test.go
@@ -606,3 +606,175 @@ func TestExecutionEventsTool_MissingSlug(t *testing.T) {
 	require.True(t, result.IsError)
 	require.Contains(t, result.Content[0].Text, "slug")
 }
+
+// ---------------------------------------------------------------------------
+// claimTool — unclaim and heartbeat missing-param tests
+// ---------------------------------------------------------------------------
+
+func TestClaimTool_Unclaim_MissingSpecSlug(t *testing.T) {
+	c := &Client{Claim: &mockClaimService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("claim")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "unclaim",
+		"agent":  "agent-1",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "spec_slug")
+}
+
+func TestClaimTool_Unclaim_MissingAgent(t *testing.T) {
+	c := &Client{Claim: &mockClaimService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("claim")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "unclaim",
+		"spec_slug": "auth-spec",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "agent")
+}
+
+func TestClaimTool_Heartbeat_MissingSpecSlug(t *testing.T) {
+	c := &Client{Claim: &mockClaimService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("claim")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "heartbeat",
+		"agent":  "agent-1",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "spec_slug")
+}
+
+func TestClaimTool_Heartbeat_MissingAgent(t *testing.T) {
+	c := &Client{Claim: &mockClaimService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("claim")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "heartbeat",
+		"spec_slug": "auth-spec",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "agent")
+}
+
+// ---------------------------------------------------------------------------
+// reportTool — missing slug/agent for progress, blocker, completion
+// ---------------------------------------------------------------------------
+
+func TestReportTool_Progress_MissingSlug(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("report")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":  "progress",
+		"agent":   "agent-1",
+		"message": "done",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestReportTool_Progress_MissingAgent(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("report")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":  "progress",
+		"slug":    "auth-spec",
+		"message": "done",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "agent")
+}
+
+func TestReportTool_Blocker_MissingSlug(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("report")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":      "blocker",
+		"agent":       "agent-1",
+		"description": "db is down",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestReportTool_Blocker_MissingAgent(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("report")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":      "blocker",
+		"slug":        "auth-spec",
+		"description": "db is down",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "agent")
+}
+
+func TestReportTool_Completion_MissingSlug(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("report")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "completion",
+		"agent":  "agent-1",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestReportTool_Completion_MissingAgent(t *testing.T) {
+	c := &Client{Execution: &mockExecutionService{}}
+	r := NewRegistry()
+	RegisterExecutionTools(r, c)
+	tool, ok := r.LookupTool("report")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "completion",
+		"slug":   "auth-spec",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "agent")
+}

--- a/internal/mcp/tools_graph.go
+++ b/internal/mcp/tools_graph.go
@@ -83,10 +83,14 @@ func (t *edgeTool) handleAdd(ctx context.Context, params map[string]any) (*ToolR
 	if fromSlug == "" || toSlug == "" {
 		return errResult("from_slug and to_slug are required for add"), nil
 	}
+	edgeType := edgeTypeFromString(stringParam(params, "edge_type"))
+	if edgeType == specv1.EdgeType_EDGE_TYPE_UNSPECIFIED {
+		return errResult("valid edge_type is required for add"), nil
+	}
 	resp, err := t.client.Graph.AddEdge(ctx, connect.NewRequest(&specv1.AddEdgeRequest{
 		FromSlug: fromSlug,
 		ToSlug:   toSlug,
-		EdgeType: edgeTypeFromString(stringParam(params, "edge_type")),
+		EdgeType: edgeType,
 	}))
 	if err != nil {
 		return connectErrResult(err)
@@ -100,10 +104,14 @@ func (t *edgeTool) handleRemove(ctx context.Context, params map[string]any) (*To
 	if fromSlug == "" || toSlug == "" {
 		return errResult("from_slug and to_slug are required for remove"), nil
 	}
+	edgeType := edgeTypeFromString(stringParam(params, "edge_type"))
+	if edgeType == specv1.EdgeType_EDGE_TYPE_UNSPECIFIED {
+		return errResult("valid edge_type is required for remove"), nil
+	}
 	resp, err := t.client.Graph.RemoveEdge(ctx, connect.NewRequest(&specv1.RemoveEdgeRequest{
 		FromSlug: fromSlug,
 		ToSlug:   toSlug,
-		EdgeType: edgeTypeFromString(stringParam(params, "edge_type")),
+		EdgeType: edgeType,
 	}))
 	if err != nil {
 		return connectErrResult(err)
@@ -116,9 +124,17 @@ func (t *edgeTool) handleList(ctx context.Context, params map[string]any) (*Tool
 	if slug == "" {
 		return errResult("slug is required for list"), nil
 	}
+	edgeTypeStr := stringParam(params, "edge_type")
+	edgeType := specv1.EdgeType_EDGE_TYPE_UNSPECIFIED
+	if edgeTypeStr != "" {
+		edgeType = edgeTypeFromString(edgeTypeStr)
+		if edgeType == specv1.EdgeType_EDGE_TYPE_UNSPECIFIED {
+			return errResult("invalid edge_type for list"), nil
+		}
+	}
 	resp, err := t.client.Graph.ListEdges(ctx, connect.NewRequest(&specv1.ListEdgesRequest{
 		Slug:     slug,
-		EdgeType: edgeTypeFromString(stringParam(params, "edge_type")),
+		EdgeType: edgeType,
 	}))
 	if err != nil {
 		return connectErrResult(err)

--- a/internal/mcp/tools_graph.go
+++ b/internal/mcp/tools_graph.go
@@ -1,0 +1,259 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+)
+
+// RegisterGraphTools registers the edge and graph_query tools into the registry.
+func RegisterGraphTools(r *Registry, c *Client) {
+	et := &edgeTool{client: c}
+	r.AddTool(et.def())
+
+	gq := &graphQueryTool{client: c}
+	r.AddTool(gq.def())
+}
+
+// edgeTypeFromString converts a friendly string (e.g. "depends_on") to a specv1.EdgeType enum.
+func edgeTypeFromString(s string) specv1.EdgeType {
+	key := "EDGE_TYPE_" + strings.ToUpper(strings.ReplaceAll(s, "-", "_"))
+	if v, ok := specv1.EdgeType_value[key]; ok {
+		return specv1.EdgeType(v)
+	}
+	return specv1.EdgeType_EDGE_TYPE_UNSPECIFIED
+}
+
+// ---------------------------------------------------------------------------
+// edgeTool — add, remove, list edges
+// ---------------------------------------------------------------------------
+
+type edgeTool struct {
+	client *Client
+}
+
+func (t *edgeTool) def() ToolDef {
+	return ToolDef{
+		Name: "edge",
+		Description: "Manage edges (relationships) between SpecGraph nodes. " +
+			"Actions: add, remove, list.",
+		Tier: TierCore,
+		Schema: objectSchema(
+			props{
+				"action": stringProp("Operation to perform", "add", "remove", "list"),
+				"slug":   stringProp("Node slug (required for list)"),
+				"from_slug": stringProp(
+					"Source node slug (required for add/remove)"),
+				"to_slug": stringProp(
+					"Destination node slug (required for add/remove)"),
+				"edge_type": stringProp(
+					"Edge type: depends_on, blocks, composes, relates_to, informs, decided_in, supersedes",
+					"depends_on", "blocks", "composes", "relates_to", "informs", "decided_in", "supersedes",
+				),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *edgeTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "add":
+		return t.handleAdd(ctx, params)
+	case "remove":
+		return t.handleRemove(ctx, params)
+	case "list":
+		return t.handleList(ctx, params)
+	default:
+		return errResult(fmt.Sprintf("unknown action %q — valid: add, remove, list", action)), nil
+	}
+}
+
+func (t *edgeTool) handleAdd(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	fromSlug := stringParam(params, "from_slug")
+	toSlug := stringParam(params, "to_slug")
+	if fromSlug == "" || toSlug == "" {
+		return errResult("from_slug and to_slug are required for add"), nil
+	}
+	resp, err := t.client.Graph.AddEdge(ctx, connect.NewRequest(&specv1.AddEdgeRequest{
+		FromSlug: fromSlug,
+		ToSlug:   toSlug,
+		EdgeType: edgeTypeFromString(stringParam(params, "edge_type")),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *edgeTool) handleRemove(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	fromSlug := stringParam(params, "from_slug")
+	toSlug := stringParam(params, "to_slug")
+	if fromSlug == "" || toSlug == "" {
+		return errResult("from_slug and to_slug are required for remove"), nil
+	}
+	resp, err := t.client.Graph.RemoveEdge(ctx, connect.NewRequest(&specv1.RemoveEdgeRequest{
+		FromSlug: fromSlug,
+		ToSlug:   toSlug,
+		EdgeType: edgeTypeFromString(stringParam(params, "edge_type")),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *edgeTool) handleList(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for list"), nil
+	}
+	resp, err := t.client.Graph.ListEdges(ctx, connect.NewRequest(&specv1.ListEdgesRequest{
+		Slug:     slug,
+		EdgeType: edgeTypeFromString(stringParam(params, "edge_type")),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// ---------------------------------------------------------------------------
+// graphQueryTool — graph traversal and analytical queries
+// ---------------------------------------------------------------------------
+
+type graphQueryTool struct {
+	client *Client
+}
+
+func (t *graphQueryTool) def() ToolDef {
+	return ToolDef{
+		Name: "graph_query",
+		Description: "Query the SpecGraph dependency graph. " +
+			"Actions: dependencies, transitive_deps, impact, ready, critical_path, full.",
+		Tier: TierCore,
+		Schema: objectSchema(
+			props{
+				"action": stringProp(
+					"Query to run",
+					"dependencies", "transitive_deps", "impact", "ready", "critical_path", "full",
+				),
+				"slug": stringProp(
+					"Spec slug (required for dependencies, transitive_deps, impact, critical_path)"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *graphQueryTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "dependencies":
+		return t.handleDeps(ctx, params)
+	case "transitive_deps":
+		return t.handleTransDeps(ctx, params)
+	case "impact":
+		return t.handleImpact(ctx, params)
+	case "ready":
+		return t.handleReady(ctx)
+	case "critical_path":
+		return t.handleCriticalPath(ctx, params)
+	case "full":
+		return t.handleFull(ctx)
+	default:
+		return errResult(fmt.Sprintf(
+			"unknown action %q — valid: dependencies, transitive_deps, impact, ready, critical_path, full",
+			action,
+		)), nil
+	}
+}
+
+func (t *graphQueryTool) requireSlug(params map[string]any) (string, *ToolResult) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return "", errResult("slug is required for this action")
+	}
+	return slug, nil
+}
+
+func (t *graphQueryTool) handleDeps(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug, errRes := t.requireSlug(params)
+	if errRes != nil {
+		return errRes, nil
+	}
+	resp, err := t.client.Graph.GetDependencies(ctx, connect.NewRequest(&specv1.GetDependenciesRequest{
+		Slug: slug,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *graphQueryTool) handleTransDeps(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug, errRes := t.requireSlug(params)
+	if errRes != nil {
+		return errRes, nil
+	}
+	resp, err := t.client.Graph.GetTransitiveDeps(ctx, connect.NewRequest(&specv1.GetTransitiveDepsRequest{
+		Slug: slug,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *graphQueryTool) handleImpact(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug, errRes := t.requireSlug(params)
+	if errRes != nil {
+		return errRes, nil
+	}
+	resp, err := t.client.Graph.GetImpact(ctx, connect.NewRequest(&specv1.GetImpactRequest{
+		Slug: slug,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *graphQueryTool) handleReady(ctx context.Context) (*ToolResult, error) {
+	resp, err := t.client.Graph.GetReady(ctx, connect.NewRequest(&specv1.GetReadyRequest{}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *graphQueryTool) handleCriticalPath(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug, errRes := t.requireSlug(params)
+	if errRes != nil {
+		return errRes, nil
+	}
+	resp, err := t.client.Graph.GetCriticalPath(ctx, connect.NewRequest(&specv1.GetCriticalPathRequest{
+		Slug: slug,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *graphQueryTool) handleFull(ctx context.Context) (*ToolResult, error) {
+	resp, err := t.client.Graph.GetFullGraph(ctx, connect.NewRequest(&specv1.GetFullGraphRequest{}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}

--- a/internal/mcp/tools_graph_test.go
+++ b/internal/mcp/tools_graph_test.go
@@ -301,3 +301,215 @@ func TestGraphQueryTool_MissingSlug(t *testing.T) {
 	require.True(t, result.IsError)
 	require.Contains(t, result.Content[0].Text, "slug")
 }
+
+func TestGraphQueryTool_TransitiveDeps_MissingSlug(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("graph_query")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "transitive_deps"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestGraphQueryTool_Impact_MissingSlug(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("graph_query")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "impact"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestGraphQueryTool_CriticalPath_MissingSlug(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("graph_query")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "critical_path"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+// ---------------------------------------------------------------------------
+// edgeTool — add/remove missing-param and invalid edge_type tests
+// ---------------------------------------------------------------------------
+
+func TestEdgeTool_Add_MissingFromSlug(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("edge")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":  "add",
+		"to_slug": "spec-b",
+		// from_slug intentionally absent
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "from_slug")
+}
+
+func TestEdgeTool_Add_MissingToSlug(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("edge")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "add",
+		"from_slug": "spec-a",
+		// to_slug intentionally absent
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+}
+
+func TestEdgeTool_Add_InvalidEdgeType(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("edge")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "add",
+		"from_slug": "spec-a",
+		"to_slug":   "spec-b",
+		"edge_type": "not_a_real_type",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "edge_type")
+}
+
+func TestEdgeTool_Remove_MissingFromSlug(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("edge")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":  "remove",
+		"to_slug": "spec-b",
+		// from_slug intentionally absent
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+}
+
+func TestEdgeTool_Remove_MissingToSlug(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("edge")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "remove",
+		"from_slug": "spec-a",
+		// to_slug intentionally absent
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+}
+
+func TestEdgeTool_Remove_InvalidEdgeType(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("edge")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "remove",
+		"from_slug": "spec-a",
+		"to_slug":   "spec-b",
+		"edge_type": "not_a_real_type",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "edge_type")
+}
+
+func TestEdgeTool_List_InvalidEdgeType(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("edge")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "list",
+		"slug":      "spec-a",
+		"edge_type": "not_a_real_type",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "edge_type")
+}
+
+func TestEdgeTool_List_WithValidEdgeType(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		listEdges: func(slug string) (*specv1.ListEdgesResponse, error) {
+			require.Equal(t, "spec-a", slug)
+			return &specv1.ListEdgesResponse{
+				Edges: []*specv1.Edge{
+					{FromId: "spec-a", ToId: "spec-b", EdgeType: specv1.EdgeType_EDGE_TYPE_BLOCKS},
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("edge")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "list",
+		"slug":      "spec-a",
+		"edge_type": "blocks",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+// ---------------------------------------------------------------------------
+// edgeTypeFromString helper tests
+// ---------------------------------------------------------------------------
+
+func TestEdgeTypeFromString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected specv1.EdgeType
+	}{
+		{"depends_on", specv1.EdgeType_EDGE_TYPE_DEPENDS_ON},
+		{"blocks", specv1.EdgeType_EDGE_TYPE_BLOCKS},
+		{"composes", specv1.EdgeType_EDGE_TYPE_COMPOSES},
+		{"relates_to", specv1.EdgeType_EDGE_TYPE_RELATES_TO},
+		{"informs", specv1.EdgeType_EDGE_TYPE_INFORMS},
+		{"decided_in", specv1.EdgeType_EDGE_TYPE_DECIDED_IN},
+		{"supersedes", specv1.EdgeType_EDGE_TYPE_SUPERSEDES},
+		{"unknown_value", specv1.EdgeType_EDGE_TYPE_UNSPECIFIED},
+		{"", specv1.EdgeType_EDGE_TYPE_UNSPECIFIED},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			require.Equal(t, tc.expected, edgeTypeFromString(tc.input))
+		})
+	}
+}

--- a/internal/mcp/tools_graph_test.go
+++ b/internal/mcp/tools_graph_test.go
@@ -1,0 +1,303 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// edgeTool tests
+// ---------------------------------------------------------------------------
+
+func TestEdgeTool_List(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		listEdges: func(slug string) (*specv1.ListEdgesResponse, error) {
+			require.Equal(t, "spec-a", slug)
+			return &specv1.ListEdgesResponse{
+				Edges: []*specv1.Edge{
+					{FromId: "spec-a", ToId: "spec-b", EdgeType: specv1.EdgeType_EDGE_TYPE_DEPENDS_ON},
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("edge")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "list",
+		"slug":   "spec-a",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "spec-a")
+}
+
+func TestEdgeTool_List_MissingSlug(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("edge")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "list"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestEdgeTool_Add(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		addEdge: func(req *specv1.AddEdgeRequest) (*specv1.AddEdgeResponse, error) {
+			require.Equal(t, "spec-a", req.GetFromSlug())
+			require.Equal(t, "spec-b", req.GetToSlug())
+			require.Equal(t, specv1.EdgeType_EDGE_TYPE_DEPENDS_ON, req.GetEdgeType())
+			return &specv1.AddEdgeResponse{
+				Edge: &specv1.Edge{
+					FromId:   "spec-a",
+					ToId:     "spec-b",
+					EdgeType: specv1.EdgeType_EDGE_TYPE_DEPENDS_ON,
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("edge")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "add",
+		"from_slug": "spec-a",
+		"to_slug":   "spec-b",
+		"edge_type": "depends_on",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestEdgeTool_Add_MissingParams(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("edge")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "add",
+		// missing from_slug and to_slug
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+}
+
+func TestEdgeTool_Remove(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		removeEdge: func(req *specv1.RemoveEdgeRequest) (*specv1.RemoveEdgeResponse, error) {
+			require.Equal(t, "spec-a", req.GetFromSlug())
+			require.Equal(t, "spec-b", req.GetToSlug())
+			return &specv1.RemoveEdgeResponse{}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("edge")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":    "remove",
+		"from_slug": "spec-a",
+		"to_slug":   "spec-b",
+		"edge_type": "depends_on",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestEdgeTool_UnknownAction(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("edge")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "frobnicate"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "frobnicate")
+}
+
+// ---------------------------------------------------------------------------
+// graphQueryTool tests
+// ---------------------------------------------------------------------------
+
+func TestGraphQueryTool_Dependencies(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		getDeps: func(slug string) (*specv1.GetDependenciesResponse, error) {
+			require.Equal(t, "spec-a", slug)
+			return &specv1.GetDependenciesResponse{
+				Dependencies: []*specv1.NodeRef{
+					{Slug: "spec-b"},
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("graph_query")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "dependencies",
+		"slug":   "spec-a",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "spec-b")
+}
+
+func TestGraphQueryTool_TransitiveDeps(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		getTransDeps: func(slug string) (*specv1.GetTransitiveDepsResponse, error) {
+			require.Equal(t, "spec-a", slug)
+			return &specv1.GetTransitiveDepsResponse{
+				Dependencies: []*specv1.NodeRef{
+					{Slug: "spec-b"},
+					{Slug: "spec-c"},
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("graph_query")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "transitive_deps",
+		"slug":   "spec-a",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestGraphQueryTool_Impact(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		getImpact: func(slug string) (*specv1.GetImpactResponse, error) {
+			require.Equal(t, "spec-a", slug)
+			return &specv1.GetImpactResponse{}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("graph_query")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "impact",
+		"slug":   "spec-a",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestGraphQueryTool_Ready(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		getReady: func() (*specv1.GetReadyResponse, error) {
+			return &specv1.GetReadyResponse{
+				Ready: []*specv1.NodeRef{
+					{Slug: "spec-x"},
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("graph_query")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "ready"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "spec-x")
+}
+
+func TestGraphQueryTool_CriticalPath(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		getCriticalPath: func(slug string) (*specv1.GetCriticalPathResponse, error) {
+			require.Equal(t, "spec-a", slug)
+			return &specv1.GetCriticalPathResponse{
+				Path: []*specv1.NodeRef{
+					{Slug: "spec-a"},
+					{Slug: "spec-b"},
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("graph_query")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "critical_path",
+		"slug":   "spec-a",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestGraphQueryTool_FullGraph(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{
+		getFullGraph: func() (*specv1.GetFullGraphResponse, error) {
+			return &specv1.GetFullGraphResponse{
+				Nodes: []*specv1.GraphNode{
+					{Slug: "spec-a"},
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("graph_query")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "full"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "spec-a")
+}
+
+func TestGraphQueryTool_UnknownAction(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("graph_query")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "invalid"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "invalid")
+}
+
+func TestGraphQueryTool_MissingSlug(t *testing.T) {
+	c := &Client{Graph: &mockGraphService{}}
+	r := NewRegistry()
+	RegisterGraphTools(r, c)
+	tool, ok := r.LookupTool("graph_query")
+	require.True(t, ok)
+
+	// actions requiring slug fail gracefully when slug is absent
+	result, err := tool.Handler(context.Background(), map[string]any{"action": "dependencies"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}

--- a/internal/mcp/tools_lifecycle.go
+++ b/internal/mcp/tools_lifecycle.go
@@ -1,0 +1,303 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+)
+
+// RegisterLifecycleTools registers drift, lint, sync, and export tools.
+func RegisterLifecycleTools(r *Registry, c *Client) {
+	dt := &driftTool{client: c}
+	r.AddTool(dt.def())
+
+	lt := &lintTool{client: c}
+	r.AddTool(lt.def())
+
+	st := &syncTool{client: c}
+	r.AddTool(st.def())
+
+	et := &exportTool{client: c}
+	r.AddTool(et.def())
+}
+
+// driftScopeFromString converts a friendly string (e.g. "deps") to a DriftScope enum.
+func driftScopeFromString(s string) specv1.DriftScope {
+	key := "DRIFT_SCOPE_" + strings.ToUpper(s)
+	if v, ok := specv1.DriftScope_value[key]; ok {
+		return specv1.DriftScope(v)
+	}
+	return specv1.DriftScope_DRIFT_SCOPE_UNSPECIFIED
+}
+
+// ---------------------------------------------------------------------------
+// driftTool — check and acknowledge spec drift
+// ---------------------------------------------------------------------------
+
+type driftTool struct {
+	client *Client
+}
+
+func (t *driftTool) def() ToolDef {
+	return ToolDef{
+		Name: "drift",
+		Description: "Check for and acknowledge spec drift against upstream dependencies. " +
+			"Actions: check, acknowledge.",
+		Tier: TierAuthoring,
+		Schema: objectSchema(
+			props{
+				"action":        stringProp("Operation to perform", "check", "acknowledge"),
+				"slug":          stringProp("Spec slug (empty = check all eligible specs for check)"),
+				"scope":         stringProp("Drift scope filter: deps, interfaces, verify"),
+				"note":          stringProp("Acknowledgment note explaining why drift is accepted (required for acknowledge)"),
+				"upstream_slug": stringProp("Specific upstream slug to acknowledge (use with acknowledge)"),
+				"all":           boolProp("Acknowledge all upstream dependencies at once"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *driftTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "check":
+		return t.handleCheck(ctx, params)
+	case "acknowledge":
+		return t.handleAcknowledge(ctx, params)
+	default:
+		return errResult(fmt.Sprintf("unknown action %q — valid: check, acknowledge", action)), nil
+	}
+}
+
+func (t *driftTool) handleCheck(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	resp, err := t.client.Lifecycle.CheckDrift(ctx, connect.NewRequest(&specv1.DriftCheckRequest{
+		Slug:  stringParam(params, "slug"),
+		Scope: driftScopeFromString(stringParam(params, "scope")),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *driftTool) handleAcknowledge(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for acknowledge"), nil
+	}
+	note := stringParam(params, "note")
+	if note == "" {
+		return errResult("note is required for acknowledge"), nil
+	}
+	resp, err := t.client.Lifecycle.AcknowledgeDrift(ctx, connect.NewRequest(&specv1.DriftAcknowledgeRequest{
+		Slug:         slug,
+		Note:         note,
+		UpstreamSlug: stringParam(params, "upstream_slug"),
+		All:          boolParam(params, "all"),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// ---------------------------------------------------------------------------
+// lintTool — lint specs
+// ---------------------------------------------------------------------------
+
+type lintTool struct {
+	client *Client
+}
+
+func (t *lintTool) def() ToolDef {
+	return ToolDef{
+		Name:        "lint",
+		Description: "Lint one or all specs for structural and rule violations. Leave slug empty to lint all specs.",
+		Tier:        TierAuthoring,
+		Schema: objectSchema(
+			props{
+				"slug": stringProp("Spec slug to lint (empty = lint all specs)"),
+			},
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *lintTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	resp, err := t.client.Lifecycle.Lint(ctx, connect.NewRequest(&specv1.LintRequest{
+		Slug: stringParam(params, "slug"),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// ---------------------------------------------------------------------------
+// syncTool — sync specs with external issue trackers and VCS
+// ---------------------------------------------------------------------------
+
+type syncTool struct {
+	client *Client
+}
+
+func (t *syncTool) def() ToolDef {
+	return ToolDef{
+		Name: "sync",
+		Description: "Sync specs with external issue trackers and VCS. " +
+			"Actions: beads, github, status.",
+		Tier: TierAuthoring,
+		Schema: objectSchema(
+			props{
+				"action": stringProp("Operation to perform", "beads", "github", "status"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *syncTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "beads":
+		return t.handleBeads(ctx)
+	case "github":
+		return t.handleGitHub(ctx)
+	case "status":
+		return t.handleStatus(ctx)
+	default:
+		return errResult(fmt.Sprintf("unknown action %q — valid: beads, github, status", action)), nil
+	}
+}
+
+func (t *syncTool) handleBeads(ctx context.Context) (*ToolResult, error) {
+	resp, err := t.client.Sync.SyncBeads(ctx, connect.NewRequest(&specv1.SyncBeadsRequest{}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *syncTool) handleGitHub(ctx context.Context) (*ToolResult, error) {
+	resp, err := t.client.Sync.SyncGitHub(ctx, connect.NewRequest(&specv1.SyncGitHubRequest{}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *syncTool) handleStatus(ctx context.Context) (*ToolResult, error) {
+	resp, err := t.client.Sync.GetSyncStatus(ctx, connect.NewRequest(&specv1.SyncStatusRequest{}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// ---------------------------------------------------------------------------
+// exportTool — export, import, and verify project bundles
+// ---------------------------------------------------------------------------
+
+type exportTool struct {
+	client *Client
+}
+
+func (t *exportTool) def() ToolDef {
+	return ToolDef{
+		Name: "export",
+		Description: "Export, import, and verify SpecGraph project bundles. " +
+			"Actions: export, import, verify. " +
+			"For import and verify, pass the export data as a base64-encoded string.",
+		Tier: TierAuthoring,
+		Schema: objectSchema(
+			props{
+				"action":            stringProp("Operation to perform", "export", "import", "verify"),
+				"project_slug":      stringProp("Project slug (required for export; optional hint for verify)"),
+				"data":              stringProp("Base64-encoded export bundle data (required for import and verify)"),
+				"force":             boolProp("Overwrite existing data on import"),
+				"require_signature": boolProp("Require a valid signature on import"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *exportTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "export":
+		return t.handleExport(ctx, params)
+	case "import":
+		return t.handleImport(ctx, params)
+	case "verify":
+		return t.handleVerify(ctx, params)
+	default:
+		return errResult(fmt.Sprintf("unknown action %q — valid: export, import, verify", action)), nil
+	}
+}
+
+func (t *exportTool) handleExport(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	projectSlug := stringParam(params, "project_slug")
+	if projectSlug == "" {
+		return errResult("project_slug is required for export"), nil
+	}
+	resp, err := t.client.Export.ExportProject(ctx, connect.NewRequest(&specv1.ExportProjectRequest{
+		ProjectSlug: projectSlug,
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	// Return base64-encoded export data for easy CLI consumption.
+	encoded := base64.StdEncoding.EncodeToString(resp.Msg.GetData())
+	return textResult(encoded), nil
+}
+
+func (t *exportTool) handleImport(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	dataStr := stringParam(params, "data")
+	if dataStr == "" {
+		return errResult("data is required for import (base64-encoded export bundle)"), nil
+	}
+	data, err := base64.StdEncoding.DecodeString(dataStr)
+	if err != nil {
+		return errResult(fmt.Sprintf("invalid base64 data: %v", err)), nil
+	}
+	resp, err := t.client.Export.ImportProject(ctx, connect.NewRequest(&specv1.ImportProjectRequest{
+		Data:             data,
+		Force:            boolParam(params, "force"),
+		RequireSignature: boolParam(params, "require_signature"),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *exportTool) handleVerify(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	dataStr := stringParam(params, "data")
+	if dataStr == "" {
+		return errResult("data is required for verify (base64-encoded export bundle)"), nil
+	}
+	data, err := base64.StdEncoding.DecodeString(dataStr)
+	if err != nil {
+		return errResult(fmt.Sprintf("invalid base64 data: %v", err)), nil
+	}
+	resp, err := t.client.Export.VerifyExport(ctx, connect.NewRequest(&specv1.VerifyExportRequest{
+		Data:        data,
+		ProjectSlug: stringParam(params, "project_slug"),
+	}))
+	if err != nil {
+		return connectErrResult(err)
+	}
+	return jsonResult(resp.Msg), nil
+}

--- a/internal/mcp/tools_lifecycle_test.go
+++ b/internal/mcp/tools_lifecycle_test.go
@@ -383,3 +383,58 @@ func TestDriftScopeFromString(t *testing.T) {
 	require.Equal(t, specv1.DriftScope_DRIFT_SCOPE_UNSPECIFIED, driftScopeFromString("unknown"))
 	require.Equal(t, specv1.DriftScope_DRIFT_SCOPE_UNSPECIFIED, driftScopeFromString(""))
 }
+
+// ---------------------------------------------------------------------------
+// syncTool — github action test
+// ---------------------------------------------------------------------------
+
+func TestSyncTool_GitHub(t *testing.T) {
+	c := &Client{Sync: &mockSyncService{
+		syncGitHub: func() (*specv1.SyncResponse, error) {
+			return &specv1.SyncResponse{
+				Synced: 3,
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("sync")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "github",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+// ---------------------------------------------------------------------------
+// driftTool — acknowledge with all flag
+// ---------------------------------------------------------------------------
+
+func TestDriftTool_Acknowledge_AllFlag(t *testing.T) {
+	c := &Client{Lifecycle: &mockLifecycleService{
+		acknowledgeDrift: func(req *specv1.DriftAcknowledgeRequest) (*specv1.DriftAcknowledgeResponse, error) {
+			require.Equal(t, "my-spec", req.GetSlug())
+			require.Equal(t, "reviewed all upstreams", req.GetNote())
+			require.True(t, req.GetAll())
+			return &specv1.DriftAcknowledgeResponse{
+				Report: &specv1.DriftReport{SpecSlug: "my-spec"},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("drift")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "acknowledge",
+		"slug":   "my-spec",
+		"note":   "reviewed all upstreams",
+		"all":    true,
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "my-spec")
+}

--- a/internal/mcp/tools_lifecycle_test.go
+++ b/internal/mcp/tools_lifecycle_test.go
@@ -1,0 +1,385 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// driftTool tests
+// ---------------------------------------------------------------------------
+
+func TestDriftTool_Check(t *testing.T) {
+	c := &Client{Lifecycle: &mockLifecycleService{
+		checkDrift: func(req *specv1.DriftCheckRequest) (*specv1.DriftCheckResponse, error) {
+			require.Equal(t, "my-spec", req.GetSlug())
+			require.Equal(t, specv1.DriftScope_DRIFT_SCOPE_DEPS, req.GetScope())
+			return &specv1.DriftCheckResponse{
+				Reports: []*specv1.DriftReport{
+					{SpecSlug: "my-spec"},
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("drift")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "check",
+		"slug":   "my-spec",
+		"scope":  "deps",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "my-spec")
+}
+
+func TestDriftTool_Check_AllSpecs(t *testing.T) {
+	c := &Client{Lifecycle: &mockLifecycleService{
+		checkDrift: func(req *specv1.DriftCheckRequest) (*specv1.DriftCheckResponse, error) {
+			require.Equal(t, "", req.GetSlug())
+			return &specv1.DriftCheckResponse{
+				SkippedCount: 3,
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("drift")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "check",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestDriftTool_Acknowledge(t *testing.T) {
+	c := &Client{Lifecycle: &mockLifecycleService{
+		acknowledgeDrift: func(req *specv1.DriftAcknowledgeRequest) (*specv1.DriftAcknowledgeResponse, error) {
+			require.Equal(t, "my-spec", req.GetSlug())
+			require.Equal(t, "upstream changed but we reviewed it", req.GetNote())
+			require.True(t, req.GetAll())
+			return &specv1.DriftAcknowledgeResponse{
+				Report: &specv1.DriftReport{SpecSlug: "my-spec"},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("drift")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "acknowledge",
+		"slug":   "my-spec",
+		"note":   "upstream changed but we reviewed it",
+		"all":    true,
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "my-spec")
+}
+
+func TestDriftTool_Acknowledge_MissingSlug(t *testing.T) {
+	c := &Client{Lifecycle: &mockLifecycleService{}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("drift")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "acknowledge",
+		"note":   "some note",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug")
+}
+
+func TestDriftTool_Acknowledge_MissingNote(t *testing.T) {
+	c := &Client{Lifecycle: &mockLifecycleService{}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("drift")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "acknowledge",
+		"slug":   "my-spec",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "note")
+}
+
+func TestDriftTool_UnknownAction(t *testing.T) {
+	c := &Client{Lifecycle: &mockLifecycleService{}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("drift")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "delete",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "delete")
+}
+
+// ---------------------------------------------------------------------------
+// lintTool tests
+// ---------------------------------------------------------------------------
+
+func TestLintTool(t *testing.T) {
+	c := &Client{Lifecycle: &mockLifecycleService{
+		lint: func(req *specv1.LintRequest) (*specv1.LintResponse, error) {
+			require.Equal(t, "my-spec", req.GetSlug())
+			return &specv1.LintResponse{
+				Results: []*specv1.LintResult{
+					{SpecSlug: "my-spec", Passed: true},
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("lint")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"slug": "my-spec",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "my-spec")
+}
+
+func TestLintTool_AllSpecs(t *testing.T) {
+	c := &Client{Lifecycle: &mockLifecycleService{
+		lint: func(req *specv1.LintRequest) (*specv1.LintResponse, error) {
+			require.Equal(t, "", req.GetSlug())
+			return &specv1.LintResponse{}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("lint")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+// ---------------------------------------------------------------------------
+// syncTool tests
+// ---------------------------------------------------------------------------
+
+func TestSyncTool_Status(t *testing.T) {
+	c := &Client{Sync: &mockSyncService{
+		getSyncStatus: func() (*specv1.SyncStatusResponse, error) {
+			return &specv1.SyncStatusResponse{
+				Mappings: []*specv1.SyncMapping{
+					{SpecSlug: "my-spec"},
+				},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("sync")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "status",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "my-spec")
+}
+
+func TestSyncTool_Beads(t *testing.T) {
+	c := &Client{Sync: &mockSyncService{
+		syncBeads: func() (*specv1.SyncResponse, error) {
+			return &specv1.SyncResponse{
+				Synced: 5,
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("sync")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "beads",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestSyncTool_UnknownAction(t *testing.T) {
+	c := &Client{Sync: &mockSyncService{}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("sync")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "delete",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "delete")
+}
+
+// ---------------------------------------------------------------------------
+// exportTool tests
+// ---------------------------------------------------------------------------
+
+func TestExportTool_Export(t *testing.T) {
+	exportData := []byte(`{"project":"my-project"}`)
+	c := &Client{Export: &mockExportService{
+		exportProject: func(projectSlug string) (*specv1.ExportProjectResponse, error) {
+			require.Equal(t, "my-project", projectSlug)
+			return &specv1.ExportProjectResponse{
+				Data: exportData,
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("export")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action":       "export",
+		"project_slug": "my-project",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	// Result should be base64 encoded
+	decoded, decErr := base64.StdEncoding.DecodeString(result.Content[0].Text)
+	require.NoError(t, decErr)
+	require.Equal(t, exportData, decoded)
+}
+
+func TestExportTool_Export_MissingSlug(t *testing.T) {
+	c := &Client{Export: &mockExportService{}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("export")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "export",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "project_slug")
+}
+
+func TestExportTool_Import(t *testing.T) {
+	exportData := []byte(`{"project":"my-project"}`)
+	encoded := base64.StdEncoding.EncodeToString(exportData)
+
+	c := &Client{Export: &mockExportService{
+		importProject: func(req *specv1.ImportProjectRequest) (*specv1.ImportProjectResponse, error) {
+			require.Equal(t, exportData, req.GetData())
+			require.True(t, req.GetForce())
+			return &specv1.ImportProjectResponse{
+				Result: &specv1.ImportResult{SpecsCreated: 3},
+			}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("export")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "import",
+		"data":   encoded,
+		"force":  true,
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestExportTool_Import_InvalidBase64(t *testing.T) {
+	c := &Client{Export: &mockExportService{}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("export")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "import",
+		"data":   "not valid base64!!!",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "invalid base64")
+}
+
+func TestExportTool_Verify(t *testing.T) {
+	exportData := []byte(`{"project":"my-project"}`)
+	encoded := base64.StdEncoding.EncodeToString(exportData)
+
+	c := &Client{Export: &mockExportService{
+		verifyExport: func(req *specv1.VerifyExportRequest) (*specv1.VerifyExportResponse, error) {
+			require.Equal(t, exportData, req.GetData())
+			return &specv1.VerifyExportResponse{Match: true}, nil
+		},
+	}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("export")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "verify",
+		"data":   encoded,
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestExportTool_UnknownAction(t *testing.T) {
+	c := &Client{Export: &mockExportService{}}
+	r := NewRegistry()
+	RegisterLifecycleTools(r, c)
+	tool, ok := r.LookupTool("export")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"action": "delete",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "delete")
+}
+
+// ---------------------------------------------------------------------------
+// driftScopeFromString enum helper
+// ---------------------------------------------------------------------------
+
+func TestDriftScopeFromString(t *testing.T) {
+	require.Equal(t, specv1.DriftScope_DRIFT_SCOPE_DEPS, driftScopeFromString("deps"))
+	require.Equal(t, specv1.DriftScope_DRIFT_SCOPE_INTERFACES, driftScopeFromString("interfaces"))
+	require.Equal(t, specv1.DriftScope_DRIFT_SCOPE_VERIFY, driftScopeFromString("verify"))
+	require.Equal(t, specv1.DriftScope_DRIFT_SCOPE_UNSPECIFIED, driftScopeFromString("unknown"))
+	require.Equal(t, specv1.DriftScope_DRIFT_SCOPE_UNSPECIFIED, driftScopeFromString(""))
+}

--- a/internal/mcp/tools_spec.go
+++ b/internal/mcp/tools_spec.go
@@ -1,0 +1,296 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+)
+
+// RegisterSpecTools registers the spec and decision tools into the registry.
+func RegisterSpecTools(r *Registry, c *Client) {
+	st := &specTool{client: c}
+	r.AddTool(st.def())
+
+	dt := &decisionTool{client: c}
+	r.AddTool(dt.def())
+}
+
+// ---------------------------------------------------------------------------
+// specTool — CRUD + history operations on Specs
+// ---------------------------------------------------------------------------
+
+type specTool struct {
+	client *Client
+}
+
+func (t *specTool) def() ToolDef {
+	return ToolDef{
+		Name: "spec",
+		Description: "Read and write SpecGraph specs. " +
+			"Actions: get, list, create, update, changes, compare.",
+		Tier: TierCore,
+		Schema: objectSchema(
+			props{
+				"action": stringProp("Operation to perform",
+					"get", "list", "create", "update", "changes", "compare"),
+				"slug":         stringProp("Spec slug (required for get/update/changes/compare)"),
+				"intent":       stringProp("What the spec is about (required for create)"),
+				"stage":        stringProp("Authoring stage filter or update value"),
+				"priority":     stringProp("Priority: p0, p1, p2, p3"),
+				"complexity":   stringProp("Complexity: low, medium, high"),
+				"notes":        stringProp("Free-text notes to attach to the spec"),
+				"limit":        intProp("Max results to return for list (default 50)"),
+				"from_version": intProp("From-version for compare"),
+				"to_version":   intProp("To-version for compare"),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *specTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "get":
+		return t.handleGet(ctx, params)
+	case "list":
+		return t.handleList(ctx, params)
+	case "create":
+		return t.handleCreate(ctx, params)
+	case "update":
+		return t.handleUpdate(ctx, params)
+	case "changes":
+		return t.handleChanges(ctx, params)
+	case "compare":
+		return t.handleCompare(ctx, params)
+	default:
+		return errResult(fmt.Sprintf("unknown action %q — valid: get, list, create, update, changes, compare", action)), nil
+	}
+}
+
+func (t *specTool) handleGet(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for get"), nil
+	}
+	resp, err := t.client.Spec.GetSpec(ctx, connect.NewRequest(&specv1.GetSpecRequest{
+		Slug: slug,
+	}))
+	if err != nil {
+		result, rerr := connectErrResult(err)
+		return result, rerr
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *specTool) handleList(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	resp, err := t.client.Spec.ListSpecs(ctx, connect.NewRequest(&specv1.ListSpecsRequest{
+		Stage:    stringParam(params, "stage"),
+		Priority: stringParam(params, "priority"),
+		Limit:    int32Param(params, "limit"),
+	}))
+	if err != nil {
+		result, rerr := connectErrResult(err)
+		return result, rerr
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *specTool) handleCreate(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	intent := stringParam(params, "intent")
+	if slug == "" {
+		return errResult("slug is required for create"), nil
+	}
+	if intent == "" {
+		return errResult("intent is required for create"), nil
+	}
+	resp, err := t.client.Spec.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+		Slug:       slug,
+		Intent:     intent,
+		Priority:   stringParam(params, "priority"),
+		Complexity: stringParam(params, "complexity"),
+	}))
+	if err != nil {
+		result, rerr := connectErrResult(err)
+		return result, rerr
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *specTool) handleUpdate(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for update"), nil
+	}
+	resp, err := t.client.Spec.UpdateSpec(ctx, connect.NewRequest(&specv1.UpdateSpecRequest{
+		Slug:       slug,
+		Intent:     stringPtrParam(params, "intent"),
+		Stage:      stringPtrParam(params, "stage"),
+		Priority:   stringPtrParam(params, "priority"),
+		Complexity: stringPtrParam(params, "complexity"),
+		Notes:      stringPtrParam(params, "notes"),
+	}))
+	if err != nil {
+		result, rerr := connectErrResult(err)
+		return result, rerr
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *specTool) handleChanges(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for changes"), nil
+	}
+	resp, err := t.client.Spec.ListChanges(ctx, connect.NewRequest(&specv1.ListChangesRequest{
+		Slug:  slug,
+		Limit: int32Param(params, "limit"),
+	}))
+	if err != nil {
+		result, rerr := connectErrResult(err)
+		return result, rerr
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *specTool) handleCompare(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for compare"), nil
+	}
+	resp, err := t.client.Spec.CompareVersions(ctx, connect.NewRequest(&specv1.CompareVersionsRequest{
+		Slug:        slug,
+		FromVersion: int32Param(params, "from_version"),
+		ToVersion:   int32Param(params, "to_version"),
+	}))
+	if err != nil {
+		result, rerr := connectErrResult(err)
+		return result, rerr
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+// ---------------------------------------------------------------------------
+// decisionTool — CRUD operations on Decisions (ADRs)
+// ---------------------------------------------------------------------------
+
+type decisionTool struct {
+	client *Client
+}
+
+func (t *decisionTool) def() ToolDef {
+	return ToolDef{
+		Name: "decision",
+		Description: "Read and write SpecGraph decisions (ADRs). " +
+			"Actions: get, list, create, update.",
+		Tier: TierCore,
+		Schema: objectSchema(
+			props{
+				"action":    stringProp("Operation to perform", "get", "list", "create", "update"),
+				"slug":      stringProp("Decision slug (required for get/update)"),
+				"title":     stringProp("Short title for the decision (required for create)"),
+				"decision":  stringProp("The decision text (required for create)"),
+				"rationale": stringProp("Why this decision was made"),
+				"question":  stringProp("The question this decision answers"),
+				"tags":      arrayProp("Tags to associate with the decision", map[string]any{"type": "string"}),
+			},
+			"action",
+		),
+		Handler: t.handle,
+	}
+}
+
+func (t *decisionTool) handle(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	action := stringParam(params, "action")
+	switch action {
+	case "get":
+		return t.handleGet(ctx, params)
+	case "list":
+		return t.handleList(ctx, params)
+	case "create":
+		return t.handleCreate(ctx, params)
+	case "update":
+		return t.handleUpdate(ctx, params)
+	default:
+		return errResult(fmt.Sprintf("unknown action %q — valid: get, list, create, update", action)), nil
+	}
+}
+
+func (t *decisionTool) handleGet(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for get"), nil
+	}
+	resp, err := t.client.Decision.GetDecision(ctx, connect.NewRequest(&specv1.GetDecisionRequest{
+		Slug: slug,
+	}))
+	if err != nil {
+		result, rerr := connectErrResult(err)
+		return result, rerr
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *decisionTool) handleList(ctx context.Context, _ map[string]any) (*ToolResult, error) {
+	resp, err := t.client.Decision.ListDecisions(ctx, connect.NewRequest(&specv1.ListDecisionsRequest{}))
+	if err != nil {
+		result, rerr := connectErrResult(err)
+		return result, rerr
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *decisionTool) handleCreate(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	title := stringParam(params, "title")
+	decision := stringParam(params, "decision")
+	if slug == "" {
+		return errResult("slug is required for create"), nil
+	}
+	if title == "" {
+		return errResult("title is required for create"), nil
+	}
+	if decision == "" {
+		return errResult("decision is required for create"), nil
+	}
+	resp, err := t.client.Decision.CreateDecision(ctx, connect.NewRequest(&specv1.CreateDecisionRequest{
+		Slug:      slug,
+		Title:     title,
+		Decision:  decision,
+		Rationale: stringParam(params, "rationale"),
+		Question:  stringParam(params, "question"),
+		Tags:      stringSliceParam(params, "tags"),
+	}))
+	if err != nil {
+		result, rerr := connectErrResult(err)
+		return result, rerr
+	}
+	return jsonResult(resp.Msg), nil
+}
+
+func (t *decisionTool) handleUpdate(ctx context.Context, params map[string]any) (*ToolResult, error) {
+	slug := stringParam(params, "slug")
+	if slug == "" {
+		return errResult("slug is required for update"), nil
+	}
+	resp, err := t.client.Decision.UpdateDecision(ctx, connect.NewRequest(&specv1.UpdateDecisionRequest{
+		Slug:      slug,
+		Title:     stringPtrParam(params, "title"),
+		Decision:  stringPtrParam(params, "decision"),
+		Rationale: stringPtrParam(params, "rationale"),
+		Question:  stringPtrParam(params, "question"),
+		Tags:      stringSliceParam(params, "tags"),
+	}))
+	if err != nil {
+		result, rerr := connectErrResult(err)
+		return result, rerr
+	}
+	return jsonResult(resp.Msg), nil
+}

--- a/internal/mcp/tools_spec.go
+++ b/internal/mcp/tools_spec.go
@@ -165,10 +165,15 @@ func (t *specTool) handleCompare(ctx context.Context, params map[string]any) (*T
 	if slug == "" {
 		return errResult("slug is required for compare"), nil
 	}
+	fromVersion := int32Param(params, "from_version")
+	toVersion := int32Param(params, "to_version")
+	if fromVersion == 0 || toVersion == 0 {
+		return errResult("from_version and to_version are required for compare"), nil
+	}
 	resp, err := t.client.Spec.CompareVersions(ctx, connect.NewRequest(&specv1.CompareVersionsRequest{
 		Slug:        slug,
-		FromVersion: int32Param(params, "from_version"),
-		ToVersion:   int32Param(params, "to_version"),
+		FromVersion: fromVersion,
+		ToVersion:   toVersion,
 	}))
 	if err != nil {
 		result, rerr := connectErrResult(err)

--- a/internal/mcp/tools_spec_test.go
+++ b/internal/mcp/tools_spec_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// spec tool tests
+// ---------------------------------------------------------------------------
+
+func TestSpecTool_Get(t *testing.T) {
+	svc := &mockSpecService{
+		getSpec: func(slug string) (*specv1.GetSpecResponse, error) {
+			require.Equal(t, "oauth-refresh", slug)
+			return &specv1.GetSpecResponse{
+				Spec: &specv1.Spec{Slug: "oauth-refresh", Intent: "Rotate tokens safely"},
+			}, nil
+		},
+	}
+	c := &Client{Spec: svc}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("spec")
+	require.True(t, ok)
+
+	params := map[string]any{"action": "get", "slug": "oauth-refresh"}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "oauth-refresh")
+}
+
+func TestSpecTool_GetNotFound(t *testing.T) {
+	svc := &mockSpecService{
+		getSpec: func(_ string) (*specv1.GetSpecResponse, error) {
+			return nil, connect.NewError(connect.CodeNotFound, nil)
+		},
+	}
+	c := &Client{Spec: svc}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("spec")
+	require.True(t, ok)
+
+	params := map[string]any{"action": "get", "slug": "no-such-spec"}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+}
+
+func TestSpecTool_List(t *testing.T) {
+	svc := &mockSpecService{
+		listSpecs: func() (*specv1.ListSpecsResponse, error) {
+			return &specv1.ListSpecsResponse{
+				Specs: []*specv1.Spec{
+					{Slug: "spec-a", Stage: "spark"},
+					{Slug: "spec-b", Stage: "shape"},
+				},
+			}, nil
+		},
+	}
+	c := &Client{Spec: svc}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("spec")
+	require.True(t, ok)
+
+	params := map[string]any{"action": "list"}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "spec-a")
+	require.Contains(t, result.Content[0].Text, "spec-b")
+}
+
+func TestSpecTool_Create(t *testing.T) {
+	svc := &mockSpecService{
+		createSpec: func(slug, intent string) (*specv1.CreateSpecResponse, error) {
+			require.Equal(t, "new-feature", slug)
+			require.Equal(t, "Build new feature", intent)
+			return &specv1.CreateSpecResponse{
+				Spec: &specv1.Spec{Slug: "new-feature", Intent: "Build new feature", Stage: "spark"},
+			}, nil
+		},
+	}
+	c := &Client{Spec: svc}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("spec")
+	require.True(t, ok)
+
+	params := map[string]any{
+		"action": "create",
+		"slug":   "new-feature",
+		"intent": "Build new feature",
+	}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "new-feature")
+}
+
+func TestSpecTool_UnknownAction(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{}}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("spec")
+	require.True(t, ok)
+
+	params := map[string]any{"action": "frobnicate"}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "unknown action")
+}
+
+// ---------------------------------------------------------------------------
+// decision tool tests
+// ---------------------------------------------------------------------------
+
+func TestDecisionTool_Get(t *testing.T) {
+	svc := &mockDecisionService{
+		getDecision: func(slug string) (*specv1.GetDecisionResponse, error) {
+			require.Equal(t, "adr-001", slug)
+			return &specv1.GetDecisionResponse{
+				Decision: &specv1.Decision{Slug: "adr-001", Title: "Use PostgreSQL"},
+			}, nil
+		},
+	}
+	c := &Client{Decision: svc}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("decision")
+	require.True(t, ok)
+
+	params := map[string]any{"action": "get", "slug": "adr-001"}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "adr-001")
+}
+
+func TestDecisionTool_List(t *testing.T) {
+	svc := &mockDecisionService{
+		listDecisions: func() (*specv1.ListDecisionsResponse, error) {
+			return &specv1.ListDecisionsResponse{
+				Decisions: []*specv1.Decision{
+					{Slug: "adr-001", Title: "Use PostgreSQL"},
+					{Slug: "adr-002", Title: "Use ConnectRPC"},
+				},
+			}, nil
+		},
+	}
+	c := &Client{Decision: svc}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("decision")
+	require.True(t, ok)
+
+	params := map[string]any{"action": "list"}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "adr-001")
+	require.Contains(t, result.Content[0].Text, "adr-002")
+}

--- a/internal/mcp/tools_spec_test.go
+++ b/internal/mcp/tools_spec_test.go
@@ -179,3 +179,327 @@ func TestDecisionTool_List(t *testing.T) {
 	require.Contains(t, result.Content[0].Text, "adr-001")
 	require.Contains(t, result.Content[0].Text, "adr-002")
 }
+
+// ---------------------------------------------------------------------------
+// spec tool — additional coverage
+// ---------------------------------------------------------------------------
+
+func TestSpecTool_Create_MissingSlug(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{}}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("spec")
+	require.True(t, ok)
+
+	params := map[string]any{"action": "create", "intent": "Something useful"}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug is required")
+}
+
+func TestSpecTool_Create_MissingIntent(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{}}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("spec")
+	require.True(t, ok)
+
+	params := map[string]any{"action": "create", "slug": "my-feature"}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "intent is required")
+}
+
+func TestSpecTool_List_WithLimit(t *testing.T) {
+	svc := &mockSpecService{
+		listSpecs: func() (*specv1.ListSpecsResponse, error) {
+			return &specv1.ListSpecsResponse{
+				Specs: []*specv1.Spec{
+					{Slug: "alpha"},
+					{Slug: "beta"},
+				},
+			}, nil
+		},
+	}
+	c := &Client{Spec: svc}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("spec")
+	require.True(t, ok)
+
+	params := map[string]any{"action": "list", "limit": 10}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "alpha")
+}
+
+func TestSpecTool_Update(t *testing.T) {
+	svc := &mockSpecService{
+		updateSpec: func(req *specv1.UpdateSpecRequest) (*specv1.UpdateSpecResponse, error) {
+			require.Equal(t, "auth", req.GetSlug())
+			return &specv1.UpdateSpecResponse{Spec: &specv1.Spec{Slug: req.GetSlug()}}, nil
+		},
+	}
+	c := &Client{Spec: svc}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("spec")
+	require.True(t, ok)
+
+	params := map[string]any{
+		"action": "update",
+		"slug":   "auth",
+		"stage":  "shape",
+	}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "auth")
+}
+
+func TestSpecTool_Update_MissingSlug(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{}}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("spec")
+	require.True(t, ok)
+
+	params := map[string]any{"action": "update", "stage": "shape"}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug is required")
+}
+
+func TestSpecTool_Changes(t *testing.T) {
+	svc := &mockSpecService{
+		listChanges: func(slug string) (*specv1.ListChangesResponse, error) {
+			require.Equal(t, "auth", slug)
+			return &specv1.ListChangesResponse{}, nil
+		},
+	}
+	c := &Client{Spec: svc}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("spec")
+	require.True(t, ok)
+
+	params := map[string]any{"action": "changes", "slug": "auth"}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestSpecTool_Changes_WithLimit(t *testing.T) {
+	svc := &mockSpecService{
+		listChanges: func(slug string) (*specv1.ListChangesResponse, error) {
+			require.Equal(t, "auth", slug)
+			return &specv1.ListChangesResponse{}, nil
+		},
+	}
+	c := &Client{Spec: svc}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("spec")
+	require.True(t, ok)
+
+	params := map[string]any{"action": "changes", "slug": "auth", "limit": 5}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestSpecTool_Changes_MissingSlug(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{}}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("spec")
+	require.True(t, ok)
+
+	params := map[string]any{"action": "changes"}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug is required")
+}
+
+func TestSpecTool_Compare(t *testing.T) {
+	svc := &mockSpecService{
+		compareVer: func(req *specv1.CompareVersionsRequest) (*specv1.CompareVersionsResponse, error) {
+			require.Equal(t, "auth", req.GetSlug())
+			require.Equal(t, int32(1), req.GetFromVersion())
+			require.Equal(t, int32(3), req.GetToVersion())
+			return &specv1.CompareVersionsResponse{}, nil
+		},
+	}
+	c := &Client{Spec: svc}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("spec")
+	require.True(t, ok)
+
+	params := map[string]any{
+		"action":       "compare",
+		"slug":         "auth",
+		"from_version": 1,
+		"to_version":   3,
+	}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestSpecTool_Compare_MissingSlug(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{}}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("spec")
+	require.True(t, ok)
+
+	params := map[string]any{"action": "compare", "from_version": 1, "to_version": 3}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug is required")
+}
+
+func TestSpecTool_Compare_MissingVersions(t *testing.T) {
+	c := &Client{Spec: &mockSpecService{}}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("spec")
+	require.True(t, ok)
+
+	params := map[string]any{"action": "compare", "slug": "auth"}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "from_version and to_version are required")
+}
+
+// ---------------------------------------------------------------------------
+// decision tool — additional coverage
+// ---------------------------------------------------------------------------
+
+func TestDecisionTool_Create(t *testing.T) {
+	svc := &mockDecisionService{
+		createDecision: func(req *specv1.CreateDecisionRequest) (*specv1.CreateDecisionResponse, error) {
+			require.Equal(t, "adr-003", req.GetSlug())
+			require.Equal(t, "Use pgx v5", req.GetTitle())
+			return &specv1.CreateDecisionResponse{
+				Decision: &specv1.Decision{Slug: req.GetSlug(), Title: req.GetTitle()},
+			}, nil
+		},
+	}
+	c := &Client{Decision: svc}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("decision")
+	require.True(t, ok)
+
+	params := map[string]any{
+		"action":   "create",
+		"slug":     "adr-003",
+		"title":    "Use pgx v5",
+		"decision": "We will use pgx v5 as the Postgres driver.",
+	}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "adr-003")
+}
+
+func TestDecisionTool_Create_MissingSlug(t *testing.T) {
+	c := &Client{Decision: &mockDecisionService{}}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("decision")
+	require.True(t, ok)
+
+	params := map[string]any{
+		"action":   "create",
+		"title":    "Use pgx v5",
+		"decision": "We will use pgx v5.",
+	}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug is required")
+}
+
+func TestDecisionTool_Create_MissingTitle(t *testing.T) {
+	c := &Client{Decision: &mockDecisionService{}}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("decision")
+	require.True(t, ok)
+
+	params := map[string]any{
+		"action":   "create",
+		"slug":     "adr-003",
+		"decision": "We will use pgx v5.",
+	}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "title is required")
+}
+
+func TestDecisionTool_Update(t *testing.T) {
+	svc := &mockDecisionService{
+		updateDecision: func(req *specv1.UpdateDecisionRequest) (*specv1.UpdateDecisionResponse, error) {
+			require.Equal(t, "adr-001", req.GetSlug())
+			return &specv1.UpdateDecisionResponse{
+				Decision: &specv1.Decision{Slug: req.GetSlug()},
+			}, nil
+		},
+	}
+	c := &Client{Decision: svc}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("decision")
+	require.True(t, ok)
+
+	params := map[string]any{
+		"action":    "update",
+		"slug":      "adr-001",
+		"rationale": "Better performance",
+	}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "adr-001")
+}
+
+func TestDecisionTool_Update_MissingSlug(t *testing.T) {
+	c := &Client{Decision: &mockDecisionService{}}
+	r := NewRegistry()
+	RegisterSpecTools(r, c)
+
+	tool, ok := r.LookupTool("decision")
+	require.True(t, ok)
+
+	params := map[string]any{"action": "update", "rationale": "Better performance"}
+	result, err := tool.Handler(context.Background(), params)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug is required")
+}

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -1,0 +1,125 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package mcp provides a Model Context Protocol server that translates
+// MCP tool calls into ConnectRPC RPCs against a running SpecGraph server.
+package mcp
+
+import "context"
+
+// Tier controls which tools are visible to an MCP client.
+type Tier int
+
+const (
+	// TierCore exposes read-heavy tools: specs, graph queries, constitution.
+	TierCore Tier = iota
+	// TierAuthoring adds authoring funnel, decisions, drift, analytical passes.
+	TierAuthoring
+	// TierExecution adds claims, slices, progress reporting, bundles.
+	TierExecution
+)
+
+// String returns the tier name used in capability negotiation.
+func (t Tier) String() string {
+	switch t {
+	case TierCore:
+		return "core"
+	case TierAuthoring:
+		return "authoring"
+	case TierExecution:
+		return "execution"
+	default:
+		return "core"
+	}
+}
+
+// ParseTier converts a string to a Tier. Returns TierCore for unknown values.
+func ParseTier(s string) Tier {
+	switch s {
+	case "authoring":
+		return TierAuthoring
+	case "execution":
+		return TierExecution
+	default:
+		return TierCore
+	}
+}
+
+// Includes reports whether tier t includes all tools visible at tier other.
+func (t Tier) Includes(other Tier) bool {
+	return t >= other
+}
+
+// ToolDef defines an MCP tool in SpecGraph's own types (no SDK dependency).
+type ToolDef struct {
+	Name        string
+	Description string
+	Tier        Tier
+	Schema      map[string]any // JSON Schema for parameters
+	Handler     ToolHandler
+}
+
+// ToolHandler processes an MCP tool call. params is the deserialized arguments map.
+type ToolHandler func(ctx context.Context, params map[string]any) (*ToolResult, error)
+
+// ToolResult is the response from a tool handler.
+type ToolResult struct {
+	Content []Content
+	IsError bool
+}
+
+// Content is a single content block in a tool result.
+type Content struct {
+	Type string // "text"
+	Text string
+}
+
+// ResourceDef defines an MCP resource.
+type ResourceDef struct {
+	URI         string // Exact URI or template pattern
+	Name        string
+	Description string
+	MimeType    string
+	IsTemplate  bool
+	Handler     ResourceHandler
+}
+
+// ResourceHandler reads a resource. uri is the resolved URI.
+type ResourceHandler func(ctx context.Context, uri string) ([]ResourceContent, error)
+
+// ResourceContent is a single content block in a resource response.
+type ResourceContent struct {
+	URI      string
+	MimeType string
+	Text     string
+}
+
+// PromptDef defines an MCP prompt.
+type PromptDef struct {
+	Name        string
+	Description string
+	Arguments   []PromptArgument
+	Handler     PromptHandler
+}
+
+// PromptArgument describes a prompt parameter.
+type PromptArgument struct {
+	Name        string
+	Description string
+	Required    bool
+}
+
+// PromptHandler renders a prompt. args is the argument map.
+type PromptHandler func(ctx context.Context, args map[string]string) (*PromptResult, error)
+
+// PromptResult is the response from a prompt handler.
+type PromptResult struct {
+	Description string
+	Messages    []PromptMessage
+}
+
+// PromptMessage is a single message in a prompt result.
+type PromptMessage struct {
+	Role    string // "user" or "assistant"
+	Content string
+}

--- a/internal/mcp/types_test.go
+++ b/internal/mcp/types_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 SpecGraph Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTierString(t *testing.T) {
+	tests := []struct {
+		tier Tier
+		want string
+	}{
+		{TierCore, "core"},
+		{TierAuthoring, "authoring"},
+		{TierExecution, "execution"},
+		// Unknown values fall back to "core" per the current implementation.
+		{Tier(99), "core"},
+		{Tier(-1), "core"},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Tier(%d)", tt.tier), func(t *testing.T) {
+			require.Equal(t, tt.want, tt.tier.String())
+		})
+	}
+}
+
+func TestParseTier(t *testing.T) {
+	tests := []struct {
+		input string
+		want  Tier
+	}{
+		{"core", TierCore},
+		{"authoring", TierAuthoring},
+		{"execution", TierExecution},
+		// Unknown strings default to TierCore.
+		{"unknown", TierCore},
+		{"", TierCore},
+		{"CORE", TierCore},
+		{"Authoring", TierCore},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("ParseTier(%q)", tt.input), func(t *testing.T) {
+			require.Equal(t, tt.want, ParseTier(tt.input))
+		})
+	}
+}
+
+func TestTierIncludes(t *testing.T) {
+	tests := []struct {
+		t     Tier
+		other Tier
+		want  bool
+	}{
+		// Core includes only core.
+		{TierCore, TierCore, true},
+		{TierCore, TierAuthoring, false},
+		{TierCore, TierExecution, false},
+		// Authoring includes core and authoring.
+		{TierAuthoring, TierCore, true},
+		{TierAuthoring, TierAuthoring, true},
+		{TierAuthoring, TierExecution, false},
+		// Execution includes all tiers.
+		{TierExecution, TierCore, true},
+		{TierExecution, TierAuthoring, true},
+		{TierExecution, TierExecution, true},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Tier(%d).Includes(Tier(%d))", tt.t, tt.other), func(t *testing.T) {
+			require.Equal(t, tt.want, tt.t.Includes(tt.other))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a full MCP (Model Context Protocol) server exposing SpecGraph's 13 ConnectRPC services as **20 tools** (tiered: core/authoring/execution), **9 resources**, and **6 prompts**
- Dual transport: `specgraph mcp` CLI command (stdio) + HTTP endpoint embedded in `specgraph serve` at `/mcp/`
- SDK isolation: only 3 files import `mcp-go` (convert.go, server.go, tiers.go) — all other MCP code uses internal types
- Tool tier system: Core (7 tools) → Authoring (+7) → Execution (+6), selected by client name heuristic at connection time
- Constitution round-trip: full JSON get → modify → update for agent workflows
- **164 new tests**, all passing with 0 lint issues

## Architecture

```
┌─────────────┐     ┌──────────────┐     ┌────────────────┐
│ MCP Client  │────▶│ mcp.Server   │────▶│ ConnectRPC     │
│ (stdio/HTTP)│     │ (per-tier)   │     │ Backend        │
└─────────────┘     └──────────────┘     └────────────────┘
                    ┌──────────────┐
                    │ internal/mcp │
                    │  types.go    │ SpecGraph MCP types
                    │  registry.go │ Tool/Resource/Prompt registry
                    │  convert.go  │ ← SDK boundary
                    │  server.go   │ ← SDK boundary
                    │  tiers.go    │ ← SDK boundary
                    │  tools_*.go  │ 20 tool handlers
                    │  resources.go│ 9 resource handlers
                    │  prompts.go  │ 6 prompt handlers
                    └──────────────┘
```

## Test plan

- [x] `task check` passes (fmt, license, lint, build, unit tests)
- [ ] `task pr-prep` — `task check` passes; integration/e2e blocked by buf registry outage (unrelated to this PR)
- [ ] Manual: `specgraph mcp --tier core` responds to MCP initialize
- [ ] Manual: `specgraph serve` exposes `/mcp/` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)