### PR TITLE
fix: change default server.listen to 0.0.0.0:9090

### DIFF
--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -127,7 +127,7 @@ func (c *GlobalConfig) ResolveServer(projectSlug, repoOverride string) string {
 func globalDefaults() *GlobalConfig {
 	return &GlobalConfig{
 		Server: ServerSection{
-			Listen:  "127.0.0.1:7890",
+			Listen:  "0.0.0.0:9090",
 			Mode:    "service",
 			Backend: "postgres",
 			Postgres: PostgresConfig{ //nolint:gosec // dev default, not a real credential
@@ -136,7 +136,7 @@ func globalDefaults() *GlobalConfig {
 			Docker: true,
 		},
 		Client: ClientConfig{
-			DefaultServer: "http://127.0.0.1:7890",
+			DefaultServer: "http://127.0.0.1:9090",
 		},
 	}
 }

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -19,12 +19,12 @@ func TestLoadGlobal_Defaults(t *testing.T) {
 
 	cfg, err := config.LoadGlobal(path)
 	require.NoError(t, err)
-	assert.Equal(t, "127.0.0.1:7890", cfg.Server.Listen)
+	assert.Equal(t, "0.0.0.0:9090", cfg.Server.Listen)
 	assert.Equal(t, "service", cfg.Server.Mode)
 	assert.Equal(t, "postgres", cfg.Server.Backend)
 	assert.Equal(t, "postgres://specgraph:specgraph@localhost:5432/specgraph?sslmode=disable", cfg.Server.Postgres.URL)
 	assert.True(t, cfg.Server.Docker)
-	assert.Equal(t, "http://127.0.0.1:7890", cfg.Client.DefaultServer)
+	assert.Equal(t, "http://127.0.0.1:9090", cfg.Client.DefaultServer)
 	assert.Empty(t, cfg.Client.Routes)
 
 	_, err = os.Stat(path)

--- a/site/docs/quickstart.md
+++ b/site/docs/quickstart.md
@@ -71,8 +71,14 @@ specgraph up
 ```
 
 This starts a PostgreSQL Docker container and installs a background service
-(launchd on macOS, systemd on Linux). The server listens at
-`http://localhost:9090` by default.
+(launchd on macOS, systemd on Linux). The server binds `0.0.0.0:9090` by
+default and is reachable at `http://localhost:9090` from the local machine.
+
+> **Heads-up:** With no auth configured, `0.0.0.0:9090` accepts non-loopback
+> traffic; SpecGraph logs a warning at startup. Set
+> `server.listen: "127.0.0.1:9090"` in `~/.config/specgraph/config.yaml` to
+> restrict to loopback, or configure API keys / OIDC before exposing the
+> server.
 
 <details><summary>Manual mode</summary>
 


### PR DESCRIPTION
## Summary
- Closes #913. \`globalDefaults()\` set \`Listen: "127.0.0.1:7890"\` while the Dockerfile \`EXPOSE\`s 9090 and \`quickstart.md\` claimed \`localhost:9090\`. Binary, Dockerfile, and docs were telling three different stories.
- Pick one: \`0.0.0.0:9090\` — matches the Dockerfile and what the docs already claim. Client \`DefaultServer\` stays loopback (\`http://127.0.0.1:9090\`) since clients reach the local server via loopback.
- Docs: \`quickstart.md\` now explicitly states the server binds \`0.0.0.0:9090\` and calls out the security implication (opt back into loopback-only with \`server.listen: "127.0.0.1:9090"\`).

## User-visible behavior change
No-config-present default previously bound loopback; now binds all interfaces. \`serve.go\` already warns when listening without auth on non-loopback, so operators will see a clear signal.

## Test plan
- [x] \`go test ./internal/config/\` — updated \`TestLoadGlobal_Defaults\` assertions for new default
- [x] \`task lint\` green
- [ ] Fresh clone + \`specgraph up\` produces a reachable server on \`localhost:9090\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)