### PR TITLE
feat(authoring): server-side polish for conversation coupling (phase B slice 1)

### DIFF
--- a/internal/server/authoring_handler.go
+++ b/internal/server/authoring_handler.go
@@ -896,16 +896,31 @@ func exchangesFromProto(ps []*specv1.ConversationExchange) []storage.Conversatio
 }
 
 // buildConversationEntry constructs a ConversationLogEntry for RecordConversation.
-// The posture parameter is accepted to match stage-handler call sites but is
-// not yet persisted; Task 10 adds a Posture field to ConversationLogEntry.
-// Posture is silently discarded in this phase; Task 10 adds a Posture field to
-// ConversationLogEntry and wires it here.
-func buildConversationEntry(stage storage.SpecStage, _ specv1.Posture, exchanges []storage.ConversationExchange) storage.ConversationLogEntry {
+// The posture enum is converted to its string form and stored alongside the
+// exchanges for future drift detection per design §Posture.
+func buildConversationEntry(stage storage.SpecStage, posture specv1.Posture, exchanges []storage.ConversationExchange) storage.ConversationLogEntry {
 	return storage.ConversationLogEntry{
 		Stage:         stage,
 		Exchanges:     exchanges,
 		ExchangeCount: safeInt32(len(exchanges)),
+		Posture:       postureToString(posture),
 		// IsAmend defaults to false; amend-originated entries use a separate code path.
+	}
+}
+
+// postureToString maps the proto Posture enum to its canonical string form.
+// Unknown values map to the empty string, which the storage layer treats as
+// "posture unspecified".
+func postureToString(p specv1.Posture) string {
+	switch p {
+	case specv1.Posture_POSTURE_DRIVE:
+		return "drive"
+	case specv1.Posture_POSTURE_PARTNER:
+		return "partner"
+	case specv1.Posture_POSTURE_SUPPORT:
+		return "support"
+	default:
+		return ""
 	}
 }
 

--- a/internal/server/authoring_handler.go
+++ b/internal/server/authoring_handler.go
@@ -23,9 +23,9 @@ import (
 const maxElements = 100
 
 // AuthoringHandler implements the ConnectRPC AuthoringService.
-// When txBackend is non-nil, multi-step RPCs (Spark, Shape, Specify, Decompose)
-// wrap their operations in a transaction for atomicity. When nil, operations
-// execute sequentially without rollback on partial failure.
+// Multi-step RPCs (Spark, Shape, Specify, Decompose, Approve) wrap their
+// storage operations in a single transaction via runInTxOrSequential /
+// RunInTransaction, providing atomic rollback if any step fails.
 type AuthoringHandler struct {
 	scoper storage.Scoper
 	logger *slog.Logger
@@ -909,10 +909,13 @@ func buildConversationEntry(stage storage.SpecStage, posture specv1.Posture, exc
 }
 
 // postureToString maps the proto Posture enum to its canonical string form.
-// Unknown values map to the empty string, which the storage layer treats as
-// "posture unspecified".
+// POSTURE_UNSPECIFIED maps to "" (the storage layer's "no posture" sentinel).
+// Any unrecognized enum value also maps to "" but logs a warning so future
+// proto additions are surfaced at runtime rather than silently dropped.
 func postureToString(p specv1.Posture) string {
 	switch p {
+	case specv1.Posture_POSTURE_UNSPECIFIED:
+		return ""
 	case specv1.Posture_POSTURE_DRIVE:
 		return "drive"
 	case specv1.Posture_POSTURE_PARTNER:
@@ -920,6 +923,8 @@ func postureToString(p specv1.Posture) string {
 	case specv1.Posture_POSTURE_SUPPORT:
 		return "support"
 	default:
+		slog.Warn("postureToString: unrecognized posture enum, storing empty string",
+			slog.Int("posture_int", int(p)))
 		return ""
 	}
 }

--- a/internal/server/authoring_handler_internal_test.go
+++ b/internal/server/authoring_handler_internal_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"testing"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostureToString(t *testing.T) {
+	tests := []struct {
+		name string
+		in   specv1.Posture
+		want string
+	}{
+		{"unspecified → empty", specv1.Posture_POSTURE_UNSPECIFIED, ""},
+		{"drive", specv1.Posture_POSTURE_DRIVE, "drive"},
+		{"partner", specv1.Posture_POSTURE_PARTNER, "partner"},
+		{"support", specv1.Posture_POSTURE_SUPPORT, "support"},
+		{"unknown int → empty", specv1.Posture(999), ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := postureToString(tt.in)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/server/authoring_handler_test.go
+++ b/internal/server/authoring_handler_test.go
@@ -214,6 +214,7 @@ func (f *fakeConversationBackend) RecordConversation(_ context.Context, _ string
 		IsAmend:       entry.IsAmend,
 		Exchanges:     entry.Exchanges,
 		ExchangeCount: entry.ExchangeCount,
+		Posture:       entry.Posture,
 		Date:          time.Now(),
 	}
 	f.entries = append(f.entries, stored)

--- a/internal/storage/conversation.go
+++ b/internal/storage/conversation.go
@@ -45,6 +45,7 @@ type ConversationLogEntry struct {
 	IsAmend       bool
 	Exchanges     []ConversationExchange
 	ExchangeCount int32
+	Posture       string // "drive", "partner", "support", or "" when unspecified
 	Date          time.Time
 }
 

--- a/internal/storage/postgres/authoring_rollback_integration_test.go
+++ b/internal/storage/postgres/authoring_rollback_integration_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage/postgres"
+	"github.com/stretchr/testify/require"
+)
+
+// failingOnSafetyFlagsStore wraps a *postgres.Store and forces StoreSafetyFlags
+// to return an injected error, simulating a mid-transaction failure on the
+// third op of the four-op Shape transaction.
+type failingOnSafetyFlagsStore struct {
+	*postgres.Store
+}
+
+func (f *failingOnSafetyFlagsStore) StoreSafetyFlags(_ context.Context, _ string, _ []storage.SafetyFlag) error {
+	return errors.New("injected safety-flags failure")
+}
+
+// rollbackTestScoper is a storage.Scoper that always returns the same backend.
+type rollbackTestScoper struct {
+	backend storage.ScopedBackend
+}
+
+func (s *rollbackTestScoper) Scoped(_ context.Context, _ string) (storage.ScopedBackend, error) {
+	return s.backend, nil
+}
+
+func (s *rollbackTestScoper) Subscribe(_ storage.ChangeSubscriber) {}
+
+// TestShape_AtomicRollback_ConversationNotPersistedOnSafetyFail verifies that
+// when StoreSafetyFlags (the third op) fails inside the four-op Shape
+// transaction, the entire transaction — TransitionStage, StoreShapeOutput, and
+// RecordConversation — is rolled back. After the error:
+//
+//   - The spec stage must still be "spark" (TransitionStage rolled back).
+//   - No conversation log must exist for the shape stage (RecordConversation
+//     rolled back).
+func TestShape_AtomicRollback_ConversationNotPersistedOnSafetyFail(t *testing.T) {
+	ctx := context.Background()
+
+	// Real store used for setup and post-rollback assertions.
+	realStore := newStore(t)
+	clearDatabase(t, realStore)
+
+	// Create a failing wrapper — embeds the real store, overrides StoreSafetyFlags.
+	failingStore := &failingOnSafetyFlagsStore{Store: realStore}
+
+	// Construct the handler via RegisterAuthoringService with a scoper that
+	// always returns the failing store.
+	scoper := &rollbackTestScoper{backend: failingStore}
+	mux := http.NewServeMux()
+	server.RegisterAuthoringService(mux, scoper)
+	srv := httptest.NewServer(injectTestProject(mux))
+	t.Cleanup(srv.Close)
+
+	client := specgraphv1connect.NewAuthoringServiceClient(http.DefaultClient, srv.URL)
+
+	// Step 1: drive the spec to spark stage via Spark RPC.
+	_, err := client.Spark(ctx, connect.NewRequest(&specv1.SparkRequest{
+		Slug: "oauth-refresh",
+		Output: &specv1.SparkOutput{
+			Seed:   "oauth refresh token flow",
+			Signal: "user request",
+		},
+		// No conversation_exchanges — Spark allows omission.
+	}))
+	// Spark may fail because StoreSafetyFlags is always broken in the wrapper.
+	// If the seed triggers a safety flag (unlikely for plain text), Spark would
+	// fail too. In practice "oauth refresh token flow" does NOT trigger patterns.
+	// But to be safe: if Spark fails, the spec won't be created and the test
+	// should report a more actionable message.
+	if err != nil {
+		t.Fatalf("Spark unexpectedly failed (check whether seed triggers safety patterns): %v", err)
+	}
+
+	// Step 2: call Shape with a risk that triggers a safety flag ("credential"),
+	// guaranteeing StoreSafetyFlags is called. The failing wrapper then returns
+	// an error, rolling back the entire transaction.
+	_, err = client.Shape(ctx, connect.NewRequest(&specv1.ShapeRequest{
+		Slug: "oauth-refresh",
+		Output: &specv1.ShapeOutput{
+			ScopeIn:        []string{"token refresh endpoint"},
+			ScopeOut:       []string{"initial login"},
+			Approaches:     []*specv1.Approach{{Name: "jwt", Description: "JWT-based refresh", Tradeoffs: []string{"expiry management"}}},
+			ChosenApproach: "jwt",
+			// "credential" matches a warning security pattern — ensures safety flags are generated.
+			Risks:       []string{"credential rotation required"},
+			SuccessMust: []string{"refresh token accepted"},
+		},
+		ConversationExchanges: []*specv1.ConversationExchange{
+			{Role: "probe", Content: "what is the shape?", Stage: "shape", Sequence: 1},
+		},
+	}))
+	if err == nil {
+		t.Fatal("expected Shape to return an error due to injected StoreSafetyFlags failure")
+	}
+
+	// Step 3: assert rollback — spec must still be at spark stage.
+	spec, specErr := realStore.GetSpec(ctx, "oauth-refresh")
+	require.NoError(t, specErr, "GetSpec after rollback")
+	if spec.Stage != storage.SpecStageSpark {
+		t.Errorf("expected spec stage %q after rollback, got %q", storage.SpecStageSpark, spec.Stage)
+	}
+
+	// Step 4: assert rollback — no conversation log for the shape stage.
+	logs, logsErr := realStore.ListConversations(ctx, "oauth-refresh", "shape")
+	require.NoError(t, logsErr, "ListConversations after rollback")
+	if len(logs) > 0 {
+		t.Errorf("expected no conversation logs for shape stage after rollback, got %d", len(logs))
+	}
+}
+
+// injectTestProject mirrors the test project middleware used in server unit
+// tests: it adds the X-Specgraph-Project header (using a valid project slug)
+// when absent, then passes through server.ProjectMiddleware.
+func injectTestProject(h http.Handler) http.Handler {
+	withProject := server.ProjectMiddleware(h)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Specgraph-Project") == "" {
+			r.Header.Set("X-Specgraph-Project", "test")
+		}
+		withProject.ServeHTTP(w, r)
+	})
+}

--- a/internal/storage/postgres/authoring_rollback_integration_test.go
+++ b/internal/storage/postgres/authoring_rollback_integration_test.go
@@ -28,6 +28,9 @@ type failingOnSafetyFlagsStore struct {
 	*postgres.Store
 }
 
+// Compile-time assertion: failingOnSafetyFlagsStore must satisfy ScopedBackend.
+var _ storage.ScopedBackend = (*failingOnSafetyFlagsStore)(nil)
+
 func (f *failingOnSafetyFlagsStore) StoreSafetyFlags(_ context.Context, _ string, _ []storage.SafetyFlag) error {
 	return errors.New("injected safety-flags failure")
 }
@@ -111,12 +114,22 @@ func TestShape_AtomicRollback_ConversationNotPersistedOnSafetyFail(t *testing.T)
 		t.Fatal("expected Shape to return an error due to injected StoreSafetyFlags failure")
 	}
 
+	// Assert the error is a ConnectRPC CodeInternal (injected storage failure maps there).
+	var connErr *connect.Error
+	require.True(t, errors.As(err, &connErr), "expected connect.Error")
+	require.Equal(t, connect.CodeInternal, connErr.Code(),
+		"injected safety-flags failure must map to CodeInternal")
+
 	// Step 3: assert rollback — spec must still be at spark stage.
 	spec, specErr := realStore.GetSpec(ctx, "oauth-refresh")
 	require.NoError(t, specErr, "GetSpec after rollback")
 	if spec.Stage != storage.SpecStageSpark {
 		t.Errorf("expected spec stage %q after rollback, got %q", storage.SpecStageSpark, spec.Stage)
 	}
+
+	// Verify ShapeOutput was also rolled back — op 2 (StoreShapeOutput) was
+	// inside the same transaction as op 3 (StoreSafetyFlags), which failed.
+	require.Nil(t, spec.ShapeOutput, "ShapeOutput should be nil after rollback")
 
 	// Step 4: assert rollback — no conversation log for the shape stage.
 	logs, logsErr := realStore.ListConversations(ctx, "oauth-refresh", "shape")

--- a/internal/storage/postgres/conversation.go
+++ b/internal/storage/postgres/conversation.go
@@ -128,11 +128,11 @@ func (s *Store) RecordConversation(ctx context.Context, slug string, entry stora
 
 		_, insertErr := s.exec(txCtx,
 			`INSERT INTO conversation_logs
-				(id, spec_slug, project_slug, stage, version, is_amend, exchanges, exchange_count, date)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+				(id, spec_slug, project_slug, stage, version, is_amend, exchanges, exchange_count, posture, date)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
 			id, slug, s.project,
 			string(entry.Stage), version, entry.IsAmend,
-			exchangesJSON, entry.ExchangeCount, now,
+			exchangesJSON, entry.ExchangeCount, entry.Posture, now,
 		)
 		if insertErr != nil {
 			return fmt.Errorf("postgres: record conversation: insert: %w", insertErr)
@@ -182,6 +182,7 @@ func (s *Store) RecordConversation(ctx context.Context, slug string, entry stora
 			IsAmend:       entry.IsAmend,
 			Exchanges:     entry.Exchanges,
 			ExchangeCount: entry.ExchangeCount,
+			Posture:       entry.Posture,
 			Date:          now,
 		}
 		return nil
@@ -216,7 +217,7 @@ func (s *Store) ListConversations(ctx context.Context, slug, stage string) ([]*s
 	)
 	if stage != "" {
 		rows, queryErr = s.query(ctx,
-			`SELECT id, stage, version, is_amend, exchanges, exchange_count, date
+			`SELECT id, stage, version, is_amend, exchanges, exchange_count, posture, date
 			 FROM conversation_logs
 			 WHERE spec_slug = $1 AND project_slug = $2 AND stage = $3
 			 ORDER BY date ASC`,
@@ -224,7 +225,7 @@ func (s *Store) ListConversations(ctx context.Context, slug, stage string) ([]*s
 		)
 	} else {
 		rows, queryErr = s.query(ctx,
-			`SELECT id, stage, version, is_amend, exchanges, exchange_count, date
+			`SELECT id, stage, version, is_amend, exchanges, exchange_count, posture, date
 			 FROM conversation_logs
 			 WHERE spec_slug = $1 AND project_slug = $2
 			 ORDER BY date ASC`,
@@ -255,7 +256,7 @@ func (s *Store) ListConversations(ctx context.Context, slug, stage string) ([]*s
 // with SpecSlug populated. Ordered by spec_slug, date ascending.
 func (s *Store) ListAllConversations(ctx context.Context) ([]*storage.ConversationLogEntry, error) {
 	rows, err := s.query(ctx,
-		`SELECT id, spec_slug, stage, version, is_amend, exchanges, exchange_count, date
+		`SELECT id, spec_slug, stage, version, is_amend, exchanges, exchange_count, posture, date
 		 FROM conversation_logs
 		 WHERE project_slug = $1
 		 ORDER BY spec_slug, date ASC`,
@@ -276,10 +277,11 @@ func (s *Store) ListAllConversations(ctx context.Context) ([]*storage.Conversati
 			isAmend       bool
 			exchangesJSON []byte
 			exchangeCount int32
+			posture       string
 			date          time.Time
 		)
 		if scanErr := rows.Scan(&id, &specSlug, &stageStr, &version, &isAmend,
-			&exchangesJSON, &exchangeCount, &date); scanErr != nil {
+			&exchangesJSON, &exchangeCount, &posture, &date); scanErr != nil {
 			return nil, fmt.Errorf("postgres: list all conversations: scan: %w", scanErr)
 		}
 		exchanges, uErr := unmarshalExchanges(exchangesJSON)
@@ -294,6 +296,7 @@ func (s *Store) ListAllConversations(ctx context.Context) ([]*storage.Conversati
 			IsAmend:       isAmend,
 			Exchanges:     exchanges,
 			ExchangeCount: exchangeCount,
+			Posture:       posture,
 			Date:          date,
 		})
 	}
@@ -304,7 +307,7 @@ func (s *Store) ListAllConversations(ctx context.Context) ([]*storage.Conversati
 }
 
 // scanConversationLogEntry scans a single conversation log row (without spec_slug).
-// Expected column order: id, stage, version, is_amend, exchanges, exchange_count, date.
+// Expected column order: id, stage, version, is_amend, exchanges, exchange_count, posture, date.
 func scanConversationLogEntry(rows pgx.Rows) (*storage.ConversationLogEntry, error) {
 	var (
 		id            string
@@ -313,10 +316,11 @@ func scanConversationLogEntry(rows pgx.Rows) (*storage.ConversationLogEntry, err
 		isAmend       bool
 		exchangesJSON []byte
 		exchangeCount int32
+		posture       string
 		date          time.Time
 	)
 	if err := rows.Scan(&id, &stageStr, &version, &isAmend,
-		&exchangesJSON, &exchangeCount, &date); err != nil {
+		&exchangesJSON, &exchangeCount, &posture, &date); err != nil {
 		return nil, fmt.Errorf("postgres: scan conversation log entry: %w", err)
 	}
 	exchanges, err := unmarshalExchanges(exchangesJSON)
@@ -330,6 +334,7 @@ func scanConversationLogEntry(rows pgx.Rows) (*storage.ConversationLogEntry, err
 		IsAmend:       isAmend,
 		Exchanges:     exchanges,
 		ExchangeCount: exchangeCount,
+		Posture:       posture,
 		Date:          date,
 	}, nil
 }

--- a/internal/storage/postgres/conversation.go
+++ b/internal/storage/postgres/conversation.go
@@ -282,7 +282,7 @@ func (s *Store) ListAllConversations(ctx context.Context) ([]*storage.Conversati
 		)
 		if scanErr := rows.Scan(&id, &specSlug, &stageStr, &version, &isAmend,
 			&exchangesJSON, &exchangeCount, &posture, &date); scanErr != nil {
-			return nil, fmt.Errorf("postgres: list all conversations: scan: %w", scanErr)
+			return nil, fmt.Errorf("postgres: list all conversations: scan id=%q spec=%q: %w", id, specSlug, scanErr)
 		}
 		exchanges, uErr := unmarshalExchanges(exchangesJSON)
 		if uErr != nil {
@@ -321,7 +321,7 @@ func scanConversationLogEntry(rows pgx.Rows) (*storage.ConversationLogEntry, err
 	)
 	if err := rows.Scan(&id, &stageStr, &version, &isAmend,
 		&exchangesJSON, &exchangeCount, &posture, &date); err != nil {
-		return nil, fmt.Errorf("postgres: scan conversation log entry: %w", err)
+		return nil, fmt.Errorf("postgres: scan conversation log entry id=%q: %w", id, err)
 	}
 	exchanges, err := unmarshalExchanges(exchangesJSON)
 	if err != nil {

--- a/internal/storage/postgres/conversation_test.go
+++ b/internal/storage/postgres/conversation_test.go
@@ -263,6 +263,34 @@ func TestRecordConversation_PersistsPosture(t *testing.T) {
 	}
 }
 
+func TestRecordConversation_PersistsEmptyPosture(t *testing.T) {
+	store := newStore(t)
+	clearDatabase(t, store)
+	ctx := context.Background()
+
+	_, err := store.CreateSpec(ctx, "spec-posture-empty", "intent", "p2", "medium")
+	require.NoError(t, err)
+
+	entry := storage.ConversationLogEntry{
+		Stage:         storage.SpecStageShape,
+		Exchanges:     []storage.ConversationExchange{{Role: "probe", Content: "q", Stage: "shape", Sequence: 1}},
+		ExchangeCount: 1,
+		Posture:       "",
+	}
+	saved, err := store.RecordConversation(ctx, "spec-posture-empty", entry)
+	require.NoError(t, err)
+	if saved.Posture != "" {
+		t.Errorf("expected posture=\"\" (unspecified), got %q", saved.Posture)
+	}
+
+	// Read back via ListConversations to verify the round-trip through the DB.
+	logs, err := store.ListConversations(ctx, "spec-posture-empty", "shape")
+	require.NoError(t, err)
+	if len(logs) != 1 || logs[0].Posture != "" {
+		t.Errorf("expected 1 log with posture=\"\", got %+v", logs)
+	}
+}
+
 func TestGetSpec_IncludesConversationLogs(t *testing.T) {
 	store := newStore(t)
 	clearDatabase(t, store)

--- a/internal/storage/postgres/conversation_test.go
+++ b/internal/storage/postgres/conversation_test.go
@@ -235,6 +235,34 @@ func TestListAllConversations(t *testing.T) {
 	assert.Equal(t, "conv-all-b", entries[1].SpecSlug)
 }
 
+func TestRecordConversation_PersistsPosture(t *testing.T) {
+	store := newStore(t)
+	clearDatabase(t, store)
+	ctx := context.Background()
+
+	_, err := store.CreateSpec(ctx, "spec-posture-1", "intent", "p2", "medium")
+	require.NoError(t, err)
+
+	entry := storage.ConversationLogEntry{
+		Stage:         storage.SpecStageShape,
+		Exchanges:     []storage.ConversationExchange{{Role: "probe", Content: "q", Stage: "shape", Sequence: 1}},
+		ExchangeCount: 1,
+		Posture:       "partner",
+	}
+	saved, err := store.RecordConversation(ctx, "spec-posture-1", entry)
+	require.NoError(t, err)
+	if saved.Posture != "partner" {
+		t.Errorf("expected posture=partner, got %q", saved.Posture)
+	}
+
+	// Read back via ListConversations too.
+	logs, err := store.ListConversations(ctx, "spec-posture-1", "shape")
+	require.NoError(t, err)
+	if len(logs) != 1 || logs[0].Posture != "partner" {
+		t.Errorf("expected 1 log with posture=partner, got %+v", logs)
+	}
+}
+
 func TestGetSpec_IncludesConversationLogs(t *testing.T) {
 	store := newStore(t)
 	clearDatabase(t, store)

--- a/internal/storage/postgres/migrations/006_conversation_logs_posture.sql
+++ b/internal/storage/postgres/migrations/006_conversation_logs_posture.sql
@@ -1,0 +1,8 @@
+-- SPDX-License-Identifier: MIT
+-- Copyright 2026 Sean Brandt
+
+-- +goose Up
+ALTER TABLE conversation_logs ADD COLUMN posture TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE conversation_logs DROP COLUMN posture;


### PR DESCRIPTION
## Summary

First slice of Phase B (tracking: spgr-bncv). Completes the server-side atomic coupling story from Phase A (PR #910) by closing two gaps:

1. **Integration-level rollback verification** — unit tests verified the 4-op transaction handling at the handler layer with fakes; this adds a real-Postgres integration test proving that when a mid-transaction op fails (StoreSafetyFlags), the stage transition, output write, AND conversation log are all rolled back together.

2. **Posture persistence** — Phase A's `buildConversationEntry` accepted a `Posture` param but discarded it with a TODO pointing at Task 10. This wires posture through: `ConversationLogEntry.Posture` field, migration 006 adding the column, INSERT/SELECT updates, and a `postureToString` helper in the handler. Provides the data for future drift detection per design §Posture.

## What's in this PR

**Test (1 commit):**
- `test(authoring): verify atomic rollback on mid-transaction failure` — `internal/storage/postgres/authoring_rollback_integration_test.go`. Wraps a real `*postgres.Store` with a `failingOnSafetyFlagsStore`, prepares a spec at spark via real Spark RPC, then calls Shape with a risk string that reliably triggers the safety net. Asserts: handler returns error, spec still at spark stage, no conversation log for shape.

**Storage (1 commit):**
- `feat(storage): record posture on ConversationLogEntry` — adds `Posture string` to the domain struct, migration `006_conversation_logs_posture.sql` (`ALTER TABLE conversation_logs ADD COLUMN posture TEXT NOT NULL DEFAULT ''`), updates pgx INSERT + all SELECT queries (RecordConversation return, ListConversations, ListAllConversations), and rewires `buildConversationEntry` with a new `postureToString` helper (DRIVE/PARTNER/SUPPORT → canonical strings; UNSPECIFIED → `""`).

**Chore:**
- `chore(beads): claim spgr-bncv for phase B work` — issue tracker update.

## Test plan

- [x] `task check` green locally
- [x] `go test -tags integration -count=1 -run TestShape_AtomicRollback -v ./internal/storage/postgres/` — PASS
- [x] `go test -tags integration -count=1 -run TestRecordConversation_PersistsPosture -v ./internal/storage/postgres/` — PASS
- [ ] CI will run the full suite

## Design notes

- Integration test lives in `internal/storage/postgres/` to reuse the existing TestMain + testcontainers setup. `internal/storage/postgres` importing `internal/server` is a clean one-way edge (no cycle).
- Safety-net trigger uses `"credential rotation required"` in the risk list — this matches the `\bcredential\b` pattern in `authoring.RunSafetyNet`'s `warningSecurityPatterns`, guaranteeing `StoreSafetyFlags` is actually called (otherwise the test would pass spuriously).
- Migration uses `NOT NULL DEFAULT ''` to match every other string column in `conversation_logs` (`stage`, etc.) — no nullable string convention elsewhere.
- `postureToString` accepts unknown enum values and returns `""`. The reverse mapping (storage string → proto enum) is not wired because `ConversationLog` proto message has no posture field — posture is currently write-only from proto into storage. When drift detection consumes posture, a reverse helper lands there.

## Out of scope (Phase B slices 2+)

- Tasks 11-20: content migration into `internal/authoring/content/` with `go:embed`
- Tasks 21-25: `authoring.Composer` implementation + golden-file tests
- Tasks 26-28: composer adapter, `author.start_stage` tool, `specgraph://prime` resource
- Tasks 29-30: `ProfileFromClientInfo` for opencode/codex
- Tasks 31-38: thin Claude Code plugin cutover + Cursor/OpenCode/Codex empirical verification

Tracking: spgr-bncv

🤖 Generated with [Claude Code](https://claude.com/claude-code)