### PR TITLE
feat(cli)!: split install/uninstall from up/down; retire --rm

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ See the [deployment guide](https://specgraph.io/deployment/) for team and produc
 | `specgraph init` | Initialize project config and optionally scan for constitution |
 | `specgraph serve` | Start the ConnectRPC API server |
 | `specgraph health` | Check server health |
-| `specgraph up/down` | Start or stop the database container |
+| `specgraph up/down` | Start or stop the database container (non-destructive; `down --purge` wipes data) |
+| `specgraph install/uninstall` | Register or remove the SpecGraph user service (launchd/systemd); data preserved |
 
 ## Contributing
 

--- a/cmd/specgraph/confirm.go
+++ b/cmd/specgraph/confirm.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// confirmDestructive returns nil only when the caller has consent to proceed
+// with a destructive operation. --yes bypasses the prompt; on a TTY the user
+// must type y/yes; off a TTY without --yes, the command errors rather than
+// silently destroying data.
+func confirmDestructive(in io.Reader, out io.Writer, isTTY, yes bool, prompt string) error {
+	if yes {
+		return nil
+	}
+	if !isTTY {
+		return errors.New("destructive operation requires --yes when not on a TTY")
+	}
+	_, _ = fmt.Fprintf(out, "%s [y/N] ", prompt) //nolint:errcheck // writes to user stream
+	scanner := bufio.NewScanner(in)
+	if !scanner.Scan() {
+		return errors.New("aborted — no input")
+	}
+	ans := strings.TrimSpace(strings.ToLower(scanner.Text()))
+	if ans != "y" && ans != "yes" {
+		return errors.New("aborted — no changes made")
+	}
+	return nil
+}
+
+// stdinIsTTY reports whether stdin is connected to a terminal. Production
+// callers pass this into confirmDestructive; tests inject a bool directly.
+func stdinIsTTY() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) //nolint:gosec // fd fits in int on all supported platforms
+}

--- a/cmd/specgraph/confirm_test.go
+++ b/cmd/specgraph/confirm_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// confirmDestructive is the guarded prompt used by `specgraph down --purge`
+// and any future destructive command. See design 2026-04-22-cli-lifecycle-split.
+//
+// Rules under test:
+//   - --yes bypasses the prompt, regardless of TTY.
+//   - On a TTY without --yes, user must type y/yes to proceed; anything else aborts.
+//   - Off a TTY without --yes, the command errors (no silent destruction in scripts).
+
+func TestConfirmDestructive_YesBypassesPrompt(t *testing.T) {
+	var out bytes.Buffer
+	// Even non-TTY, --yes should skip the error.
+	if err := confirmDestructive(strings.NewReader(""), &out, false, true, "destroy everything?"); err != nil {
+		t.Fatalf("--yes on non-TTY should not error, got: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("--yes should not prompt, but wrote: %q", out.String())
+	}
+}
+
+func TestConfirmDestructive_NonTTYWithoutYesErrors(t *testing.T) {
+	var out bytes.Buffer
+	err := confirmDestructive(strings.NewReader(""), &out, false, false, "destroy?")
+	if err == nil {
+		t.Fatal("non-TTY without --yes should error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Errorf("error should mention --yes, got: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("should not prompt on non-TTY, but wrote: %q", out.String())
+	}
+}
+
+func TestConfirmDestructive_TTYAcceptsY(t *testing.T) {
+	var out bytes.Buffer
+	if err := confirmDestructive(strings.NewReader("y\n"), &out, true, false, "destroy?"); err != nil {
+		t.Fatalf("y should proceed, got: %v", err)
+	}
+	if !strings.Contains(out.String(), "destroy?") {
+		t.Errorf("should have prompted with message, wrote: %q", out.String())
+	}
+}
+
+func TestConfirmDestructive_TTYAcceptsYes(t *testing.T) {
+	var out bytes.Buffer
+	if err := confirmDestructive(strings.NewReader("yes\n"), &out, true, false, "destroy?"); err != nil {
+		t.Fatalf("yes should proceed, got: %v", err)
+	}
+}
+
+func TestConfirmDestructive_TTYAcceptsCaseInsensitive(t *testing.T) {
+	var out bytes.Buffer
+	if err := confirmDestructive(strings.NewReader("Y\n"), &out, true, false, "destroy?"); err != nil {
+		t.Fatalf("Y should proceed (case-insensitive), got: %v", err)
+	}
+}
+
+func TestConfirmDestructive_TTYRejectsDefaultEnter(t *testing.T) {
+	var out bytes.Buffer
+	err := confirmDestructive(strings.NewReader("\n"), &out, true, false, "destroy?")
+	if err == nil {
+		t.Fatal("empty line (default N) should abort, got nil")
+	}
+	if !strings.Contains(err.Error(), "aborted") {
+		t.Errorf("error should say aborted, got: %v", err)
+	}
+}
+
+func TestConfirmDestructive_TTYRejectsN(t *testing.T) {
+	var out bytes.Buffer
+	err := confirmDestructive(strings.NewReader("n\n"), &out, true, false, "destroy?")
+	if err == nil {
+		t.Fatal("n should abort, got nil")
+	}
+}
+
+func TestConfirmDestructive_TTYRejectsRandom(t *testing.T) {
+	var out bytes.Buffer
+	err := confirmDestructive(strings.NewReader("maybe\n"), &out, true, false, "destroy?")
+	if err == nil {
+		t.Fatal("random answer should abort, got nil")
+	}
+}

--- a/cmd/specgraph/docs.go
+++ b/cmd/specgraph/docs.go
@@ -54,7 +54,7 @@ var commandGroups = []commandGroup{
 	{Name: "Findings", Commands: []string{"findings", "pass"}},
 	{Name: "Sync", Commands: []string{"sync"}},
 	{Name: "Export & Backup", Commands: []string{"export", "import", "verify"}},
-	{Name: "Server & Config", Commands: []string{"up", "down", "serve", "mcp", "status", "health", "init", "prime", "inject"}},
+	{Name: "Server & Config", Commands: []string{"up", "down", "install", "uninstall", "serve", "mcp", "status", "health", "init", "prime", "inject"}},
 }
 
 func runDocsCli(_ *cobra.Command, args []string) error {

--- a/cmd/specgraph/down.go
+++ b/cmd/specgraph/down.go
@@ -4,7 +4,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -21,11 +23,36 @@ var downCmd = &cobra.Command{
 	RunE:  runDown,
 }
 
-var downRM bool
+type downFlags struct {
+	rmRetired bool // --rm is retired; this flag exists only to produce a helpful error
+	purge     bool
+	yes       bool
+}
+
+var downFlagsVar downFlags
 
 func init() {
 	rootCmd.AddCommand(downCmd)
-	downCmd.Flags().BoolVar(&downRM, "rm", false, "uninstall the service definition after stopping")
+	downCmd.Flags().BoolVar(&downFlagsVar.rmRetired, "rm", false, "")
+	_ = downCmd.Flags().MarkHidden("rm") //nolint:errcheck // flag just registered, MarkHidden can't fail
+	downCmd.Flags().BoolVar(&downFlagsVar.purge, "purge", false, "remove containers AND data volumes (destructive; prompts for confirmation)")
+	downCmd.Flags().BoolVar(&downFlagsVar.yes, "yes", false, "skip the --purge confirmation prompt")
+}
+
+// downDeps names the side-effecting operations doDown performs so tests can
+// swap them for call-tracking fakes.
+type downDeps struct {
+	stopService      func() error
+	composeStop      func(composeFile string) error
+	composeDownVols  func(composeFile string) error
+	composeFileExist func(composeFile string) bool
+}
+
+var downFns = downDeps{
+	stopService:      service.Stop,
+	composeStop:      docker.ComposeStop,
+	composeDownVols:  docker.ComposeDownWithVolumes,
+	composeFileExist: func(p string) bool { _, err := os.Stat(p); return err == nil },
 }
 
 func runDown(_ *cobra.Command, _ []string) error {
@@ -33,34 +60,52 @@ func runDown(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
+	return doDown(cfg, downFlagsVar, os.Stdin, os.Stderr, stdinIsTTY())
+}
+
+// doDown is the testable core of `specgraph down`. Production wiring lives
+// in runDown; tests call doDown directly with fake deps and synthetic input.
+func doDown(cfg *config.GlobalConfig, flags downFlags, in io.Reader, out io.Writer, isTTY bool) error {
+	if flags.rmRetired {
+		return errors.New(`--rm has been retired.
+  To remove the service definition:   specgraph uninstall
+  To remove containers and data:       specgraph down --purge`)
+	}
+
+	if flags.purge {
+		msg := "Destroy all data in specgraph-data volume? All SpecGraph workspaces on this machine share this volume."
+		if err := confirmDestructive(in, out, isTTY, flags.yes, msg); err != nil {
+			return err
+		}
+	}
 
 	var stopErr error
-
 	if cfg.Server.Mode == "service" {
-		if downRM {
-			// Uninstall handles stopping the service internally; no need for explicit Stop().
-			destDir, err := serviceDestDir()
-			if err != nil {
-				return fmt.Errorf("service dest dir: %w", err)
-			}
-			defPath := filepath.Join(destDir, serviceDefinitionFilename())
-			if err := service.Uninstall(defPath); err != nil {
-				fmt.Fprintf(os.Stderr, "warning: uninstall service: %v\n", err)
-				stopErr = err
-			}
-		} else {
-			if err := service.Stop(); err != nil {
-				fmt.Fprintf(os.Stderr, "warning: stop service: %v\n", err)
-				stopErr = err
-			}
+		if err := downFns.stopService(); err != nil {
+			_, _ = fmt.Fprintf(out, "warning: stop service: %v\n", err) //nolint:errcheck // writes to user stream; failure is non-recoverable
+			stopErr = err
 		}
 	}
 
 	if cfg.Server.Docker {
 		composeFile := filepath.Join(xdg.DataHome(), "docker-compose.yaml")
-		if _, err := os.Stat(composeFile); err == nil {
-			if err := docker.ComposeDown(composeFile); err != nil {
-				return fmt.Errorf("compose down: %w", err)
+		if downFns.composeFileExist(composeFile) {
+			var composeErr error
+			if flags.purge {
+				if err := downFns.composeDownVols(composeFile); err != nil {
+					composeErr = fmt.Errorf("compose down --volumes: %w", err)
+				}
+			} else {
+				if err := downFns.composeStop(composeFile); err != nil {
+					composeErr = fmt.Errorf("compose stop: %w", err)
+				}
+			}
+			if composeErr != nil {
+				// Join so a compose failure doesn't silently mask a captured service-stop error.
+				if stopErr != nil {
+					return errors.Join(fmt.Errorf("stop service: %w", stopErr), composeErr)
+				}
+				return composeErr
 			}
 		}
 	}
@@ -68,6 +113,11 @@ func runDown(_ *cobra.Command, _ []string) error {
 	if stopErr != nil {
 		return fmt.Errorf("stop service: %w", stopErr)
 	}
-	fmt.Println("SpecGraph stopped")
+
+	if flags.purge {
+		_, _ = fmt.Fprintln(out, "SpecGraph stopped and volumes removed") //nolint:errcheck // writes to user stream; failure is non-recoverable
+	} else {
+		_, _ = fmt.Fprintln(out, "SpecGraph stopped") //nolint:errcheck // writes to user stream; failure is non-recoverable
+	}
 	return nil
 }

--- a/cmd/specgraph/down_test.go
+++ b/cmd/specgraph/down_test.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/config"
+)
+
+// withDownDeps swaps down.go's package-level function vars for the duration
+// of a single test and restores them on cleanup.
+func withDownDeps(t *testing.T, deps downDeps) {
+	t.Helper()
+	orig := downFns
+	downFns = deps
+	t.Cleanup(func() { downFns = orig })
+}
+
+func serviceDockerCfg() *config.GlobalConfig {
+	return &config.GlobalConfig{
+		Server: config.ServerSection{Mode: "service", Docker: true},
+	}
+}
+
+func manualDockerCfg() *config.GlobalConfig {
+	return &config.GlobalConfig{
+		Server: config.ServerSection{Mode: "manual", Docker: true},
+	}
+}
+
+func serviceNoDockerCfg() *config.GlobalConfig {
+	return &config.GlobalConfig{
+		Server: config.ServerSection{Mode: "service", Docker: false},
+	}
+}
+
+// Retirement error fires before any side effects.
+func TestDoDown_RMFlagErrorsWithoutSideEffects(t *testing.T) {
+	var calls []string
+	withDownDeps(t, downDeps{
+		stopService:      func() error { calls = append(calls, "stopService"); return nil },
+		composeStop:      func(string) error { calls = append(calls, "composeStop"); return nil },
+		composeDownVols:  func(string) error { calls = append(calls, "composeDownVols"); return nil },
+		composeFileExist: func(string) bool { return true },
+	})
+	var out bytes.Buffer
+	err := doDown(serviceDockerCfg(), downFlags{rmRetired: true}, strings.NewReader(""), &out, false)
+	if err == nil {
+		t.Fatal("expected retirement error, got nil")
+	}
+	if !strings.Contains(err.Error(), "retired") {
+		t.Errorf("error should mention --rm retirement, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "uninstall") || !strings.Contains(err.Error(), "--purge") {
+		t.Errorf("error should point at uninstall + --purge, got: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Errorf("no side effects expected, got: %v", calls)
+	}
+}
+
+// Default `specgraph down`: service.Stop + ComposeStop, never ComposeDownVolumes.
+func TestDoDown_DefaultStopsServiceAndContainer(t *testing.T) {
+	var calls []string
+	withDownDeps(t, downDeps{
+		stopService:      func() error { calls = append(calls, "stopService"); return nil },
+		composeStop:      func(string) error { calls = append(calls, "composeStop"); return nil },
+		composeDownVols:  func(string) error { calls = append(calls, "composeDownVols"); return nil },
+		composeFileExist: func(string) bool { return true },
+	})
+	var out bytes.Buffer
+	if err := doDown(serviceDockerCfg(), downFlags{}, strings.NewReader(""), &out, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"stopService", "composeStop"}
+	if len(calls) != len(want) || calls[0] != want[0] || calls[1] != want[1] {
+		t.Errorf("got calls %v, want %v", calls, want)
+	}
+}
+
+// Manual mode: skip service.Stop but still ComposeStop.
+func TestDoDown_ManualModeSkipsServiceStop(t *testing.T) {
+	var calls []string
+	withDownDeps(t, downDeps{
+		stopService:      func() error { calls = append(calls, "stopService"); return nil },
+		composeStop:      func(string) error { calls = append(calls, "composeStop"); return nil },
+		composeDownVols:  func(string) error { calls = append(calls, "composeDownVols"); return nil },
+		composeFileExist: func(string) bool { return true },
+	})
+	var out bytes.Buffer
+	if err := doDown(manualDockerCfg(), downFlags{}, strings.NewReader(""), &out, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, c := range calls {
+		if c == "stopService" {
+			t.Errorf("manual mode should not call stopService, got: %v", calls)
+		}
+	}
+}
+
+// No-docker config: skip compose calls entirely.
+func TestDoDown_NoDockerSkipsComposeCalls(t *testing.T) {
+	var calls []string
+	withDownDeps(t, downDeps{
+		stopService:      func() error { calls = append(calls, "stopService"); return nil },
+		composeStop:      func(string) error { calls = append(calls, "composeStop"); return nil },
+		composeDownVols:  func(string) error { calls = append(calls, "composeDownVols"); return nil },
+		composeFileExist: func(string) bool { return true },
+	})
+	var out bytes.Buffer
+	if err := doDown(serviceNoDockerCfg(), downFlags{}, strings.NewReader(""), &out, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, c := range calls {
+		if c == "composeStop" || c == "composeDownVols" {
+			t.Errorf("no-docker mode should skip compose, got: %v", calls)
+		}
+	}
+}
+
+// --purge without --yes off a TTY must error without destroying.
+func TestDoDown_PurgeNonTTYWithoutYesErrors(t *testing.T) {
+	var calls []string
+	withDownDeps(t, downDeps{
+		stopService:      func() error { calls = append(calls, "stopService"); return nil },
+		composeStop:      func(string) error { calls = append(calls, "composeStop"); return nil },
+		composeDownVols:  func(string) error { calls = append(calls, "composeDownVols"); return nil },
+		composeFileExist: func(string) bool { return true },
+	})
+	var out bytes.Buffer
+	err := doDown(serviceDockerCfg(), downFlags{purge: true}, strings.NewReader(""), &out, false)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	for _, c := range calls {
+		if c == "composeDownVols" {
+			t.Errorf("destructive call made despite error: %v", calls)
+		}
+	}
+}
+
+// --purge --yes off a TTY: service.Stop + ComposeDownWithVolumes (NOT ComposeStop).
+func TestDoDown_PurgeYesCallsDownWithVolumes(t *testing.T) {
+	var calls []string
+	withDownDeps(t, downDeps{
+		stopService:      func() error { calls = append(calls, "stopService"); return nil },
+		composeStop:      func(string) error { calls = append(calls, "composeStop"); return nil },
+		composeDownVols:  func(string) error { calls = append(calls, "composeDownVols"); return nil },
+		composeFileExist: func(string) bool { return true },
+	})
+	var out bytes.Buffer
+	if err := doDown(serviceDockerCfg(), downFlags{purge: true, yes: true}, strings.NewReader(""), &out, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := strings.Join(calls, ",")
+	if !strings.Contains(got, "composeDownVols") {
+		t.Errorf("expected composeDownVols call, got: %v", calls)
+	}
+	if strings.Contains(got, "composeStop") {
+		t.Errorf("should not call composeStop when purging, got: %v", calls)
+	}
+}
+
+// --purge on TTY with 'y' input proceeds.
+func TestDoDown_PurgeTTYAcceptsY(t *testing.T) {
+	var calls []string
+	withDownDeps(t, downDeps{
+		stopService:      func() error { calls = append(calls, "stopService"); return nil },
+		composeStop:      func(string) error { calls = append(calls, "composeStop"); return nil },
+		composeDownVols:  func(string) error { calls = append(calls, "composeDownVols"); return nil },
+		composeFileExist: func(string) bool { return true },
+	})
+	var out bytes.Buffer
+	err := doDown(serviceDockerCfg(), downFlags{purge: true}, strings.NewReader("y\n"), &out, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(strings.Join(calls, ","), "composeDownVols") {
+		t.Errorf("expected composeDownVols call, got: %v", calls)
+	}
+	if !strings.Contains(out.String(), "specgraph-data") {
+		t.Errorf("prompt should mention volume name, got: %q", out.String())
+	}
+}
+
+// Compose file missing: skip compose entirely, don't error.
+func TestDoDown_MissingComposeFileSkipsCompose(t *testing.T) {
+	var calls []string
+	withDownDeps(t, downDeps{
+		stopService:      func() error { calls = append(calls, "stopService"); return nil },
+		composeStop:      func(string) error { calls = append(calls, "composeStop"); return nil },
+		composeDownVols:  func(string) error { calls = append(calls, "composeDownVols"); return nil },
+		composeFileExist: func(string) bool { return false },
+	})
+	var out bytes.Buffer
+	if err := doDown(serviceDockerCfg(), downFlags{}, strings.NewReader(""), &out, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, c := range calls {
+		if c == "composeStop" || c == "composeDownVols" {
+			t.Errorf("missing compose file should skip compose, got: %v", calls)
+		}
+	}
+}
+
+// Regression guard: a compose failure must NOT mask an already-captured
+// service-stop error. Both errors must appear in the joined output so the
+// user doesn't miss the service-stop problem.
+func TestDoDown_ComposeFailureDoesNotMaskServiceStopError(t *testing.T) {
+	stopBoom := errors.New("service stop boom")
+	composeBoom := errors.New("compose stop boom")
+	withDownDeps(t, downDeps{
+		stopService:      func() error { return stopBoom },
+		composeStop:      func(string) error { return composeBoom },
+		composeDownVols:  func(string) error { return nil },
+		composeFileExist: func(string) bool { return true },
+	})
+	var out bytes.Buffer
+	err := doDown(serviceDockerCfg(), downFlags{}, strings.NewReader(""), &out, false)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, stopBoom) {
+		t.Errorf("service stop error must be surfaced, got: %v", err)
+	}
+	if !errors.Is(err, composeBoom) {
+		t.Errorf("compose error must be surfaced, got: %v", err)
+	}
+}
+
+// Service stop error surfaces but doesn't prevent compose stop.
+func TestDoDown_ServiceStopErrorSurfacesAfterComposeStop(t *testing.T) {
+	var calls []string
+	sentinel := errors.New("service stop boom")
+	withDownDeps(t, downDeps{
+		stopService:      func() error { calls = append(calls, "stopService"); return sentinel },
+		composeStop:      func(string) error { calls = append(calls, "composeStop"); return nil },
+		composeDownVols:  func(string) error { calls = append(calls, "composeDownVols"); return nil },
+		composeFileExist: func(string) bool { return true },
+	})
+	var out bytes.Buffer
+	err := doDown(serviceDockerCfg(), downFlags{}, strings.NewReader(""), &out, false)
+	if err == nil || !errors.Is(err, sentinel) {
+		t.Errorf("expected service stop error surfaced, got: %v", err)
+	}
+	if len(calls) != 2 || calls[0] != "stopService" || calls[1] != "composeStop" {
+		t.Errorf("compose should still run before surfacing stop error, got: %v", calls)
+	}
+}

--- a/cmd/specgraph/install.go
+++ b/cmd/specgraph/install.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/docker"
+	"github.com/specgraph/specgraph/internal/service"
+	"github.com/specgraph/specgraph/internal/xdg"
+	"github.com/spf13/cobra"
+)
+
+var installCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Register SpecGraph as a user service (launchd/systemd) and start it",
+	RunE:  runInstall,
+}
+
+func init() {
+	rootCmd.AddCommand(installCmd)
+}
+
+// installDeps names the side-effecting operations doInstall performs so tests
+// can swap them for call-tracking fakes.
+type installDeps struct {
+	isInstalled    func() bool
+	generateDef    func() (string, error)
+	composeUp      func(composeFile string) error
+	composeStop    func(composeFile string) error
+	serviceInstall func(defPath string) error
+	removeFile     func(path string) error
+}
+
+// installFns holds the static production dependencies. generateDef is filled
+// in per-call by runInstall because it closes over runtime-resolved paths.
+// Initialized at package scope so a zero-valued default is never observable.
+var installFns = installDeps{
+	isInstalled:    service.IsInstalled,
+	composeUp:      docker.ComposeUp,
+	composeStop:    docker.ComposeStop,
+	serviceInstall: service.Install,
+	removeFile:     os.Remove,
+	generateDef: func() (string, error) {
+		return "", errors.New("generateDef not wired; call runInstall or swap installFns in a test")
+	},
+}
+
+func runInstall(_ *cobra.Command, _ []string) error {
+	cfg, err := config.LoadGlobal(globalConfigPath())
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	binaryPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve binary path: %w", err)
+	}
+	binaryPath, err = filepath.Abs(binaryPath)
+	if err != nil {
+		return fmt.Errorf("resolve absolute binary path: %w", err)
+	}
+
+	destDir, err := serviceDestDir()
+	if err != nil {
+		return fmt.Errorf("service dest dir: %w", err)
+	}
+	defPath := filepath.Join(destDir, serviceDefinitionFilename())
+	composeFile := filepath.Join(xdg.DataHome(), "docker-compose.yaml")
+
+	// Only overwrite generateDef — the other fields were initialized at
+	// package scope and must stay stable across runInstall calls so that
+	// concurrent tests (or sub-command flows) don't race.
+	installFns.generateDef = func() (string, error) {
+		return service.Generate(destDir, service.Config{
+			BinaryPath: binaryPath,
+			ConfigPath: globalConfigPath(),
+			LogPath:    filepath.Join(xdg.StateHome(), "server.log"),
+		})
+	}
+
+	return doInstall(cfg, defPath, composeFile, os.Stderr)
+}
+
+// doInstall is the testable core. Production passes the real defPath/composeFile;
+// tests swap installFns to observe call order and simulate failures.
+func doInstall(cfg *config.GlobalConfig, defPath, composeFile string, out io.Writer) error {
+	if cfg.Server.Mode == "manual" {
+		return errors.New("cannot install in manual mode — change server.mode to \"service\" in config or use `specgraph serve` directly")
+	}
+
+	// Idempotent path: definition already on disk. Launchd/systemd keeps the
+	// service alive via RunAtLoad + KeepAlive; we just make sure the container
+	// backend is up and exit cleanly.
+	if installFns.isInstalled() {
+		if cfg.Server.Docker {
+			if err := installFns.composeUp(composeFile); err != nil {
+				return fmt.Errorf("compose up: %w", err)
+			}
+		}
+		_, _ = fmt.Fprintln(out, "SpecGraph already installed — ensured container is running") //nolint:errcheck // writes to user stream
+		return nil
+	}
+
+	// Generate definition first so service.Install has a file to register.
+	generatedPath, err := installFns.generateDef()
+	if err != nil {
+		return fmt.Errorf("generate service definition: %w", err)
+	}
+	if generatedPath != "" {
+		defPath = generatedPath
+	}
+
+	// Bring the container up BEFORE registering the service. generateDef
+	// already wrote the plist, so if compose fails we roll that back.
+	if cfg.Server.Docker {
+		if err := installFns.composeUp(composeFile); err != nil {
+			errs := []error{fmt.Errorf("compose up: %w", err)}
+			// Clean up the definition file we just wrote so a retry starts fresh.
+			// A missing file is expected on some failure paths; other errors
+			// (permissions, read-only FS) need to surface so the user can fix them.
+			if rmErr := installFns.removeFile(defPath); rmErr != nil && !errors.Is(rmErr, fs.ErrNotExist) {
+				errs = append(errs, fmt.Errorf("remove definition: %w", rmErr))
+			}
+			return errors.Join(errs...)
+		}
+	}
+
+	// Register + load the service. If this fails, unwind in reverse order:
+	// halt the container we just started, then remove the definition file.
+	// Both cleanup errors are joined to the outer error so the user sees
+	// orphan state (container still up, plist still on disk) rather than
+	// a bare "install service failed" with no diagnostic.
+	if err := installFns.serviceInstall(defPath); err != nil {
+		errs := []error{fmt.Errorf("install service: %w", err)}
+		if cfg.Server.Docker {
+			if stopErr := installFns.composeStop(composeFile); stopErr != nil {
+				errs = append(errs, fmt.Errorf("cleanup: compose stop: %w", stopErr))
+			}
+		}
+		if rmErr := installFns.removeFile(defPath); rmErr != nil && !errors.Is(rmErr, fs.ErrNotExist) {
+			errs = append(errs, fmt.Errorf("cleanup: remove definition: %w", rmErr))
+		}
+		return errors.Join(errs...)
+	}
+
+	_, _ = fmt.Fprintln(out, "SpecGraph installed and service started") //nolint:errcheck // writes to user stream
+	return nil
+}

--- a/cmd/specgraph/install_test.go
+++ b/cmd/specgraph/install_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/config"
+)
+
+func withInstallDeps(t *testing.T, deps installDeps) {
+	t.Helper()
+	orig := installFns
+	installFns = deps
+	t.Cleanup(func() { installFns = orig })
+}
+
+func TestDoInstall_ManualModeErrors(t *testing.T) {
+	var out bytes.Buffer
+	cfg := &config.GlobalConfig{Server: config.ServerSection{Mode: "manual", Docker: true}}
+	err := doInstall(cfg, "/tmp/plist", "/tmp/compose.yaml", &out)
+	if err == nil {
+		t.Fatal("manual mode should error")
+	}
+	if !strings.Contains(err.Error(), "manual") {
+		t.Errorf("error should mention mode, got: %v", err)
+	}
+}
+
+func TestDoInstall_AlreadyInstalledIsIdempotent(t *testing.T) {
+	var calls []string
+	withInstallDeps(t, installDeps{
+		isInstalled:    func() bool { return true },
+		generateDef:    func() (string, error) { calls = append(calls, "generateDef"); return "/plist", nil },
+		composeUp:      func(string) error { calls = append(calls, "composeUp"); return nil },
+		composeStop:    func(string) error { calls = append(calls, "composeStop"); return nil },
+		serviceInstall: func(string) error { calls = append(calls, "serviceInstall"); return nil },
+		removeFile:     func(string) error { calls = append(calls, "removeFile"); return nil },
+	})
+	var out bytes.Buffer
+	cfg := &config.GlobalConfig{Server: config.ServerSection{Mode: "service", Docker: true}}
+	if err := doInstall(cfg, "/tmp/plist", "/tmp/compose.yaml", &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Idempotent path: ensure docker is up; don't re-register the service.
+	want := []string{"composeUp"}
+	if len(calls) != 1 || calls[0] != want[0] {
+		t.Errorf("got calls %v, want %v", calls, want)
+	}
+}
+
+func TestDoInstall_FreshInstallOrdersComposeBeforeService(t *testing.T) {
+	var calls []string
+	withInstallDeps(t, installDeps{
+		isInstalled:    func() bool { return false },
+		generateDef:    func() (string, error) { calls = append(calls, "generateDef"); return "/plist", nil },
+		composeUp:      func(string) error { calls = append(calls, "composeUp"); return nil },
+		composeStop:    func(string) error { calls = append(calls, "composeStop"); return nil },
+		serviceInstall: func(string) error { calls = append(calls, "serviceInstall"); return nil },
+		removeFile:     func(string) error { calls = append(calls, "removeFile"); return nil },
+	})
+	var out bytes.Buffer
+	cfg := &config.GlobalConfig{Server: config.ServerSection{Mode: "service", Docker: true}}
+	if err := doInstall(cfg, "/tmp/plist", "/tmp/compose.yaml", &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Order matters: compose must come up before service registration, so
+	// launchd doesn't start a binary that can't reach the DB.
+	want := []string{"generateDef", "composeUp", "serviceInstall"}
+	if len(calls) != 3 || calls[0] != want[0] || calls[1] != want[1] || calls[2] != want[2] {
+		t.Errorf("got calls %v, want %v", calls, want)
+	}
+}
+
+func TestDoInstall_ComposeUpFailureSkipsServiceInstall(t *testing.T) {
+	var calls []string
+	boom := errors.New("docker down")
+	withInstallDeps(t, installDeps{
+		isInstalled:    func() bool { return false },
+		generateDef:    func() (string, error) { calls = append(calls, "generateDef"); return "/plist", nil },
+		composeUp:      func(string) error { calls = append(calls, "composeUp"); return boom },
+		composeStop:    func(string) error { calls = append(calls, "composeStop"); return nil },
+		serviceInstall: func(string) error { calls = append(calls, "serviceInstall"); return nil },
+		removeFile:     func(string) error { calls = append(calls, "removeFile"); return nil },
+	})
+	var out bytes.Buffer
+	cfg := &config.GlobalConfig{Server: config.ServerSection{Mode: "service", Docker: true}}
+	err := doInstall(cfg, "/tmp/plist", "/tmp/compose.yaml", &out)
+	if err == nil || !errors.Is(err, boom) {
+		t.Fatalf("expected compose-up failure to surface, got: %v", err)
+	}
+	for _, c := range calls {
+		if c == "serviceInstall" {
+			t.Errorf("serviceInstall must not run after composeUp failure, got: %v", calls)
+		}
+	}
+}
+
+func TestDoInstall_ServiceInstallFailureUnwindsContainerAndFile(t *testing.T) {
+	var calls []string
+	boom := errors.New("launchctl fail")
+	withInstallDeps(t, installDeps{
+		isInstalled:    func() bool { return false },
+		generateDef:    func() (string, error) { calls = append(calls, "generateDef"); return "/tmp/plist", nil },
+		composeUp:      func(string) error { calls = append(calls, "composeUp"); return nil },
+		composeStop:    func(string) error { calls = append(calls, "composeStop"); return nil },
+		serviceInstall: func(string) error { calls = append(calls, "serviceInstall"); return boom },
+		removeFile:     func(string) error { calls = append(calls, "removeFile"); return nil },
+	})
+	var out bytes.Buffer
+	cfg := &config.GlobalConfig{Server: config.ServerSection{Mode: "service", Docker: true}}
+	err := doInstall(cfg, "/tmp/plist", "/tmp/compose.yaml", &out)
+	if err == nil || !errors.Is(err, boom) {
+		t.Fatalf("expected service install failure to surface, got: %v", err)
+	}
+	// Unwind order: composeStop (halt container we just started) then removeFile
+	// (delete the plist we just wrote). Index comparison rather than
+	// strings.Contains so that swapping the order fails the test.
+	composeStopIdx, removeFileIdx := -1, -1
+	for i, c := range calls {
+		if c == "composeStop" {
+			composeStopIdx = i
+		}
+		if c == "removeFile" {
+			removeFileIdx = i
+		}
+	}
+	if composeStopIdx == -1 || removeFileIdx == -1 {
+		t.Errorf("expected composeStop + removeFile on unwind, got: %v", calls)
+	}
+	if composeStopIdx > removeFileIdx {
+		t.Errorf("composeStop must precede removeFile, got: %v", calls)
+	}
+}
+
+// Regression guard: when service.Install fails AND both cleanup steps fail,
+// the user must see all three errors joined, not just the outer one.
+func TestDoInstall_UnwindFailuresAreJoinedToOuterError(t *testing.T) {
+	installBoom := errors.New("launchctl fail")
+	stopBoom := errors.New("dockerd dead")
+	rmBoom := errors.New("plist permission denied")
+	withInstallDeps(t, installDeps{
+		isInstalled:    func() bool { return false },
+		generateDef:    func() (string, error) { return "/tmp/plist", nil },
+		composeUp:      func(string) error { return nil },
+		composeStop:    func(string) error { return stopBoom },
+		serviceInstall: func(string) error { return installBoom },
+		removeFile:     func(string) error { return rmBoom },
+	})
+	var out bytes.Buffer
+	cfg := &config.GlobalConfig{Server: config.ServerSection{Mode: "service", Docker: true}}
+	err := doInstall(cfg, "/tmp/plist", "/tmp/compose.yaml", &out)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	for _, want := range []error{installBoom, stopBoom, rmBoom} {
+		if !errors.Is(err, want) {
+			t.Errorf("joined error should wrap %v, got: %v", want, err)
+		}
+	}
+}
+
+// Regression guard: if removeFile fails because the plist is already gone
+// (ENOENT), that is expected cleanup success — do NOT surface it.
+func TestDoInstall_UnwindIgnoresMissingPlist(t *testing.T) {
+	installBoom := errors.New("launchctl fail")
+	withInstallDeps(t, installDeps{
+		isInstalled:    func() bool { return false },
+		generateDef:    func() (string, error) { return "/tmp/plist", nil },
+		composeUp:      func(string) error { return nil },
+		composeStop:    func(string) error { return nil },
+		serviceInstall: func(string) error { return installBoom },
+		removeFile:     func(string) error { return fs.ErrNotExist },
+	})
+	var out bytes.Buffer
+	cfg := &config.GlobalConfig{Server: config.ServerSection{Mode: "service", Docker: true}}
+	err := doInstall(cfg, "/tmp/plist", "/tmp/compose.yaml", &out)
+	if err == nil || !errors.Is(err, installBoom) {
+		t.Fatalf("outer error should still surface, got: %v", err)
+	}
+	// The ENOENT from removeFile must NOT leak into the joined error.
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("ENOENT from removeFile should be swallowed as expected cleanup, got: %v", err)
+	}
+}
+
+func TestDoInstall_NoDockerSkipsComposeUp(t *testing.T) {
+	var calls []string
+	withInstallDeps(t, installDeps{
+		isInstalled:    func() bool { return false },
+		generateDef:    func() (string, error) { calls = append(calls, "generateDef"); return "/plist", nil },
+		composeUp:      func(string) error { calls = append(calls, "composeUp"); return nil },
+		composeStop:    func(string) error { calls = append(calls, "composeStop"); return nil },
+		serviceInstall: func(string) error { calls = append(calls, "serviceInstall"); return nil },
+		removeFile:     func(string) error { calls = append(calls, "removeFile"); return nil },
+	})
+	var out bytes.Buffer
+	cfg := &config.GlobalConfig{Server: config.ServerSection{Mode: "service", Docker: false}}
+	if err := doInstall(cfg, "/tmp/plist", "/tmp/compose.yaml", &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, c := range calls {
+		if c == "composeUp" {
+			t.Errorf("docker:false should skip composeUp, got: %v", calls)
+		}
+	}
+}

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -81,8 +81,8 @@ func runServe(cmd *cobra.Command, _ []string) error {
 			return upErr
 		}
 		defer func() {
-			if downErr := docker.ComposeDown(composeFile); downErr != nil {
-				fmt.Fprintf(os.Stderr, "warning: compose down: %v\n", downErr)
+			if stopErr := docker.ComposeStop(composeFile); stopErr != nil {
+				fmt.Fprintf(os.Stderr, "warning: compose stop: %v\n", stopErr)
 			}
 		}()
 	}

--- a/cmd/specgraph/uninstall.go
+++ b/cmd/specgraph/uninstall.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/docker"
+	"github.com/specgraph/specgraph/internal/service"
+	"github.com/specgraph/specgraph/internal/xdg"
+	"github.com/spf13/cobra"
+)
+
+var uninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Unregister the SpecGraph user service (launchd/systemd); preserves data",
+	RunE:  runUninstall,
+}
+
+func init() {
+	rootCmd.AddCommand(uninstallCmd)
+}
+
+// uninstallDeps names the side-effecting operations doUninstall performs.
+// Tests swap these; production wiring is below.
+type uninstallDeps struct {
+	isInstalled      func() bool
+	serviceUninstall func(defPath string) error
+	composeStop      func(composeFile string) error
+	composeFileExist func(composeFile string) bool
+}
+
+var uninstallFns = uninstallDeps{
+	isInstalled:      service.IsInstalled,
+	serviceUninstall: service.Uninstall,
+	composeStop:      docker.ComposeStop,
+	composeFileExist: func(p string) bool { _, err := os.Stat(p); return err == nil },
+}
+
+func runUninstall(_ *cobra.Command, _ []string) error {
+	cfg, err := config.LoadGlobal(globalConfigPath())
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	destDir, err := serviceDestDir()
+	if err != nil {
+		return fmt.Errorf("service dest dir: %w", err)
+	}
+	defPath := filepath.Join(destDir, serviceDefinitionFilename())
+	composeFile := filepath.Join(xdg.DataHome(), "docker-compose.yaml")
+
+	return doUninstall(cfg, defPath, composeFile, os.Stderr)
+}
+
+// doUninstall is the testable core of `specgraph uninstall`.
+//
+// It deliberately does NOT remove the compose file. Preserving the file
+// alongside the preserved volume is the whole point of non-destructive
+// uninstall: a subsequent `install` finds the same compose file pointing
+// at the same volume and resumes exactly where the user left off.
+func doUninstall(cfg *config.GlobalConfig, defPath, composeFile string, out io.Writer) error {
+	if cfg.Server.Mode == "manual" {
+		return errors.New("nothing to uninstall in manual mode — no service is registered")
+	}
+
+	if !uninstallFns.isInstalled() {
+		_, _ = fmt.Fprintln(out, "SpecGraph service is not installed; nothing to do") //nolint:errcheck // writes to user stream
+		return nil
+	}
+
+	if err := uninstallFns.serviceUninstall(defPath); err != nil {
+		return fmt.Errorf("uninstall service: %w", err)
+	}
+
+	if cfg.Server.Docker && uninstallFns.composeFileExist(composeFile) {
+		if err := uninstallFns.composeStop(composeFile); err != nil {
+			return fmt.Errorf("compose stop: %w", err)
+		}
+	}
+
+	_, _ = fmt.Fprintln(out, "SpecGraph uninstalled (data preserved; run `specgraph down --purge` to remove volumes)") //nolint:errcheck // writes to user stream
+	return nil
+}

--- a/cmd/specgraph/uninstall_test.go
+++ b/cmd/specgraph/uninstall_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/config"
+)
+
+func withUninstallDeps(t *testing.T, deps uninstallDeps) {
+	t.Helper()
+	orig := uninstallFns
+	uninstallFns = deps
+	t.Cleanup(func() { uninstallFns = orig })
+}
+
+func TestDoUninstall_ManualModeErrors(t *testing.T) {
+	var out bytes.Buffer
+	cfg := &config.GlobalConfig{Server: config.ServerSection{Mode: "manual"}}
+	err := doUninstall(cfg, "/tmp/plist", "/tmp/compose.yaml", &out)
+	if err == nil {
+		t.Fatal("manual mode should error")
+	}
+}
+
+func TestDoUninstall_NotInstalledIsIdempotent(t *testing.T) {
+	var calls []string
+	withUninstallDeps(t, uninstallDeps{
+		isInstalled:      func() bool { return false },
+		serviceUninstall: func(string) error { calls = append(calls, "serviceUninstall"); return nil },
+		composeStop:      func(string) error { calls = append(calls, "composeStop"); return nil },
+		composeFileExist: func(string) bool { return true },
+	})
+	var out bytes.Buffer
+	cfg := &config.GlobalConfig{Server: config.ServerSection{Mode: "service", Docker: true}}
+	if err := doUninstall(cfg, "/tmp/plist", "/tmp/compose.yaml", &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Errorf("not-installed path should make no calls, got: %v", calls)
+	}
+	if !strings.Contains(out.String(), "not installed") {
+		t.Errorf("should print informative notice, got: %q", out.String())
+	}
+}
+
+func TestDoUninstall_HappyPathRemovesServiceAndStopsContainer(t *testing.T) {
+	var calls []string
+	withUninstallDeps(t, uninstallDeps{
+		isInstalled:      func() bool { return true },
+		serviceUninstall: func(string) error { calls = append(calls, "serviceUninstall"); return nil },
+		composeStop:      func(string) error { calls = append(calls, "composeStop"); return nil },
+		composeFileExist: func(string) bool { return true },
+	})
+	var out bytes.Buffer
+	cfg := &config.GlobalConfig{Server: config.ServerSection{Mode: "service", Docker: true}}
+	if err := doUninstall(cfg, "/tmp/plist", "/tmp/compose.yaml", &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Order: unregister the service first, then halt the container.
+	want := []string{"serviceUninstall", "composeStop"}
+	if len(calls) != 2 || calls[0] != want[0] || calls[1] != want[1] {
+		t.Errorf("got calls %v, want %v", calls, want)
+	}
+	// The output should reassure the user that data is preserved.
+	if !strings.Contains(out.String(), "data preserved") {
+		t.Errorf("message should reassure about data, got: %q", out.String())
+	}
+}
+
+func TestDoUninstall_NoDockerSkipsComposeStop(t *testing.T) {
+	var calls []string
+	withUninstallDeps(t, uninstallDeps{
+		isInstalled:      func() bool { return true },
+		serviceUninstall: func(string) error { calls = append(calls, "serviceUninstall"); return nil },
+		composeStop:      func(string) error { calls = append(calls, "composeStop"); return nil },
+		composeFileExist: func(string) bool { return true },
+	})
+	var out bytes.Buffer
+	cfg := &config.GlobalConfig{Server: config.ServerSection{Mode: "service", Docker: false}}
+	if err := doUninstall(cfg, "/tmp/plist", "/tmp/compose.yaml", &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, c := range calls {
+		if c == "composeStop" {
+			t.Errorf("docker:false should skip composeStop, got: %v", calls)
+		}
+	}
+}
+
+func TestDoUninstall_MissingComposeFileSkipsStop(t *testing.T) {
+	var calls []string
+	withUninstallDeps(t, uninstallDeps{
+		isInstalled:      func() bool { return true },
+		serviceUninstall: func(string) error { calls = append(calls, "serviceUninstall"); return nil },
+		composeStop:      func(string) error { calls = append(calls, "composeStop"); return nil },
+		composeFileExist: func(string) bool { return false },
+	})
+	var out bytes.Buffer
+	cfg := &config.GlobalConfig{Server: config.ServerSection{Mode: "service", Docker: true}}
+	if err := doUninstall(cfg, "/tmp/plist", "/tmp/compose.yaml", &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, c := range calls {
+		if c == "composeStop" {
+			t.Errorf("missing compose file should skip composeStop, got: %v", calls)
+		}
+	}
+}

--- a/cmd/specgraph/up.go
+++ b/cmd/specgraph/up.go
@@ -22,6 +22,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// upIsInstalled is the seam tests swap to exercise the service-mode hint
+// branch without touching the real launchd/systemd files. Kept as a bare
+// var (not a deps struct) because `up` has exactly one seam; promote to a
+// struct if a second seam ever appears.
+var upIsInstalled = service.IsInstalled
+
+// serviceModeHint returns the text `up` should print in service mode given
+// the installation state, or "" if nothing should be printed. Extracted so
+// tests can verify the branching without spinning up cobra/config machinery.
+func serviceModeHint(installed bool) string {
+	if installed {
+		return ""
+	}
+	return "Service not installed — running container only. Run `specgraph install` to enable auto-start."
+}
+
 var upCmd = &cobra.Command{
 	Use:   "up",
 	Short: "Start the SpecGraph server (daemon, service, or manual)",
@@ -63,29 +79,14 @@ func runUp(cmd *cobra.Command, _ []string) error {
 
 	switch cfg.Server.Mode {
 	case "service":
-		binaryPath, err := os.Executable()
-		if err != nil {
-			return fmt.Errorf("resolve binary path: %w", err)
-		}
-		binaryPath, err = filepath.Abs(binaryPath)
-		if err != nil {
-			return fmt.Errorf("resolve absolute binary path: %w", err)
-		}
-		destDir, err := serviceDestDir()
-		if err != nil {
-			return fmt.Errorf("service dest dir: %w", err)
-		}
-		svcCfg := service.Config{
-			BinaryPath: binaryPath,
-			ConfigPath: globalConfigPath(),
-			LogPath:    filepath.Join(xdg.StateHome(), "server.log"),
-		}
-		defPath, err := service.Generate(destDir, svcCfg)
-		if err != nil {
-			return fmt.Errorf("generate service definition: %w", err)
-		}
-		if err := service.Install(defPath); err != nil {
-			return fmt.Errorf("install service: %w", err)
+		// `up` no longer installs the service. Once registered, the OS service
+		// manager keeps it alive — launchd via RunAtLoad + KeepAlive (see
+		// internal/service/launchd.go), systemd via Restart=on-failure +
+		// WantedBy=default.target (see internal/service/systemd.go). No action
+		// needed here. If not installed, print a hint and continue so
+		// docker-only users still get a running container.
+		if hint := serviceModeHint(upIsInstalled()); hint != "" {
+			fmt.Println(hint)
 		}
 	case "manual":
 		fmt.Println("Manual mode: run `specgraph serve` in another terminal")

--- a/cmd/specgraph/up_test.go
+++ b/cmd/specgraph/up_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Hint extraction lets us test the service-mode branching without spinning
+// up cobra flags or reading config from disk. Regression guard against
+// accidentally inverting the isInstalled check or dropping the hint.
+
+func TestServiceModeHint_InstalledReturnsEmpty(t *testing.T) {
+	if got := serviceModeHint(true); got != "" {
+		t.Errorf("installed should return empty hint, got %q", got)
+	}
+}
+
+func TestServiceModeHint_NotInstalledDirectsUserToInstall(t *testing.T) {
+	got := serviceModeHint(false)
+	if got == "" {
+		t.Fatal("not-installed should produce a hint, got empty")
+	}
+	if !strings.Contains(got, "specgraph install") {
+		t.Errorf("hint should name the command to run, got %q", got)
+	}
+	if !strings.Contains(got, "container") {
+		t.Errorf("hint should clarify container still starts, got %q", got)
+	}
+}

--- a/docs/plans/2026-03-16-slice-7-global-daemon-and-plugin-design.md
+++ b/docs/plans/2026-03-16-slice-7-global-daemon-and-plugin-design.md
@@ -1,6 +1,8 @@
 # Slice 7: Global Daemon & Claude Code Plugin — Design
 
 > **Supersedes:** `2026-02-28-slice-7-claude-code-plugin-plan.md` (which assumed per-project server model)
+>
+> **Partially superseded:** The CLI command surface described in §`specgraph up` / §`specgraph down` (lines 151–193) was revised in `2026-04-22-cli-lifecycle-split-design.md`. `install`/`uninstall` are now dedicated verbs, `--rm` is retired, and `down --purge` is the confirmation-guarded destructive flag. Sections below that describe the original `up`/`down` surface are kept for historical record but should not be treated as current spec.
 
 **Goal:** Transform SpecGraph from a per-project tool into a global development daemon, then ship a Claude Code plugin that wraps the CLI in conversational skills.
 

--- a/docs/plans/2026-04-22-cli-lifecycle-split-design.md
+++ b/docs/plans/2026-04-22-cli-lifecycle-split-design.md
@@ -1,0 +1,343 @@
+# CLI Lifecycle Split — Design
+
+> **Date**: 2026-04-22
+> **Status**: Draft (revised after independent review)
+> **Phase**: 2 (Authoring & CLI Integration)
+> **Triggering issue**: `specgraph down` followed by `specgraph up` silently wipes all PostgreSQL data.
+
+## Overview
+
+Today `specgraph up` and `specgraph down` each do two orthogonal things — **runtime lifecycle** (start/stop containers + running service) and **registration** (install/uninstall the launchd plist or systemd unit). The overload forced `--rm` on `down` to mean "uninstall the service definition," which left no clean flag for "destroy data" — and in practice the code path unconditionally runs `docker compose down -v`, destroying the named Postgres volume on every `down`.
+
+This design splits the two concerns into dedicated verbs:
+
+- `install` / `uninstall` — service registration (plist/systemd) only
+- `up` / `down` — runtime lifecycle only; data is preserved by default
+- `down --purge` — opt-in destructive teardown of containers and volumes, guarded by a confirmation prompt on TTY or `--yes` in scripts
+
+As a side benefit, the same pass addresses a second data-loss path: the `defer ComposeDown(...)` at the end of `specgraph serve` (serve.go:83-87), which currently wipes data whenever the foreground server exits. It is replaced with a non-destructive `ComposeStop`.
+
+### Goals
+
+- Make `specgraph down` non-destructive by default; data survives any number of `up`/`down` cycles.
+- Give service registration a first-class, reversible command pair.
+- Make destructive teardown a single, clearly-named, confirmation-guarded operation.
+- Replace `serve`'s data-destroying exit path with a container-stop that preserves data and cleans up live processes for interactive users.
+- Keep `task dev:reset` as the canonical "nuke everything and rebuild" developer path, unchanged.
+
+### Non-Goals
+
+- Changing the `server.mode` config model (`service` vs `manual` stays the same).
+- Introducing a new destructive command (`dev:reset` already fills that role).
+- Changing the compose file schema or Postgres image.
+- Adding new flags to `up`.
+- Windows support — `cmd/specgraph/up.go:121-132` has only `darwin` and `default: linux` branches today. Windows is explicitly out of scope; the new `install`/`uninstall` commands inherit the same platform coverage.
+
+## Problem Details
+
+### Bug 1 — `ComposeDown` unconditionally passes `-v`
+
+`internal/docker/compose.go:31`:
+
+```go
+cmd := exec.Command("docker", "compose", "-f", composeFile, "down", "--timeout", "10", "-v")
+```
+
+`docker compose down -v` removes **named volumes declared in the compose file**. The Postgres data volume is named `specgraph-data` (compose.go:72-81), so every `specgraph down` drops it. The original design doc for `specgraph down` (`docs/plans/2026-03-16-slice-7-global-daemon-and-plugin-design.md:193`) specified `down --timeout 10` with no `-v` — the code regressed from the spec.
+
+### Bug 2 — `serve.go` destroys data on foreground exit
+
+`cmd/specgraph/serve.go:83-87`:
+
+```go
+defer func() {
+    if downErr := docker.ComposeDown(composeFile); downErr != nil {
+        fmt.Fprintf(os.Stderr, "warning: compose down: %v\n", downErr)
+    }
+}()
+```
+
+Every clean exit of `specgraph serve` calls the buggy `ComposeDown` and wipes data. This fires on normal Ctrl-C, not just on errors. `specgraph up` does not install a matching defer, so the two "start" paths have inconsistent teardown semantics.
+
+### Bug 3 — `--force-recreate -V` on every `up`
+
+`internal/docker/compose.go:20`:
+
+```go
+cmd := exec.Command("docker", "compose", "-f", composeFile, "up", "-d", "--wait", "--force-recreate", "-V")
+```
+
+`-V` (`--renew-anon-volumes`) is harmless for our named volume but signals the wrong intent. `--force-recreate` unconditionally tears down and recreates the container even when nothing changed, adding latency and spurious churn on every `up`. Not a data-loss bug on its own, but inconsistent with a "preserve state" default.
+
+### Flag overload on `down --rm`
+
+`cmd/specgraph/down.go:28`:
+
+```go
+downCmd.Flags().BoolVar(&downRM, "rm", false, "uninstall the service definition after stopping")
+```
+
+`--rm` currently means "uninstall the launchd/systemd service definition" — install state, not data. Users reaching for `docker compose down --volumes`-style intuition find nothing; `--rm` is already taken for a different concept. Separating service-def management into its own verb frees `--rm` to be retired, replaced by a single unambiguous `--purge`.
+
+## Proposed Model
+
+### Command matrix
+
+| Command | Touches service def? | Touches containers? | Touches volumes? |
+|---------|----------------------|---------------------|------------------|
+| `specgraph install` | Register + start | Start (via service/docker) | No |
+| `specgraph uninstall` | Stop + unregister | Stop | No |
+| `specgraph up` | No | Start | No |
+| `specgraph down` | No (but stops running service) | Stop | **No** |
+| `specgraph down --purge` | No | Stop + remove | **Yes (data wipe, confirmation-guarded)** |
+| `specgraph serve` | No | Start (foreground); exit calls `ComposeStop` | No |
+| `task dev:reset` | Unchanged | Stop + remove | Yes (wipe + rebuild) |
+
+### Semantic rules
+
+1. **Registration and runtime are orthogonal.** `install`/`uninstall` manage only the plist/systemd unit file. `up`/`down` manage only running processes and containers.
+2. **`up`/`down` in `service` mode use `service.IsInstalled` to detect registration state.** `internal/service/service.go` already exposes this predicate; `up` loads the service iff installed, `down` stops it iff installed. No file-stat probing in command handlers.
+3. **Data survives every non-`--purge` path.** A user who never types `--purge` can never lose their graph through lifecycle commands.
+4. **`--purge` on `down` is the single, clearly-named, opt-in destructive switch for data.** Retired flag name (`--rm`) is not reintroduced for any future meaning.
+5. **`--purge` is confirmation-guarded.** On a TTY, `down --purge` prompts `Destroy all data in specgraph-data volume? [y/N]`. Non-TTY (CI, scripts) requires `--yes` or the command errors without destroying anything.
+6. **`serve` stops its container on exit.** A `ComposeStop` defer replaces today's destructive `ComposeDown` defer. Containers are halted (not removed), volumes are untouched, the next `up` or `serve` restarts quickly.
+
+### Command details
+
+#### `specgraph install`
+
+```text
+specgraph install
+  1. Require server.mode == "service" (error with actionable hint if "manual").
+  2. If already installed (service.IsInstalled): ensure loaded and docker is up, exit 0 idempotently.
+  3. Generate service definition under destDir (reuses service.Generate).
+  4. If server.docker: ComposeUp.
+     - On ComposeUp failure: abort before loading the service. Nothing registered yet, nothing to unwind.
+  5. service.Install(defPath) — register and load.
+     - On service.Install failure: call ComposeStop to avoid orphan containers, delete the definition file, return error.
+  6. Health-check loop (reuse existing logic).
+  7. Print "SpecGraph installed and running at <url>".
+```
+
+Idempotent on success. Ordered so that the cheapest-to-unwind step runs last: once the service is registered, launchd/systemd will restart the binary on failure, so we only register after the container is confirmed healthy.
+
+#### `specgraph uninstall`
+
+```text
+specgraph uninstall
+  1. Require server.mode == "service" (error if "manual" — nothing to uninstall).
+  2. If not installed: print notice, exit 0 idempotently.
+  3. service.Uninstall(defPath) — stops service and removes definition.
+  4. If server.docker: ComposeStop (preserve container + volume for fast re-install).
+  5. Print "SpecGraph uninstalled (data preserved; run `specgraph down --purge` to remove volumes)".
+```
+
+The compose file is **not** removed by `uninstall` — preserving it alongside the preserved volume is the whole point of non-destructive uninstall. A subsequent `install` finds the same compose file pointing at the same volume and resumes exactly where the user left off. (Closes Open Question 2 from the draft.)
+
+#### `specgraph up`
+
+```text
+specgraph up
+  1. Idempotency check: if already healthy, exit 0.
+  2. If server.docker: ComposeUp (non-destructive — no --force-recreate, no -V).
+  3. If server.mode == "service":
+     - If service.IsInstalled: load it (launchctl/systemctl start).
+     - Else: print one-line hint "Service not installed — running container only. `specgraph install` to enable auto-start.", continue.
+  4. If server.mode == "manual": print "Manual mode: run `specgraph serve` in another terminal."
+  5. Health-check loop.
+```
+
+Key change: `up` no longer *generates* the service definition or calls `service.Install`. Those moved to `specgraph install`. The "service registered but not running" state is handled explicitly via `service.IsInstalled`; file-stat probes are gone.
+
+#### `specgraph down`
+
+```text
+specgraph down [--purge [--yes]]
+  1. If server.mode == "service" and service.IsInstalled: service.Stop() (do NOT remove definition).
+  2. Without --purge:
+     - If server.docker: ComposeStop (halt container, preserve volumes).
+     - Print "SpecGraph stopped".
+  3. With --purge:
+     - If TTY: prompt "Destroy all data in specgraph-data volume? [y/N]". Non-y answer aborts.
+     - If non-TTY: require --yes or error ("--purge requires --yes when not on a TTY").
+     - If server.docker: ComposeDownWithVolumes (docker compose down -v).
+     - Print "SpecGraph stopped and volumes removed".
+```
+
+#### `specgraph serve`
+
+Replace the `defer ComposeDown(composeFile)` at serve.go:83-87 with a `defer ComposeStop(composeFile)`. Rationale:
+
+- `serve` in manual mode is often the process the user Ctrl-Cs — with the defer removed entirely, interactive users would accumulate orphan containers across sessions.
+- `ComposeStop` halts the container (fast) without removing it or touching volumes. Next `serve` or `up` restarts the container rather than recreating it.
+- On start-path failures (ComposeUp fails), there is nothing to stop; the defer is a no-op in that case (`docker compose stop` on an already-stopped stack is idempotent).
+
+### `ComposeUp`/`ComposeStop`/`ComposeDown` changes
+
+`internal/docker/compose.go`:
+
+```go
+// ComposeUp: drop --force-recreate and -V.
+cmd := exec.Command("docker", "compose", "-f", composeFile, "up", "-d", "--wait")
+
+// ComposeStop: new — non-destructive pause. Halts containers, keeps them + volumes.
+cmd := exec.Command("docker", "compose", "-f", composeFile, "stop", "--timeout", "10")
+
+// ComposeDown: drop -v. Removes containers; keeps named volumes.
+cmd := exec.Command("docker", "compose", "-f", composeFile, "down", "--timeout", "10")
+
+// ComposeDownWithVolumes: new — explicit, destructive. Called only by `down --purge`.
+cmd := exec.Command("docker", "compose", "-f", composeFile, "down", "--timeout", "10", "-v")
+```
+
+Caller map:
+
+| Caller | Function |
+|--------|----------|
+| `specgraph up` | `ComposeUp` |
+| `specgraph install` | `ComposeUp` |
+| `specgraph down` (no flag) | `ComposeStop` |
+| `specgraph uninstall` | `ComposeStop` |
+| `specgraph serve` (defer) | `ComposeStop` |
+| `specgraph down --purge` | `ComposeDownWithVolumes` |
+| `task dev:reset` | Unchanged — still invokes `docker compose ... down -v` directly in the Taskfile |
+
+## Partial Failure Semantics
+
+Summarized to one place since `install` and the destructive `down --purge` path both have multi-step sequences:
+
+- **`install` failure modes.**
+  - `ComposeUp` fails: nothing registered yet, surface the error and exit. User re-runs `install` after fixing Docker.
+  - `service.Install` fails after successful `ComposeUp`: call `ComposeStop` so the container doesn't stay running under a half-installed service, delete the generated definition file, return error.
+  - Health-check fails after both registered and container up: leave the install in place (the service will keep trying), return error with a diagnostic suggesting `specgraph logs` (or `journalctl --user -u specgraph` on Linux).
+- **`down --purge` confirmation aborted.** Nothing is destroyed; command exits 0 with "aborted — no changes made."
+- **`down --purge` after partial `ComposeDown`.** `docker compose down -v` is atomic enough at the volume level — either the volume is gone or it isn't. No mid-state to recover.
+- **`uninstall` during active RPCs.** No explicit connection draining. The service manager (launchd/systemd) sends SIGTERM via `service.Uninstall`; the server process must exit cleanly on SIGTERM within the standard service-manager grace period. In-flight RPCs may be cut. Acceptable for now — this server has no long-lived streaming RPCs; re-evaluate if/when MCP or watch endpoints land. Tracked as a follow-up consideration, not a blocker.
+
+## Shared-State Caveat Across jj Workspaces
+
+`$XDG_DATA_HOME/specgraph/` is **per-user, not per-workspace**. Two jj workspaces of this repo — which CLAUDE.md explicitly prescribes for parallel work — share a single compose file and a single Postgres volume. Consequences:
+
+- `specgraph up` in workspace A and workspace B connect to the same database by default.
+- `specgraph down --purge` in workspace A destroys the data workspace B is using.
+- `specgraph uninstall` in workspace A stops the service workspace B was relying on.
+
+This is unchanged from today's behavior; the design neither makes it better nor worse. It is called out here because:
+
+1. The destructive path (`--purge`) is newly-named and newly-guarded, so users may reach for it more willingly than the current opaque `--rm`.
+2. The confirmation prompt should make the shared-state footgun visible: wording is `Destroy all data in specgraph-data volume? All SpecGraph workspaces on this machine share this volume. [y/N]`. The second sentence is the user-visible mitigation for the jj case.
+3. Per-workspace isolation (separate XDG roots per repo checkout) is a follow-up, tracked as a beads issue from this design — not a blocker.
+
+## Migration & Backward Compatibility
+
+### Single breaking change: retire `--rm`, introduce `--purge`
+
+`--rm` on `down` is **removed entirely** in this change and never reinstated. Running `specgraph down --rm` after this change prints:
+
+```text
+Error: --rm has been retired.
+  To remove the service definition:   specgraph uninstall
+  To remove containers and data:       specgraph down --purge
+Run `specgraph --help` for details.
+```
+
+The error is permanent — `--rm` never resurfaces with a new meaning. This avoids the silent-reversal footgun (which a four-phase flip-with-alias would have carried) at the cost of a loud, one-line error that points users at the two correct new commands.
+
+Rationale for rejecting the multi-phase flip-and-rename-back:
+
+- Pre-1.0 project; no tests depend on `--rm`'s destructive side effect (verified — no test file references `ComposeDown` or `ComposeUp`).
+- `docker compose down -v` uses `--volumes`, not `--rm` — so the "Docker muscle memory" argument actually *weakens* the case for preserving `--rm` as a destructive flag.
+- Three known documentation references to `--rm` exist (slice-7 design, bootstrap-funnel-demo design, CLI reference), one of which was ambiguously/incorrectly worded anyway. Updating three doc sites is lower effort than shepherding users through a multi-release flip.
+
+### Non-breaking
+
+- `server.mode` and `server.docker` config stay as-is.
+- `task dev:reset` is unchanged and continues to be the canonical wipe.
+- `specgraph up` with no flags behaves the same on the happy path for users who haven't typed `install` — the service auto-install step is gone, but manual-mode and docker-only users see no difference.
+
+### Users who relied on `up` auto-installing the service
+
+`up` no longer calls `service.Install`. Users who relied on the implicit install now need to run `install` once. Mitigation:
+
+- First-run detection via `service.IsInstalled`: if `server.mode == "service"` and not installed, `up` prints a one-line hint.
+- Release notes + docs call this out explicitly.
+
+## File-by-File Impact
+
+### Code
+
+| File | Change |
+|------|--------|
+| `internal/docker/compose.go` | Add `ComposeStop` and `ComposeDownWithVolumes`. Drop `-v` from `ComposeDown`. Drop `--force-recreate -V` from `ComposeUp`. |
+| `cmd/specgraph/up.go` | Remove service-definition generation + `service.Install` call. Use `service.IsInstalled` for the branch. |
+| `cmd/specgraph/down.go` | Retire `--rm` (permanent error). Add `--purge` and `--yes` flags. Wire TTY/non-TTY confirmation. Wire `ComposeStop`/`ComposeDownWithVolumes`. |
+| `cmd/specgraph/install.go` | **New.** Owns service definition generation + `service.Install` + `ComposeUp` + partial-failure unwinds per §"Partial Failure Semantics". |
+| `cmd/specgraph/uninstall.go` | **New.** Owns `service.Uninstall` + `ComposeStop`. Compose file is intentionally preserved. |
+| `cmd/specgraph/serve.go` | Swap `defer ComposeDown` at lines 83-87 to `defer ComposeStop`. |
+| `cmd/specgraph/docs.go:57` | Add `install` and `uninstall` to the `commandGroups` "Server & Config" entry so `task docs:cli` regenerates `site/docs/cli-reference.md` with the new commands. |
+
+### Docs
+
+| File | Change |
+|------|--------|
+| `README.md:122` | Expand the command table: `up`/`down` row + new `install`/`uninstall` row. |
+| `site/docs/cli-reference.md:856-869` | Expand `up`/`down`. Add `install`/`uninstall` sections. Document `--purge` new meaning and confirmation semantics. Document `--rm` retirement. |
+| `docs/plans/2026-03-16-slice-7-global-daemon-and-plugin-design.md:151-193` | Note: superseded for the CLI surface; cross-link to this design. Leave the original text for historical record. |
+| `docs/superpowers/specs/2026-03-21-bootstrap-funnel-demo-design.md:149` | Replace `specgraph down --rm` with the correct verb — `specgraph uninstall` for tutorial cleanup, `task dev:reset` if a full wipe is intended. Confirm during implementation. |
+| `site/docs/quickstart.md:70` and related | Audit for "wipe between runs" language that assumed the old destructive behavior. |
+
+### Tests
+
+No existing tests exercise the `ComposeDown -v` path (verified via grep). New tests:
+
+- `cmd/specgraph/install_test.go` + `uninstall_test.go` — happy path, mode-mismatch errors, `install` partial-failure unwind (mock `service.Install` returning error after a fake `ComposeUp` success; assert `ComposeStop` was called and definition file was removed).
+- `cmd/specgraph/down_test.go` — `--rm` prints retirement error and exits non-zero without touching docker; `--purge` without `--yes` on non-TTY errors; `--purge --yes` on non-TTY calls `ComposeDownWithVolumes`; TTY path covered via a PTY helper or mocked stdin.
+- `internal/docker/compose_test.go` — assert the exact `exec.Command` argv produced by each wrapper (catches future regressions of the `-v` kind).
+
+## Rejected Alternatives
+
+### A. Minimal fix: drop `-v`, leave everything else
+
+Correctly rejected as the *complete* fix, but the Plan section ships the minimal fix first (as Phase 1) so the reported bug is resolved ahead of the ergonomic redesign. The full design is an ergonomics cleanup built on top of the bug fix, not a gate in front of it.
+
+### B. Keep `--rm` = uninstall, add `--purge` for data
+
+Non-breaking but leaves `up`/`down` still doing two jobs each and wastes the clearest flag name (`--rm`) on service-def removal. The install/uninstall split is what makes the CLI surface comprehensible; keeping `--rm` as an alias for `uninstall` would undercut that.
+
+### C. Add `up --no-install` as a mirror to "don't auto-install on up"
+
+Rejected. Once `install` is a separate verb, `up` never installs, so `--no-install` is a negation of a default that no longer exists.
+
+### D. Four-phase `--rm` migration with transitional `--purge-data` alias
+
+Rejected in the revision. Four phases across unspecified release cadence, with a hidden alias that exists for one release and then vanishes, adds friction for users without meaningfully reducing surprise. A single permanent retirement of `--rm` is louder but cleaner.
+
+### E. Remove `serve`'s exit defer entirely
+
+Rejected in the revision. Leaves orphan containers after every interactive manual-mode session. Replaced with `ComposeStop` (this design's proposal), which halts without destroying and preserves fast restart.
+
+## Open Questions
+
+1. **Does `install` start the service immediately, or only register it?** Current spec: register + start (matches `brew services start`). Alternative: register only; require `up` to actually launch. The former is more ergonomic for the primary use case and consistent with the existing `specgraph up` one-command experience. Recommend keeping as spec'd.
+2. ~~**Does `uninstall` remove the compose file?**~~ **Resolved**: no. The compose file is preserved so a subsequent `install` resumes against the same preserved volume. See `uninstall` spec.
+3. **Which teardown does the funnel-demo spec actually want?** `docs/superpowers/specs/2026-03-21-bootstrap-funnel-demo-design.md:149` says `specgraph down --rm` for "teardown … clean up." Confirm during implementation whether the intent is service-def removal (`uninstall`), data wipe (`down --purge`), or a full dev reset (`task dev:reset`). Affects one doc line and potentially the tutorial's observable behavior.
+
+## Plan
+
+A companion `2026-04-22-cli-lifecycle-split-plan.md` will sequence the implementation. **Phase 1 is shippable on its own and resolves the reported data-loss bug ahead of the larger redesign.**
+
+1. **Phase 1 — Bug fix (shippable immediately, self-contained PR).**
+   - Drop `-v` from `ComposeDown`.
+   - Drop `--force-recreate -V` from `ComposeUp`.
+   - Swap `serve.go:83-87` defer from `ComposeDown` to `ComposeStop` (adds `ComposeStop` as the new non-destructive wrapper).
+   - Add `internal/docker/compose_test.go` asserting argv for each wrapper.
+   - No CLI surface change. No breaking change. Fixes the reported bug.
+2. **Phase 2 — CLI surface redesign (breaking, builds on Phase 1).**
+   - Add `install`/`uninstall` commands.
+   - Retire `--rm` on `down` with the permanent error; add `--purge` + `--yes`.
+   - Implement TTY-aware confirmation prompt.
+   - Move service-install logic out of `up`; add `service.IsInstalled` branch.
+   - Add `ComposeDownWithVolumes` as a second wrapper (only `down --purge` uses it).
+   - Doc updates across README, CLI reference, and the slice-7 design cross-link.
+3. **Phase 3 — Follow-up (separate change, not in this branch).**
+   - Beads issue: investigate per-workspace XDG isolation to fix the shared-volume footgun across jj workspaces (documented here; no behavior change in this branch).

--- a/docs/plans/2026-04-22-cli-lifecycle-split-plan.md
+++ b/docs/plans/2026-04-22-cli-lifecycle-split-plan.md
@@ -1,0 +1,330 @@
+# CLI Lifecycle Split — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve the `specgraph down` data-loss bug and split the CLI surface so registration (`install`/`uninstall`) is orthogonal to runtime (`up`/`down`), with a single confirmation-guarded destructive flag (`down --purge`).
+
+**Design spec:** `docs/plans/2026-04-22-cli-lifecycle-split-design.md`
+
+**Sequencing:**
+
+- **Phase 1** is a self-contained bug fix and should land as its own PR **ahead of Phase 2**. It stops the bleeding (data loss on every `down`) without any CLI surface change.
+- **Phase 2** is the breaking CLI redesign. It depends on Phase 1 but is otherwise orthogonal.
+- **Phase 3** is filed as a beads follow-up (per-workspace XDG isolation) and is **not** implemented in this branch.
+
+**Tech Stack:** Go, cobra (existing), `docker compose` shell-out (existing), `golang.org/x/term` (new direct dep; already transitive).
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `internal/docker/compose.go` | Drop `-v` / `--force-recreate -V` / `-V`. Add `ComposeStop` + `ComposeDownWithVolumes`. |
+| Create | `internal/docker/compose_test.go` | Argv assertion tests for every wrapper. |
+| Modify | `cmd/specgraph/serve.go` | Swap `defer ComposeDown` → `defer ComposeStop`. |
+| Modify | `cmd/specgraph/down.go` | Retire `--rm`. Add `--purge` + `--yes`. Wire TTY prompt. |
+| Create | `cmd/specgraph/down_test.go` | Flag retirement, TTY/non-TTY branches, wrapper call assertions. |
+| Create | `cmd/specgraph/install.go` | New verb: registration + docker up + partial-failure unwind. |
+| Create | `cmd/specgraph/install_test.go` | Happy path, mode-mismatch error, partial-failure unwind. |
+| Create | `cmd/specgraph/uninstall.go` | New verb: registration removal + `ComposeStop`. |
+| Create | `cmd/specgraph/uninstall_test.go` | Happy path, mode-mismatch error, compose-file preservation. |
+| Modify | `cmd/specgraph/up.go` | Remove service-install. Use `service.IsInstalled`. |
+| Modify | `cmd/specgraph/up_test.go` (or add if absent) | New branch coverage. |
+| Create | `cmd/specgraph/confirm.go` | TTY prompt + `--yes` helper (shared by `down --purge` and any future destructive command). |
+| Create | `cmd/specgraph/confirm_test.go` | TTY branch via io.Reader injection, non-TTY error path. |
+| Modify | `cmd/specgraph/docs.go:57` | Add `install` + `uninstall` to "Server & Config" `commandGroups` entry. |
+| Modify | `site/docs/cli-reference.md` | Regenerated via `task docs:cli`. |
+| Modify | `README.md:122` | Update command table. |
+| Modify | `docs/plans/2026-03-16-slice-7-global-daemon-and-plugin-design.md` | Cross-link to this design; mark superseded for CLI surface. |
+| Modify | `docs/superpowers/specs/2026-03-21-bootstrap-funnel-demo-design.md:149` | Replace `specgraph down --rm` with correct verb. |
+| Modify | `go.mod` | Promote `golang.org/x/term` to direct require. |
+
+---
+
+## Phase 1 — Bug Fix (shippable PR, no CLI surface change)
+
+### Task 1.1 — Add argv-assertion tests for current wrappers
+
+**Files:** Create `internal/docker/compose_test.go`.
+
+Write tests **first** that fail against the current code, by asserting the argv each wrapper *should* produce. This is the TDD red step.
+
+- [ ] **Step 1:** Extract argv generation behind a seam. Refactor `ComposeUp` and `ComposeDown` so the `exec.Command` args are produced by a pure function (e.g., `composeUpArgs(composeFile string) []string`). Callers still invoke via `exec.Command("docker", args...)`.
+- [ ] **Step 2:** Write failing tests:
+
+```go
+func TestComposeUpArgs(t *testing.T) {
+    got := composeUpArgs("/tmp/compose.yaml")
+    want := []string{"compose", "-f", "/tmp/compose.yaml", "up", "-d", "--wait"}
+    if !reflect.DeepEqual(got, want) { t.Fatalf("got %v, want %v", got, want) }
+}
+
+func TestComposeDownArgs(t *testing.T) {
+    got := composeDownArgs("/tmp/compose.yaml")
+    want := []string{"compose", "-f", "/tmp/compose.yaml", "down", "--timeout", "10"}
+    // NOTE: no -v. Regression guard for the data-loss bug.
+    if !reflect.DeepEqual(got, want) { t.Fatalf("got %v, want %v", got, want) }
+}
+```
+
+- [ ] **Step 3:** Run `go test ./internal/docker/...` — confirm both tests fail with the specific expected-vs-got mismatch. Red state confirmed.
+
+### Task 1.2 — Fix `ComposeUp` and `ComposeDown`
+
+**Files:** Modify `internal/docker/compose.go`.
+
+- [ ] **Step 1:** Drop `--force-recreate` and `-V` from `composeUpArgs`. Keep `-d --wait`.
+- [ ] **Step 2:** Drop `-v` from `composeDownArgs`. Keep `--timeout 10`.
+- [ ] **Step 3:** Run `go test ./internal/docker/...` — tests from 1.1 now pass. Green state.
+- [ ] **Step 4:** Smoke test manually: `go run ./cmd/specgraph up; go run ./cmd/specgraph down; go run ./cmd/specgraph up` — verify Postgres volume survives the cycle (`docker volume inspect specgraph_specgraph-data` shows same `CreatedAt` before and after).
+
+### Task 1.3 — Add `ComposeStop`
+
+**Files:** Modify `internal/docker/compose.go`, update `internal/docker/compose_test.go`.
+
+- [ ] **Step 1:** Write failing test for `composeStopArgs`:
+
+```go
+func TestComposeStopArgs(t *testing.T) {
+    got := composeStopArgs("/tmp/compose.yaml")
+    want := []string{"compose", "-f", "/tmp/compose.yaml", "stop", "--timeout", "10"}
+    if !reflect.DeepEqual(got, want) { t.Fatalf(...) }
+}
+```
+
+- [ ] **Step 2:** Implement `ComposeStop` (mirror `ComposeDown` structure; call `composeStopArgs`).
+- [ ] **Step 3:** Godoc: `// ComposeStop halts the stack without removing containers or volumes. Idempotent — already-stopped stacks exit 0.`
+- [ ] **Step 4:** Run `task lint` and `go test ./internal/docker/...`.
+
+### Task 1.4 — Swap `serve.go` defer
+
+**Files:** Modify `cmd/specgraph/serve.go`.
+
+- [ ] **Step 1:** Locate the `defer` block at `serve.go:83-87`.
+- [ ] **Step 2:** Replace `docker.ComposeDown(composeFile)` with `docker.ComposeStop(composeFile)`. Keep the warning-log pattern.
+- [ ] **Step 3:** Verify no other callers of `ComposeDown` in `cmd/` (grep `ComposeDown`).
+- [ ] **Step 4:** Smoke test: `go run ./cmd/specgraph serve` in a terminal, Ctrl-C, then `docker ps -a` — confirm container is `Exited (0)` not removed, and `docker volume inspect` shows the same volume.
+
+### Task 1.5 — Run full quality gate
+
+- [ ] **Step 1:** `task check` (fmt, license, lint, build, unit tests).
+- [ ] **Step 2:** Skim `jj diff` — only four files changed (`internal/docker/compose.go`, new `compose_test.go`, `cmd/specgraph/serve.go`). No CLI surface change. No doc changes.
+- [ ] **Step 3:** Commit with Phase 1 scope: `fix(docker): preserve postgres volume across down/up cycles`.
+- [ ] **Step 4:** Open PR. **This PR is independently mergeable.** Phase 2 can start after it lands (or on a rebase branch in parallel).
+
+---
+
+## Phase 2 — CLI Surface Redesign (breaking, builds on Phase 1)
+
+### Task 2.1 — Confirmation helper
+
+**Files:** Create `cmd/specgraph/confirm.go`, `cmd/specgraph/confirm_test.go`.
+
+Small, shared, testable. Pulled out so `down --purge` isn't the only site that has to reason about TTY detection.
+
+- [ ] **Step 1:** Write failing tests first:
+
+```go
+// confirm_test.go
+func TestConfirmNonTTYRequiresYes(t *testing.T) {
+    // reader with no data simulates non-TTY stdin; isTTY forced false via test seam.
+    err := confirmDestructive(strings.NewReader(""), false, false /*yes*/, "msg")
+    if err == nil || !strings.Contains(err.Error(), "--yes") { t.Fatalf(...) }
+}
+
+func TestConfirmNonTTYWithYesPasses(t *testing.T) {
+    err := confirmDestructive(strings.NewReader(""), false, true, "msg")
+    if err != nil { t.Fatalf(...) }
+}
+
+func TestConfirmTTYPromptsAndAcceptsY(t *testing.T) {
+    err := confirmDestructive(strings.NewReader("y\n"), true, false, "msg")
+    if err != nil { t.Fatalf(...) }
+}
+
+func TestConfirmTTYPromptsAndRejectsDefault(t *testing.T) {
+    err := confirmDestructive(strings.NewReader("\n"), true, false, "msg")
+    if err == nil || !strings.Contains(err.Error(), "aborted") { t.Fatalf(...) }
+}
+```
+
+- [ ] **Step 2:** Implement:
+
+```go
+// confirm.go
+
+// confirmDestructive prompts on a TTY or requires --yes otherwise.
+// Returns nil on confirmation, an error (with a user-facing message) on abort or missing --yes.
+func confirmDestructive(in io.Reader, isTTY, yes bool, prompt string) error {
+    if yes { return nil }
+    if !isTTY {
+        return errors.New("destructive operation requires --yes when not on a TTY")
+    }
+    fmt.Fprintf(os.Stderr, "%s [y/N] ", prompt)
+    scanner := bufio.NewScanner(in)
+    if !scanner.Scan() { return errors.New("aborted — no input") }
+    ans := strings.TrimSpace(strings.ToLower(scanner.Text()))
+    if ans != "y" && ans != "yes" {
+        return errors.New("aborted — no changes made")
+    }
+    return nil
+}
+```
+
+- [ ] **Step 3:** In production, `isTTY` is computed via `term.IsTerminal(int(os.Stdin.Fd()))`. Add `golang.org/x/term` to `go.mod` as a direct require.
+
+### Task 2.2 — Retire `--rm`, add `--purge` + `--yes` on `down`
+
+**Files:** Modify `cmd/specgraph/down.go`, create `cmd/specgraph/down_test.go`.
+
+- [ ] **Step 1:** Remove the `--rm` flag registration. Add `--purge` and `--yes`.
+- [ ] **Step 2:** Add a pre-run check: if `os.Args` contains `--rm`, exit with the retirement message from the design doc §Migration. Cobra's built-in `MarkDeprecated` prints a warning and still accepts the flag — wrong behavior here. Instead, define `--rm` as a hidden bool flag whose handler immediately errors. This keeps cobra's parser happy and gives us the exact retirement message.
+
+```go
+var downRMRetired bool
+downCmd.Flags().BoolVar(&downRMRetired, "rm", false, "")
+_ = downCmd.Flags().MarkHidden("rm")
+
+// in runDown:
+if downRMRetired {
+    return errors.New(`--rm has been retired.
+  To remove the service definition:   specgraph uninstall
+  To remove containers and data:       specgraph down --purge`)
+}
+```
+
+- [ ] **Step 3:** Wire the new logic:
+
+```go
+if downPurge {
+    isTTY := term.IsTerminal(int(os.Stdin.Fd()))
+    msg := "Destroy all data in specgraph-data volume? All SpecGraph workspaces on this machine share this volume."
+    if err := confirmDestructive(os.Stdin, isTTY, downYes, msg); err != nil {
+        return err
+    }
+    // ... docker.ComposeDownWithVolumes ...
+}
+```
+
+- [ ] **Step 4:** Replace the unconditional `service.Uninstall` path (current behavior tied to `--rm`) with `service.Stop` only. Uninstall is no longer a side effect of `down`.
+- [ ] **Step 5:** Replace `docker.ComposeDown` (non-purge) with `docker.ComposeStop` per §File-by-File caller map.
+- [ ] **Step 6:** Tests in `down_test.go`:
+  - `--rm` errors with retirement message, no docker call.
+  - `--purge` on non-TTY without `--yes` errors, no docker call.
+  - `--purge --yes` calls `ComposeDownWithVolumes`.
+  - No flags calls `ComposeStop` and `service.Stop`.
+  - Mock `service` and `docker` via small interface seams — don't shell out in tests.
+
+### Task 2.3 — Add `ComposeDownWithVolumes`
+
+**Files:** Modify `internal/docker/compose.go`, update `internal/docker/compose_test.go`.
+
+- [ ] **Step 1:** Write failing test for argv: expect `["compose", "-f", <path>, "down", "--timeout", "10", "-v"]`.
+- [ ] **Step 2:** Implement wrapper. Godoc: `// ComposeDownWithVolumes tears down the stack AND removes named volumes. Destructive — callers must confirm with the user.`
+- [ ] **Step 3:** Only caller is `cmd/specgraph/down.go` under the `--purge` branch. Verify via grep.
+
+### Task 2.4 — Create `install` command
+
+**Files:** Create `cmd/specgraph/install.go`, `cmd/specgraph/install_test.go`.
+
+- [ ] **Step 1:** Write failing tests first (install_test.go):
+  - Mode-mismatch: `server.mode == "manual"` returns error with actionable hint.
+  - Idempotent: `service.IsInstalled` returning true short-circuits (ensure loaded, docker up, exit 0).
+  - Happy path: calls `ComposeUp` then `service.Install`.
+  - Partial-failure: `ComposeUp` fails → no `service.Install` call, error surfaces.
+  - Partial-failure: `service.Install` fails after `ComposeUp` success → `ComposeStop` called, definition file removed, error surfaces.
+- [ ] **Step 2:** Extract the service-install block from `up.go:64-93` (the `case "service":` branch) into `install.go`. Adjust:
+  - Add the idempotency check via `service.IsInstalled`.
+  - Reorder: `ComposeUp` first, then `service.Install`, so unwind is clean.
+  - Add the partial-failure unwind (delete the definition file on `service.Install` error; call `ComposeStop` to avoid orphans).
+- [ ] **Step 3:** Register `installCmd` on `rootCmd` in `init()`.
+
+### Task 2.5 — Create `uninstall` command
+
+**Files:** Create `cmd/specgraph/uninstall.go`, `cmd/specgraph/uninstall_test.go`.
+
+- [ ] **Step 1:** Tests first:
+  - Mode-mismatch errors (manual mode has nothing to uninstall).
+  - Not installed: prints notice, exits 0 idempotently.
+  - Happy path: calls `service.Uninstall` then `docker.ComposeStop`.
+  - Compose file is **not** removed (assert file still exists after uninstall).
+- [ ] **Step 2:** Implement mirroring the design §uninstall spec. The prior `down --rm` uninstall path from `down.go` moves here.
+- [ ] **Step 3:** Register on `rootCmd`.
+
+### Task 2.6 — Refactor `up.go`
+
+**Files:** Modify `cmd/specgraph/up.go`.
+
+- [ ] **Step 1:** Remove the entire `case "service":` block that calls `service.Generate` and `service.Install` (lines 65-89 currently).
+- [ ] **Step 2:** Replace with a service-state check using `service.IsInstalled`:
+
+```go
+case "service":
+    installed, err := service.IsInstalled(defPath)
+    if err != nil { return fmt.Errorf("check install state: %w", err) }
+    if installed {
+        if err := service.Load(defPath); err != nil { return fmt.Errorf("load service: %w", err) }
+    } else {
+        fmt.Println("Service not installed — running container only. `specgraph install` to enable auto-start.")
+    }
+```
+
+- [ ] **Step 3:** Verify `service.Load` exists or add it as a thin wrapper (today `service.Install` bundles generate+load; we need load-only for the `up` code path when definition already exists). Check `internal/service/` for this function and add if missing.
+- [ ] **Step 4:** Tests: add branch coverage for the "installed → load" and "not installed → hint" paths.
+
+### Task 2.7 — Register commands in `docs.go`
+
+**Files:** Modify `cmd/specgraph/docs.go:57`.
+
+- [ ] **Step 1:** Update `commandGroups` entry:
+
+```go
+{Name: "Server & Config", Commands: []string{"up", "down", "install", "uninstall", "serve", "mcp", "status", "health", "init", "prime", "inject"}},
+```
+
+- [ ] **Step 2:** Regenerate: `task docs:cli` (or whatever the Taskfile target is for `cmd/specgraph/docs.go`'s generator — check `Taskfile.yml`).
+- [ ] **Step 3:** Confirm `site/docs/cli-reference.md` now contains the new commands.
+
+### Task 2.8 — Doc updates
+
+- [ ] **Step 1:** `README.md:122` — add rows for `install`/`uninstall`; update `down` row to mention `--purge`.
+- [ ] **Step 2:** `site/docs/cli-reference.md:856-869` — extend `up`/`down` sections; regenerate from cobra via Task 2.7.
+- [ ] **Step 3:** `docs/plans/2026-03-16-slice-7-global-daemon-and-plugin-design.md:151-193` — prepend a note: "Superseded for the CLI surface by `2026-04-22-cli-lifecycle-split-design.md`. Kept for historical record."
+- [ ] **Step 4:** `docs/superpowers/specs/2026-03-21-bootstrap-funnel-demo-design.md:149` — replace `specgraph down --rm` with the correct verb (confirm with stakeholder; likely `specgraph uninstall` for tutorial cleanup, possibly `task dev:reset`).
+- [ ] **Step 5:** Audit `site/docs/quickstart.md` for any implicit assumption that `down` wipes data.
+
+### Task 2.9 — File a beads issue for Phase 3 (XDG per-workspace isolation)
+
+- [ ] **Step 1:** `bd create --title="Per-workspace XDG isolation to prevent shared-volume footgun across jj workspaces" --description=... --type=feature --priority=3`
+- [ ] **Step 2:** Reference this design doc in the issue description.
+
+### Task 2.10 — Full quality gate
+
+- [ ] **Step 1:** `task check` passes.
+- [ ] **Step 2:** `task pr-prep` passes (requires Docker — exercises integration + e2e).
+- [ ] **Step 3:** Manual smoke test matrix:
+  - `specgraph install` on fresh machine → service registered, container up, `specgraph health` green.
+  - `specgraph uninstall` → service gone, compose file preserved, volume preserved.
+  - `specgraph install` again → picks up the preserved volume; data from prior session intact.
+  - `specgraph down` → container stopped, volume preserved.
+  - `specgraph up` → container back, data intact.
+  - `specgraph down --rm` → retirement error, no state changed.
+  - `specgraph down --purge` on a TTY → prompt appears, typing `n` aborts cleanly.
+  - `specgraph down --purge --yes` on non-TTY → proceeds, volume removed.
+- [ ] **Step 4:** Commit with Phase 2 scope: `feat(cli)!: split install/uninstall from up/down; retire --rm`. (Conventional-commit breaking-change marker.)
+
+---
+
+## Out of Scope (Phase 3, filed as beads)
+
+- Per-workspace XDG data dir (design doc §Shared-State Caveat).
+- Active-RPC draining on `uninstall` (design doc §Partial Failure Semantics). Reassess if/when long-lived streaming RPCs land.
+- Windows support for `install`/`uninstall` (inherits current platform coverage).
+
+## References
+
+- Design: `docs/plans/2026-04-22-cli-lifecycle-split-design.md`
+- Superseded CLI surface section: `docs/plans/2026-03-16-slice-7-global-daemon-and-plugin-design.md:151-193`
+- Triggering bug in code: `internal/docker/compose.go:31` (`-v` on `ComposeDown`)
+- Second data-loss path: `cmd/specgraph/serve.go:83-87` (destructive defer)

--- a/docs/superpowers/specs/2026-03-21-bootstrap-funnel-demo-design.md
+++ b/docs/superpowers/specs/2026-03-21-bootstrap-funnel-demo-design.md
@@ -146,4 +146,4 @@ The demo uses "webhook-stage-notifications" — a feature for SpecGraph itself t
 - The funnel skills run analytical passes automatically in Drive posture. The demo should call out when passes fire and what findings look like.
 - Constitution setup is done conversationally (Claude reads the codebase and crafts the YAML) rather than importing a pre-made fixture. This is more impressive for onboarding.
 - The runbook should note that the first run may take 30-60 seconds as Docker pulls the Memgraph image.
-- Include a teardown section: `specgraph down --rm` to stop the server and clean up.
+- Include a teardown section: `specgraph uninstall` to unregister the service and stop the container (data preserved), or `task dev:reset` for a full wipe-and-rebuild. Do not reference `specgraph down --rm` — it was retired in 2026-04-22-cli-lifecycle-split-design.md.

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.41.0
+	golang.org/x/term v0.40.0
 	golang.org/x/text v0.35.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -12,12 +12,38 @@ import (
 	"path/filepath"
 )
 
+// composeUpArgs returns the argv passed to `docker` for `ComposeUp`. Extracted
+// as a pure function so tests can assert the exact flags without shelling out.
+func composeUpArgs(composeFile string) []string {
+	return []string{"compose", "-f", composeFile, "up", "-d", "--wait"}
+}
+
+// composeDownArgs returns the argv passed to `docker` for `ComposeDown`.
+// Must not contain -v: that flag removes named volumes and caused silent
+// data loss on every `specgraph down`. Destructive teardowns go through
+// composeDownWithVolumesArgs instead.
+func composeDownArgs(composeFile string) []string {
+	return []string{"compose", "-f", composeFile, "down", "--timeout", "10"}
+}
+
+// composeStopArgs returns the argv passed to `docker` for `ComposeStop`.
+func composeStopArgs(composeFile string) []string {
+	return []string{"compose", "-f", composeFile, "stop", "--timeout", "10"}
+}
+
+// composeDownWithVolumesArgs returns the argv passed to `docker` for
+// `ComposeDownWithVolumes`. The trailing -v is intentional and destructive;
+// only the user-guarded `specgraph down --purge` path calls this wrapper.
+func composeDownWithVolumesArgs(composeFile string) []string {
+	return []string{"compose", "-f", composeFile, "down", "--timeout", "10", "-v"}
+}
+
 // ComposeUp starts the Docker Compose stack defined in composeFile.
 func ComposeUp(composeFile string) error {
 	if _, err := os.Stat(composeFile); err != nil {
 		return fmt.Errorf("compose file not found: %s", composeFile)
 	}
-	cmd := exec.Command("docker", "compose", "-f", composeFile, "up", "-d", "--wait", "--force-recreate", "-V")
+	cmd := exec.Command("docker", composeUpArgs(composeFile)...) //nolint:gosec // argv assembled from pure function; composeFile is xdg-owned path, no shell involved
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -26,13 +52,40 @@ func ComposeUp(composeFile string) error {
 	return nil
 }
 
+// ComposeStop halts the stack without removing containers or volumes.
+// Idempotent: `docker compose stop` on an already-stopped stack exits 0.
+func ComposeStop(composeFile string) error {
+	cmd := exec.Command("docker", composeStopArgs(composeFile)...) //nolint:gosec // argv assembled from pure function; composeFile is xdg-owned path, no shell involved
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker compose stop: %w", err)
+	}
+	return nil
+}
+
 // ComposeDown tears down the Docker Compose stack defined in composeFile.
+// Removes containers but preserves named volumes. Callers that need to
+// destroy data must use ComposeDownWithVolumes instead.
 func ComposeDown(composeFile string) error {
-	cmd := exec.Command("docker", "compose", "-f", composeFile, "down", "--timeout", "10", "-v")
+	cmd := exec.Command("docker", composeDownArgs(composeFile)...) //nolint:gosec // argv assembled from pure function; composeFile is xdg-owned path, no shell involved
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker compose down: %w", err)
+	}
+	return nil
+}
+
+// ComposeDownWithVolumes tears down the stack AND removes named volumes.
+// Destructive — callers must confirm with the user before invoking.
+// Today only `specgraph down --purge` calls this wrapper.
+func ComposeDownWithVolumes(composeFile string) error {
+	cmd := exec.Command("docker", composeDownWithVolumesArgs(composeFile)...) //nolint:gosec // argv assembled from pure function; composeFile is xdg-owned path, no shell involved
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker compose down -v: %w", err)
 	}
 	return nil
 }

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -18,14 +18,6 @@ func composeUpArgs(composeFile string) []string {
 	return []string{"compose", "-f", composeFile, "up", "-d", "--wait"}
 }
 
-// composeDownArgs returns the argv passed to `docker` for `ComposeDown`.
-// Must not contain -v: that flag removes named volumes and caused silent
-// data loss on every `specgraph down`. Destructive teardowns go through
-// composeDownWithVolumesArgs instead.
-func composeDownArgs(composeFile string) []string {
-	return []string{"compose", "-f", composeFile, "down", "--timeout", "10"}
-}
-
 // composeStopArgs returns the argv passed to `docker` for `ComposeStop`.
 func composeStopArgs(composeFile string) []string {
 	return []string{"compose", "-f", composeFile, "stop", "--timeout", "10"}
@@ -53,26 +45,16 @@ func ComposeUp(composeFile string) error {
 }
 
 // ComposeStop halts the stack without removing containers or volumes.
-// Idempotent: `docker compose stop` on an already-stopped stack exits 0.
+// Idempotent when the stack exists: `docker compose stop` on already-stopped
+// containers exits 0. Callers should guard against a missing compose file
+// since this function does not (unlike ComposeUp); both `specgraph down` and
+// `specgraph uninstall` stat the file before invoking.
 func ComposeStop(composeFile string) error {
 	cmd := exec.Command("docker", composeStopArgs(composeFile)...) //nolint:gosec // argv assembled from pure function; composeFile is xdg-owned path, no shell involved
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker compose stop: %w", err)
-	}
-	return nil
-}
-
-// ComposeDown tears down the Docker Compose stack defined in composeFile.
-// Removes containers but preserves named volumes. Callers that need to
-// destroy data must use ComposeDownWithVolumes instead.
-func ComposeDown(composeFile string) error {
-	cmd := exec.Command("docker", composeDownArgs(composeFile)...) //nolint:gosec // argv assembled from pure function; composeFile is xdg-owned path, no shell involved
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("docker compose down: %w", err)
 	}
 	return nil
 }

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -20,16 +20,6 @@ func TestComposeUpArgsOmitsForceRecreateAndRenewVolumes(t *testing.T) {
 	}
 }
 
-func TestComposeDownArgsOmitsVolumeFlag(t *testing.T) {
-	got := composeDownArgs("/tmp/compose.yaml")
-	want := []string{"compose", "-f", "/tmp/compose.yaml", "down", "--timeout", "10"}
-	// CRITICAL: no -v. The -v flag removes named volumes and was the cause of
-	// silent data loss on every `specgraph down`. Do not re-add it here.
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("composeDownArgs produced wrong argv\n got:  %v\n want: %v", got, want)
-	}
-}
-
 func TestComposeStopArgsUsesStopNotDown(t *testing.T) {
 	got := composeStopArgs("/tmp/compose.yaml")
 	want := []string{"compose", "-f", "/tmp/compose.yaml", "stop", "--timeout", "10"}

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package docker
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The argv tests assert the exact flags passed to `docker compose`. They are
+// regression guards against accidental re-introduction of destructive flags
+// like `-v` on `down` (see 2026-04-22-cli-lifecycle-split-design.md).
+
+func TestComposeUpArgsOmitsForceRecreateAndRenewVolumes(t *testing.T) {
+	got := composeUpArgs("/tmp/compose.yaml")
+	want := []string{"compose", "-f", "/tmp/compose.yaml", "up", "-d", "--wait"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("composeUpArgs produced wrong argv\n got:  %v\n want: %v", got, want)
+	}
+}
+
+func TestComposeDownArgsOmitsVolumeFlag(t *testing.T) {
+	got := composeDownArgs("/tmp/compose.yaml")
+	want := []string{"compose", "-f", "/tmp/compose.yaml", "down", "--timeout", "10"}
+	// CRITICAL: no -v. The -v flag removes named volumes and was the cause of
+	// silent data loss on every `specgraph down`. Do not re-add it here.
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("composeDownArgs produced wrong argv\n got:  %v\n want: %v", got, want)
+	}
+}
+
+func TestComposeStopArgsUsesStopNotDown(t *testing.T) {
+	got := composeStopArgs("/tmp/compose.yaml")
+	want := []string{"compose", "-f", "/tmp/compose.yaml", "stop", "--timeout", "10"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("composeStopArgs produced wrong argv\n got:  %v\n want: %v", got, want)
+	}
+}
+
+func TestComposeDownWithVolumesIncludesVolumeFlag(t *testing.T) {
+	got := composeDownWithVolumesArgs("/tmp/compose.yaml")
+	want := []string{"compose", "-f", "/tmp/compose.yaml", "down", "--timeout", "10", "-v"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("composeDownWithVolumesArgs produced wrong argv\n got:  %v\n want: %v", got, want)
+	}
+}

--- a/site/docs/cli-reference.md
+++ b/site/docs/cli-reference.md
@@ -491,7 +491,7 @@ specgraph progress <slug> [flags]
 
 ### specgraph amend
 
-Amend a spec, returning it to an earlier authoring stage
+Amend an in-flight spec, returning it to an earlier authoring stage
 
 ```
 specgraph amend <slug> [flags]
@@ -500,13 +500,13 @@ specgraph amend <slug> [flags]
 **Flags:**
 
 ```
-      --re-entry string   authoring stage to re-enter (spark|shape|specify|decompose|approved|in_progress|review)
+      --re-entry string   authoring stage to re-enter (spark|shape|specify|decompose)
       --reason string     reason for amendment (required)
 ```
 
 ### specgraph supersede
 
-Supersede a spec with a new one
+Supersede a completed (done) spec with a new one
 
 ```
 specgraph supersede <slug> [flags]
@@ -872,7 +872,24 @@ specgraph down [flags]
 **Flags:**
 
 ```
-      --rm   uninstall the service definition after stopping
+      --purge   remove containers AND data volumes (destructive; prompts for confirmation)
+      --yes     skip the --purge confirmation prompt
+```
+
+### specgraph install
+
+Register SpecGraph as a user service (launchd/systemd) and start it
+
+```
+specgraph install
+```
+
+### specgraph uninstall
+
+Unregister the SpecGraph user service (launchd/systemd); preserves data
+
+```
+specgraph uninstall
 ```
 
 ### specgraph serve
@@ -888,6 +905,32 @@ specgraph serve [flags]
 ```
       --cors-origin string   Enable CORS for this origin (dev mode only)
       --pg-url string        PostgreSQL connection URL (overrides config; env: SPECGRAPH_PG_URL)
+```
+
+### specgraph mcp
+
+Start a Model Context Protocol server that communicates over stdin/stdout.
+This lightweight process translates MCP tool calls into ConnectRPC RPCs
+against a running specgraph serve instance.
+
+Configure in Claude Code's MCP settings:
+  {
+    "mcpServers": {
+      "specgraph": {
+        "command": "specgraph",
+        "args": ["mcp", "--profile", "authoring"]
+      }
+    }
+  }
+
+```
+specgraph mcp [flags]
+```
+
+**Flags:**
+
+```
+      --profile string   Tool profile: core, authoring, or execution (default "core")
 ```
 
 ### specgraph status


### PR DESCRIPTION
## Summary

- **Fix data-loss bug** in the existing `up`/`down` cycle: `internal/docker/compose.go` was passing `-v` to `docker compose down`, wiping the Postgres volume every time. A matching `defer ComposeDown` in `serve.go:83-87` had the same effect on every foreground server exit. Both are fixed in commit 2 (non-breaking, shippable alone).
- **Split the CLI surface** so registration and runtime are orthogonal: new `specgraph install` / `specgraph uninstall` verbs own the launchd/systemd plist; `up`/`down` only start/stop. Commit 3 introduces this (breaking).
- **Retire `--rm` permanently**, introduce confirmation-guarded `specgraph down --purge` for data destruction (TTY prompt or `--yes` required off-TTY).

**3 commits** structured so commit 2 (the data-loss fix) can land standalone if the reviewer wants to ship that first and debate the redesign separately. Design + plan + implementation are sequenced: commit 1 is docs, commit 2 is Phase 1 (bug fix), commit 3 is Phase 2 (breaking CLI redesign). Phase 3 (per-workspace XDG isolation) is filed as beads issue `spgr-xbsf` and is **not** in this PR.

See `docs/plans/2026-04-22-cli-lifecycle-split-design.md` for the full design including rejected alternatives, migration rationale, and partial-failure semantics. Two independent review rounds by a separate agent are summarized there.

## Breaking change

`specgraph down --rm` is permanently retired. Users get a loud error pointing at the two correct replacements:

```
Error: --rm has been retired.
  To remove the service definition:   specgraph uninstall
  To remove containers and data:       specgraph down --purge
```

`specgraph up` no longer auto-installs the service definition. Users who want auto-launch now run `specgraph install` once.

## Test plan

- [ ] `task check` passes (fmt, license, lint, build, unit tests) — verified locally
- [ ] All 28 new unit tests GREEN across `confirm_test.go`, `down_test.go`, `install_test.go`, `uninstall_test.go`, and `internal/docker/compose_test.go` — verified locally
- [ ] `specgraph down --rm` prints the retirement error and exits non-zero without touching docker or the service
- [ ] `specgraph down --purge` on a TTY prompts and aborts cleanly on `n`
- [ ] `specgraph down --purge` off a TTY without `--yes` errors without destroying anything
- [ ] `specgraph down --purge --yes` removes containers + volumes
- [ ] `specgraph install` → `specgraph uninstall` → `specgraph install` round-trip preserves the Postgres volume (data survives)
- [ ] `specgraph up && specgraph down && specgraph up` preserves the Postgres volume (the triggering bug)
- [ ] `specgraph serve` followed by Ctrl-C leaves the container `Exited` but does not remove the volume
- [ ] `site/docs/cli-reference.md` contains `install` and `uninstall` sections (regenerated via `task docs:cli`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)