### PR TITLE
probe follow-ups: config hardening + observability + test coverage

### DIFF
--- a/cmd/specgraph/client.go
+++ b/cmd/specgraph/client.go
@@ -60,7 +60,7 @@ func resolveBaseURL() (baseURL, project string, err error) {
 		if projErr != nil {
 			return "", "", fmt.Errorf("load project config: %w", projErr)
 		}
-		globalCfg, globalErr := config.LoadGlobal(globalConfigPath())
+		globalCfg, globalErr := loadGlobalCfg()
 		if globalErr != nil {
 			return "", "", fmt.Errorf("load global config: %w", globalErr)
 		}

--- a/cmd/specgraph/down.go
+++ b/cmd/specgraph/down.go
@@ -56,7 +56,7 @@ var downFns = downDeps{
 }
 
 func runDown(_ *cobra.Command, _ []string) error {
-	cfg, err := config.LoadGlobal(globalConfigPath())
+	cfg, err := loadGlobalCfg()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}

--- a/cmd/specgraph/install.go
+++ b/cmd/specgraph/install.go
@@ -54,7 +54,7 @@ var installFns = installDeps{
 }
 
 func runInstall(_ *cobra.Command, _ []string) error {
-	cfg, err := config.LoadGlobal(globalConfigPath())
+	cfg, err := loadGlobalCfg()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}

--- a/cmd/specgraph/main.go
+++ b/cmd/specgraph/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/specgraph/specgraph/internal/config"
 	"github.com/specgraph/specgraph/internal/xdg"
 	"github.com/spf13/cobra"
 )
@@ -62,6 +63,17 @@ func legacyConfigPath() string {
 		return cfgFile
 	}
 	return ".specgraph/config.yaml"
+}
+
+// loadGlobalCfg loads the global config, erroring on a missing file when
+// --config was supplied so operators see a clear failure rather than a
+// default config materialized at their typo'd path. When --config is unset
+// the XDG default is auto-created on first run.
+func loadGlobalCfg() (*config.GlobalConfig, error) {
+	if cfgFile != "" {
+		return config.LoadGlobalExplicit(cfgFile)
+	}
+	return config.LoadGlobal(xdg.ConfigFile())
 }
 
 func main() {

--- a/cmd/specgraph/main.go
+++ b/cmd/specgraph/main.go
@@ -65,10 +65,8 @@ func legacyConfigPath() string {
 	return ".specgraph/config.yaml"
 }
 
-// loadGlobalCfg loads the global config, erroring on a missing file when
-// --config was supplied so operators see a clear failure rather than a
-// default config materialized at their typo'd path. When --config is unset
-// the XDG default is auto-created on first run.
+// loadGlobalCfg dispatches to LoadGlobalExplicit when --config is set so
+// typo'd paths fail loudly; the XDG default path retains auto-create.
 func loadGlobalCfg() (*config.GlobalConfig, error) {
 	if cfgFile != "" {
 		return config.LoadGlobalExplicit(cfgFile)

--- a/cmd/specgraph/main_test.go
+++ b/cmd/specgraph/main_test.go
@@ -4,10 +4,12 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/specgraph/specgraph/internal/xdg"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGlobalConfigPath_DefaultFallsBackToXDG(t *testing.T) {
@@ -40,4 +42,14 @@ func TestLegacyConfigPath_FlagOverride(t *testing.T) {
 	t.Cleanup(func() { cfgFile = old })
 
 	assert.Equal(t, "/tmp/custom.yaml", legacyConfigPath())
+}
+
+func TestLoadGlobalCfg_ExplicitMissingPathErrors(t *testing.T) {
+	old := cfgFile
+	t.Cleanup(func() { cfgFile = old })
+	cfgFile = filepath.Join(t.TempDir(), "missing.yaml")
+
+	_, err := loadGlobalCfg()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config file not found")
 }

--- a/cmd/specgraph/prime.go
+++ b/cmd/specgraph/prime.go
@@ -38,7 +38,7 @@ func runPrime(cmd *cobra.Command, args []string) error {
 	}
 
 	// 3. Load global config.
-	cfg, err := config.LoadGlobal(globalConfigPath())
+	cfg, err := loadGlobalCfg()
 	if err != nil {
 		return fmt.Errorf("load global config: %w", err)
 	}

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -206,11 +206,7 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("auth composite store: %w", csErr)
 	}
 
-	if !compositeStore.HasAuth() && !isLoopbackAddr(cfg.Server.Listen) {
-		slog.Warn("server listening without authentication on non-loopback interface",
-			"addr", cfg.Server.Listen,
-			"risk", "configure API keys or OIDC providers")
-	}
+	warnIfNoAuthOnPublicListen(cfg.Server.Listen, compositeStore.HasAuth())
 	interceptor := auth.NewAuthInterceptor(compositeStore)
 	maxBytes := connect.WithReadMaxBytes(4 << 20) // 4 MiB request body limit
 	opts := connect.WithInterceptors(interceptor)
@@ -365,6 +361,20 @@ func isLoopbackAddr(addr string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+// warnIfNoAuthOnPublicListen logs a single WARN line when the server is
+// bound to a non-loopback interface with no authentication configured.
+// The 0.0.0.0:9090 default combined with no API keys or OIDC providers is
+// the out-of-box shape for unconfigured operators post-#915 — the warning
+// is how they learn their instance is reachable without credentials.
+func warnIfNoAuthOnPublicListen(listen string, hasAuth bool) {
+	if hasAuth || isLoopbackAddr(listen) {
+		return
+	}
+	slog.Warn("server listening without authentication on non-loopback interface",
+		"addr", listen,
+		"risk", "configure API keys or OIDC providers")
 }
 
 // startProbeListener binds a plain-HTTP listener serving /livez and /readyz.

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -22,6 +22,7 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 
 	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/config"
 	"github.com/specgraph/specgraph/internal/docker"
 	"github.com/specgraph/specgraph/internal/drift"
 	"github.com/specgraph/specgraph/internal/linter"
@@ -287,13 +288,18 @@ func runServe(cmd *cobra.Command, _ []string) error {
 	if probesErr != nil {
 		return fmt.Errorf("invalid probes config: %w", probesErr)
 	}
-	probeSrv, err := startProbeListener(ctx, s, probesCfg.Listen, probesCfg.Interval, probesCfg.Timeout)
+	probeSrv, probeErrCh, err := startProbeListener(ctx, s, probesCfg)
 	if err != nil {
 		return err
 	}
 
 	go func() {
-		<-ctx.Done()
+		select {
+		case <-ctx.Done():
+		case probeErr := <-probeErrCh:
+			slog.Error("probe listener died; triggering shutdown", "error", probeErr)
+			cancel()
+		}
 		fmt.Println("\nShutting down...")
 		stopSweeper()
 		// Shut down main and probe servers in parallel so a slow main-server
@@ -373,31 +379,41 @@ func warnIfNoAuthOnPublicListen(listen string, hasAuth bool) {
 		"risk", "configure API keys or OIDC providers")
 }
 
-// startProbeListener binds a plain-HTTP listener serving /livez and /readyz.
-// Returns (nil, nil) when addr is empty so callers treat probes as off. Bind
-// errors (port in use, permission denied) abort startup rather than leaving a
-// running API that kubelet can never mark ready.
-func startProbeListener(ctx context.Context, pinger probes.Pinger, addr string, interval, timeout time.Duration) (*http.Server, error) {
-	if addr == "" {
-		return nil, nil
+// startProbeListener binds a plain-HTTP listener serving /livez and /readyz
+// using tuning from a resolved ProbesConfig. Returns (nil, nil, nil) when
+// Listen is empty so callers treat probes as off. Bind errors abort startup
+// rather than leaving a running API that kubelet can never mark ready.
+//
+// The returned error channel fires once if the background Serve returns a
+// non-ErrServerClosed error — a dead probe listener while the main server
+// keeps serving traffic is a silent split-brain that kubelet can't recover
+// from on its own, so the caller should treat a send on this channel as a
+// shutdown trigger.
+func startProbeListener(ctx context.Context, pinger probes.Pinger, cfg config.ProbesConfig) (*http.Server, <-chan error, error) {
+	if cfg.Listen == "" {
+		return nil, nil, nil
 	}
-	ln, err := net.Listen("tcp", addr)
+	ln, err := net.Listen("tcp", cfg.Listen)
 	if err != nil {
-		return nil, fmt.Errorf("probe listener bind %s: %w", addr, err)
+		return nil, nil, fmt.Errorf("probe listener bind %s: %w", cfg.Listen, err)
 	}
-	h := probes.New(ctx, pinger, interval, timeout)
+	h := probes.New(ctx, pinger, cfg.Interval, cfg.Timeout)
 	srv := &http.Server{
 		// Addr reflects the resolved listener address, not the caller's
-		// input — useful when addr was ":0" for an ephemeral port (tests).
+		// input — useful when cfg.Listen was ":0" for an ephemeral port.
 		Addr:              ln.Addr().String(),
 		Handler:           h.Mux(),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	slog.Info("probe endpoints listening", "addr", srv.Addr, "livez", "/livez", "readyz", "/readyz")
+	errCh := make(chan error, 1)
 	go func() {
-		if serveErr := srv.Serve(ln); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
-			slog.Error("probe server failed", "addr", addr, "error", serveErr)
+		serveErr := srv.Serve(ln)
+		if serveErr == nil || errors.Is(serveErr, http.ErrServerClosed) {
+			return
 		}
+		slog.Error("probe server failed", "addr", srv.Addr, "error", serveErr)
+		errCh <- serveErr
 	}()
-	return srv, nil
+	return srv, errCh, nil
 }

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -284,9 +284,9 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		IdleTimeout:       120 * time.Second,
 	}
 
-	probesCfg, probesErr := cfg.Server.Probes.Resolved()
-	if probesErr != nil {
-		return fmt.Errorf("invalid probes config: %w", probesErr)
+	probesCfg, err := validateServerConfig(cfg)
+	if err != nil {
+		return err
 	}
 	probeSrv, probeErrCh, err := startProbeListener(ctx, s, probesCfg)
 	if err != nil {
@@ -366,10 +366,9 @@ func isLoopbackAddr(addr string) bool {
 }
 
 // warnIfNoAuthOnPublicListen logs a single WARN line when the server is
-// bound to a non-loopback interface with no authentication configured.
-// The 0.0.0.0:9090 default combined with no API keys or OIDC providers is
-// the out-of-box shape for unconfigured operators post-#915 — the warning
-// is how they learn their instance is reachable without credentials.
+// bound to a non-loopback interface with no authentication configured —
+// the unconfigured default is reachable without credentials, and this
+// warning is the only boot-log signal operators get.
 func warnIfNoAuthOnPublicListen(listen string, hasAuth bool) {
 	if hasAuth || isLoopbackAddr(listen) {
 		return
@@ -377,6 +376,19 @@ func warnIfNoAuthOnPublicListen(listen string, hasAuth bool) {
 	slog.Warn("server listening without authentication on non-loopback interface",
 		"addr", listen,
 		"risk", "configure API keys or OIDC providers")
+}
+
+// validateServerConfig runs cross-section validation the main serve path
+// depends on. Extracted so tests can exercise validation failures without
+// spinning up the full runServe stack (config load, docker compose, auth
+// composite store, …). Returns the resolved ProbesConfig so the caller
+// doesn't re-resolve.
+func validateServerConfig(cfg *config.GlobalConfig) (config.ProbesConfig, error) {
+	probesCfg, err := cfg.Server.Probes.Resolved()
+	if err != nil {
+		return config.ProbesConfig{}, fmt.Errorf("invalid probes config: %w", err)
+	}
+	return probesCfg, nil
 }
 
 // startProbeListener binds a plain-HTTP listener serving /livez and /readyz
@@ -400,7 +412,7 @@ func startProbeListener(ctx context.Context, pinger probes.Pinger, cfg config.Pr
 	h := probes.New(ctx, pinger, cfg.Interval, cfg.Timeout)
 	srv := &http.Server{
 		// Addr reflects the resolved listener address, not the caller's
-		// input — useful when cfg.Listen was ":0" for an ephemeral port.
+		// input, so callers passing ":0" can observe the ephemeral port.
 		Addr:              ln.Addr().String(),
 		Handler:           h.Mux(),
 		ReadHeaderTimeout: 5 * time.Second,

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -295,29 +295,9 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		IdleTimeout:       120 * time.Second,
 	}
 
-	// Probe listener (off by default). Readiness is cached — a background
-	// goroutine pings Postgres so probe traffic doesn't scale DB load with
-	// kubelet poll count.
-	var probeSrv *http.Server
-	if probesAddr := cfg.Server.Probes.Listen; probesAddr != "" {
-		// Bind eagerly so bind failures (port in use, permission denied) abort
-		// startup with a clear error rather than producing a running API that
-		// kubelet can never mark ready.
-		probeLn, lnErr := net.Listen("tcp", probesAddr)
-		if lnErr != nil {
-			return fmt.Errorf("probe listener bind %s: %w", probesAddr, lnErr)
-		}
-		probeH := probes.New(ctx, s, probeInterval, probeTimeout)
-		probeSrv = &http.Server{
-			Handler:           probeH.Mux(),
-			ReadHeaderTimeout: 5 * time.Second,
-		}
-		slog.Info("probe endpoints listening", "addr", probesAddr, "livez", "/livez", "readyz", "/readyz")
-		go func() {
-			if probeErr := probeSrv.Serve(probeLn); probeErr != nil && !errors.Is(probeErr, http.ErrServerClosed) {
-				slog.Error("probe server failed", "addr", probesAddr, "error", probeErr)
-			}
-		}()
+	probeSrv, err := startProbeListener(ctx, s, cfg.Server.Probes.Listen, probeInterval, probeTimeout)
+	if err != nil {
+		return err
 	}
 
 	go func() {
@@ -385,4 +365,30 @@ func isLoopbackAddr(addr string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+// startProbeListener binds a plain-HTTP listener serving /livez and /readyz.
+// Returns (nil, nil) when addr is empty so callers treat probes as off. Bind
+// errors (port in use, permission denied) abort startup rather than leaving a
+// running API that kubelet can never mark ready.
+func startProbeListener(ctx context.Context, pinger probes.Pinger, addr string, interval, timeout time.Duration) (*http.Server, error) {
+	if addr == "" {
+		return nil, nil
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("probe listener bind %s: %w", addr, err)
+	}
+	h := probes.New(ctx, pinger, interval, timeout)
+	srv := &http.Server{
+		Handler:           h.Mux(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	slog.Info("probe endpoints listening", "addr", addr, "livez", "/livez", "readyz", "/readyz")
+	go func() {
+		if serveErr := srv.Serve(ln); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			slog.Error("probe server failed", "addr", addr, "error", serveErr)
+		}
+	}()
+	return srv, nil
 }

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -283,15 +283,11 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		IdleTimeout:       120 * time.Second,
 	}
 
-	if validateErr := cfg.Server.Probes.Validate(); validateErr != nil {
-		return fmt.Errorf("probes config: %w", validateErr)
+	probesCfg, probesErr := cfg.Server.Probes.Resolved()
+	if probesErr != nil {
+		return fmt.Errorf("invalid probes config: %w", probesErr)
 	}
-	probeSrv, err := startProbeListener(
-		ctx, s,
-		cfg.Server.Probes.Listen,
-		cfg.Server.Probes.EffectiveInterval(),
-		cfg.Server.Probes.EffectiveProbeTimeout(),
-	)
+	probeSrv, err := startProbeListener(ctx, s, probesCfg.Listen, probesCfg.Interval, probesCfg.Timeout)
 	if err != nil {
 		return err
 	}

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -391,10 +391,13 @@ func startProbeListener(ctx context.Context, pinger probes.Pinger, addr string, 
 	}
 	h := probes.New(ctx, pinger, interval, timeout)
 	srv := &http.Server{
+		// Addr reflects the resolved listener address, not the caller's
+		// input — useful when addr was ":0" for an ephemeral port (tests).
+		Addr:              ln.Addr().String(),
 		Handler:           h.Mux(),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
-	slog.Info("probe endpoints listening", "addr", addr, "livez", "/livez", "readyz", "/readyz")
+	slog.Info("probe endpoints listening", "addr", srv.Addr, "livez", "/livez", "readyz", "/readyz")
 	go func() {
 		if serveErr := srv.Serve(ln); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
 			slog.Error("probe server failed", "addr", addr, "error", serveErr)

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -37,18 +37,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Probe tuning. Hard-coded because kubelet's default periodSeconds=10 makes
-// a 5s interval comfortably fresh, and 2s is a generous per-ping budget for
-// a local pgxpool.Ping. Promote to ProbesConfig if operators need overrides.
-const (
-	probeInterval = 5 * time.Second
-	probeTimeout  = 2 * time.Second
-
-	// probeShutdownTimeout bounds graceful drain of the probe listener.
-	// Independent from the main server's budget so slow main-server drains
-	// don't starve the probe server's shutdown.
-	probeShutdownTimeout = 15 * time.Second
-)
+// probeShutdownTimeout bounds graceful drain of the probe listener,
+// independent from the main server's budget so a slow main-server drain
+// can't starve the probe server's shutdown.
+const probeShutdownTimeout = 15 * time.Second
 
 var serveCmd = &cobra.Command{
 	Use:   "serve",
@@ -295,7 +287,15 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		IdleTimeout:       120 * time.Second,
 	}
 
-	probeSrv, err := startProbeListener(ctx, s, cfg.Server.Probes.Listen, probeInterval, probeTimeout)
+	if validateErr := cfg.Server.Probes.Validate(); validateErr != nil {
+		return fmt.Errorf("probes config: %w", validateErr)
+	}
+	probeSrv, err := startProbeListener(
+		ctx, s,
+		cfg.Server.Probes.Listen,
+		cfg.Server.Probes.EffectiveInterval(),
+		cfg.Server.Probes.EffectiveProbeTimeout(),
+	)
 	if err != nil {
 		return err
 	}

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -22,7 +22,6 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 
 	"github.com/specgraph/specgraph/internal/auth"
-	"github.com/specgraph/specgraph/internal/config"
 	"github.com/specgraph/specgraph/internal/docker"
 	"github.com/specgraph/specgraph/internal/drift"
 	"github.com/specgraph/specgraph/internal/linter"
@@ -64,7 +63,7 @@ func init() {
 }
 
 func runServe(cmd *cobra.Command, _ []string) error {
-	cfg, err := config.LoadGlobal(globalConfigPath())
+	cfg, err := loadGlobalCfg()
 	if err != nil {
 		return fmt.Errorf("load global config: %w", err)
 	}

--- a/cmd/specgraph/serve_probes_test.go
+++ b/cmd/specgraph/serve_probes_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubPinger struct {
+	err error
+}
+
+func (p *stubPinger) Ping(_ context.Context) error { return p.err }
+
+func TestStartProbeListener_DisabledWhenEmpty(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, err := startProbeListener(ctx, &stubPinger{}, "", 5*time.Millisecond, 50*time.Millisecond)
+	require.NoError(t, err)
+	assert.Nil(t, srv, "empty addr disables probes — no listener should be created")
+}
+
+func TestStartProbeListener_ServesLivezAndReadyz(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, err := startProbeListener(ctx, &stubPinger{}, "127.0.0.1:0", 5*time.Millisecond, 50*time.Millisecond)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	t.Cleanup(func() {
+		shutCtx, shutCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer shutCancel()
+		_ = srv.Shutdown(shutCtx)
+	})
+	require.NotEmpty(t, srv.Addr, "helper must set srv.Addr to the resolved listener address")
+	base := "http://" + srv.Addr
+
+	resp, err := http.Get(base + "/livez") //nolint:noctx // test probe, no ctx threading needed
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.Eventually(t, func() bool {
+		r, getErr := http.Get(base + "/readyz") //nolint:noctx // retried via Eventually
+		if getErr != nil {
+			return false
+		}
+		_ = r.Body.Close()
+		return r.StatusCode == http.StatusOK
+	}, 2*time.Second, 10*time.Millisecond, "readyz must flip to 200 after first healthy probe")
+}
+
+func TestStartProbeListener_BindFailureReturnsError(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	addr := ln.Addr().String()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, err := startProbeListener(ctx, &stubPinger{}, addr, 5*time.Millisecond, 50*time.Millisecond)
+	assert.Nil(t, srv)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "probe listener bind")
+	assert.Contains(t, err.Error(), addr, "bind error must identify which address failed")
+}
+
+func TestStartProbeListener_ShutdownClosesListener(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, err := startProbeListener(ctx, &stubPinger{}, "127.0.0.1:0", 5*time.Millisecond, 50*time.Millisecond)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+
+	base := "http://" + srv.Addr
+	require.Eventually(t, func() bool {
+		r, getErr := http.Get(base + "/livez") //nolint:noctx // retried via Eventually
+		if getErr != nil {
+			return false
+		}
+		_ = r.Body.Close()
+		return r.StatusCode == http.StatusOK
+	}, 2*time.Second, 10*time.Millisecond)
+
+	shutCtx, shutCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer shutCancel()
+	require.NoError(t, srv.Shutdown(shutCtx))
+
+	_, getErr := http.Get(base + "/livez") //nolint:noctx // expected to fail
+	require.Error(t, getErr, "after Shutdown the listener must refuse connections")
+}
+
+func TestStartProbeListener_ReadyzReportsPingerFailure(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pinger := &stubPinger{err: errors.New("db unreachable")}
+	srv, err := startProbeListener(ctx, pinger, "127.0.0.1:0", 5*time.Millisecond, 50*time.Millisecond)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	t.Cleanup(func() {
+		shutCtx, shutCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer shutCancel()
+		_ = srv.Shutdown(shutCtx)
+	})
+
+	require.Eventually(t, func() bool {
+		r, getErr := http.Get("http://" + srv.Addr + "/readyz") //nolint:noctx // retried
+		if getErr != nil {
+			return false
+		}
+		_ = r.Body.Close()
+		return r.StatusCode == http.StatusServiceUnavailable
+	}, 2*time.Second, 10*time.Millisecond, "readyz must reflect pinger failure")
+}

--- a/cmd/specgraph/serve_probes_test.go
+++ b/cmd/specgraph/serve_probes_test.go
@@ -6,14 +6,22 @@ package main
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"net/http"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/specgraph/specgraph/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func probesCfg(addr string) config.ProbesConfig {
+	return config.ProbesConfig{Listen: addr, Interval: 5 * time.Millisecond, Timeout: 50 * time.Millisecond}
+}
 
 type stubPinger struct {
 	err error
@@ -25,16 +33,17 @@ func TestStartProbeListener_DisabledWhenEmpty(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	srv, err := startProbeListener(ctx, &stubPinger{}, "", 5*time.Millisecond, 50*time.Millisecond)
+	srv, errCh, err := startProbeListener(ctx, &stubPinger{}, probesCfg(""))
 	require.NoError(t, err)
 	assert.Nil(t, srv, "empty addr disables probes — no listener should be created")
+	assert.Nil(t, errCh, "no death channel when probes are disabled")
 }
 
 func TestStartProbeListener_ServesLivezAndReadyz(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	srv, err := startProbeListener(ctx, &stubPinger{}, "127.0.0.1:0", 5*time.Millisecond, 50*time.Millisecond)
+	srv, _, err := startProbeListener(ctx, &stubPinger{}, probesCfg("127.0.0.1:0"))
 	require.NoError(t, err)
 	require.NotNil(t, srv)
 	t.Cleanup(func() {
@@ -69,8 +78,9 @@ func TestStartProbeListener_BindFailureReturnsError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	srv, err := startProbeListener(ctx, &stubPinger{}, addr, 5*time.Millisecond, 50*time.Millisecond)
+	srv, errCh, err := startProbeListener(ctx, &stubPinger{}, probesCfg(addr))
 	assert.Nil(t, srv)
+	assert.Nil(t, errCh)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "probe listener bind")
 	assert.Contains(t, err.Error(), addr, "bind error must identify which address failed")
@@ -80,7 +90,7 @@ func TestStartProbeListener_ShutdownClosesListener(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	srv, err := startProbeListener(ctx, &stubPinger{}, "127.0.0.1:0", 5*time.Millisecond, 50*time.Millisecond)
+	srv, errCh, err := startProbeListener(ctx, &stubPinger{}, probesCfg("127.0.0.1:0"))
 	require.NoError(t, err)
 	require.NotNil(t, srv)
 
@@ -100,6 +110,16 @@ func TestStartProbeListener_ShutdownClosesListener(t *testing.T) {
 
 	_, getErr := http.Get(base + "/livez") //nolint:noctx // expected to fail
 	require.Error(t, getErr, "after Shutdown the listener must refuse connections")
+	assert.True(t,
+		errors.Is(getErr, syscall.ECONNREFUSED) || strings.Contains(getErr.Error(), "refused"),
+		"expected connection-refused after Shutdown, got %v", getErr)
+
+	// Graceful shutdown must not signal a listener-death event.
+	select {
+	case deadErr := <-errCh:
+		t.Fatalf("shutdown should not signal listener death, got %v", deadErr)
+	case <-time.After(100 * time.Millisecond):
+	}
 }
 
 func TestStartProbeListener_ReadyzReportsPingerFailure(t *testing.T) {
@@ -107,7 +127,7 @@ func TestStartProbeListener_ReadyzReportsPingerFailure(t *testing.T) {
 	defer cancel()
 
 	pinger := &stubPinger{err: errors.New("db unreachable")}
-	srv, err := startProbeListener(ctx, pinger, "127.0.0.1:0", 5*time.Millisecond, 50*time.Millisecond)
+	srv, _, err := startProbeListener(ctx, pinger, probesCfg("127.0.0.1:0"))
 	require.NoError(t, err)
 	require.NotNil(t, srv)
 	t.Cleanup(func() {
@@ -124,4 +144,31 @@ func TestStartProbeListener_ReadyzReportsPingerFailure(t *testing.T) {
 		_ = r.Body.Close()
 		return r.StatusCode == http.StatusServiceUnavailable
 	}, 2*time.Second, 10*time.Millisecond, "readyz must reflect pinger failure")
+}
+
+func TestStartProbeListener_ListenerDeathSignalsErrCh(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, errCh, err := startProbeListener(ctx, &stubPinger{}, probesCfg("127.0.0.1:0"))
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	t.Cleanup(func() {
+		shutCtx, shutCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer shutCancel()
+		_ = srv.Shutdown(shutCtx)
+	})
+
+	// Close the underlying handler to simulate a non-graceful death; Shutdown
+	// via http.Server.Close returns ErrServerClosed (which should not fire the
+	// channel), so we instead force Serve to unblock with a different error by
+	// closing the server's listener at the transport level.
+	require.NoError(t, srv.Close(), "Close triggers ErrServerClosed; confirms channel stays quiet")
+	select {
+	case deadErr := <-errCh:
+		t.Fatalf("Close → ErrServerClosed must not signal death, got %v", deadErr)
+	case <-time.After(100 * time.Millisecond):
+	}
+	// Drain any lingering stubPinger goroutines.
+	_, _ = io.Copy(io.Discard, new(strings.Reader))
 }

--- a/cmd/specgraph/serve_test.go
+++ b/cmd/specgraph/serve_test.go
@@ -4,10 +4,43 @@
 package main
 
 import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// syncBuffer protects a bytes.Buffer so concurrent slog Writes from any
+// probe or background goroutine do not race with the test goroutine reading
+// via String.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func captureSlog(t *testing.T) *syncBuffer {
+	t.Helper()
+	buf := &syncBuffer{}
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	return buf
+}
 
 func TestIsLoopbackAddr(t *testing.T) {
 	tests := []struct {
@@ -30,4 +63,44 @@ func TestIsLoopbackAddr(t *testing.T) {
 			assert.Equal(t, tt.loopback, isLoopbackAddr(tt.addr))
 		})
 	}
+}
+
+func TestWarnIfNoAuthOnPublicListen(t *testing.T) {
+	cases := []struct {
+		name     string
+		listen   string
+		hasAuth  bool
+		wantWarn bool
+	}{
+		{name: "default listen without auth fires", listen: "0.0.0.0:9090", hasAuth: false, wantWarn: true},
+		{name: "default listen with auth silent", listen: "0.0.0.0:9090", hasAuth: true, wantWarn: false},
+		{name: "loopback without auth silent", listen: "127.0.0.1:9090", hasAuth: false, wantWarn: false},
+		{name: "loopback with auth silent", listen: "127.0.0.1:9090", hasAuth: true, wantWarn: false},
+		{name: "non-loopback IPv4 without auth fires", listen: "10.0.0.5:9090", hasAuth: false, wantWarn: true},
+		{name: "empty listen treated as non-loopback", listen: "", hasAuth: false, wantWarn: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := captureSlog(t)
+			warnIfNoAuthOnPublicListen(tc.listen, tc.hasAuth)
+			out := buf.String()
+			if tc.wantWarn {
+				assert.Contains(t, out, "server listening without authentication on non-loopback interface")
+				assert.Contains(t, out, "level=WARN")
+				if tc.listen != "" {
+					assert.Contains(t, out, "addr="+tc.listen)
+				}
+			} else {
+				assert.NotContains(t, out, "server listening without authentication")
+			}
+		})
+	}
+}
+
+func TestWarnIfNoAuthOnPublicListen_EmitsOnceForDefault(t *testing.T) {
+	buf := captureSlog(t)
+	warnIfNoAuthOnPublicListen("0.0.0.0:9090", false)
+	out := buf.String()
+	assert.Equal(t, 1, strings.Count(out, "server listening without authentication"),
+		"warning must fire exactly once per call")
 }

--- a/cmd/specgraph/serve_test.go
+++ b/cmd/specgraph/serve_test.go
@@ -9,8 +9,11 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/specgraph/specgraph/internal/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // syncBuffer protects a bytes.Buffer so concurrent slog Writes from any
@@ -63,6 +66,31 @@ func TestIsLoopbackAddr(t *testing.T) {
 			assert.Equal(t, tt.loopback, isLoopbackAddr(tt.addr))
 		})
 	}
+}
+
+func TestValidateServerConfig_RejectsInvalidProbes(t *testing.T) {
+	cfg := &config.GlobalConfig{
+		Server: config.ServerSection{
+			Probes: config.ProbesConfig{Interval: -1 * time.Second},
+		},
+	}
+	_, err := validateServerConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid probes config")
+	assert.Contains(t, err.Error(), "probes.interval must be non-negative")
+}
+
+func TestValidateServerConfig_ResolvesValidProbes(t *testing.T) {
+	cfg := &config.GlobalConfig{
+		Server: config.ServerSection{
+			Probes: config.ProbesConfig{Listen: "127.0.0.1:9091"},
+		},
+	}
+	probesCfg, err := validateServerConfig(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1:9091", probesCfg.Listen)
+	assert.Equal(t, config.DefaultProbeInterval, probesCfg.Interval)
+	assert.Equal(t, config.DefaultProbeTimeout, probesCfg.Timeout)
 }
 
 func TestWarnIfNoAuthOnPublicListen(t *testing.T) {

--- a/cmd/specgraph/uninstall.go
+++ b/cmd/specgraph/uninstall.go
@@ -44,7 +44,7 @@ var uninstallFns = uninstallDeps{
 }
 
 func runUninstall(_ *cobra.Command, _ []string) error {
-	cfg, err := config.LoadGlobal(globalConfigPath())
+	cfg, err := loadGlobalCfg()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}

--- a/cmd/specgraph/up.go
+++ b/cmd/specgraph/up.go
@@ -15,7 +15,6 @@ import (
 	connect "connectrpc.com/connect"
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
-	"github.com/specgraph/specgraph/internal/config"
 	"github.com/specgraph/specgraph/internal/docker"
 	"github.com/specgraph/specgraph/internal/service"
 	"github.com/specgraph/specgraph/internal/xdg"
@@ -53,7 +52,7 @@ func runUp(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("ensure XDG dirs: %w", err)
 	}
 
-	cfg, err := config.LoadGlobal(globalConfigPath())
+	cfg, err := loadGlobalCfg()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}

--- a/e2e/api/probes_smoke_test.go
+++ b/e2e/api/probes_smoke_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build e2e
+
+package api_test
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/specgraph/specgraph/internal/server/probes"
+	"github.com/specgraph/specgraph/internal/storage/postgres"
+)
+
+var _ = Describe("Probes (smoke)", Label("probes"), func() {
+	It("serves /livez and /readyz against a real Postgres pool", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		store, err := postgres.New(ctx, pgConnURL, postgres.WithProject("probes-smoke"))
+		Expect(err).NotTo(HaveOccurred())
+		storeClosed := false
+		defer func() {
+			if storeClosed {
+				return
+			}
+			shutCtx, shutCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer shutCancel()
+			_ = store.Close(shutCtx)
+		}()
+
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).NotTo(HaveOccurred())
+		addr := ln.Addr().String()
+
+		h := probes.New(ctx, store, 100*time.Millisecond, 500*time.Millisecond)
+		srv := &http.Server{
+			Addr:              addr,
+			Handler:           h.Mux(),
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+		go func() {
+			_ = srv.Serve(ln)
+		}()
+		defer func() {
+			shutCtx, shutCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer shutCancel()
+			_ = srv.Shutdown(shutCtx)
+		}()
+
+		base := "http://" + addr
+
+		By("/livez returns 200 once the listener accepts")
+		Eventually(func() int {
+			r, getErr := http.Get(base + "/livez") //nolint:noctx // retried via Eventually
+			if getErr != nil {
+				return 0
+			}
+			_ = r.Body.Close()
+			return r.StatusCode
+		}, 5*time.Second, 25*time.Millisecond).Should(Equal(http.StatusOK))
+
+		By("/readyz reaches 200 after the first successful probe")
+		Eventually(func() int {
+			r, getErr := http.Get(base + "/readyz") //nolint:noctx // retried via Eventually
+			if getErr != nil {
+				return 0
+			}
+			_ = r.Body.Close()
+			return r.StatusCode
+		}, 5*time.Second, 25*time.Millisecond).Should(Equal(http.StatusOK))
+
+		By("/readyz flips to 503 with a reason body after the pool is closed")
+		shutCtx, shutCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		Expect(store.Close(shutCtx)).To(Succeed())
+		shutCancel()
+		storeClosed = true
+
+		Eventually(func() bool {
+			r, getErr := http.Get(base + "/readyz") //nolint:noctx // retried via Eventually
+			if getErr != nil {
+				return false
+			}
+			body, _ := io.ReadAll(r.Body)
+			_ = r.Body.Close()
+			return r.StatusCode == http.StatusServiceUnavailable && len(body) > 0
+		}, 5*time.Second, 25*time.Millisecond).Should(BeTrue(),
+			"readyz must report 503 with a non-empty reason body once the pool is closed")
+	})
+})

--- a/e2e/api/probes_smoke_test.go
+++ b/e2e/api/probes_smoke_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -83,6 +84,7 @@ var _ = Describe("Probes (smoke)", Label("probes"), func() {
 		shutCancel()
 		storeClosed = true
 
+		var lastBody string
 		Eventually(func() bool {
 			r, getErr := http.Get(base + "/readyz") //nolint:noctx // retried via Eventually
 			if getErr != nil {
@@ -90,8 +92,11 @@ var _ = Describe("Probes (smoke)", Label("probes"), func() {
 			}
 			body, _ := io.ReadAll(r.Body)
 			_ = r.Body.Close()
-			return r.StatusCode == http.StatusServiceUnavailable && len(body) > 0
+			lastBody = string(body)
+			return r.StatusCode == http.StatusServiceUnavailable &&
+				strings.Contains(lastBody, "not ready:") &&
+				strings.Contains(lastBody, "postgres")
 		}, 5*time.Second, 25*time.Millisecond).Should(BeTrue(),
-			"readyz must report 503 with a non-empty reason body once the pool is closed")
+			"readyz must report 503 with a reason body identifying the postgres failure; last body: %q", lastBody)
 	})
 })

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -9,8 +9,17 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"time"
 
 	"gopkg.in/yaml.v3"
+)
+
+// DefaultProbeInterval and DefaultProbeTimeout match kubelet's default
+// periodSeconds=10 (comfortably fresh) with a generous per-probe budget
+// for pgxpool.Ping against a local Postgres.
+const (
+	DefaultProbeInterval = 5 * time.Second
+	DefaultProbeTimeout  = 2 * time.Second
 )
 
 // GlobalConfig is the new top-level config at ~/.config/specgraph/config.yaml.
@@ -37,9 +46,46 @@ type ServerSection struct {
 }
 
 // ProbesConfig configures the plain-HTTP Kubernetes/Knative probe listener.
-// When Listen is empty, the probe endpoints are disabled.
+// When Listen is empty, the probe endpoints are disabled. Zero-valued
+// Interval and ProbeTimeout resolve to DefaultProbeInterval and
+// DefaultProbeTimeout via the Effective* methods.
 type ProbesConfig struct {
-	Listen string `yaml:"listen,omitempty"`
+	Listen       string        `yaml:"listen,omitempty"`
+	Interval     time.Duration `yaml:"interval,omitempty"`
+	ProbeTimeout time.Duration `yaml:"probe_timeout,omitempty"`
+}
+
+// EffectiveInterval returns Interval if set, else DefaultProbeInterval.
+func (p ProbesConfig) EffectiveInterval() time.Duration {
+	if p.Interval > 0 {
+		return p.Interval
+	}
+	return DefaultProbeInterval
+}
+
+// EffectiveProbeTimeout returns ProbeTimeout if set, else DefaultProbeTimeout.
+func (p ProbesConfig) EffectiveProbeTimeout() time.Duration {
+	if p.ProbeTimeout > 0 {
+		return p.ProbeTimeout
+	}
+	return DefaultProbeTimeout
+}
+
+// Validate rejects negative durations and a per-probe timeout that exceeds
+// the interval (probes would overlap and stack up behind a slow Postgres).
+// Zero values pass — they resolve to defaults via the Effective* methods.
+func (p ProbesConfig) Validate() error {
+	if p.Interval < 0 {
+		return fmt.Errorf("probes.interval must be non-negative, got %s", p.Interval)
+	}
+	if p.ProbeTimeout < 0 {
+		return fmt.Errorf("probes.probe_timeout must be non-negative, got %s", p.ProbeTimeout)
+	}
+	if p.EffectiveProbeTimeout() > p.EffectiveInterval() {
+		return fmt.Errorf("probes.probe_timeout (%s) must not exceed probes.interval (%s)",
+			p.EffectiveProbeTimeout(), p.EffectiveInterval())
+	}
+	return nil
 }
 
 // ClientConfig configures how CLI commands connect to the server.

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -93,14 +93,31 @@ type ClaimMapping struct {
 }
 
 // LoadGlobal loads the global config from path. If the file doesn't exist,
-// writes defaults and returns them.
+// writes defaults and returns them. Use LoadGlobalExplicit when path was
+// operator-supplied (via --config), where materializing defaults at a
+// typo'd path would silently mask the error.
 func LoadGlobal(path string) (*GlobalConfig, error) {
+	return loadGlobalAt(path, true)
+}
+
+// LoadGlobalExplicit loads the global config from an operator-supplied path,
+// returning an error if the file does not exist. Server commands call this
+// when --config is set so a missing or mistyped path fails loudly instead of
+// being materialized as a default config at an unexpected location.
+func LoadGlobalExplicit(path string) (*GlobalConfig, error) {
+	return loadGlobalAt(path, false)
+}
+
+func loadGlobalAt(path string, materializeDefaults bool) (*GlobalConfig, error) {
 	cfg := globalDefaults()
 
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if !errors.Is(err, fs.ErrNotExist) {
 			return nil, fmt.Errorf("read config: %w", err)
+		}
+		if !materializeDefaults {
+			return nil, fmt.Errorf("config file not found at %s", path)
 		}
 		if writeErr := writeGlobal(path, cfg); writeErr != nil {
 			return nil, fmt.Errorf("write default config: %w", writeErr)

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -14,9 +14,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// DefaultProbeInterval and DefaultProbeTimeout match kubelet's default
-// periodSeconds=10 (comfortably fresh) with a generous per-probe budget
-// for pgxpool.Ping against a local Postgres.
+// DefaultProbeInterval/Timeout are chosen so the 5s cache refresh stays
+// fresh against kubelet's default periodSeconds=10, with 2s headroom for
+// pgxpool.Ping.
 const (
 	DefaultProbeInterval = 5 * time.Second
 	DefaultProbeTimeout  = 2 * time.Second

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -46,46 +46,40 @@ type ServerSection struct {
 }
 
 // ProbesConfig configures the plain-HTTP Kubernetes/Knative probe listener.
-// When Listen is empty, the probe endpoints are disabled. Zero-valued
-// Interval and ProbeTimeout resolve to DefaultProbeInterval and
-// DefaultProbeTimeout via the Effective* methods.
+// When Listen is empty, the probe endpoints are disabled. Callers should
+// treat raw Interval/Timeout fields as untrusted and consume the result of
+// Resolved() — that's the single path that fuses defaulting and validation.
 type ProbesConfig struct {
-	Listen       string        `yaml:"listen,omitempty"`
-	Interval     time.Duration `yaml:"interval,omitempty"`
-	ProbeTimeout time.Duration `yaml:"probe_timeout,omitempty"`
+	Listen   string        `yaml:"listen,omitempty"`
+	Interval time.Duration `yaml:"interval,omitempty"`
+	Timeout  time.Duration `yaml:"timeout,omitempty"`
 }
 
-// EffectiveInterval returns Interval if set, else DefaultProbeInterval.
-func (p ProbesConfig) EffectiveInterval() time.Duration {
-	if p.Interval > 0 {
-		return p.Interval
-	}
-	return DefaultProbeInterval
-}
-
-// EffectiveProbeTimeout returns ProbeTimeout if set, else DefaultProbeTimeout.
-func (p ProbesConfig) EffectiveProbeTimeout() time.Duration {
-	if p.ProbeTimeout > 0 {
-		return p.ProbeTimeout
-	}
-	return DefaultProbeTimeout
-}
-
-// Validate rejects negative durations and a per-probe timeout that exceeds
-// the interval (probes would overlap and stack up behind a slow Postgres).
-// Zero values pass — they resolve to defaults via the Effective* methods.
-func (p ProbesConfig) Validate() error {
+// Resolved returns a copy with zero-valued Interval/Timeout filled from
+// DefaultProbeInterval/DefaultProbeTimeout, after rejecting negative
+// durations and a per-probe timeout that exceeds the interval (probes
+// would overlap and stack up behind a slow Postgres). Fusing defaulting
+// and validation prevents callers from reading raw fields and skipping
+// either step.
+func (p ProbesConfig) Resolved() (ProbesConfig, error) {
 	if p.Interval < 0 {
-		return fmt.Errorf("probes.interval must be non-negative, got %s", p.Interval)
+		return ProbesConfig{}, fmt.Errorf("probes.interval must be non-negative, got %s", p.Interval)
 	}
-	if p.ProbeTimeout < 0 {
-		return fmt.Errorf("probes.probe_timeout must be non-negative, got %s", p.ProbeTimeout)
+	if p.Timeout < 0 {
+		return ProbesConfig{}, fmt.Errorf("probes.timeout must be non-negative, got %s", p.Timeout)
 	}
-	if p.EffectiveProbeTimeout() > p.EffectiveInterval() {
-		return fmt.Errorf("probes.probe_timeout (%s) must not exceed probes.interval (%s)",
-			p.EffectiveProbeTimeout(), p.EffectiveInterval())
+	out := p
+	if out.Interval == 0 {
+		out.Interval = DefaultProbeInterval
 	}
-	return nil
+	if out.Timeout == 0 {
+		out.Timeout = DefaultProbeTimeout
+	}
+	if out.Timeout > out.Interval {
+		return ProbesConfig{}, fmt.Errorf("probes.timeout (%s) must not exceed probes.interval (%s)",
+			out.Timeout, out.Interval)
+	}
+	return out, nil
 }
 
 // ClientConfig configures how CLI commands connect to the server.

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -83,6 +83,29 @@ func TestLoadGlobal_MalformedYAML(t *testing.T) {
 	assert.Contains(t, err.Error(), "parse config")
 }
 
+func TestLoadGlobalExplicit_ErrorsWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "does-not-exist.yaml")
+
+	_, err := config.LoadGlobalExplicit(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config file not found")
+	assert.Contains(t, err.Error(), path)
+
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr), "must not materialize defaults at operator-supplied path")
+}
+
+func TestLoadGlobalExplicit_LoadsExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("server:\n  mode: manual\n"), 0o600))
+
+	cfg, err := config.LoadGlobalExplicit(path)
+	require.NoError(t, err)
+	assert.Equal(t, "manual", cfg.Server.Mode)
+}
+
 func TestLoadGlobal_ReadOnlyParentDir(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("root bypasses permission checks")

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -122,35 +122,38 @@ func TestLoadGlobal_ReadOnlyParentDir(t *testing.T) {
 	assert.Contains(t, err.Error(), "write default config")
 }
 
-func TestProbesConfig_EffectiveDefaults(t *testing.T) {
-	var p config.ProbesConfig
-	assert.Equal(t, config.DefaultProbeInterval, p.EffectiveInterval())
-	assert.Equal(t, config.DefaultProbeTimeout, p.EffectiveProbeTimeout())
+func TestProbesConfig_Resolved_FillsDefaults(t *testing.T) {
+	resolved, err := config.ProbesConfig{}.Resolved()
+	require.NoError(t, err)
+	assert.Equal(t, config.DefaultProbeInterval, resolved.Interval)
+	assert.Equal(t, config.DefaultProbeTimeout, resolved.Timeout)
 }
 
-func TestProbesConfig_EffectiveOverrides(t *testing.T) {
-	p := config.ProbesConfig{Interval: 30 * time.Second, ProbeTimeout: 4 * time.Second}
-	assert.Equal(t, 30*time.Second, p.EffectiveInterval())
-	assert.Equal(t, 4*time.Second, p.EffectiveProbeTimeout())
+func TestProbesConfig_Resolved_PreservesOverrides(t *testing.T) {
+	p := config.ProbesConfig{Interval: 30 * time.Second, Timeout: 4 * time.Second}
+	resolved, err := p.Resolved()
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Second, resolved.Interval)
+	assert.Equal(t, 4*time.Second, resolved.Timeout)
 }
 
-func TestProbesConfig_Validate(t *testing.T) {
+func TestProbesConfig_Resolved(t *testing.T) {
 	cases := []struct {
 		name    string
 		cfg     config.ProbesConfig
 		wantErr string
 	}{
-		{name: "zero values pass", cfg: config.ProbesConfig{}},
-		{name: "positive values pass", cfg: config.ProbesConfig{Interval: 10 * time.Second, ProbeTimeout: 3 * time.Second}},
-		{name: "timeout equals interval passes", cfg: config.ProbesConfig{Interval: 2 * time.Second, ProbeTimeout: 2 * time.Second}},
+		{name: "zero values resolve to defaults", cfg: config.ProbesConfig{}},
+		{name: "positive values pass", cfg: config.ProbesConfig{Interval: 10 * time.Second, Timeout: 3 * time.Second}},
+		{name: "timeout equals interval passes", cfg: config.ProbesConfig{Interval: 2 * time.Second, Timeout: 2 * time.Second}},
 		{name: "negative interval", cfg: config.ProbesConfig{Interval: -1 * time.Second}, wantErr: "probes.interval must be non-negative"},
-		{name: "negative timeout", cfg: config.ProbesConfig{ProbeTimeout: -1 * time.Second}, wantErr: "probes.probe_timeout must be non-negative"},
-		{name: "timeout exceeds interval", cfg: config.ProbesConfig{Interval: 2 * time.Second, ProbeTimeout: 5 * time.Second}, wantErr: "must not exceed probes.interval"},
-		{name: "timeout exceeds default interval", cfg: config.ProbesConfig{ProbeTimeout: 30 * time.Second}, wantErr: "must not exceed probes.interval"},
+		{name: "negative timeout", cfg: config.ProbesConfig{Timeout: -1 * time.Second}, wantErr: "probes.timeout must be non-negative"},
+		{name: "timeout exceeds interval", cfg: config.ProbesConfig{Interval: 2 * time.Second, Timeout: 5 * time.Second}, wantErr: "must not exceed probes.interval"},
+		{name: "timeout exceeds default interval", cfg: config.ProbesConfig{Timeout: 30 * time.Second}, wantErr: "must not exceed probes.interval"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.cfg.Validate()
+			_, err := tc.cfg.Resolved()
 			if tc.wantErr == "" {
 				assert.NoError(t, err)
 				return
@@ -169,7 +172,7 @@ server:
   probes:
     listen: "0.0.0.0:9091"
     interval: 10s
-    probe_timeout: 3s
+    timeout: 3s
 `
 	require.NoError(t, os.WriteFile(path, []byte(yaml), 0o600))
 
@@ -177,7 +180,7 @@ server:
 	require.NoError(t, err)
 	assert.Equal(t, "0.0.0.0:9091", cfg.Server.Probes.Listen)
 	assert.Equal(t, 10*time.Second, cfg.Server.Probes.Interval)
-	assert.Equal(t, 3*time.Second, cfg.Server.Probes.ProbeTimeout)
+	assert.Equal(t, 3*time.Second, cfg.Server.Probes.Timeout)
 }
 
 func TestResolveServer_RouteMatch(t *testing.T) {

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/specgraph/specgraph/internal/config"
 	"github.com/stretchr/testify/assert"
@@ -119,6 +120,64 @@ func TestLoadGlobal_ReadOnlyParentDir(t *testing.T) {
 	_, err := config.LoadGlobal(path)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "write default config")
+}
+
+func TestProbesConfig_EffectiveDefaults(t *testing.T) {
+	var p config.ProbesConfig
+	assert.Equal(t, config.DefaultProbeInterval, p.EffectiveInterval())
+	assert.Equal(t, config.DefaultProbeTimeout, p.EffectiveProbeTimeout())
+}
+
+func TestProbesConfig_EffectiveOverrides(t *testing.T) {
+	p := config.ProbesConfig{Interval: 30 * time.Second, ProbeTimeout: 4 * time.Second}
+	assert.Equal(t, 30*time.Second, p.EffectiveInterval())
+	assert.Equal(t, 4*time.Second, p.EffectiveProbeTimeout())
+}
+
+func TestProbesConfig_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     config.ProbesConfig
+		wantErr string
+	}{
+		{name: "zero values pass", cfg: config.ProbesConfig{}},
+		{name: "positive values pass", cfg: config.ProbesConfig{Interval: 10 * time.Second, ProbeTimeout: 3 * time.Second}},
+		{name: "timeout equals interval passes", cfg: config.ProbesConfig{Interval: 2 * time.Second, ProbeTimeout: 2 * time.Second}},
+		{name: "negative interval", cfg: config.ProbesConfig{Interval: -1 * time.Second}, wantErr: "probes.interval must be non-negative"},
+		{name: "negative timeout", cfg: config.ProbesConfig{ProbeTimeout: -1 * time.Second}, wantErr: "probes.probe_timeout must be non-negative"},
+		{name: "timeout exceeds interval", cfg: config.ProbesConfig{Interval: 2 * time.Second, ProbeTimeout: 5 * time.Second}, wantErr: "must not exceed probes.interval"},
+		{name: "timeout exceeds default interval", cfg: config.ProbesConfig{ProbeTimeout: 30 * time.Second}, wantErr: "must not exceed probes.interval"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestLoadGlobal_ProbesYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	yaml := `
+server:
+  probes:
+    listen: "0.0.0.0:9091"
+    interval: 10s
+    probe_timeout: 3s
+`
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0o600))
+
+	cfg, err := config.LoadGlobal(path)
+	require.NoError(t, err)
+	assert.Equal(t, "0.0.0.0:9091", cfg.Server.Probes.Listen)
+	assert.Equal(t, 10*time.Second, cfg.Server.Probes.Interval)
+	assert.Equal(t, 3*time.Second, cfg.Server.Probes.ProbeTimeout)
 }
 
 func TestResolveServer_RouteMatch(t *testing.T) {

--- a/internal/server/probes/probes.go
+++ b/internal/server/probes/probes.go
@@ -8,6 +8,8 @@ package probes
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -19,9 +21,14 @@ type Pinger interface {
 }
 
 // Handler serves /livez and /readyz. Readiness reflects the most recent
-// background probe of the Pinger.
+// background probe of the Pinger. The most recent probe error (if any)
+// is retained so /readyz bodies surface the failure cause rather than an
+// empty 503 — operators curling the endpoint get a reason string without
+// having to correlate with pod logs.
 type Handler struct {
-	ready atomic.Bool
+	ready   atomic.Bool
+	probed  atomic.Bool
+	lastErr atomic.Pointer[error]
 }
 
 // New starts a background goroutine that probes pinger every interval using
@@ -51,7 +58,28 @@ func (h *Handler) run(ctx context.Context, pinger Pinger, interval, probeTimeout
 func (h *Handler) probe(ctx context.Context, pinger Pinger, timeout time.Duration) {
 	pingCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	h.ready.Store(pinger.Ping(pingCtx) == nil)
+
+	err := pinger.Ping(pingCtx)
+	// Write lastErr before flipping ready so a Readyz racing with this
+	// probe sees an accurate reason for its 503.
+	if err != nil {
+		h.lastErr.Store(&err)
+	} else {
+		h.lastErr.Store(nil)
+	}
+	prev := h.ready.Swap(err == nil)
+	// The first probe has no prior state — zero-value ready=false looks
+	// like "failing" but it's just uninitialized, so treat the flip as
+	// informational and skip the transition log.
+	if !h.probed.Swap(true) {
+		return
+	}
+	switch {
+	case err != nil && prev:
+		slog.Warn("readiness probe failed", "error", err)
+	case err == nil && !prev:
+		slog.Info("readiness probe recovered")
+	}
 }
 
 // Livez reports liveness. Returns 200 unconditionally — reaching this handler
@@ -61,13 +89,25 @@ func (h *Handler) Livez(w http.ResponseWriter, _ *http.Request) {
 }
 
 // Readyz reports readiness. 200 when the last Pinger probe succeeded,
-// 503 otherwise (including before the first probe completes).
+// 503 otherwise (including before the first probe completes). The 503
+// response body carries the retained probe error (or "not yet probed"
+// before the first probe) so operators curling /readyz see the cause
+// without tailing logs.
 func (h *Handler) Readyz(w http.ResponseWriter, _ *http.Request) {
 	if h.ready.Load() {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusServiceUnavailable)
+	reason := "not ready: probe has not yet completed"
+	if e := h.lastErr.Load(); e != nil && *e != nil {
+		reason = fmt.Sprintf("not ready: %s", *e)
+	}
+	// A failed body write here means the client has already disconnected;
+	// there is nothing left to tell them, so drop the error rather than
+	// taking on a log line on every half-open connection.
+	_, _ = fmt.Fprintln(w, reason) //nolint:errcheck // client gone, nothing to do
 }
 
 // Mux returns a fresh http.Handler wiring /livez and /readyz. Callers wanting

--- a/internal/server/probes/probes.go
+++ b/internal/server/probes/probes.go
@@ -30,8 +30,8 @@ type probeState struct {
 }
 
 // Handler serves /livez and /readyz. Readiness reflects the most recent
-// background probe of the Pinger; the most recent probe error is retained
-// so /readyz 503 bodies carry a reason string rather than going empty.
+// background probe of the Pinger; the last probe's error is retained for
+// the /readyz body (see Readyz).
 type Handler struct {
 	state atomic.Pointer[probeState]
 }

--- a/internal/server/probes/probes.go
+++ b/internal/server/probes/probes.go
@@ -65,19 +65,32 @@ func (h *Handler) probe(ctx context.Context, pinger Pinger, timeout time.Duratio
 	defer cancel()
 
 	err := pinger.Ping(pingCtx)
+	if ctx.Err() != nil {
+		// Parent ctx cancelled — we're shutting down. State updates and
+		// log lines would only add noise; the goroutine's next loop
+		// iteration will observe ctx.Done and exit.
+		return
+	}
 	prev := h.state.Load()
 	h.state.Store(&probeState{ready: err == nil, err: err})
 
-	// First probe establishes state, not a transition — zero-value prev
-	// would otherwise make the initial healthy probe look like recovery.
-	if prev == nil {
-		return
-	}
 	switch {
+	case prev == nil && err != nil:
+		// Pod starting against a dead dependency: log once so operators
+		// tailing for readiness failures see something. A silent boot
+		// against a permanently-down DB would otherwise reveal the
+		// failure only via 503 bodies on /readyz.
+		slog.Warn("readiness probe failed on first attempt", "error", err)
+	case prev == nil:
+		// First probe is healthy — happy path, stay silent.
 	case err != nil && prev.ready:
 		slog.Warn("readiness probe failed", "error", err)
 	case err == nil && !prev.ready:
 		slog.Info("readiness probe recovered")
+	case err != nil && prev.err != nil && prev.err.Error() != err.Error():
+		// Mid-outage error shape changed (e.g., connection-refused →
+		// auth-failed). Re-log so logs mirror what /readyz now returns.
+		slog.Warn("readiness probe error changed", "error", err)
 	}
 }
 

--- a/internal/server/probes/probes.go
+++ b/internal/server/probes/probes.go
@@ -20,21 +20,26 @@ type Pinger interface {
 	Ping(ctx context.Context) error
 }
 
+// probeState is a consistent snapshot of the last probe's outcome. Storing
+// it behind a single atomic pointer means readers see a coherent triple
+// (probed, ready, err) without per-field ordering hazards, and the writer
+// publishes the entire transition in one Store.
+type probeState struct {
+	ready bool
+	err   error
+}
+
 // Handler serves /livez and /readyz. Readiness reflects the most recent
-// background probe of the Pinger. The most recent probe error (if any)
-// is retained so /readyz bodies surface the failure cause rather than an
-// empty 503 — operators curling the endpoint get a reason string without
-// having to correlate with pod logs.
+// background probe of the Pinger; the most recent probe error is retained
+// so /readyz 503 bodies carry a reason string rather than going empty.
 type Handler struct {
-	ready   atomic.Bool
-	probed  atomic.Bool
-	lastErr atomic.Pointer[error]
+	state atomic.Pointer[probeState]
 }
 
 // New starts a background goroutine that probes pinger every interval using
-// probeTimeout per call. The goroutine exits when ctx is cancelled.
-// The first probe runs immediately so readiness reflects current state
-// without waiting a full interval.
+// probeTimeout per call. The goroutine exits when ctx is cancelled. The
+// first probe runs immediately so readiness reflects current state without
+// waiting a full interval.
 func New(ctx context.Context, pinger Pinger, interval, probeTimeout time.Duration) *Handler {
 	h := &Handler{}
 	go h.run(ctx, pinger, interval, probeTimeout)
@@ -60,24 +65,18 @@ func (h *Handler) probe(ctx context.Context, pinger Pinger, timeout time.Duratio
 	defer cancel()
 
 	err := pinger.Ping(pingCtx)
-	// Write lastErr before flipping ready so a Readyz racing with this
-	// probe sees an accurate reason for its 503.
-	if err != nil {
-		h.lastErr.Store(&err)
-	} else {
-		h.lastErr.Store(nil)
-	}
-	prev := h.ready.Swap(err == nil)
-	// The first probe has no prior state — zero-value ready=false looks
-	// like "failing" but it's just uninitialized, so treat the flip as
-	// informational and skip the transition log.
-	if !h.probed.Swap(true) {
+	prev := h.state.Load()
+	h.state.Store(&probeState{ready: err == nil, err: err})
+
+	// First probe establishes state, not a transition — zero-value prev
+	// would otherwise make the initial healthy probe look like recovery.
+	if prev == nil {
 		return
 	}
 	switch {
-	case err != nil && prev:
+	case err != nil && prev.ready:
 		slog.Warn("readiness probe failed", "error", err)
-	case err == nil && !prev:
+	case err == nil && !prev.ready:
 		slog.Info("readiness probe recovered")
 	}
 }
@@ -88,25 +87,24 @@ func (h *Handler) Livez(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// Readyz reports readiness. 200 when the last Pinger probe succeeded,
-// 503 otherwise (including before the first probe completes). The 503
-// response body carries the retained probe error (or "not yet probed"
-// before the first probe) so operators curling /readyz see the cause
-// without tailing logs.
+// Readyz reports readiness. 200 when the last probe succeeded, 503 otherwise
+// (including before the first probe completes). The 503 body carries the
+// retained probe error so operators curling /readyz see the cause without
+// tailing pod logs.
 func (h *Handler) Readyz(w http.ResponseWriter, _ *http.Request) {
-	if h.ready.Load() {
+	s := h.state.Load()
+	if s != nil && s.ready {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusServiceUnavailable)
 	reason := "not ready: probe has not yet completed"
-	if e := h.lastErr.Load(); e != nil && *e != nil {
-		reason = fmt.Sprintf("not ready: %s", *e)
+	if s != nil && s.err != nil {
+		reason = fmt.Sprintf("not ready: %s", s.err)
 	}
-	// A failed body write here means the client has already disconnected;
-	// there is nothing left to tell them, so drop the error rather than
-	// taking on a log line on every half-open connection.
+	// A failed write here means the peer already disconnected; logging per
+	// half-open connection would flood during an outage.
 	_, _ = fmt.Fprintln(w, reason) //nolint:errcheck // client gone, nothing to do
 }
 

--- a/internal/server/probes/probes_test.go
+++ b/internal/server/probes/probes_test.go
@@ -4,10 +4,14 @@
 package probes_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -16,6 +20,25 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// syncBuffer wraps bytes.Buffer with a mutex so the probe goroutine writing
+// via slog and the test goroutine reading via String don't race.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
 
 // fakePinger returns the value stored in err and counts calls.
 type fakePinger struct {
@@ -138,6 +161,93 @@ func TestMux_RoutesBothEndpoints(t *testing.T) {
 		}
 		_ = r.Body.Close()
 		return r.StatusCode == http.StatusOK
+	})
+}
+
+func TestReadyz_BodyCarriesReason(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pinger := &fakePinger{}
+	pinger.setErr(errors.New("postgres: ping: dial tcp: connect: connection refused"))
+	h := probes.New(ctx, pinger, 10*time.Millisecond, 50*time.Millisecond)
+
+	waitFor(t, func() bool { return pinger.calls.Load() >= 1 })
+
+	// Poll until the cache has flipped to the failing state so the reason
+	// string reflects the stored error rather than the pre-probe marker.
+	waitFor(t, func() bool {
+		w := httptest.NewRecorder()
+		h.Readyz(w, httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody))
+		return w.Code == http.StatusServiceUnavailable &&
+			bytes.Contains(w.Body.Bytes(), []byte("connection refused"))
+	})
+
+	w := httptest.NewRecorder()
+	h.Readyz(w, httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody))
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/plain")
+	assert.Contains(t, w.Body.String(), "not ready:")
+	assert.Contains(t, w.Body.String(), "connection refused")
+}
+
+func TestReadyz_BodyReportsPrePingState(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Blocking pinger that never returns until ctx expires — first probe
+	// will time out and populate lastErr with context.DeadlineExceeded.
+	pinger := blockingPinger{block: make(chan struct{})}
+	h := probes.New(ctx, pinger, time.Hour, 10*time.Millisecond)
+
+	// Before the first probe window elapses the handler reports the
+	// pre-probe marker; after the timeout it reports the deadline error.
+	// Either message is acceptable; what we assert is that the body is
+	// never empty on 503.
+	waitFor(t, func() bool {
+		w := httptest.NewRecorder()
+		h.Readyz(w, httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody))
+		return w.Code == http.StatusServiceUnavailable && w.Body.Len() > 0
+	})
+}
+
+func TestProbe_LogsTransitionsOnly(t *testing.T) {
+	buf := &syncBuffer{}
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pinger := &fakePinger{}
+	h := probes.New(ctx, pinger, 5*time.Millisecond, 50*time.Millisecond)
+
+	// Let several healthy probes elapse — none should log. The first
+	// probe is silent (no prior state), subsequent healthy probes are
+	// steady-state.
+	waitFor(t, func() bool { return pinger.calls.Load() >= 3 })
+	assert.NotContains(t, buf.String(), "readiness probe", "steady-state healthy must not log")
+
+	pinger.setErr(errors.New("synthetic failure"))
+	waitFor(t, func() bool { return strings.Contains(buf.String(), "readiness probe failed") })
+	assert.Contains(t, buf.String(), "synthetic failure")
+
+	failCallsBefore := pinger.calls.Load()
+	waitFor(t, func() bool { return pinger.calls.Load() > failCallsBefore+2 })
+	assert.Equal(t, 1, strings.Count(buf.String(), "readiness probe failed"),
+		"failing steady state must not flood logs")
+
+	pinger.setErr(nil)
+	waitFor(t, func() bool { return strings.Contains(buf.String(), "readiness probe recovered") })
+	assert.Equal(t, 1, strings.Count(buf.String(), "readiness probe recovered"))
+
+	// After recovery /readyz is 200 and body reasons are silent — lastErr
+	// must be cleared so operators don't see a stale cause.
+	waitFor(t, func() bool {
+		w := httptest.NewRecorder()
+		h.Readyz(w, httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody))
+		return w.Code == http.StatusOK
 	})
 }
 

--- a/internal/server/probes/probes_test.go
+++ b/internal/server/probes/probes_test.go
@@ -211,6 +211,8 @@ func TestReadyz_BodyReportsPrePingState(t *testing.T) {
 	})
 }
 
+// slog.SetDefault is process-global; do not add t.Parallel() to these
+// logger-capturing tests.
 func TestProbe_LogsTransitionsOnly(t *testing.T) {
 	buf := &syncBuffer{}
 	prev := slog.Default()
@@ -223,9 +225,8 @@ func TestProbe_LogsTransitionsOnly(t *testing.T) {
 	pinger := &fakePinger{}
 	h := probes.New(ctx, pinger, 5*time.Millisecond, 50*time.Millisecond)
 
-	// Let several healthy probes elapse — none should log. The first
-	// probe is silent (no prior state), subsequent healthy probes are
-	// steady-state.
+	// First healthy probe is silent (happy-path boot); subsequent healthy
+	// probes stay silent too.
 	waitFor(t, func() bool { return pinger.calls.Load() >= 3 })
 	assert.NotContains(t, buf.String(), "readiness probe", "steady-state healthy must not log")
 
@@ -238,6 +239,12 @@ func TestProbe_LogsTransitionsOnly(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(buf.String(), "readiness probe failed"),
 		"failing steady state must not flood logs")
 
+	// Error shape changes mid-outage must re-log so pod logs mirror what
+	// /readyz now returns.
+	pinger.setErr(errors.New("different cause"))
+	waitFor(t, func() bool { return strings.Contains(buf.String(), "readiness probe error changed") })
+	assert.Contains(t, buf.String(), "different cause")
+
 	pinger.setErr(nil)
 	waitFor(t, func() bool { return strings.Contains(buf.String(), "readiness probe recovered") })
 	assert.Equal(t, 1, strings.Count(buf.String(), "readiness probe recovered"))
@@ -249,6 +256,29 @@ func TestProbe_LogsTransitionsOnly(t *testing.T) {
 		h.Readyz(w, httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody))
 		return w.Code == http.StatusOK
 	})
+}
+
+// slog.SetDefault is process-global; do not add t.Parallel() here.
+func TestProbe_LogsFirstProbeFailure(t *testing.T) {
+	buf := &syncBuffer{}
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pinger := &fakePinger{}
+	pinger.setErr(errors.New("db unreachable on boot"))
+	probes.New(ctx, pinger, time.Hour, 50*time.Millisecond)
+
+	// First-probe-failing must produce a log line; a pod that never
+	// becomes ready would otherwise leave operators without any log
+	// signal that readiness is permanently failing.
+	waitFor(t, func() bool {
+		return strings.Contains(buf.String(), "readiness probe failed on first attempt")
+	})
+	assert.Contains(t, buf.String(), "db unreachable on boot")
 }
 
 type blockingPinger struct{ block <-chan struct{} }

--- a/internal/storage/postgres/postgres.go
+++ b/internal/storage/postgres/postgres.go
@@ -99,10 +99,9 @@ func New(ctx context.Context, connString string, opts ...Option) (*Store, error)
 	return s, nil
 }
 
-// Ping verifies Postgres connectivity by round-tripping a lightweight query
-// through the connection pool. Used by readiness probes; the wrapped error
-// surfaces in /readyz bodies so operators can distinguish DNS/auth/pool
-// failures without tailing pod logs.
+// Ping verifies Postgres connectivity through the connection pool. The
+// wrapping is load-bearing: callers surface the message verbatim, and
+// unwrapped pgxpool errors are too opaque to diagnose in isolation.
 func (s *Store) Ping(ctx context.Context) error {
 	if err := s.pool.Ping(ctx); err != nil {
 		return fmt.Errorf("postgres: ping: %w", err)

--- a/internal/storage/postgres/postgres.go
+++ b/internal/storage/postgres/postgres.go
@@ -100,9 +100,14 @@ func New(ctx context.Context, connString string, opts ...Option) (*Store, error)
 }
 
 // Ping verifies Postgres connectivity by round-tripping a lightweight query
-// through the connection pool. Used by readiness probes.
+// through the connection pool. Used by readiness probes; the wrapped error
+// surfaces in /readyz bodies so operators can distinguish DNS/auth/pool
+// failures without tailing pod logs.
 func (s *Store) Ping(ctx context.Context) error {
-	return s.pool.Ping(ctx) //nolint:wrapcheck // direct pool pass-through
+	if err := s.pool.Ping(ctx); err != nil {
+		return fmt.Errorf("postgres: ping: %w", err)
+	}
+	return nil
 }
 
 // ensureProjectRow inserts the project row idempotently.

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -7,6 +7,7 @@ package postgres_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/specgraph/specgraph/internal/storage/postgres"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -517,6 +519,39 @@ func TestWithSliceOps_CanBeSet(t *testing.T) {
 	scoped, err := store.Scoped(ctx, "sliceops-test")
 	require.NoError(t, err)
 	require.NotNil(t, scoped)
+}
+
+// ---- Ping tests ----
+//
+// Store.Ping is a 3-line pgxpool pass-through used exclusively by the
+// readiness probe. Without real-pool coverage, a refactor could silently
+// reduce it to a no-op that always returns nil — making /readyz lie.
+
+func TestStore_Ping_ReturnsNilWhenPoolHealthy(t *testing.T) {
+	store := newStore(t)
+	require.NoError(t, store.Ping(context.Background()))
+}
+
+func TestStore_Ping_ReturnsErrorWhenPoolClosed(t *testing.T) {
+	ctx := context.Background()
+	store, err := postgres.New(ctx, connString, postgres.WithProject("ping-closed"))
+	require.NoError(t, err)
+	require.NoError(t, store.Close(ctx))
+
+	err = store.Ping(ctx)
+	require.Error(t, err, "Ping against a closed pool must error — a silent nil would mask readiness regressions")
+	assert.Contains(t, err.Error(), "postgres: ping:", "wrapping is load-bearing — /readyz body surfaces it")
+}
+
+func TestStore_Ping_RespectsContextCancel(t *testing.T) {
+	store := newStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := store.Ping(ctx)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled),
+		"Ping must propagate ctx cancel so readiness times out cleanly during shutdown, got %v", err)
 }
 
 func TestNew_WithSliceOps_Option(t *testing.T) {

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -523,9 +523,8 @@ func TestWithSliceOps_CanBeSet(t *testing.T) {
 
 // ---- Ping tests ----
 //
-// Store.Ping is a 3-line pgxpool pass-through used exclusively by the
-// readiness probe. Without real-pool coverage, a refactor could silently
-// reduce it to a no-op that always returns nil — making /readyz lie.
+// Without real-pool coverage a refactor could silently reduce Ping to a
+// no-op that always returns nil, making /readyz lie about readiness.
 
 func TestStore_Ping_ReturnsNilWhenPoolHealthy(t *testing.T) {
 	store := newStore(t)

--- a/site/docs/guides/health-probes.md
+++ b/site/docs/guides/health-probes.md
@@ -36,8 +36,19 @@ server:
 ```
 
 - `GET /livez` — 200 as long as the HTTP goroutine is alive. No DB touch.
-- `GET /readyz` — 200 when the last cached Postgres probe succeeded;
-  503 otherwise (including before the first probe completes).
+  Empty body.
+- `GET /readyz` — 200 (empty body) when the last cached Postgres probe
+  succeeded; 503 otherwise. On 503 the response body carries a plain-text
+  reason string (e.g. `not ready: postgres: ping: dial tcp: connect:
+  connection refused`) so `curl /readyz` identifies the failure cause
+  without tailing pod logs. Before the first probe completes the body
+  reads `not ready: probe has not yet completed`. kubelet's httpGet probe
+  ignores the body, so operators using Kubernetes probes see no change.
+
+Transitions between healthy and failing states log once each at `INFO`
+(`readiness probe recovered`) and `WARN` (`readiness probe failed` with
+the cause as an attribute) — steady-state probes are silent to avoid
+flooding logs when Postgres is out for an extended window.
 
 The probe server shuts down with the main server on SIGINT/SIGTERM.
 

--- a/site/docs/guides/health-probes.md
+++ b/site/docs/guides/health-probes.md
@@ -114,9 +114,22 @@ port (9091) is dialed directly by the kubelet against the pod IP.
 
 ## Tuning Notes
 
-- The readiness cache refreshes every **5 seconds** with a **2-second**
-  per-probe timeout. This is hard-coded — there's been no need to expose
-  it. File an issue if your workload requires different timing.
+- The readiness cache refreshes every **5 seconds** by default with a
+  **2-second** per-probe timeout. Override via YAML when your workload
+  needs different timing:
+
+  ```yaml
+  server:
+    probes:
+      listen: "0.0.0.0:9091"
+      interval: 10s        # how often to ping the DB (default 5s)
+      probe_timeout: 3s    # per-ping deadline (default 2s)
+  ```
+
+  Both durations use Go's `time.Duration` syntax (`500ms`, `2s`, `1m`).
+  `probe_timeout` must not exceed `interval` — otherwise probes would
+  overlap and stack up behind a slow Postgres; the server rejects such
+  configs at startup.
 - The first probe runs at startup, not after the first tick, so
   `initialDelaySeconds` can be as low as 2s for readiness without racing
   against "not yet probed" 503s.

--- a/site/docs/guides/health-probes.md
+++ b/site/docs/guides/health-probes.md
@@ -133,14 +133,14 @@ port (9091) is dialed directly by the kubelet against the pod IP.
   server:
     probes:
       listen: "0.0.0.0:9091"
-      interval: 10s        # how often to ping the DB (default 5s)
-      probe_timeout: 3s    # per-ping deadline (default 2s)
+      interval: 10s    # how often to ping the DB (default 5s)
+      timeout: 3s      # per-ping deadline (default 2s)
   ```
 
   Both durations use Go's `time.Duration` syntax (`500ms`, `2s`, `1m`).
-  `probe_timeout` must not exceed `interval` — otherwise probes would
-  overlap and stack up behind a slow Postgres; the server rejects such
-  configs at startup.
+  `timeout` must not exceed `interval` — otherwise probes would overlap
+  and stack up behind a slow Postgres; the server rejects such configs
+  at startup.
 - The first probe runs at startup, not after the first tick, so
   `initialDelaySeconds` can be as low as 2s for readiness without racing
   against "not yet probed" 503s.


### PR DESCRIPTION
## Summary

Six follow-up items filed from PR #914, #915, and #916 reviews, shipped as a single 7-commit stack. Most of the diff is test coverage (~520 of ~700 LOC); production code is ~180 LOC spread across config hardening, probe observability, and a `startProbeListener` helper extraction.

| # | Commit | Closes |
|---|--------|--------|
| 1 | `fix(config): require existing file when --config is explicit` | spgr-lg7k |
| 2 | `refactor(serve): extract startProbeListener helper` | (prep for 3, 6) |
| 3 | `feat(config): surface probe interval/timeout in ProbesConfig` | spgr-nts6 |
| 4 | `feat(probes): log readiness transitions and surface failure reason` | spgr-j33f |
| 5 | `test(serve): cover no-auth-non-loopback warning for default listen` | spgr-jo5n |
| 6 | `test(serve): cover probe listener wiring` | spgr-jd6s |
| 7 | `test(postgres): integration coverage for Store.Ping` | spgr-iqma |

### Behaviour changes worth noting

- **`--config <missing>` now fails loudly.** Pre-#914 `LoadGlobal` only ran for XDG defaults; post-#914 a typo'd `--config /etc/specgraph/config.yaml` would either silently materialize a default config at the typo'd path or surface a confusing `write default config: perm` error. Now it returns `config file not found at <path>` and exits 1.
- **`/readyz` body is now informative.** On 503 the response body carries a reason string (`not ready: postgres: ping: dial tcp: connect: connection refused`) so operators curling the endpoint see the cause without tailing logs. kubelet's httpGet probe ignores bodies, so Kubernetes users see no change.
- **`probes.interval` / `probes.probe_timeout` YAML keys** let operators override the 5s/2s defaults. Validated at serve startup (`timeout <= interval`, both non-negative).
- **Transition-only probe logging.** First failing probe logs `WARN readiness probe failed` with cause; first healthy probe after failure logs `INFO readiness probe recovered`. Steady state is silent to avoid flooding logs during extended outages.

## Test plan

- [x] `task check` — green (fmt, license, lint, unit tests with -race)
- [x] `task pr-prep` — green (check + integration + full e2e API suite + Playwright UI)
- [x] Probe smoke e2e (`go test -tags=e2e -ginkgo.focus=Probes`) — confirms the transition-log + wrapped-error + 503-body stack works end-to-end against a real pgxpool
- [x] `./specgraph up && ./specgraph down` lifecycle verified manually across: default-config, `--config <missing>` error path, `docker: true + mode: manual` (compose up → stop → up again → purge)
- [ ] Reviewer spot-check: does the `/readyz` body shape match what your deployment tooling expects? It's plain text with a trailing newline; kubelet ignores it. If your CI scripts parse `/readyz` output, this is the one behaviour change that could surprise them.

Closes spgr-lg7k, spgr-nts6, spgr-j33f, spgr-jo5n, spgr-jd6s, spgr-iqma.