### PR TITLE
feat(authoring): composer adapter and MCP prompt delegation (phase B slice 4)

### DIFF
--- a/internal/authoring/composer.go
+++ b/internal/authoring/composer.go
@@ -46,13 +46,20 @@ func (r Relationship) IsValid() bool {
 	}
 }
 
-var validStages = map[Stage]struct{}{
-	StageSpark:     {},
-	StageShape:     {},
-	StageSpecify:   {},
-	StageDecompose: {},
-	StageApprove:   {},
-}
+// composerValidStages is the ordered set of stages the Composer accepts for
+// content routing. This differs from authoringStages in stages.go: the
+// composer accepts StageApprove ("approve") as a content-file routing key,
+// while authoringStages uses StageApproved ("approved") for storage-side
+// transition validation. The two lists intentionally diverge at the final step.
+var composerValidStages = []Stage{StageSpark, StageShape, StageSpecify, StageDecompose, StageApprove}
+
+var validStages = func() map[Stage]struct{} {
+	m := make(map[Stage]struct{}, len(composerValidStages))
+	for _, s := range composerValidStages {
+		m[s] = struct{}{}
+	}
+	return m
+}()
 
 // ConstitutionSummary is a bounded digest of the current constitution for
 // inclusion in composed prompts. Full constitution available at specgraph://constitution.
@@ -128,7 +135,11 @@ func (c *Composer) ComposeStagePrompt(ctx context.Context, in ComposeInput) (res
 		return nil, fmt.Errorf("compose stage %q: %w", string(in.Stage), err)
 	}
 	if _, ok := validStages[in.Stage]; !ok {
-		return nil, fmt.Errorf("stage %q (valid: spark, shape, specify, decompose, approve): %w", string(in.Stage), ErrInvalidStage)
+		validNames := make([]string, len(composerValidStages))
+		for i, s := range composerValidStages {
+			validNames[i] = string(s)
+		}
+		return nil, fmt.Errorf("stage %q (valid: %s): %w", string(in.Stage), strings.Join(validNames, ", "), ErrInvalidStage)
 	}
 
 	defer func() {

--- a/internal/authoring/composer.go
+++ b/internal/authoring/composer.go
@@ -17,12 +17,24 @@ import (
 // Callers can map this to connect.CodeInvalidArgument at the RPC boundary.
 var ErrInvalidStage = errors.New("invalid authoring stage")
 
-var validStages = map[string]struct{}{
-	"spark":     {},
-	"shape":     {},
-	"specify":   {},
-	"decompose": {},
-	"approve":   {},
+// Relationship is a typed edge-relationship label used in RelatedSpec.
+type Relationship string
+
+const (
+	// RelationshipDependsOn indicates a spec depends on another.
+	RelationshipDependsOn Relationship = "dependsOn"
+	// RelationshipBlocks indicates a spec blocks another.
+	RelationshipBlocks Relationship = "blocks"
+	// RelationshipComposes indicates a spec composes another.
+	RelationshipComposes Relationship = "composes"
+)
+
+var validStages = map[Stage]struct{}{
+	StageSpark:     {},
+	StageShape:     {},
+	StageSpecify:   {},
+	StageDecompose: {},
+	StageApprove:   {},
 }
 
 // ConstitutionSummary is a bounded digest of the current constitution for
@@ -45,7 +57,7 @@ type SpecSummary struct {
 type RelatedSpec struct {
 	Slug         string
 	Intent       string
-	Relationship string // "dependsOn", "blocks", "composes", etc.
+	Relationship Relationship // RelationshipDependsOn, RelationshipBlocks, RelationshipComposes, etc.
 }
 
 // ComposerBackend is the read-only storage surface the composer needs.
@@ -73,7 +85,7 @@ func NewComposer(b ComposerBackend) *Composer {
 
 // ComposeInput selects which stage prompt to compose.
 type ComposeInput struct {
-	Stage   string
+	Stage   Stage
 	Slug    string
 	Posture string
 }
@@ -90,16 +102,16 @@ type ComposeResult struct {
 // ComposeStagePrompt assembles the full composed prompt for the given stage.
 func (c *Composer) ComposeStagePrompt(ctx context.Context, in ComposeInput) (result *ComposeResult, retErr error) {
 	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("compose stage %q: %w", in.Stage, err)
+		return nil, fmt.Errorf("compose stage %q: %w", string(in.Stage), err)
 	}
 	if _, ok := validStages[in.Stage]; !ok {
-		return nil, fmt.Errorf("stage %q (valid: spark, shape, specify, decompose, approve): %w", in.Stage, ErrInvalidStage)
+		return nil, fmt.Errorf("stage %q (valid: spark, shape, specify, decompose, approve): %w", string(in.Stage), ErrInvalidStage)
 	}
 
 	defer func() {
 		if retErr != nil {
 			slog.ErrorContext(ctx, "composer.invocation_failed",
-				slog.String("stage", in.Stage),
+				slog.String("stage", string(in.Stage)),
 				slog.String("slug", in.Slug),
 				slog.String("posture", in.Posture),
 				slog.String("err", retErr.Error()),
@@ -114,7 +126,7 @@ func (c *Composer) ComposeStagePrompt(ctx context.Context, in ComposeInput) (res
 		"orchestration.md",
 		"conversation-recording.md",
 		"quality-heuristics.md",
-		"stage-" + in.Stage + ".md",
+		"stage-" + string(in.Stage) + ".md",
 	} {
 		data, err := Content(name)
 		if err != nil {
@@ -137,7 +149,7 @@ func (c *Composer) ComposeStagePrompt(ctx context.Context, in ComposeInput) (res
 
 	totalTokens := approxTokens(b.String())
 	slog.InfoContext(ctx, "composer.invocation",
-		slog.String("stage", in.Stage),
+		slog.String("stage", string(in.Stage)),
 		slog.String("slug", in.Slug),
 		slog.String("posture", in.Posture),
 		slog.Int("stable_tokens", stableLen),

--- a/internal/authoring/composer.go
+++ b/internal/authoring/composer.go
@@ -17,6 +17,12 @@ import (
 // Callers can map this to connect.CodeInvalidArgument at the RPC boundary.
 var ErrInvalidStage = errors.New("invalid authoring stage")
 
+// ErrSpecNotFound is returned by ComposerBackend.GetSpecSummary when the
+// requested slug has no corresponding spec. Callers should treat this as a
+// soft miss: the composed prompt succeeds but omits the spec state block.
+// GetSpecSummary MUST return this sentinel (never nil, nil) when the spec is absent.
+var ErrSpecNotFound = errors.New("spec not found")
+
 // Relationship is a typed edge-relationship label used in RelatedSpec.
 type Relationship string
 
@@ -61,6 +67,12 @@ type RelatedSpec struct {
 }
 
 // ComposerBackend is the read-only storage surface the composer needs.
+// GetSpecSummary returns ErrSpecNotFound if the slug has no spec; callers
+// receive a nil summary in that case and the compose succeeds without the
+// spec state block. Implementations MUST NOT return (nil, nil) — the nil
+// summary path is only valid when error is ErrSpecNotFound.
+// GetConstitution may return (nil, nil) to indicate no constitution is
+// configured; that is a distinct concept from "not found."
 type ComposerBackend interface {
 	GetConstitution(ctx context.Context) (*ConstitutionSummary, error)
 	GetSpecSummary(ctx context.Context, slug string) (*SpecSummary, error)
@@ -198,7 +210,7 @@ func (c *Composer) appendDynamicState(ctx context.Context, b *strings.Builder, i
 
 	if in.Slug != "" {
 		spec, err := c.backend.GetSpecSummary(ctx, in.Slug)
-		if err != nil {
+		if err != nil && !errors.Is(err, ErrSpecNotFound) {
 			return truncated, fmt.Errorf("get spec summary: %w", err)
 		}
 		if spec != nil {

--- a/internal/authoring/composer.go
+++ b/internal/authoring/composer.go
@@ -20,7 +20,7 @@ var ErrInvalidStage = errors.New("invalid authoring stage")
 // ErrSpecNotFound is returned by ComposerBackend.GetSpecSummary when the
 // requested slug has no corresponding spec. Callers should treat this as a
 // soft miss: the composed prompt succeeds but omits the spec state block.
-// GetSpecSummary MUST return this sentinel (never nil, nil) when the spec is absent.
+// Implementations should return this sentinel rather than (nil, nil) when the spec is absent.
 var ErrSpecNotFound = errors.New("spec not found")
 
 // Relationship is a typed edge-relationship label used in RelatedSpec.
@@ -63,14 +63,14 @@ type SpecSummary struct {
 type RelatedSpec struct {
 	Slug         string
 	Intent       string
-	Relationship Relationship // RelationshipDependsOn, RelationshipBlocks, RelationshipComposes, etc.
+	Relationship Relationship // RelationshipDependsOn, RelationshipBlocks, or RelationshipComposes
 }
 
 // ComposerBackend is the read-only storage surface the composer needs.
-// GetSpecSummary returns ErrSpecNotFound if the slug has no spec; callers
-// receive a nil summary in that case and the compose succeeds without the
-// spec state block. Implementations MUST NOT return (nil, nil) — the nil
-// summary path is only valid when error is ErrSpecNotFound.
+// GetSpecSummary returns ErrSpecNotFound when the slug has no spec.
+// Implementations should return ErrSpecNotFound rather than (nil, nil) when
+// the spec is absent; the composer treats both equivalently as soft-miss but
+// the sentinel preserves the not-found / not-configured distinction for callers.
 // GetConstitution may return (nil, nil) to indicate no constitution is
 // configured; that is a distinct concept from "not found."
 type ComposerBackend interface {

--- a/internal/authoring/composer.go
+++ b/internal/authoring/composer.go
@@ -35,6 +35,17 @@ const (
 	RelationshipComposes Relationship = "composes"
 )
 
+// IsValid reports whether r is one of the three exported Relationship constants.
+// Use a switch for O(1) performance with no allocations.
+func (r Relationship) IsValid() bool {
+	switch r {
+	case RelationshipDependsOn, RelationshipBlocks, RelationshipComposes:
+		return true
+	default:
+		return false
+	}
+}
+
 var validStages = map[Stage]struct{}{
 	StageSpark:     {},
 	StageShape:     {},
@@ -225,9 +236,20 @@ func (c *Composer) appendDynamicState(ctx context.Context, b *strings.Builder, i
 		if err != nil {
 			return truncated, fmt.Errorf("get related specs: %w", err)
 		}
-		if len(related) > 0 {
+		var validRelated []*RelatedSpec
+		for _, r := range related {
+			if !r.Relationship.IsValid() {
+				slog.WarnContext(ctx, "composer.invalid_relationship_skipped",
+					slog.String("slug", r.Slug),
+					slog.String("relationship", string(r.Relationship)),
+				)
+				continue
+			}
+			validRelated = append(validRelated, r)
+		}
+		if len(validRelated) > 0 {
 			b.WriteString("**Related specs**: ")
-			for i, r := range related {
+			for i, r := range validRelated {
 				if i > 0 {
 					b.WriteString(", ")
 				}

--- a/internal/authoring/composer_golden_test.go
+++ b/internal/authoring/composer_golden_test.go
@@ -16,16 +16,16 @@ var update = flag.Bool("update", false, "update golden files")
 func TestComposeGolden(t *testing.T) {
 	cases := []struct {
 		name      string
-		stage     string
+		stage     Stage
 		slug      string
 		maxStable int
 		maxTotal  int
 	}{
-		{"spark", "spark", "", 4000, 6000},
-		{"shape", "shape", "oauth-refresh", 4500, 7000},
-		{"specify", "specify", "oauth-refresh", 4500, 7000},
-		{"decompose", "decompose", "oauth-refresh", 4500, 7000},
-		{"approve", "approve", "oauth-refresh", 4500, 7000},
+		{"spark", StageSpark, "", 4000, 6000},
+		{"shape", StageShape, "oauth-refresh", 4500, 7000},
+		{"specify", StageSpecify, "oauth-refresh", 4500, 7000},
+		{"decompose", StageDecompose, "oauth-refresh", 4500, 7000},
+		{"approve", StageApprove, "oauth-refresh", 4500, 7000},
 	}
 	c := NewComposer(&fakeComposerBackend{
 		constitution: &ConstitutionSummary{

--- a/internal/authoring/composer_test.go
+++ b/internal/authoring/composer_test.go
@@ -43,7 +43,7 @@ func TestComposer_EmitsInvocationLog(t *testing.T) {
 
 	c := NewComposer(&fakeComposerBackend{})
 	if _, err := c.ComposeStagePrompt(context.Background(), ComposeInput{
-		Stage:   "shape",
+		Stage:   StageShape,
 		Slug:    "oauth-refresh",
 		Posture: "partner",
 	}); err != nil {
@@ -66,7 +66,7 @@ func TestComposer_EmitsInvocationLog(t *testing.T) {
 
 func TestComposer_InvalidStageReturnsErrInvalidStage(t *testing.T) {
 	c := NewComposer(&fakeComposerBackend{})
-	for _, stage := range []string{"", "Shape", "bogus", "APPROVE"} {
+	for _, stage := range []Stage{"", "Shape", "bogus", "APPROVE"} {
 		_, err := c.ComposeStagePrompt(context.Background(), ComposeInput{Stage: stage, Slug: "s"})
 		if !errors.Is(err, ErrInvalidStage) {
 			t.Errorf("Stage=%q: err = %v, want errors.Is(err, ErrInvalidStage)", stage, err)
@@ -87,7 +87,7 @@ func TestComposer_CanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	c := NewComposer(&fakeComposerBackend{})
-	_, err := c.ComposeStagePrompt(ctx, ComposeInput{Stage: "shape", Slug: "s"})
+	_, err := c.ComposeStagePrompt(ctx, ComposeInput{Stage: StageShape, Slug: "s"})
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("err = %v, want errors.Is(err, context.Canceled)", err)
 	}
@@ -131,7 +131,7 @@ func TestComposer_BackendErrorsPropagate(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			c := NewComposer(tc.backend)
-			result, err := c.ComposeStagePrompt(context.Background(), ComposeInput{Stage: "shape", Slug: "s"})
+			result, err := c.ComposeStagePrompt(context.Background(), ComposeInput{Stage: StageShape, Slug: "s"})
 			if result != nil {
 				t.Errorf("result = %v, want nil on error", result)
 			}
@@ -154,7 +154,7 @@ func (b *bulkConstitutionBackend) GetConstitution(_ context.Context) (*Constitut
 
 func TestComposer_TruncationCounter(t *testing.T) {
 	c := NewComposer(&bulkConstitutionBackend{})
-	result, err := c.ComposeStagePrompt(context.Background(), ComposeInput{Stage: "shape", Slug: "s"})
+	result, err := c.ComposeStagePrompt(context.Background(), ComposeInput{Stage: StageShape, Slug: "s"})
 	if err != nil {
 		t.Fatalf("ComposeStagePrompt: %v", err)
 	}
@@ -188,7 +188,7 @@ func TestVersionString_RealOrDev(t *testing.T) {
 func TestComposer_StageSectionsPresent(t *testing.T) {
 	c := NewComposer(&fakeComposerBackend{})
 	result, err := c.ComposeStagePrompt(context.Background(), ComposeInput{
-		Stage:   "shape",
+		Stage:   StageShape,
 		Slug:    "oauth-refresh",
 		Posture: "partner",
 	})

--- a/internal/authoring/composer_test.go
+++ b/internal/authoring/composer_test.go
@@ -142,6 +142,18 @@ func TestComposer_BackendErrorsPropagate(t *testing.T) {
 	}
 }
 
+func TestComposer_SpecNotFoundIsSoftMiss(t *testing.T) {
+	backend := &errorBackend{specErr: ErrSpecNotFound}
+	c := NewComposer(backend)
+	result, err := c.ComposeStagePrompt(context.Background(), ComposeInput{Stage: StageShape, Slug: "missing-slug"})
+	if err != nil {
+		t.Fatalf("ComposeStagePrompt: expected no error on ErrSpecNotFound, got %v", err)
+	}
+	if strings.Contains(result.Body, "**Spec missing-slug**") {
+		t.Error("body should not contain spec block when ErrSpecNotFound is returned")
+	}
+}
+
 type bulkConstitutionBackend struct{ fakeComposerBackend }
 
 func (b *bulkConstitutionBackend) GetConstitution(_ context.Context) (*ConstitutionSummary, error) {

--- a/internal/authoring/composer_test.go
+++ b/internal/authoring/composer_test.go
@@ -213,3 +213,92 @@ func TestComposer_StageSectionsPresent(t *testing.T) {
 		}
 	}
 }
+
+// TestComposer_PriorStageSummaryRendered verifies that a non-empty PriorStageSummary
+// produces the expected "**Prior stage summary**: <value>" line in the body.
+func TestComposer_PriorStageSummaryRendered(t *testing.T) {
+	b := &fakeComposerBackend{
+		specSummary: &SpecSummary{
+			Slug:              "my-spec",
+			Intent:            "Do something useful",
+			Stage:             "shape",
+			PriorStageSummary: "The spark identified a caching problem.",
+		},
+	}
+	c := NewComposer(b)
+	result, err := c.ComposeStagePrompt(context.Background(), ComposeInput{Stage: StageShape, Slug: "my-spec"})
+	if err != nil {
+		t.Fatalf("ComposeStagePrompt: %v", err)
+	}
+	want := "**Prior stage summary**: The spark identified a caching problem."
+	if !strings.Contains(result.Body, want) {
+		t.Errorf("body missing %q", want)
+	}
+}
+
+// TestComposer_MultipleRelatedSpecs verifies that three related specs appear
+// comma-separated in the body.
+func TestComposer_MultipleRelatedSpecs(t *testing.T) {
+	b := &fakeComposerBackend{
+		related: []*RelatedSpec{
+			{Slug: "alpha", Relationship: RelationshipDependsOn},
+			{Slug: "beta", Relationship: RelationshipBlocks},
+			{Slug: "gamma", Relationship: RelationshipComposes},
+		},
+	}
+	c := NewComposer(b)
+	result, err := c.ComposeStagePrompt(context.Background(), ComposeInput{Stage: StageShape, Slug: "root-spec"})
+	if err != nil {
+		t.Fatalf("ComposeStagePrompt: %v", err)
+	}
+	for _, slug := range []string{"alpha", "beta", "gamma"} {
+		if !strings.Contains(result.Body, slug) {
+			t.Errorf("body missing related spec slug %q", slug)
+		}
+	}
+	// Verify the ", " joiner between entries.
+	if !strings.Contains(result.Body, "alpha (dependsOn), beta (blocks), gamma (composes)") {
+		t.Errorf("related specs not comma-joined correctly")
+	}
+}
+
+// TestComposer_NilConstitutionSkipped verifies that a (nil, nil) return from
+// GetConstitution causes the body to have "# Current State" but no
+// "**Constitution summary**" line.
+func TestComposer_NilConstitutionSkipped(t *testing.T) {
+	b := &nilConstitutionBackend{}
+	c := NewComposer(b)
+	result, err := c.ComposeStagePrompt(context.Background(), ComposeInput{Stage: StageShape, Slug: "any-spec"})
+	if err != nil {
+		t.Fatalf("ComposeStagePrompt: %v", err)
+	}
+	if !strings.Contains(result.Body, "# Current State") {
+		t.Error("body missing '# Current State' section")
+	}
+	if strings.Contains(result.Body, "**Constitution summary**") {
+		t.Error("body should not contain '**Constitution summary**' when constitution is nil")
+	}
+}
+
+type nilConstitutionBackend struct{ fakeComposerBackend }
+
+func (n *nilConstitutionBackend) GetConstitution(_ context.Context) (*ConstitutionSummary, error) {
+	return nil, nil
+}
+
+// TestComposer_InvalidStageErrorFormat verifies that the error message for an
+// invalid stage contains both the offending value and the word "valid".
+func TestComposer_InvalidStageErrorFormat(t *testing.T) {
+	c := NewComposer(&fakeComposerBackend{})
+	_, err := c.ComposeStagePrompt(context.Background(), ComposeInput{Stage: "bogus-stage", Slug: "s"})
+	if err == nil {
+		t.Fatal("expected error for invalid stage, got nil")
+	}
+	if !strings.Contains(err.Error(), "bogus-stage") {
+		t.Errorf("error %q does not contain offending stage value %q", err.Error(), "bogus-stage")
+	}
+	if !strings.Contains(err.Error(), "valid") {
+		t.Errorf("error %q does not contain the word 'valid'", err.Error())
+	}
+}
+

--- a/internal/authoring/composer_test.go
+++ b/internal/authoring/composer_test.go
@@ -286,6 +286,92 @@ func (n *nilConstitutionBackend) GetConstitution(_ context.Context) (*Constituti
 	return nil, nil
 }
 
+// TestRelationship_IsValid verifies that IsValid returns true for the three
+// exported constants and false for everything else (empty, unknown, case-mismatch).
+func TestRelationship_IsValid(t *testing.T) {
+	cases := []struct {
+		name string
+		r    Relationship
+		want bool
+	}{
+		{"DependsOn constant", RelationshipDependsOn, true},
+		{"Blocks constant", RelationshipBlocks, true},
+		{"Composes constant", RelationshipComposes, true},
+		{"empty string", Relationship(""), false},
+		{"unknown value", Relationship("BlockedBy"), false},
+		{"case mismatch", Relationship("DependsOn"), false}, // constant is "dependsOn" (lowercase d)
+		{"trailing whitespace", Relationship("dependsOn "), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.r.IsValid(); got != tc.want {
+				t.Errorf("Relationship(%q).IsValid() = %v, want %v", string(tc.r), got, tc.want)
+			}
+		})
+	}
+}
+
+// TestComposer_InvalidRelationshipSkipped verifies that a RelatedSpec with an
+// unrecognised Relationship is silently dropped from the body and that a
+// slog.Warn record is emitted for observability.
+func TestComposer_InvalidRelationshipSkipped(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	b := &fakeComposerBackend{
+		related: []*RelatedSpec{
+			{Slug: "alpha", Relationship: RelationshipDependsOn},
+			{Slug: "invalid-spec", Relationship: Relationship("BlockedBy")}, // capital B — invalid
+			{Slug: "gamma", Relationship: RelationshipBlocks},
+		},
+	}
+	c := NewComposer(b)
+	result, err := c.ComposeStagePrompt(context.Background(), ComposeInput{Stage: StageShape, Slug: "root-spec"})
+	if err != nil {
+		t.Fatalf("ComposeStagePrompt: %v", err)
+	}
+
+	// Valid entries must appear.
+	if !strings.Contains(result.Body, "alpha (dependsOn)") {
+		t.Errorf("body missing %q", "alpha (dependsOn)")
+	}
+	if !strings.Contains(result.Body, "gamma (blocks)") {
+		t.Errorf("body missing %q", "gamma (blocks)")
+	}
+
+	// The invalid relationship must NOT leak into the body.
+	if strings.Contains(result.Body, "BlockedBy") {
+		t.Error("body must not contain invalid relationship value \"BlockedBy\"")
+	}
+
+	// Decode all log records — there may be the invocation log plus the warn.
+	var warnFound bool
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("decode log record: %v; raw=%q", err, line)
+		}
+		if record["msg"] == "composer.invalid_relationship_skipped" {
+			warnFound = true
+			if record["level"] != "WARN" {
+				t.Errorf("warn record level = %v, want WARN", record["level"])
+			}
+			if record["relationship"] != "BlockedBy" {
+				t.Errorf("warn record relationship = %v, want BlockedBy", record["relationship"])
+			}
+		}
+	}
+	if !warnFound {
+		t.Errorf("expected slog WARN record with msg %q; log output: %q",
+			"composer.invalid_relationship_skipped", buf.String())
+	}
+}
+
 // TestComposer_InvalidStageErrorFormat verifies that the error message for an
 // invalid stage contains both the offending value and the word "valid",
 // and that the error wraps ErrInvalidStage so callers can sentinel-check it.

--- a/internal/authoring/composer_test.go
+++ b/internal/authoring/composer_test.go
@@ -287,7 +287,8 @@ func (n *nilConstitutionBackend) GetConstitution(_ context.Context) (*Constituti
 }
 
 // TestComposer_InvalidStageErrorFormat verifies that the error message for an
-// invalid stage contains both the offending value and the word "valid".
+// invalid stage contains both the offending value and the word "valid",
+// and that the error wraps ErrInvalidStage so callers can sentinel-check it.
 func TestComposer_InvalidStageErrorFormat(t *testing.T) {
 	c := NewComposer(&fakeComposerBackend{})
 	_, err := c.ComposeStagePrompt(context.Background(), ComposeInput{Stage: "bogus-stage", Slug: "s"})
@@ -299,6 +300,10 @@ func TestComposer_InvalidStageErrorFormat(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "valid") {
 		t.Errorf("error %q does not contain the word 'valid'", err.Error())
+	}
+	// B.4: The error must wrap ErrInvalidStage so callers can use errors.Is.
+	if !errors.Is(err, ErrInvalidStage) {
+		t.Errorf("errors.Is(err, ErrInvalidStage) = false; got %v", err)
 	}
 }
 

--- a/internal/authoring/stages.go
+++ b/internal/authoring/stages.go
@@ -9,8 +9,10 @@ import (
 	"github.com/specgraph/specgraph/internal/storage"
 )
 
-// Stage is an alias for storage.SpecStage, kept for backward compatibility
-// within the authoring package. New code should use storage.SpecStage directly.
+// Stage is the typed authoring-stage value used by Composer and friends
+// (ComposeInput, validStages, RelatedSpec). Aliased to storage.SpecStage so
+// storage and authoring agree on the wire type — assignments flow both ways
+// without conversion.
 type Stage = storage.SpecStage
 
 // Stage name constants used across the authoring funnel.

--- a/internal/authoring/stages.go
+++ b/internal/authoring/stages.go
@@ -21,6 +21,10 @@ const (
 	StageSpecify   = storage.SpecStageSpecify
 	StageDecompose = storage.SpecStageDecompose
 	StageApproved  = storage.SpecStageApproved
+	// StageApprove is the authoring-funnel stage name for the approve phase,
+	// distinct from StageApproved (storage value "approved"). Used by the composer
+	// and MCP prompt handlers to select the embedded stage-approve.md content.
+	StageApprove Stage = "approve"
 )
 
 // authoringStages defines the ordered authoring funnel stages.

--- a/internal/authoring/stages.go
+++ b/internal/authoring/stages.go
@@ -9,29 +9,65 @@ import (
 	"github.com/specgraph/specgraph/internal/storage"
 )
 
-// Stage is the typed authoring-stage value used by Composer and friends
-// (ComposeInput, validStages, RelatedSpec). Aliased to storage.SpecStage so
-// storage and authoring agree on the wire type — assignments flow both ways
-// without conversion.
-type Stage = storage.SpecStage
+// Stage is the typed authoring-stage value used by Composer and the funnel
+// helpers. It shares an underlying string with storage.SpecStage so values
+// flow through proto-string fields unchanged, but the defined type prevents
+// implicit assignment of lifecycle-only storage values (in_progress, done,
+// superseded, …) into authoring APIs. Use StageFromStorage to narrow a
+// storage value into an authoring Stage; use Stage.AsStorage() for the
+// reverse. The pair AsStorage / StageFromStorage are the only legitimate
+// crossings between the two types.
+type Stage string
 
-// Stage name constants used across the authoring funnel. Most are aliases for
-// the corresponding storage.SpecStage* constants; StageApprove is the one
-// exception — see its inline comment.
+// Authoring funnel stage constants. Most map 1:1 to storage.SpecStage* values;
+// StageApprove is the one exception — it is the composer's content-routing key
+// and is never written to storage (storage uses StageApproved).
 const (
-	StageSpark     = storage.SpecStageSpark
-	StageShape     = storage.SpecStageShape
-	StageSpecify   = storage.SpecStageSpecify
-	StageDecompose = storage.SpecStageDecompose
-	StageApproved  = storage.SpecStageApproved
-	// StageApprove is the authoring-funnel stage name for the approve phase,
-	// distinct from StageApproved (storage value "approved"). Used by the composer
-	// and MCP prompt handlers to select the embedded stage-approve.md content.
+	StageSpark     Stage = "spark"
+	StageShape     Stage = "shape"
+	StageSpecify   Stage = "specify"
+	StageDecompose Stage = "decompose"
+	// StageApprove is the authoring-funnel verb stage. Used only as a
+	// content-file routing key (stage-approve.md) and as a validStages
+	// member; never written to storage or returned in proto responses
+	// (storage uses StageApproved for the post-funnel state).
 	StageApprove Stage = "approve"
+	// StageApproved is the post-funnel storage state. Equal to
+	// storage.SpecStageApproved by value.
+	StageApproved Stage = "approved"
 )
 
-// authoringStages defines the ordered authoring funnel stages.
-var authoringStages = []storage.SpecStage{StageSpark, StageShape, StageSpecify, StageDecompose, StageApproved}
+// authoringStages defines the ordered authoring funnel stages used for
+// transition validation and storage-side operations. Note: this list uses
+// StageApproved ("approved"), not StageApprove ("approve") — the latter is
+// the composer's content-routing key, not a storage stage value.
+var authoringStages = []Stage{StageSpark, StageShape, StageSpecify, StageDecompose, StageApproved}
+
+// AsStorage returns s as a storage.SpecStage. Always safe — the underlying
+// string is identical; the conversion only re-types the value for storage
+// call sites.
+func (s Stage) AsStorage() storage.SpecStage { return storage.SpecStage(s) }
+
+// StageFromStorage narrows a storage.SpecStage to an authoring.Stage,
+// returning (Stage, false) when s is not one of the funnel stages
+// (i.e., lifecycle-only values like "in_progress", "done", "superseded").
+func StageFromStorage(s storage.SpecStage) (Stage, bool) {
+	candidate := Stage(s)
+	for _, stage := range authoringStages {
+		if candidate == stage {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+// IsAuthoringStage reports whether s is one of the authoring funnel stages.
+// Thin wrapper over StageFromStorage; kept for backward-compatible callers
+// that only need a boolean.
+func IsAuthoringStage(s storage.SpecStage) bool {
+	_, ok := StageFromStorage(s)
+	return ok
+}
 
 // AllStages returns a copy of the ordered stage list as strings (for backward compat with callers that need []string).
 func AllStages() []string {
@@ -42,15 +78,9 @@ func AllStages() []string {
 	return out
 }
 
-// IsAuthoringStage reports whether the given SpecStage is one of the five
-// authoring funnel stages (spark, shape, specify, decompose, approved).
-func IsAuthoringStage(s storage.SpecStage) bool {
-	return indexOf(s) >= 0
-}
-
 // validateStageNames returns an error if from or to are unknown authoring stage names.
 // allowEmptyFrom controls whether from=="" is accepted (used for initial transitions).
-func validateStageNames(from, to storage.SpecStage, allowEmptyFrom bool) (fromIdx, toIdx int, err error) {
+func validateStageNames(from, to Stage, allowEmptyFrom bool) (fromIdx, toIdx int, err error) {
 	fromIdx = indexOf(from)
 	toIdx = indexOf(to)
 	var unknowns []string
@@ -70,7 +100,7 @@ func validateStageNames(from, to storage.SpecStage, allowEmptyFrom bool) (fromId
 // Forward transitions must follow the defined order (no skipping).
 // Backward (amend) transitions are allowed to any earlier stage.
 // Same-to-same transitions are not allowed.
-func ValidateTransition(from, to storage.SpecStage) error {
+func ValidateTransition(from, to Stage) error {
 	if from == to {
 		return fmt.Errorf("transition from %q to %q is a no-op", from, to)
 	}
@@ -98,7 +128,7 @@ func ValidateTransition(from, to storage.SpecStage) error {
 // ValidateAmendTransition checks whether an amend (backward) transition is valid.
 // It only allows moving to an earlier stage — forward transitions and same-to-same
 // are rejected. This is distinct from ValidateTransition which allows both directions.
-func ValidateAmendTransition(from, to storage.SpecStage) error {
+func ValidateAmendTransition(from, to Stage) error {
 	if from == to {
 		return fmt.Errorf("amend transition from %q to %q is a no-op", from, to)
 	}
@@ -116,7 +146,7 @@ func ValidateAmendTransition(from, to storage.SpecStage) error {
 }
 
 // indexOf returns the position of a stage in the ordered authoring funnel list, or -1 if not found.
-func indexOf(stage storage.SpecStage) int {
+func indexOf(stage Stage) int {
 	for i, s := range authoringStages {
 		if s == stage {
 			return i

--- a/internal/authoring/stages.go
+++ b/internal/authoring/stages.go
@@ -43,9 +43,13 @@ const (
 // the composer's content-routing key, not a storage stage value.
 var authoringStages = []Stage{StageSpark, StageShape, StageSpecify, StageDecompose, StageApproved}
 
-// AsStorage returns s as a storage.SpecStage. Always safe — the underlying
-// string is identical; the conversion only re-types the value for storage
-// call sites.
+// AsStorage returns s as a storage.SpecStage. The conversion is type-safe
+// (same underlying string), but s == StageApprove yields storage.SpecStage("approve")
+// which is NOT a valid storage stage value — storage uses StageApproved
+// ("approved") for the post-funnel state. Callers persisting the result MUST
+// either ensure s != StageApprove or remap StageApprove → StageApproved at
+// the call site. This footgun is intentional: silently returning empty would
+// be worse (callers would write "" to storage thinking they wrote "approve").
 func (s Stage) AsStorage() storage.SpecStage { return storage.SpecStage(s) }
 
 // StageFromStorage narrows a storage.SpecStage to an authoring.Stage,

--- a/internal/authoring/stages.go
+++ b/internal/authoring/stages.go
@@ -15,8 +15,9 @@ import (
 // without conversion.
 type Stage = storage.SpecStage
 
-// Stage name constants used across the authoring funnel.
-// These are aliases for the corresponding storage.SpecStage* constants.
+// Stage name constants used across the authoring funnel. Most are aliases for
+// the corresponding storage.SpecStage* constants; StageApprove is the one
+// exception — see its inline comment.
 const (
 	StageSpark     = storage.SpecStageSpark
 	StageShape     = storage.SpecStageShape

--- a/internal/authoring/stages_test.go
+++ b/internal/authoring/stages_test.go
@@ -174,3 +174,50 @@ func TestAllStages(t *testing.T) {
 	got[0] = "mutated"
 	require.Equal(t, expected, authoring.AllStages())
 }
+
+func TestStageFromStorage(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        storage.SpecStage
+		wantStage authoring.Stage
+		wantOk    bool
+	}{
+		{"spark funnel value", storage.SpecStageSpark, authoring.StageSpark, true},
+		{"shape funnel value", storage.SpecStageShape, authoring.StageShape, true},
+		{"specify funnel value", storage.SpecStageSpecify, authoring.StageSpecify, true},
+		{"decompose funnel value", storage.SpecStageDecompose, authoring.StageDecompose, true},
+		{"approved funnel value", storage.SpecStageApproved, authoring.StageApproved, true},
+		{"in_progress lifecycle value rejected", storage.SpecStageInProgress, authoring.Stage(""), false},
+		{"done lifecycle value rejected", storage.SpecStageDone, authoring.Stage(""), false},
+		{"superseded lifecycle value rejected", storage.SpecStageSuperseded, authoring.Stage(""), false},
+		{"abandoned lifecycle value rejected", storage.SpecStageAbandoned, authoring.Stage(""), false},
+		{"review lifecycle value rejected", storage.SpecStageReview, authoring.Stage(""), false},
+		{"empty rejected", storage.SpecStage(""), authoring.Stage(""), false},
+		{"unknown rejected", storage.SpecStage("bogus"), authoring.Stage(""), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStage, gotOk := authoring.StageFromStorage(tc.in)
+			if gotStage != tc.wantStage || gotOk != tc.wantOk {
+				t.Errorf("StageFromStorage(%q) = (%q, %v), want (%q, %v)",
+					string(tc.in), string(gotStage), gotOk, string(tc.wantStage), tc.wantOk)
+			}
+		})
+	}
+}
+
+func TestStage_AsStorage_RoundTrip(t *testing.T) {
+	for _, s := range []authoring.Stage{
+		authoring.StageSpark,
+		authoring.StageShape,
+		authoring.StageSpecify,
+		authoring.StageDecompose,
+		authoring.StageApproved,
+	} {
+		narrow, ok := authoring.StageFromStorage(s.AsStorage())
+		if !ok || narrow != s {
+			t.Errorf("round-trip Stage(%q).AsStorage().StageFromStorage = (%q, %v), want (%q, true)",
+				string(s), string(narrow), ok, string(s))
+		}
+	}
+}

--- a/internal/mcp/client_id_contract_test.go
+++ b/internal/mcp/client_id_contract_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 // TestClientIDContract documents the expected clientInfo.name each platform
-// reports during MCP initialize. Update when docs/verification/*.md captures
-// empirical findings; regressing any of these without updating the test
-// indicates a platform renamed itself and the profile mapping is stale.
+// reports during MCP initialize and the profile each name maps to. A failing
+// test indicates a platform renamed itself; update the case list here AND
+// update ProfileFromClientInfo in profiles.go to match.
 func TestClientIDContract(t *testing.T) {
 	cases := []struct {
 		platform string
@@ -31,7 +31,7 @@ func TestClientIDContract(t *testing.T) {
 		t.Run(tc.platform, func(t *testing.T) {
 			got := ProfileFromClientInfo(&sdkmcp.Implementation{Name: tc.name})
 			if got != tc.profile {
-				t.Errorf("%s reports %q → want %v, got %v (did the platform rename? See docs/verification/)",
+				t.Errorf("%s reports clientInfo.name=%q → want profile %v, got %v (platform may have renamed; update ProfileFromClientInfo and this test)",
 					tc.platform, tc.name, tc.profile, got)
 			}
 		})

--- a/internal/mcp/client_id_contract_test.go
+++ b/internal/mcp/client_id_contract_test.go
@@ -1,5 +1,5 @@
+// Copyright 2026 SpecGraph Contributors
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Sean Brandt
 
 package mcp
 

--- a/internal/mcp/client_id_contract_test.go
+++ b/internal/mcp/client_id_contract_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package mcp
+
+import (
+	"testing"
+
+	sdkmcp "github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestClientIDContract documents the expected clientInfo.name each platform
+// reports during MCP initialize. Update when docs/verification/*.md captures
+// empirical findings; regressing any of these without updating the test
+// indicates a platform renamed itself and the profile mapping is stale.
+func TestClientIDContract(t *testing.T) {
+	cases := []struct {
+		platform string
+		name     string
+		profile  Profile
+	}{
+		{"Claude Code", "claude-code", ProfileAuthoring},
+		{"Cursor", "cursor", ProfileAuthoring},
+		{"OpenCode", "opencode", ProfileAuthoring},
+		{"Codex", "codex", ProfileAuthoring},
+		{"Windsurf", "windsurf", ProfileAuthoring},
+		{"Polecat", "polecat", ProfileExecution},
+		{"Gastown", "gastown", ProfileExecution},
+	}
+	for _, tc := range cases {
+		t.Run(tc.platform, func(t *testing.T) {
+			got := ProfileFromClientInfo(&sdkmcp.Implementation{Name: tc.name})
+			if got != tc.profile {
+				t.Errorf("%s reports %q → want %v, got %v (did the platform rename? See docs/verification/)",
+					tc.platform, tc.name, tc.profile, got)
+			}
+		})
+	}
+}

--- a/internal/mcp/composer_adapter.go
+++ b/internal/mcp/composer_adapter.go
@@ -45,20 +45,30 @@ func (b *composerBackend) GetConstitution(ctx context.Context) (*authoring.Const
 }
 
 // GetSpecSummary fetches a bounded view of the spec identified by slug.
-// Returns authoring.ErrSpecNotFound when the server reports the spec is absent.
+// Returns authoring.ErrSpecNotFound when the server reports the spec is absent
+// (either via connect.CodeNotFound or — defensively — via a nil Spec payload).
 func (b *composerBackend) GetSpecSummary(ctx context.Context, slug string) (*authoring.SpecSummary, error) {
 	resp, err := b.client.Spec.GetSpec(ctx, connect.NewRequest(&specv1.GetSpecRequest{Slug: slug}))
 	if err != nil {
+		// The real server maps storage.ErrSpecNotFound → connect.CodeNotFound
+		// (see internal/server/authoring_handler.go). Translate that into the
+		// composer's soft-miss sentinel so callers can skip the spec block.
+		if connect.CodeOf(err) == connect.CodeNotFound {
+			return nil, authoring.ErrSpecNotFound
+		}
 		return nil, fmt.Errorf("get spec: %w", err)
 	}
 	s := resp.Msg.GetSpec()
 	if s == nil {
+		// Defense in depth: the real server never returns (success, nil-Spec),
+		// but a fake or future implementation might.
 		return nil, authoring.ErrSpecNotFound
 	}
 	return &authoring.SpecSummary{
 		Slug:   s.GetSlug(),
 		Intent: s.GetIntent(),
 		Stage:  s.GetStage(),
+		// PriorStageSummary intentionally left zero: no proto field yet (deferred).
 	}, nil
 }
 

--- a/internal/mcp/composer_adapter.go
+++ b/internal/mcp/composer_adapter.go
@@ -1,5 +1,5 @@
+// Copyright 2026 SpecGraph Contributors
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Sean Brandt
 
 package mcp
 

--- a/internal/mcp/composer_adapter.go
+++ b/internal/mcp/composer_adapter.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/authoring"
+)
+
+// composerBackend bridges the MCP Client's ConnectRPC calls to the
+// authoring.ComposerBackend interface required by authoring.Composer.
+type composerBackend struct {
+	client *Client
+}
+
+// GetConstitution fetches the active constitution and returns a bounded summary.
+// Returns (nil, nil) when the server reports no constitution is configured.
+func (b *composerBackend) GetConstitution(ctx context.Context) (*authoring.ConstitutionSummary, error) {
+	resp, err := b.client.Constitution.GetConstitution(ctx, connect.NewRequest(&specv1.GetConstitutionRequest{}))
+	if err != nil {
+		return nil, fmt.Errorf("get constitution: %w", err)
+	}
+	c := resp.Msg.GetConstitution()
+	if c == nil {
+		return nil, nil
+	}
+	var lang string
+	if c.GetTech() != nil && c.GetTech().GetLanguages() != nil {
+		lang = c.GetTech().GetLanguages().GetPrimary()
+	}
+	var antipatterns []string
+	for _, ap := range c.GetAntipatterns() {
+		antipatterns = append(antipatterns, ap.GetPattern())
+	}
+	return &authoring.ConstitutionSummary{
+		PrimaryLanguage: lang,
+		KeyConstraints:  c.GetConstraints(),
+		Antipatterns:    antipatterns,
+	}, nil
+}
+
+// GetSpecSummary fetches a bounded view of the spec identified by slug.
+// Returns authoring.ErrSpecNotFound when the server reports the spec is absent.
+func (b *composerBackend) GetSpecSummary(ctx context.Context, slug string) (*authoring.SpecSummary, error) {
+	resp, err := b.client.Spec.GetSpec(ctx, connect.NewRequest(&specv1.GetSpecRequest{Slug: slug}))
+	if err != nil {
+		return nil, fmt.Errorf("get spec: %w", err)
+	}
+	s := resp.Msg.GetSpec()
+	if s == nil {
+		return nil, authoring.ErrSpecNotFound
+	}
+	return &authoring.SpecSummary{
+		Slug:   s.GetSlug(),
+		Intent: s.GetIntent(),
+		Stage:  s.GetStage(),
+	}, nil
+}
+
+// GetRelatedSpecs fetches the direct dependencies of the spec identified by slug.
+func (b *composerBackend) GetRelatedSpecs(ctx context.Context, slug string) ([]*authoring.RelatedSpec, error) {
+	resp, err := b.client.Graph.GetDependencies(ctx, connect.NewRequest(&specv1.GetDependenciesRequest{Slug: slug}))
+	if err != nil {
+		return nil, fmt.Errorf("get dependencies: %w", err)
+	}
+	var out []*authoring.RelatedSpec
+	for _, dep := range resp.Msg.GetDependencies() {
+		out = append(out, &authoring.RelatedSpec{
+			Slug:         dep.GetSlug(),
+			Intent:       dep.GetLabel(),
+			Relationship: authoring.RelationshipDependsOn,
+		})
+	}
+	return out, nil
+}

--- a/internal/mcp/composer_adapter.go
+++ b/internal/mcp/composer_adapter.go
@@ -18,6 +18,8 @@ type composerBackend struct {
 	client *Client
 }
 
+var _ authoring.ComposerBackend = (*composerBackend)(nil)
+
 // GetConstitution fetches the active constitution and returns a bounded summary.
 // Returns (nil, nil) when the server reports no constitution is configured.
 func (b *composerBackend) GetConstitution(ctx context.Context) (*authoring.ConstitutionSummary, error) {
@@ -50,8 +52,8 @@ func (b *composerBackend) GetConstitution(ctx context.Context) (*authoring.Const
 func (b *composerBackend) GetSpecSummary(ctx context.Context, slug string) (*authoring.SpecSummary, error) {
 	resp, err := b.client.Spec.GetSpec(ctx, connect.NewRequest(&specv1.GetSpecRequest{Slug: slug}))
 	if err != nil {
-		// The real server maps storage.ErrSpecNotFound → connect.CodeNotFound
-		// (see internal/server/authoring_handler.go). Translate that into the
+		// The real server's SpecService.GetSpec maps storage.ErrSpecNotFound → connect.CodeNotFound
+		// (see internal/server/spec_handler.go specError helper). Translate that into the
 		// composer's soft-miss sentinel so callers can skip the spec block.
 		if connect.CodeOf(err) == connect.CodeNotFound {
 			return nil, authoring.ErrSpecNotFound

--- a/internal/mcp/composer_adapter_test.go
+++ b/internal/mcp/composer_adapter_test.go
@@ -1,5 +1,5 @@
+// Copyright 2026 SpecGraph Contributors
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Sean Brandt
 
 package mcp
 
@@ -19,10 +19,13 @@ import (
 // B.1 — composerBackend.GetConstitution tests
 // ---------------------------------------------------------------------------
 
-// TestComposerAdapter_GetConstitution_NilConstitutionMapsToEmpty verifies that
-// when GetConstitution returns a response with no Constitution field set, the
-// adapter returns an empty (non-nil) ConstitutionSummary rather than nil.
-func TestComposerAdapter_GetConstitution_NilConstitutionMapsToEmpty(t *testing.T) {
+// TestComposerAdapter_GetConstitution_NilConstitutionMapsToNil verifies that
+// the adapter returns a nil ConstitutionSummary when the GetConstitution RPC
+// succeeds but the response carries no Constitution field. This (nil, nil)
+// pattern is documented on the ComposerBackend.GetConstitution interface as
+// "no constitution configured" — distinct from the ErrSpecNotFound soft-miss
+// path used by GetSpecSummary.
+func TestComposerAdapter_GetConstitution_NilConstitutionMapsToNil(t *testing.T) {
 	c := &Client{
 		Constitution: &mockConstitutionService{
 			getConstitution: func() (*specv1.GetConstitutionResponse, error) {

--- a/internal/mcp/composer_adapter_test.go
+++ b/internal/mcp/composer_adapter_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/authoring"
+	"github.com/stretchr/testify/require"
+)
+
+// TestComposerAdapter_GetSpecSummary_NotFoundMaps verifies that a
+// connect.CodeNotFound error from the underlying GetSpec RPC is translated
+// into authoring.ErrSpecNotFound. Without this mapping the soft-miss path
+// documented on authoring.ErrSpecNotFound would never trigger in production
+// (the real server maps storage.ErrSpecNotFound → connect.CodeNotFound).
+func TestComposerAdapter_GetSpecSummary_NotFoundMaps(t *testing.T) {
+	c := &Client{
+		Spec: &mockSpecService{
+			getSpec: func(_ string) (*specv1.GetSpecResponse, error) {
+				return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("spec not found"))
+			},
+		},
+	}
+	b := &composerBackend{client: c}
+
+	summary, err := b.GetSpecSummary(context.Background(), "missing-slug")
+	require.Nil(t, summary)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, authoring.ErrSpecNotFound),
+		"expected errors.Is(err, authoring.ErrSpecNotFound), got %v", err)
+}
+
+// TestComposerAdapter_GetSpecSummary_NilSpecMaps verifies the defense-in-depth
+// nil-Spec branch: if a backend returns success with no spec payload, the
+// adapter still produces ErrSpecNotFound rather than a nil-summary leak.
+func TestComposerAdapter_GetSpecSummary_NilSpecMaps(t *testing.T) {
+	c := &Client{
+		Spec: &mockSpecService{
+			getSpec: func(_ string) (*specv1.GetSpecResponse, error) {
+				return &specv1.GetSpecResponse{}, nil
+			},
+		},
+	}
+	b := &composerBackend{client: c}
+
+	summary, err := b.GetSpecSummary(context.Background(), "any-slug")
+	require.Nil(t, summary)
+	require.True(t, errors.Is(err, authoring.ErrSpecNotFound),
+		"expected errors.Is(err, authoring.ErrSpecNotFound), got %v", err)
+}
+
+// TestComposerAdapter_GetSpecSummary_OtherErrorWrapped verifies that
+// non-NotFound errors are wrapped opaquely (callers should not treat them
+// as a soft miss).
+func TestComposerAdapter_GetSpecSummary_OtherErrorWrapped(t *testing.T) {
+	c := &Client{
+		Spec: &mockSpecService{
+			getSpec: func(_ string) (*specv1.GetSpecResponse, error) {
+				return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("boom"))
+			},
+		},
+	}
+	b := &composerBackend{client: c}
+
+	summary, err := b.GetSpecSummary(context.Background(), "any-slug")
+	require.Nil(t, summary)
+	require.Error(t, err)
+	require.False(t, errors.Is(err, authoring.ErrSpecNotFound),
+		"non-NotFound error should not match ErrSpecNotFound, got %v", err)
+}
+
+// TestComposerAdapter_GetSpecSummary_Success verifies the happy path: a
+// populated Spec produces a SpecSummary with Slug/Intent/Stage copied through.
+func TestComposerAdapter_GetSpecSummary_Success(t *testing.T) {
+	c := &Client{
+		Spec: &mockSpecService{
+			getSpec: func(slug string) (*specv1.GetSpecResponse, error) {
+				return &specv1.GetSpecResponse{
+					Spec: &specv1.Spec{Slug: slug, Intent: "the intent", Stage: "shape"},
+				}, nil
+			},
+		},
+	}
+	b := &composerBackend{client: c}
+
+	summary, err := b.GetSpecSummary(context.Background(), "my-spec")
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	require.Equal(t, "my-spec", summary.Slug)
+	require.Equal(t, "the intent", summary.Intent)
+	require.Equal(t, "shape", summary.Stage)
+}

--- a/internal/mcp/composer_adapter_test.go
+++ b/internal/mcp/composer_adapter_test.go
@@ -15,6 +15,135 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// ---------------------------------------------------------------------------
+// B.1 — composerBackend.GetConstitution tests
+// ---------------------------------------------------------------------------
+
+// TestComposerAdapter_GetConstitution_NilConstitutionMapsToEmpty verifies that
+// when GetConstitution returns a response with no Constitution field set, the
+// adapter returns an empty (non-nil) ConstitutionSummary rather than nil.
+func TestComposerAdapter_GetConstitution_NilConstitutionMapsToEmpty(t *testing.T) {
+	c := &Client{
+		Constitution: &mockConstitutionService{
+			getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+				return &specv1.GetConstitutionResponse{}, nil
+			},
+		},
+	}
+	b := &composerBackend{client: c}
+
+	summary, err := b.GetConstitution(context.Background())
+	require.NoError(t, err)
+	// Nil constitution maps to (nil, nil) per the GetConstitution docstring —
+	// the adapter returns nil when no constitution is configured.
+	require.Nil(t, summary, "nil Constitution in response should produce nil summary")
+}
+
+// TestComposerAdapter_GetConstitution_RPCErrorWrapped verifies that an RPC error
+// is wrapped via "get constitution: %w" and the original error is reachable via errors.Is.
+func TestComposerAdapter_GetConstitution_RPCErrorWrapped(t *testing.T) {
+	inner := connect.NewError(connect.CodeInternal, fmt.Errorf("boom"))
+	c := &Client{
+		Constitution: &mockConstitutionService{
+			getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+				return nil, inner
+			},
+		},
+	}
+	b := &composerBackend{client: c}
+
+	summary, err := b.GetConstitution(context.Background())
+	require.Nil(t, summary)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, inner),
+		"expected errors.Is(err, inner), got %v", err)
+}
+
+// TestComposerAdapter_GetConstitution_PopulatesFields verifies that a populated
+// Constitution response is correctly mapped to ConstitutionSummary fields.
+func TestComposerAdapter_GetConstitution_PopulatesFields(t *testing.T) {
+	c := &Client{
+		Constitution: &mockConstitutionService{
+			getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+				return &specv1.GetConstitutionResponse{
+					Constitution: &specv1.Constitution{
+						Tech: &specv1.TechConfig{
+							Languages: &specv1.LanguageConfig{
+								Primary: "Go",
+							},
+						},
+						Constraints:  []string{"c1", "c2"},
+						Antipatterns: []*specv1.Antipattern{{Pattern: "ap1"}, {Pattern: "ap2"}},
+					},
+				}, nil
+			},
+		},
+	}
+	b := &composerBackend{client: c}
+
+	summary, err := b.GetConstitution(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	require.Equal(t, "Go", summary.PrimaryLanguage)
+	require.Equal(t, []string{"c1", "c2"}, summary.KeyConstraints)
+	require.Equal(t, []string{"ap1", "ap2"}, summary.Antipatterns)
+}
+
+// ---------------------------------------------------------------------------
+// B.2 — composerBackend.GetRelatedSpecs tests
+// ---------------------------------------------------------------------------
+
+// TestComposerAdapter_GetRelatedSpecs_RPCErrorWrapped verifies that an RPC error
+// from GetDependencies is wrapped via "get dependencies: %w".
+func TestComposerAdapter_GetRelatedSpecs_RPCErrorWrapped(t *testing.T) {
+	inner := connect.NewError(connect.CodeInternal, fmt.Errorf("deps boom"))
+	c := &Client{
+		Graph: &mockGraphService{
+			getDeps: func(_ string) (*specv1.GetDependenciesResponse, error) {
+				return nil, inner
+			},
+		},
+	}
+	b := &composerBackend{client: c}
+
+	result, err := b.GetRelatedSpecs(context.Background(), "any-slug")
+	require.Nil(t, result)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, inner),
+		"expected errors.Is(err, inner) to hold through wrap, got %v", err)
+}
+
+// TestComposerAdapter_GetRelatedSpecs_TranslatesDependencies verifies that
+// NodeRef.Slug/Label are mapped to RelatedSpec.Slug/Intent and that
+// Relationship is set to RelationshipDependsOn for all entries.
+func TestComposerAdapter_GetRelatedSpecs_TranslatesDependencies(t *testing.T) {
+	c := &Client{
+		Graph: &mockGraphService{
+			getDeps: func(_ string) (*specv1.GetDependenciesResponse, error) {
+				return &specv1.GetDependenciesResponse{
+					Dependencies: []*specv1.NodeRef{
+						{Slug: "alpha", Label: "Alpha intent"},
+						{Slug: "beta", Label: "Beta intent"},
+					},
+				}, nil
+			},
+		},
+	}
+	b := &composerBackend{client: c}
+
+	result, err := b.GetRelatedSpecs(context.Background(), "root")
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	require.Equal(t, "alpha", result[0].Slug)
+	require.Equal(t, "Alpha intent", result[0].Intent)
+	require.Equal(t, authoring.RelationshipDependsOn, result[0].Relationship)
+
+	require.Equal(t, "beta", result[1].Slug)
+	require.Equal(t, "Beta intent", result[1].Intent)
+	require.Equal(t, authoring.RelationshipDependsOn, result[1].Relationship)
+}
+
 // TestComposerAdapter_GetSpecSummary_NotFoundMaps verifies that a
 // connect.CodeNotFound error from the underlying GetSpec RPC is translated
 // into authoring.ErrSpecNotFound. Without this mapping the soft-miss path

--- a/internal/mcp/profiles.go
+++ b/internal/mcp/profiles.go
@@ -18,7 +18,7 @@ func ProfileFromClientInfo(info *sdkmcp.Implementation) Profile {
 	switch info.Name {
 	case "polecat", "gastown":
 		return ProfileExecution
-	case "claude-code", "cursor", "windsurf":
+	case "claude-code", "cursor", "windsurf", "opencode", "codex":
 		return ProfileAuthoring
 	default:
 		return ProfileCore

--- a/internal/mcp/profiles_test.go
+++ b/internal/mcp/profiles_test.go
@@ -27,6 +27,8 @@ func TestProfileFromClientInfo(t *testing.T) {
 		{"claude-code gets authoring", "claude-code", ProfileAuthoring},
 		{"cursor gets authoring", "cursor", ProfileAuthoring},
 		{"windsurf gets authoring", "windsurf", ProfileAuthoring},
+		{"opencode gets authoring", "opencode", ProfileAuthoring},
+		{"codex gets authoring", "codex", ProfileAuthoring},
 		{"unknown gets core", "some-other-client", ProfileCore},
 		{"empty gets core", "", ProfileCore},
 	}

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -81,9 +81,8 @@ func stagePromptHandler(c *Client, stage string) PromptHandler {
 			return nil, fmt.Errorf("spec_slug is required for %s prompt", stage)
 		}
 		result, err := composer.ComposeStagePrompt(ctx, authoring.ComposeInput{
-			Stage:   authoring.Stage(stage),
-			Slug:    specSlug,
-			Posture: args["posture"],
+			Stage: authoring.Stage(stage),
+			Slug:  specSlug,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("compose %s prompt: %w", stage, err)
@@ -104,9 +103,8 @@ func sparkPromptHandler(c *Client) PromptHandler {
 			return nil, fmt.Errorf("topic is required for spark prompt")
 		}
 		result, err := composer.ComposeStagePrompt(ctx, authoring.ComposeInput{
-			Stage:   authoring.StageSpark,
-			Slug:    args["spec_slug"],
-			Posture: args["posture"],
+			Stage: authoring.StageSpark,
+			Slug:  args["spec_slug"],
 		})
 		if err != nil {
 			return nil, fmt.Errorf("compose spark prompt: %w", err)

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -9,6 +9,7 @@ import (
 
 	"connectrpc.com/connect"
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/authoring"
 )
 
 // RegisterPrompts registers all MCP prompt definitions into the registry.
@@ -69,66 +70,53 @@ func RegisterPrompts(r *Registry, c *Client) {
 	})
 }
 
-// stagePromptHandler returns a PromptHandler that fetches prompt templates for
-// the given authoring stage and returns the first template as a user message.
+// stagePromptHandler returns a PromptHandler that uses authoring.Composer to
+// assemble a rich composed prompt (persona + orchestration + recording +
+// heuristics + stage + dynamic state) for the given authoring stage.
 func stagePromptHandler(c *Client, stage string) PromptHandler {
+	composer := authoring.NewComposer(&composerBackend{client: c})
 	return func(ctx context.Context, args map[string]string) (*PromptResult, error) {
 		specSlug := args["spec_slug"]
 		if specSlug == "" {
 			return nil, fmt.Errorf("spec_slug is required for %s prompt", stage)
 		}
-		resp, err := c.Authoring.GetPrompts(ctx, connect.NewRequest(&specv1.GetPromptsRequest{
-			Stage: authoringStageFromString(stage),
-		}))
+		result, err := composer.ComposeStagePrompt(ctx, authoring.ComposeInput{
+			Stage:   authoring.Stage(stage),
+			Slug:    specSlug,
+			Posture: args["posture"],
+		})
 		if err != nil {
-			return nil, fmt.Errorf("get prompts for stage %s: %w", stage, err)
+			return nil, fmt.Errorf("compose %s prompt: %w", stage, err)
 		}
-		templates := resp.Msg.GetPrompts()
-		var text string
-		if len(templates) == 0 {
-			text = "No prompt template available for stage: " + stage
-		} else {
-			text = templates[0].GetTemplate()
-		}
-		text += "\n\nSpec: " + specSlug
 		return &PromptResult{
-			Messages: []PromptMessage{
-				{Role: "user", Content: text},
-			},
+			Messages: []PromptMessage{{Role: "user", Content: result.Body}},
 		}, nil
 	}
 }
 
-// sparkPromptHandler returns a PromptHandler for the spark stage that appends
-// the topic and optional context to the fetched template.
+// sparkPromptHandler returns a PromptHandler for the spark stage that composes
+// a rich prompt and appends the required topic and optional context.
 func sparkPromptHandler(c *Client) PromptHandler {
+	composer := authoring.NewComposer(&composerBackend{client: c})
 	return func(ctx context.Context, args map[string]string) (*PromptResult, error) {
-		if args["topic"] == "" {
+		topic := args["topic"]
+		if topic == "" {
 			return nil, fmt.Errorf("topic is required for spark prompt")
 		}
-		resp, err := c.Authoring.GetPrompts(ctx, connect.NewRequest(&specv1.GetPromptsRequest{
-			Stage: authoringStageFromString("spark"),
-		}))
+		result, err := composer.ComposeStagePrompt(ctx, authoring.ComposeInput{
+			Stage:   authoring.StageSpark,
+			Slug:    args["spec_slug"],
+			Posture: args["posture"],
+		})
 		if err != nil {
-			return nil, fmt.Errorf("get prompts for stage spark: %w", err)
+			return nil, fmt.Errorf("compose spark prompt: %w", err)
 		}
-		templates := resp.Msg.GetPrompts()
-		var text string
-		if len(templates) == 0 {
-			text = "No prompt template available for stage: spark"
-		} else {
-			text = templates[0].GetTemplate()
-		}
-		if topic := args["topic"]; topic != "" {
-			text += "\n\nTopic: " + topic
-		}
+		body := result.Body + "\n\n# Topic\n\n" + topic
 		if ctxVal := args["context"]; ctxVal != "" {
-			text += "\nContext: " + ctxVal
+			body += "\n\n# Additional Context\n\n" + ctxVal
 		}
 		return &PromptResult{
-			Messages: []PromptMessage{
-				{Role: "user", Content: text},
-			},
+			Messages: []PromptMessage{{Role: "user", Content: body}},
 		}, nil
 	}
 }

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -104,7 +104,11 @@ func sparkPromptHandler(c *Client) PromptHandler {
 		}
 		result, err := composer.ComposeStagePrompt(ctx, authoring.ComposeInput{
 			Stage: authoring.StageSpark,
-			Slug:  args["spec_slug"],
+			// Spark stage has no spec yet (PromptDef declares only topic + context).
+			// If mid-stream re-entry into spark with an existing slug becomes a
+			// requirement, declare spec_slug as an optional PromptArgument and read
+			// it here.
+			Slug: "",
 		})
 		if err != nil {
 			return nil, fmt.Errorf("compose spark prompt: %w", err)

--- a/internal/mcp/prompts_test.go
+++ b/internal/mcp/prompts_test.go
@@ -13,29 +13,66 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// newComposerClient builds a Client pre-wired with the three services that the
+// composerBackend calls: Constitution, Spec, and Graph.
+func newComposerClient(
+	constitution *mockConstitutionService,
+	spec *mockSpecService,
+	graph *mockGraphService,
+) *Client {
+	return &Client{
+		Constitution: constitution,
+		Spec:         spec,
+		Graph:        graph,
+	}
+}
+
+// defaultConstitutionMock returns a minimal GetConstitution mock.
+func defaultConstitutionMock() *mockConstitutionService {
+	return &mockConstitutionService{
+		getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+			return &specv1.GetConstitutionResponse{}, nil
+		},
+	}
+}
+
+// defaultSpecMock returns a minimal GetSpec mock for the given slug.
+func defaultSpecMock(slug string) *mockSpecService {
+	return &mockSpecService{
+		getSpec: func(s string) (*specv1.GetSpecResponse, error) {
+			if s == slug {
+				return &specv1.GetSpecResponse{
+					Spec: &specv1.Spec{Slug: slug, Intent: "test intent", Stage: "shape"},
+				}, nil
+			}
+			return &specv1.GetSpecResponse{}, nil
+		},
+	}
+}
+
+// defaultGraphMock returns an empty GetDependencies mock.
+func defaultGraphMock() *mockGraphService {
+	return &mockGraphService{
+		getDeps: func(_ string) (*specv1.GetDependenciesResponse, error) {
+			return &specv1.GetDependenciesResponse{}, nil
+		},
+	}
+}
+
 // ---------------------------------------------------------------------------
 // TestSparkPrompt
 // ---------------------------------------------------------------------------
 
 func TestSparkPrompt_WithTopicAndContext(t *testing.T) {
-	c := &Client{Authoring: &mockAuthoringService{
-		getPrompts: func(req *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
-			require.Equal(t, specv1.AuthoringStage_AUTHORING_STAGE_SPARK, req.GetStage())
-			return &specv1.GetPromptsResponse{
-				Prompts: []*specv1.PromptTemplate{
-					{Stage: specv1.AuthoringStage_AUTHORING_STAGE_SPARK, Name: "spark", Template: "Generate a spec idea"},
-				},
-			}, nil
-		},
-	}}
+	c := newComposerClient(defaultConstitutionMock(), defaultSpecMock(""), defaultGraphMock())
 
 	r := NewRegistry()
 	RegisterPrompts(r, c)
-	prompts := r.Prompts()
 	var sparkDef *PromptDef
-	for i := range prompts {
-		if prompts[i].Name == "spark" {
-			sparkDef = &prompts[i]
+	for i := range r.Prompts() {
+		if r.Prompts()[i].Name == "spark" {
+			d := r.Prompts()[i]
+			sparkDef = &d
 			break
 		}
 	}
@@ -49,29 +86,22 @@ func TestSparkPrompt_WithTopicAndContext(t *testing.T) {
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.Messages)
 	require.Equal(t, "user", result.Messages[0].Role)
-	require.Contains(t, result.Messages[0].Content, "Generate a spec idea")
+	// Composer produces rich content — verify stage marker and topic appendix.
+	require.Contains(t, result.Messages[0].Content, "# Persona")
 	require.Contains(t, result.Messages[0].Content, "OAuth token rotation")
 	require.Contains(t, result.Messages[0].Content, "Used by mobile apps")
 }
 
 func TestSparkPrompt_TopicOnly(t *testing.T) {
-	c := &Client{Authoring: &mockAuthoringService{
-		getPrompts: func(_ *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
-			return &specv1.GetPromptsResponse{
-				Prompts: []*specv1.PromptTemplate{
-					{Template: "Spark template text"},
-				},
-			}, nil
-		},
-	}}
+	c := newComposerClient(defaultConstitutionMock(), defaultSpecMock(""), defaultGraphMock())
 
 	r := NewRegistry()
 	RegisterPrompts(r, c)
-	prompts := r.Prompts()
 	var sparkDef *PromptDef
-	for i := range prompts {
-		if prompts[i].Name == "spark" {
-			sparkDef = &prompts[i]
+	for i := range r.Prompts() {
+		if r.Prompts()[i].Name == "spark" {
+			d := r.Prompts()[i]
+			sparkDef = &d
 			break
 		}
 	}
@@ -83,52 +113,25 @@ func TestSparkPrompt_TopicOnly(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Contains(t, result.Messages[0].Content, "rate limiting")
-	// No context provided; should not contain "Context:" line
-	require.NotContains(t, result.Messages[0].Content, "Context:")
-}
-
-func TestSparkPrompt_NoTemplates(t *testing.T) {
-	c := &Client{Authoring: &mockAuthoringService{
-		getPrompts: func(_ *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
-			return &specv1.GetPromptsResponse{Prompts: nil}, nil
-		},
-	}}
-
-	r := NewRegistry()
-	RegisterPrompts(r, c)
-	prompts := r.Prompts()
-	var sparkDef *PromptDef
-	for i := range prompts {
-		if prompts[i].Name == "spark" {
-			sparkDef = &prompts[i]
-			break
-		}
-	}
-	require.NotNil(t, sparkDef)
-
-	result, err := sparkDef.Handler(context.Background(), map[string]string{
-		"topic": "something",
-	})
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.NotEmpty(t, result.Messages)
-	require.Contains(t, result.Messages[0].Content, "spark")
+	// No context provided; should not contain Additional Context section.
+	require.NotContains(t, result.Messages[0].Content, "# Additional Context")
 }
 
 func TestSparkPrompt_RPCError(t *testing.T) {
-	c := &Client{Authoring: &mockAuthoringService{
-		getPrompts: func(_ *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
+	constitutionMock := &mockConstitutionService{
+		getConstitution: func() (*specv1.GetConstitutionResponse, error) {
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("server error"))
 		},
-	}}
+	}
+	c := newComposerClient(constitutionMock, defaultSpecMock(""), defaultGraphMock())
 
 	r := NewRegistry()
 	RegisterPrompts(r, c)
-	prompts := r.Prompts()
 	var sparkDef *PromptDef
-	for i := range prompts {
-		if prompts[i].Name == "spark" {
-			sparkDef = &prompts[i]
+	for _, p := range r.Prompts() {
+		if p.Name == "spark" {
+			d := p
+			sparkDef = &d
 			break
 		}
 	}
@@ -143,24 +146,15 @@ func TestSparkPrompt_RPCError(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestShapePrompt(t *testing.T) {
-	c := &Client{Authoring: &mockAuthoringService{
-		getPrompts: func(req *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
-			require.Equal(t, specv1.AuthoringStage_AUTHORING_STAGE_SHAPE, req.GetStage())
-			return &specv1.GetPromptsResponse{
-				Prompts: []*specv1.PromptTemplate{
-					{Template: "Shape this spec into a problem statement"},
-				},
-			}, nil
-		},
-	}}
+	c := newComposerClient(defaultConstitutionMock(), defaultSpecMock("oauth-refresh"), defaultGraphMock())
 
 	r := NewRegistry()
 	RegisterPrompts(r, c)
-	prompts := r.Prompts()
 	var shapeDef *PromptDef
-	for i := range prompts {
-		if prompts[i].Name == "shape" {
-			shapeDef = &prompts[i]
+	for _, p := range r.Prompts() {
+		if p.Name == "shape" {
+			d := p
+			shapeDef = &d
 			break
 		}
 	}
@@ -172,23 +166,22 @@ func TestShapePrompt(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, "user", result.Messages[0].Role)
-	require.Contains(t, result.Messages[0].Content, "Shape this spec into a problem statement")
+	// Verify composer markers are present.
+	require.Contains(t, result.Messages[0].Content, "# Persona")
+	require.Contains(t, result.Messages[0].Content, "# Stage:")
 }
 
 func TestShapePrompt_NoTemplates(t *testing.T) {
-	c := &Client{Authoring: &mockAuthoringService{
-		getPrompts: func(_ *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
-			return &specv1.GetPromptsResponse{}, nil
-		},
-	}}
+	// Now delegates to composer — no "templates" concept. Verify round-trip succeeds.
+	c := newComposerClient(defaultConstitutionMock(), defaultSpecMock("oauth-refresh"), defaultGraphMock())
 
 	r := NewRegistry()
 	RegisterPrompts(r, c)
-	prompts := r.Prompts()
 	var shapeDef *PromptDef
-	for i := range prompts {
-		if prompts[i].Name == "shape" {
-			shapeDef = &prompts[i]
+	for _, p := range r.Prompts() {
+		if p.Name == "shape" {
+			d := p
+			shapeDef = &d
 			break
 		}
 	}
@@ -207,24 +200,15 @@ func TestShapePrompt_NoTemplates(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestSpecifyPrompt(t *testing.T) {
-	c := &Client{Authoring: &mockAuthoringService{
-		getPrompts: func(req *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
-			require.Equal(t, specv1.AuthoringStage_AUTHORING_STAGE_SPECIFY, req.GetStage())
-			return &specv1.GetPromptsResponse{
-				Prompts: []*specv1.PromptTemplate{
-					{Template: "Add full specification detail"},
-				},
-			}, nil
-		},
-	}}
+	c := newComposerClient(defaultConstitutionMock(), defaultSpecMock("oauth-refresh"), defaultGraphMock())
 
 	r := NewRegistry()
 	RegisterPrompts(r, c)
-	prompts := r.Prompts()
 	var specifyDef *PromptDef
-	for i := range prompts {
-		if prompts[i].Name == "specify" {
-			specifyDef = &prompts[i]
+	for _, p := range r.Prompts() {
+		if p.Name == "specify" {
+			d := p
+			specifyDef = &d
 			break
 		}
 	}
@@ -236,7 +220,8 @@ func TestSpecifyPrompt(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, "user", result.Messages[0].Role)
-	require.Contains(t, result.Messages[0].Content, "Add full specification detail")
+	require.Contains(t, result.Messages[0].Content, "# Persona")
+	require.Contains(t, result.Messages[0].Content, "# Stage:")
 }
 
 // ---------------------------------------------------------------------------
@@ -244,24 +229,15 @@ func TestSpecifyPrompt(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDecomposePrompt(t *testing.T) {
-	c := &Client{Authoring: &mockAuthoringService{
-		getPrompts: func(req *specv1.GetPromptsRequest) (*specv1.GetPromptsResponse, error) {
-			require.Equal(t, specv1.AuthoringStage_AUTHORING_STAGE_DECOMPOSE, req.GetStage())
-			return &specv1.GetPromptsResponse{
-				Prompts: []*specv1.PromptTemplate{
-					{Template: "Break into work slices"},
-				},
-			}, nil
-		},
-	}}
+	c := newComposerClient(defaultConstitutionMock(), defaultSpecMock("oauth-refresh"), defaultGraphMock())
 
 	r := NewRegistry()
 	RegisterPrompts(r, c)
-	prompts := r.Prompts()
 	var decomposeDef *PromptDef
-	for i := range prompts {
-		if prompts[i].Name == "decompose" {
-			decomposeDef = &prompts[i]
+	for _, p := range r.Prompts() {
+		if p.Name == "decompose" {
+			d := p
+			decomposeDef = &d
 			break
 		}
 	}
@@ -273,7 +249,8 @@ func TestDecomposePrompt(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, "user", result.Messages[0].Role)
-	require.Contains(t, result.Messages[0].Content, "Break into work slices")
+	require.Contains(t, result.Messages[0].Content, "# Persona")
+	require.Contains(t, result.Messages[0].Content, "# Stage:")
 }
 
 // ---------------------------------------------------------------------------
@@ -293,11 +270,11 @@ func TestConstitutionCheckPrompt(t *testing.T) {
 
 	r := NewRegistry()
 	RegisterPrompts(r, c)
-	prompts := r.Prompts()
 	var checkDef *PromptDef
-	for i := range prompts {
-		if prompts[i].Name == "constitution_check" {
-			checkDef = &prompts[i]
+	for _, p := range r.Prompts() {
+		if p.Name == "constitution_check" {
+			d := p
+			checkDef = &d
 			break
 		}
 	}
@@ -321,11 +298,11 @@ func TestConstitutionCheckPrompt_RPCError(t *testing.T) {
 
 	r := NewRegistry()
 	RegisterPrompts(r, c)
-	prompts := r.Prompts()
 	var checkDef *PromptDef
-	for i := range prompts {
-		if prompts[i].Name == "constitution_check" {
-			checkDef = &prompts[i]
+	for _, p := range r.Prompts() {
+		if p.Name == "constitution_check" {
+			d := p
+			checkDef = &d
 			break
 		}
 	}
@@ -354,11 +331,11 @@ func TestDependencyReviewPrompt(t *testing.T) {
 
 	r := NewRegistry()
 	RegisterPrompts(r, c)
-	prompts := r.Prompts()
 	var depDef *PromptDef
-	for i := range prompts {
-		if prompts[i].Name == "dependency_review" {
-			depDef = &prompts[i]
+	for _, p := range r.Prompts() {
+		if p.Name == "dependency_review" {
+			d := p
+			depDef = &d
 			break
 		}
 	}
@@ -402,13 +379,14 @@ func TestRegisterPrompts_Names(t *testing.T) {
 }
 
 func TestSparkPrompt_MissingTopic(t *testing.T) {
-	c := &Client{Authoring: &mockAuthoringService{}}
+	c := newComposerClient(defaultConstitutionMock(), defaultSpecMock(""), defaultGraphMock())
 	r := NewRegistry()
 	RegisterPrompts(r, c)
 	var sparkDef *PromptDef
 	for _, p := range r.Prompts() {
 		if p.Name == "spark" {
-			sparkDef = &p
+			d := p
+			sparkDef = &d
 			break
 		}
 	}
@@ -419,13 +397,14 @@ func TestSparkPrompt_MissingTopic(t *testing.T) {
 }
 
 func TestShapePrompt_MissingSpecSlug(t *testing.T) {
-	c := &Client{Authoring: &mockAuthoringService{}}
+	c := newComposerClient(defaultConstitutionMock(), defaultSpecMock(""), defaultGraphMock())
 	r := NewRegistry()
 	RegisterPrompts(r, c)
 	var shapeDef *PromptDef
 	for _, p := range r.Prompts() {
 		if p.Name == "shape" {
-			shapeDef = &p
+			d := p
+			shapeDef = &d
 			break
 		}
 	}
@@ -442,7 +421,8 @@ func TestConstitutionCheckPrompt_MissingSpecSlug(t *testing.T) {
 	var def *PromptDef
 	for _, p := range r.Prompts() {
 		if p.Name == "constitution_check" {
-			def = &p
+			d := p
+			def = &d
 			break
 		}
 	}

--- a/internal/mcp/prompts_test.go
+++ b/internal/mcp/prompts_test.go
@@ -69,9 +69,9 @@ func TestSparkPrompt_WithTopicAndContext(t *testing.T) {
 	r := NewRegistry()
 	RegisterPrompts(r, c)
 	var sparkDef *PromptDef
-	for i := range r.Prompts() {
-		if r.Prompts()[i].Name == "spark" {
-			d := r.Prompts()[i]
+	for _, p := range r.Prompts() {
+		if p.Name == "spark" {
+			d := p
 			sparkDef = &d
 			break
 		}
@@ -98,9 +98,9 @@ func TestSparkPrompt_TopicOnly(t *testing.T) {
 	r := NewRegistry()
 	RegisterPrompts(r, c)
 	var sparkDef *PromptDef
-	for i := range r.Prompts() {
-		if r.Prompts()[i].Name == "spark" {
-			d := r.Prompts()[i]
+	for _, p := range r.Prompts() {
+		if p.Name == "spark" {
+			d := p
 			sparkDef = &d
 			break
 		}
@@ -169,30 +169,6 @@ func TestShapePrompt(t *testing.T) {
 	// Verify composer markers are present.
 	require.Contains(t, result.Messages[0].Content, "# Persona")
 	require.Contains(t, result.Messages[0].Content, "# Stage:")
-}
-
-func TestShapePrompt_NoTemplates(t *testing.T) {
-	// Now delegates to composer — no "templates" concept. Verify round-trip succeeds.
-	c := newComposerClient(defaultConstitutionMock(), defaultSpecMock("oauth-refresh"), defaultGraphMock())
-
-	r := NewRegistry()
-	RegisterPrompts(r, c)
-	var shapeDef *PromptDef
-	for _, p := range r.Prompts() {
-		if p.Name == "shape" {
-			d := p
-			shapeDef = &d
-			break
-		}
-	}
-	require.NotNil(t, shapeDef)
-
-	result, err := shapeDef.Handler(context.Background(), map[string]string{
-		"spec_slug": "oauth-refresh",
-	})
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Contains(t, result.Messages[0].Content, "shape")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/mcp/prompts_test.go
+++ b/internal/mcp/prompts_test.go
@@ -90,6 +90,9 @@ func TestSparkPrompt_WithTopicAndContext(t *testing.T) {
 	require.Contains(t, result.Messages[0].Content, "# Persona")
 	require.Contains(t, result.Messages[0].Content, "OAuth token rotation")
 	require.Contains(t, result.Messages[0].Content, "Used by mobile apps")
+	// B.5: Assert the exact section headings are present with the supplied values.
+	require.Contains(t, result.Messages[0].Content, "# Topic\n\nOAuth token rotation")
+	require.Contains(t, result.Messages[0].Content, "# Additional Context\n\nUsed by mobile apps")
 }
 
 func TestSparkPrompt_TopicOnly(t *testing.T) {

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -216,20 +216,22 @@ func primeResourceHandler(c *Client) ResourceHandler {
 		}
 
 		if listResp, err := c.Spec.ListSpecs(ctx, connect.NewRequest(&specv1.ListSpecsRequest{})); err == nil {
-			b.WriteString("## Graph Overview\n\n")
-			counts := map[string]int{}
-			for _, s := range listResp.Msg.GetSpecs() {
-				counts[s.GetStage()]++
+			if len(listResp.Msg.GetSpecs()) > 0 {
+				b.WriteString("## Graph Overview\n\n")
+				counts := map[string]int{}
+				for _, s := range listResp.Msg.GetSpecs() {
+					counts[s.GetStage()]++
+				}
+				stages := make([]string, 0, len(counts))
+				for stage := range counts {
+					stages = append(stages, stage)
+				}
+				sort.Strings(stages)
+				for _, stage := range stages {
+					fmt.Fprintf(&b, "- %s: %d\n", stage, counts[stage])
+				}
+				b.WriteString("\n")
 			}
-			stages := make([]string, 0, len(counts))
-			for stage := range counts {
-				stages = append(stages, stage)
-			}
-			sort.Strings(stages)
-			for _, stage := range stages {
-				fmt.Fprintf(&b, "- %s: %d\n", stage, counts[stage])
-			}
-			b.WriteString("\n")
 		}
 
 		if readyResp, err := c.Graph.GetReady(ctx, connect.NewRequest(&specv1.GetReadyRequest{})); err == nil {

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -233,15 +233,17 @@ func primeResourceHandler(c *Client) ResourceHandler {
 		}
 
 		if readyResp, err := c.Graph.GetReady(ctx, connect.NewRequest(&specv1.GetReadyRequest{})); err == nil {
-			b.WriteString("## Ready to Work\n\n")
 			ready := readyResp.Msg.GetReady()
-			if len(ready) > 10 {
-				ready = ready[:10]
+			if len(ready) > 0 {
+				b.WriteString("## Ready to Work\n\n")
+				if len(ready) > 10 {
+					ready = ready[:10]
+				}
+				for _, s := range ready {
+					fmt.Fprintf(&b, "- `%s` (%s)\n", s.GetSlug(), s.GetStage())
+				}
+				b.WriteString("\nFull list at `specgraph://graph/ready`.\n\n")
 			}
-			for _, s := range ready {
-				fmt.Fprintf(&b, "- `%s` (%s)\n", s.GetSlug(), s.GetStage())
-			}
-			b.WriteString("\nFull list at `specgraph://graph/ready`.\n\n")
 		}
 
 		if findingsResp, err := c.AnalyticalPass.ListFindings(ctx, connect.NewRequest(&specv1.ListFindingsRequest{})); err == nil {

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -6,6 +6,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -182,7 +183,92 @@ func changesResourceHandler(c *Client) ResourceHandler {
 }
 
 // ---------------------------------------------------------------------------
-// RegisterResources adds all 9 MCP resources to the registry.
+// primeResourceHandler — specgraph://prime
+// ---------------------------------------------------------------------------
+
+// primeResourceHandler returns a session-priming digest in markdown. It
+// stitches together constitution summary, spec counts by stage, the top 10
+// ready specs, and open-findings counts by severity. Each section is
+// conditional: if the upstream RPC fails, that section is silently omitted so
+// partial connectivity still produces a useful digest.
+func primeResourceHandler(c *Client) ResourceHandler {
+	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
+		var b strings.Builder
+		b.WriteString("# SpecGraph Session Prime\n\n")
+
+		if conResp, err := c.Constitution.GetConstitution(ctx, connect.NewRequest(&specv1.GetConstitutionRequest{})); err == nil && conResp.Msg.GetConstitution() != nil {
+			con := conResp.Msg.GetConstitution()
+			b.WriteString("## Constitution\n\n")
+			if con.GetTech() != nil && con.GetTech().GetLanguages() != nil {
+				fmt.Fprintf(&b, "Primary language: %s\n\n", con.GetTech().GetLanguages().GetPrimary())
+			}
+			if cs := con.GetConstraints(); len(cs) > 0 {
+				top := cs
+				if len(top) > 5 {
+					top = top[:5]
+				}
+				b.WriteString("Top constraints:\n")
+				for _, constraint := range top {
+					fmt.Fprintf(&b, "- %s\n", constraint)
+				}
+				b.WriteString("\nFull at `specgraph://constitution`.\n\n")
+			}
+		}
+
+		if listResp, err := c.Spec.ListSpecs(ctx, connect.NewRequest(&specv1.ListSpecsRequest{})); err == nil {
+			b.WriteString("## Graph Overview\n\n")
+			counts := map[string]int{}
+			for _, s := range listResp.Msg.GetSpecs() {
+				counts[s.GetStage()]++
+			}
+			stages := make([]string, 0, len(counts))
+			for stage := range counts {
+				stages = append(stages, stage)
+			}
+			sort.Strings(stages)
+			for _, stage := range stages {
+				fmt.Fprintf(&b, "- %s: %d\n", stage, counts[stage])
+			}
+			b.WriteString("\n")
+		}
+
+		if readyResp, err := c.Graph.GetReady(ctx, connect.NewRequest(&specv1.GetReadyRequest{})); err == nil {
+			b.WriteString("## Ready to Work\n\n")
+			ready := readyResp.Msg.GetReady()
+			if len(ready) > 10 {
+				ready = ready[:10]
+			}
+			for _, s := range ready {
+				fmt.Fprintf(&b, "- `%s` (%s)\n", s.GetSlug(), s.GetStage())
+			}
+			b.WriteString("\nFull list at `specgraph://graph/ready`.\n\n")
+		}
+
+		if findingsResp, err := c.AnalyticalPass.ListFindings(ctx, connect.NewRequest(&specv1.ListFindingsRequest{})); err == nil {
+			counts := map[string]int{}
+			for _, f := range findingsResp.Msg.GetFindings() {
+				counts[f.GetSeverity().String()]++
+			}
+			if len(counts) > 0 {
+				b.WriteString("## Open Findings\n\n")
+				sevs := make([]string, 0, len(counts))
+				for sev := range counts {
+					sevs = append(sevs, sev)
+				}
+				sort.Strings(sevs)
+				for _, sev := range sevs {
+					fmt.Fprintf(&b, "- %s: %d\n", sev, counts[sev])
+				}
+				b.WriteString("\nFull at `specgraph://findings`.\n\n")
+			}
+		}
+
+		return []ResourceContent{{URI: uri, MimeType: "text/markdown", Text: b.String()}}, nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RegisterResources adds all 10 MCP resources to the registry.
 // ---------------------------------------------------------------------------
 
 // RegisterResources registers all SpecGraph MCP resources into r using the
@@ -260,5 +346,13 @@ func RegisterResources(r *Registry, c *Client) {
 		MimeType:    "application/json",
 		IsTemplate:  true,
 		Handler:     changesResourceHandler(c),
+	})
+	r.AddResource(ResourceDef{
+		URI:         "specgraph://prime",
+		Name:        "prime",
+		Description: "Session-priming digest: constitution summary, graph counts, ready specs, findings summary.",
+		MimeType:    "text/markdown",
+		IsTemplate:  false,
+		Handler:     primeResourceHandler(c),
 	})
 }

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -6,11 +6,13 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 
 	"connectrpc.com/connect"
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/authoring"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -188,15 +190,25 @@ func changesResourceHandler(c *Client) ResourceHandler {
 
 // primeResourceHandler returns a session-priming digest in markdown. It
 // stitches together constitution summary, spec counts by stage, the top 10
-// ready specs, and open-findings counts by severity. Each section is
-// conditional: if the upstream RPC fails, that section is silently omitted so
-// partial connectivity still produces a useful digest.
+// ready specs, and open-findings counts by severity. Each section renders
+// its heading unconditionally; RPC failures log a warning and render a
+// visible "_(unable to load: ...)_" marker under the heading so partial
+// connectivity is observable rather than silently degrading the digest.
 func primeResourceHandler(c *Client) ResourceHandler {
 	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
 		var b strings.Builder
 		b.WriteString("# SpecGraph Session Prime\n\n")
 
-		if conResp, err := c.Constitution.GetConstitution(ctx, connect.NewRequest(&specv1.GetConstitutionRequest{})); err == nil && conResp.Msg.GetConstitution() != nil {
+		conResp, err := c.Constitution.GetConstitution(ctx, connect.NewRequest(&specv1.GetConstitutionRequest{}))
+		switch {
+		case err != nil:
+			slog.WarnContext(ctx, "prime.section_failed",
+				slog.String("section", "constitution"),
+				slog.String("err", err.Error()))
+			b.WriteString("## Constitution\n\n_(unable to load: " + err.Error() + ")_\n\n")
+		case conResp.Msg.GetConstitution() == nil:
+			// No constitution configured — skip section silently. Distinct from RPC failure.
+		default:
 			con := conResp.Msg.GetConstitution()
 			b.WriteString("## Constitution\n\n")
 			if con.GetTech() != nil && con.GetTech().GetLanguages() != nil {
@@ -215,26 +227,45 @@ func primeResourceHandler(c *Client) ResourceHandler {
 			}
 		}
 
-		if listResp, err := c.Spec.ListSpecs(ctx, connect.NewRequest(&specv1.ListSpecsRequest{})); err == nil {
-			if len(listResp.Msg.GetSpecs()) > 0 {
-				b.WriteString("## Graph Overview\n\n")
-				counts := map[string]int{}
-				for _, s := range listResp.Msg.GetSpecs() {
-					counts[s.GetStage()]++
-				}
-				stages := make([]string, 0, len(counts))
-				for stage := range counts {
-					stages = append(stages, stage)
-				}
-				sort.Strings(stages)
-				for _, stage := range stages {
-					fmt.Fprintf(&b, "- %s: %d\n", stage, counts[stage])
-				}
-				b.WriteString("\n")
+		listResp, err := c.Spec.ListSpecs(ctx, connect.NewRequest(&specv1.ListSpecsRequest{}))
+		switch {
+		case err != nil:
+			slog.WarnContext(ctx, "prime.section_failed",
+				slog.String("section", "graph_overview"),
+				slog.String("err", err.Error()))
+			b.WriteString("## Graph Overview\n\n_(unable to load: " + err.Error() + ")_\n\n")
+		case len(listResp.Msg.GetSpecs()) > 0:
+			b.WriteString("## Graph Overview\n\n")
+			counts := map[string]int{}
+			for _, s := range listResp.Msg.GetSpecs() {
+				counts[s.GetStage()]++
 			}
+			// Render in funnel order, then any unexpected stages alphabetically.
+			for _, stage := range authoring.AllStages() {
+				if n, ok := counts[stage]; ok {
+					fmt.Fprintf(&b, "- %s: %d\n", stage, n)
+					delete(counts, stage)
+				}
+			}
+			leftover := make([]string, 0, len(counts))
+			for stage := range counts {
+				leftover = append(leftover, stage)
+			}
+			sort.Strings(leftover)
+			for _, stage := range leftover {
+				fmt.Fprintf(&b, "- %s: %d\n", stage, counts[stage])
+			}
+			b.WriteString("\n")
 		}
 
-		if readyResp, err := c.Graph.GetReady(ctx, connect.NewRequest(&specv1.GetReadyRequest{})); err == nil {
+		readyResp, err := c.Graph.GetReady(ctx, connect.NewRequest(&specv1.GetReadyRequest{}))
+		switch {
+		case err != nil:
+			slog.WarnContext(ctx, "prime.section_failed",
+				slog.String("section", "ready_to_work"),
+				slog.String("err", err.Error()))
+			b.WriteString("## Ready to Work\n\n_(unable to load: " + err.Error() + ")_\n\n")
+		default:
 			ready := readyResp.Msg.GetReady()
 			if len(ready) > 0 {
 				b.WriteString("## Ready to Work\n\n")
@@ -248,26 +279,50 @@ func primeResourceHandler(c *Client) ResourceHandler {
 			}
 		}
 
-		if findingsResp, err := c.AnalyticalPass.ListFindings(ctx, connect.NewRequest(&specv1.ListFindingsRequest{})); err == nil {
-			counts := map[string]int{}
+		findingsResp, err := c.AnalyticalPass.ListFindings(ctx, connect.NewRequest(&specv1.ListFindingsRequest{}))
+		switch {
+		case err != nil:
+			slog.WarnContext(ctx, "prime.section_failed",
+				slog.String("section", "open_findings"),
+				slog.String("err", err.Error()))
+			b.WriteString("## Open Findings\n\n_(unable to load: " + err.Error() + ")_\n\n")
+		default:
+			counts := map[specv1.FindingSeverity]int{}
 			for _, f := range findingsResp.Msg.GetFindings() {
-				counts[f.GetSeverity().String()]++
+				counts[f.GetSeverity()]++
 			}
 			if len(counts) > 0 {
 				b.WriteString("## Open Findings\n\n")
-				sevs := make([]string, 0, len(counts))
+				sevs := make([]specv1.FindingSeverity, 0, len(counts))
 				for sev := range counts {
 					sevs = append(sevs, sev)
 				}
-				sort.Strings(sevs)
+				sort.Slice(sevs, func(i, j int) bool {
+					return severityRank(sevs[i]) < severityRank(sevs[j])
+				})
 				for _, sev := range sevs {
-					fmt.Fprintf(&b, "- %s: %d\n", sev, counts[sev])
+					fmt.Fprintf(&b, "- %s: %d\n", sev.String(), counts[sev])
 				}
 				b.WriteString("\nFull at `specgraph://findings`.\n\n")
 			}
 		}
 
 		return []ResourceContent{{URI: uri, MimeType: "text/markdown", Text: b.String()}}, nil
+	}
+}
+
+// severityRank gives a display order for finding severities: critical first,
+// warning second, note third, anything else last. Lower rank renders earlier.
+func severityRank(s specv1.FindingSeverity) int {
+	switch s {
+	case specv1.FindingSeverity_FINDING_SEVERITY_CRITICAL:
+		return 0
+	case specv1.FindingSeverity_FINDING_SEVERITY_WARNING:
+		return 1
+	case specv1.FindingSeverity_FINDING_SEVERITY_NOTE:
+		return 2
+	default:
+		return 99
 	}
 }
 

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -6,6 +6,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -485,11 +486,145 @@ func TestPrimeResource_FindingsSection(t *testing.T) {
 	// B.3: Assert per-severity counts rendered by the handler (f.GetSeverity().String()).
 	require.Contains(t, text, "FINDING_SEVERITY_CRITICAL: 2")
 	require.Contains(t, text, "FINDING_SEVERITY_WARNING: 1")
-	// Failed sections must NOT leak into the digest — section-by-section
-	// tolerance is the property this test exists to verify.
-	require.NotContains(t, text, "## Constitution")
-	require.NotContains(t, text, "## Graph Overview")
-	require.NotContains(t, text, "## Ready to Work")
+	// Failed sections render visible error markers (behavior change from PR #924 fixup):
+	// each section heading IS present, followed by an unable-to-load line.
+	require.Contains(t, text, "## Constitution")
+	require.Contains(t, text, "## Graph Overview")
+	require.Contains(t, text, "## Ready to Work")
+	require.Contains(t, text, "(unable to load")
+}
+
+// TestPrimeResource_SeverityOrdering verifies findings are rendered
+// in CRITICAL → WARNING → NOTE order (not alphabetical).
+func TestPrimeResource_SeverityOrdering(t *testing.T) {
+	c := &Client{
+		Constitution: &mockConstitutionService{
+			getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+				return nil, fmt.Errorf("unavailable")
+			},
+		},
+		Spec: &mockSpecService{
+			listSpecs: func() (*specv1.ListSpecsResponse, error) {
+				return nil, fmt.Errorf("unavailable")
+			},
+		},
+		Graph: &mockGraphService{
+			getReady: func() (*specv1.GetReadyResponse, error) {
+				return nil, fmt.Errorf("unavailable")
+			},
+		},
+		AnalyticalPass: &mockAnalyticalPassService{
+			listFindings: func(_ string) (*specv1.ListFindingsResponse, error) {
+				return &specv1.ListFindingsResponse{
+					Findings: []*specv1.AnalyticalFinding{
+						{Id: "f1", Severity: specv1.FindingSeverity_FINDING_SEVERITY_NOTE},
+						{Id: "f2", Severity: specv1.FindingSeverity_FINDING_SEVERITY_CRITICAL},
+						{Id: "f3", Severity: specv1.FindingSeverity_FINDING_SEVERITY_WARNING},
+					},
+				}, nil
+			},
+		},
+	}
+
+	handler := primeResourceHandler(c)
+	contents, err := handler(context.Background(), "specgraph://prime")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+
+	text := contents[0].Text
+	// Severity ordering: critical findings should render before warnings, warnings before notes.
+	criticalIdx := strings.Index(text, "FINDING_SEVERITY_CRITICAL")
+	warningIdx := strings.Index(text, "FINDING_SEVERITY_WARNING")
+	noteIdx := strings.Index(text, "FINDING_SEVERITY_NOTE")
+	require.Greater(t, warningIdx, criticalIdx, "WARNING should appear after CRITICAL")
+	require.Greater(t, noteIdx, warningIdx, "NOTE should appear after WARNING")
+}
+
+// TestPrimeResource_StageOrdering verifies that funnel stages are rendered
+// in spark → shape → specify → decompose → approved order, not alphabetically.
+func TestPrimeResource_StageOrdering(t *testing.T) {
+	c := &Client{
+		Constitution: &mockConstitutionService{
+			getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+				return nil, fmt.Errorf("unavailable")
+			},
+		},
+		Spec: &mockSpecService{
+			listSpecs: func() (*specv1.ListSpecsResponse, error) {
+				return &specv1.ListSpecsResponse{
+					Specs: []*specv1.Spec{
+						{Slug: "spec-a", Stage: "spark"},
+						{Slug: "spec-b", Stage: "decompose"},
+						{Slug: "spec-c", Stage: "shape"},
+						{Slug: "spec-d", Stage: "specify"},
+					},
+				}, nil
+			},
+		},
+		Graph: &mockGraphService{
+			getReady: func() (*specv1.GetReadyResponse, error) {
+				return nil, fmt.Errorf("unavailable")
+			},
+		},
+		AnalyticalPass: defaultAnalyticalPassMock(),
+	}
+
+	handler := primeResourceHandler(c)
+	contents, err := handler(context.Background(), "specgraph://prime")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+
+	text := contents[0].Text
+	sparkIdx := strings.Index(text, "spark:")
+	shapeIdx := strings.Index(text, "shape:")
+	specifyIdx := strings.Index(text, "specify:")
+	decomposeIdx := strings.Index(text, "decompose:")
+	require.Greater(t, shapeIdx, sparkIdx, "shape should appear after spark")
+	require.Greater(t, specifyIdx, shapeIdx, "specify should appear after shape")
+	require.Greater(t, decomposeIdx, specifyIdx, "decompose should appear after specify")
+}
+
+// TestPrimeResource_RPCFailureRendersErrorMarker verifies that when an RPC fails
+// the section heading is still rendered with a visible error marker rather than
+// silently omitting the section.
+func TestPrimeResource_RPCFailureRendersErrorMarker(t *testing.T) {
+	c := &Client{
+		Constitution: &mockConstitutionService{
+			getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+				return nil, fmt.Errorf("backend connection refused")
+			},
+		},
+		Spec: &mockSpecService{
+			listSpecs: func() (*specv1.ListSpecsResponse, error) {
+				return nil, fmt.Errorf("backend connection refused")
+			},
+		},
+		Graph: &mockGraphService{
+			getReady: func() (*specv1.GetReadyResponse, error) {
+				return nil, fmt.Errorf("backend connection refused")
+			},
+		},
+		AnalyticalPass: &mockAnalyticalPassService{
+			listFindings: func(_ string) (*specv1.ListFindingsResponse, error) {
+				return nil, fmt.Errorf("backend connection refused")
+			},
+		},
+	}
+
+	handler := primeResourceHandler(c)
+	contents, err := handler(context.Background(), "specgraph://prime")
+	// The handler itself must not error — it returns the partial digest.
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+
+	text := contents[0].Text
+	// All four section headings must appear.
+	require.Contains(t, text, "## Constitution")
+	require.Contains(t, text, "## Graph Overview")
+	require.Contains(t, text, "## Ready to Work")
+	require.Contains(t, text, "## Open Findings")
+	// Failures are visible to the user.
+	require.Contains(t, text, "_(unable to load:")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -493,6 +493,45 @@ func TestPrimeResource_FindingsSection(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// C.1 — primeResourceHandler empty Graph Overview guard
+// ---------------------------------------------------------------------------
+
+// defaultAnalyticalPassMock returns a minimal ListFindings mock that returns no findings.
+func defaultAnalyticalPassMock() *mockAnalyticalPassService {
+	return &mockAnalyticalPassService{
+		listFindings: func(_ string) (*specv1.ListFindingsResponse, error) {
+			return &specv1.ListFindingsResponse{}, nil
+		},
+	}
+}
+
+// TestPrimeResource_EmptyGraphSkipped verifies that when ListSpecs succeeds but
+// returns an empty list, the "## Graph Overview" heading is NOT emitted.
+// The Ready and Findings sections were already guarded; Graph Overview must match.
+func TestPrimeResource_EmptyGraphSkipped(t *testing.T) {
+	c := &Client{
+		Constitution: defaultConstitutionMock(), // succeeds — header rendered
+		Spec: &mockSpecService{
+			listSpecs: func() (*specv1.ListSpecsResponse, error) {
+				return &specv1.ListSpecsResponse{}, nil // empty list, no error
+			},
+		},
+		Graph: &mockGraphService{
+			getReady: func() (*specv1.GetReadyResponse, error) {
+				return &specv1.GetReadyResponse{}, nil // also empty
+			},
+		},
+		AnalyticalPass: defaultAnalyticalPassMock(), // empty findings
+	}
+	content, err := primeResourceHandler(c)(context.Background(), "specgraph://prime")
+	require.NoError(t, err)
+	require.NotEmpty(t, content)
+	text := content[0].Text
+	require.NotContains(t, text, "## Graph Overview",
+		"Graph Overview heading should not render for empty spec list")
+}
+
+// ---------------------------------------------------------------------------
 // extractSlugFromURI tests
 // ---------------------------------------------------------------------------
 

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -438,6 +438,10 @@ func TestPrimeResource(t *testing.T) {
 	// Should reference the full resources
 	require.Contains(t, text, "specgraph://constitution")
 	require.Contains(t, text, "specgraph://graph/ready")
+	// B.3: Assert aggregated stage counts from the two specs in the fake.
+	// spec-a is stage "spark", spec-b is stage "shape" → each count 1.
+	require.Contains(t, text, "spark: 1")
+	require.Contains(t, text, "shape: 1")
 }
 
 func TestPrimeResource_FindingsSection(t *testing.T) {
@@ -478,6 +482,9 @@ func TestPrimeResource_FindingsSection(t *testing.T) {
 	text := contents[0].Text
 	require.Contains(t, text, "Open Findings")
 	require.Contains(t, text, "specgraph://findings")
+	// B.3: Assert per-severity counts rendered by the handler (f.GetSeverity().String()).
+	require.Contains(t, text, "FINDING_SEVERITY_CRITICAL: 2")
+	require.Contains(t, text, "FINDING_SEVERITY_WARNING: 1")
 	// Failed sections must NOT leak into the digest — section-by-section
 	// tolerance is the property this test exists to verify.
 	require.NotContains(t, text, "## Constitution")

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -478,6 +478,11 @@ func TestPrimeResource_FindingsSection(t *testing.T) {
 	text := contents[0].Text
 	require.Contains(t, text, "Open Findings")
 	require.Contains(t, text, "specgraph://findings")
+	// Failed sections must NOT leak into the digest — section-by-section
+	// tolerance is the property this test exists to verify.
+	require.NotContains(t, text, "## Constitution")
+	require.NotContains(t, text, "## Graph Overview")
+	require.NotContains(t, text, "## Ready to Work")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -348,7 +348,7 @@ func TestRegisterResources_Count(t *testing.T) {
 	c := &Client{}
 	r := NewRegistry()
 	RegisterResources(r, c)
-	require.Len(t, r.Resources(), 9)
+	require.Len(t, r.Resources(), 10)
 }
 
 func TestRegisterResources_Templates(t *testing.T) {
@@ -378,6 +378,106 @@ func TestRegisterResources_Templates(t *testing.T) {
 	require.True(t, exactURIs["specgraph://graph"], "graph exact URI missing")
 	require.True(t, exactURIs["specgraph://graph/ready"], "graph/ready exact URI missing")
 	require.True(t, exactURIs["specgraph://findings"], "findings exact URI missing")
+	require.True(t, exactURIs["specgraph://prime"], "prime exact URI missing")
+}
+
+// ---------------------------------------------------------------------------
+// primeResourceHandler tests
+// ---------------------------------------------------------------------------
+
+func TestPrimeResource(t *testing.T) {
+	c := &Client{
+		Constitution: &mockConstitutionService{
+			getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+				return &specv1.GetConstitutionResponse{
+					Constitution: &specv1.Constitution{
+						Constraints: []string{"no GPL", "no circular deps"},
+					},
+				}, nil
+			},
+		},
+		Spec: &mockSpecService{
+			listSpecs: func() (*specv1.ListSpecsResponse, error) {
+				return &specv1.ListSpecsResponse{
+					Specs: []*specv1.Spec{
+						{Slug: "spec-a", Stage: "spark"},
+						{Slug: "spec-b", Stage: "shape"},
+					},
+				}, nil
+			},
+		},
+		Graph: &mockGraphService{
+			getReady: func() (*specv1.GetReadyResponse, error) {
+				return &specv1.GetReadyResponse{
+					Ready: []*specv1.NodeRef{
+						{Slug: "spec-a", Stage: "spark"},
+					},
+				}, nil
+			},
+		},
+		AnalyticalPass: &mockAnalyticalPassService{
+			listFindings: func(_ string) (*specv1.ListFindingsResponse, error) {
+				return &specv1.ListFindingsResponse{}, nil
+			},
+		},
+	}
+
+	handler := primeResourceHandler(c)
+	contents, err := handler(context.Background(), "specgraph://prime")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+	require.Equal(t, "text/markdown", contents[0].MimeType)
+	require.Equal(t, "specgraph://prime", contents[0].URI)
+
+	text := contents[0].Text
+	for _, marker := range []string{"Constitution", "Graph", "Ready"} {
+		require.Contains(t, text, marker)
+	}
+	// Should contain constraint text
+	require.Contains(t, text, "no GPL")
+	// Should reference the full resources
+	require.Contains(t, text, "specgraph://constitution")
+	require.Contains(t, text, "specgraph://graph/ready")
+}
+
+func TestPrimeResource_FindingsSection(t *testing.T) {
+	c := &Client{
+		Constitution: &mockConstitutionService{
+			getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+				return nil, fmt.Errorf("unavailable")
+			},
+		},
+		Spec: &mockSpecService{
+			listSpecs: func() (*specv1.ListSpecsResponse, error) {
+				return nil, fmt.Errorf("unavailable")
+			},
+		},
+		Graph: &mockGraphService{
+			getReady: func() (*specv1.GetReadyResponse, error) {
+				return nil, fmt.Errorf("unavailable")
+			},
+		},
+		AnalyticalPass: &mockAnalyticalPassService{
+			listFindings: func(_ string) (*specv1.ListFindingsResponse, error) {
+				return &specv1.ListFindingsResponse{
+					Findings: []*specv1.AnalyticalFinding{
+						{Id: "f1", Severity: specv1.FindingSeverity_FINDING_SEVERITY_CRITICAL},
+						{Id: "f2", Severity: specv1.FindingSeverity_FINDING_SEVERITY_CRITICAL},
+						{Id: "f3", Severity: specv1.FindingSeverity_FINDING_SEVERITY_WARNING},
+					},
+				}, nil
+			},
+		},
+	}
+
+	handler := primeResourceHandler(c)
+	contents, err := handler(context.Background(), "specgraph://prime")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+
+	text := contents[0].Text
+	require.Contains(t, text, "Open Findings")
+	require.Contains(t, text, "specgraph://findings")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -13,8 +13,8 @@ import (
 func TestNewServer_AllToolsRegistered(t *testing.T) {
 	srv := NewServer(&Client{})
 	tools := srv.MCPServer().ListTools()
-	if len(tools) != 20 {
-		t.Errorf("total tool count = %d, want 20", len(tools))
+	if len(tools) != 21 {
+		t.Errorf("total tool count = %d, want 21", len(tools))
 	}
 }
 
@@ -26,8 +26,8 @@ func TestNewServer_ProfileToolSets(t *testing.T) {
 		want    int
 	}{
 		{ProfileCore, 7},
-		{ProfileAuthoring, 14},
-		{ProfileExecution, 20},
+		{ProfileAuthoring, 15},
+		{ProfileExecution, 21},
 	}
 
 	for _, tt := range tests {

--- a/internal/mcp/tools_authoring.go
+++ b/internal/mcp/tools_authoring.go
@@ -31,9 +31,9 @@ func RegisterAuthoringTools(r *Registry, c *Client) {
 			"Use when the client does not expose MCP prompts to users, or for mid-conversation re-entry into a stage.",
 		Profile: ProfileAuthoring,
 		Schema: objectSchema(props{
-			"stage":   stringProp("Stage: spark, shape, specify, decompose, approve"),
+			"stage":   stringProp("Stage", "spark", "shape", "specify", "decompose", "approve"),
 			"slug":    stringProp("Spec slug (required for shape/specify/decompose/approve; optional for spark)"),
-			"posture": stringProp("Posture: drive, partner, support"),
+			"posture": stringProp("Posture", "drive", "partner", "support"),
 		}, "stage"),
 		Handler: authoringStartStageHandler(c),
 	})

--- a/internal/mcp/tools_authoring.go
+++ b/internal/mcp/tools_authoring.go
@@ -10,6 +10,7 @@ import (
 
 	"connectrpc.com/connect"
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/authoring"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -23,6 +24,43 @@ func RegisterAuthoringTools(r *Registry, c *Client) {
 
 	apt := &analyticalPassTool{client: c}
 	r.AddTool(apt.def())
+
+	r.AddTool(ToolDef{
+		Name: "author.start_stage",
+		Description: "Returns composed stage guidance (persona + orchestration + stage-specific content + current state). " +
+			"Use when the client does not expose MCP prompts to users, or for mid-conversation re-entry into a stage.",
+		Profile: ProfileAuthoring,
+		Schema: objectSchema(props{
+			"stage":   stringProp("Stage: spark, shape, specify, decompose, approve"),
+			"slug":    stringProp("Spec slug (required for shape/specify/decompose/approve; optional for spark)"),
+			"posture": stringProp("Posture: drive, partner, support"),
+		}, "stage"),
+		Handler: authoringStartStageHandler(c),
+	})
+}
+
+// authoringStartStageHandler returns a ToolHandler that composes and returns stage guidance.
+func authoringStartStageHandler(c *Client) ToolHandler {
+	composer := authoring.NewComposer(&composerBackend{client: c})
+	return func(ctx context.Context, params map[string]any) (*ToolResult, error) {
+		stage := stringParam(params, "stage")
+		if stage == "" {
+			return errResult("stage is required (spark|shape|specify|decompose|approve)"), nil
+		}
+		slug := stringParam(params, "slug")
+		if stage != "spark" && slug == "" {
+			return errResult(fmt.Sprintf("slug is required for stage %s", stage)), nil
+		}
+		result, err := composer.ComposeStagePrompt(ctx, authoring.ComposeInput{
+			Stage:   authoring.Stage(stage),
+			Slug:    slug,
+			Posture: stringParam(params, "posture"),
+		})
+		if err != nil {
+			return errResult(fmt.Sprintf("compose: %v", err)), nil
+		}
+		return &ToolResult{Content: []Content{{Type: "text", Text: result.Body}}}, nil
+	}
 }
 
 // validateOptionalPosture checks that a non-empty posture string maps to a known enum.

--- a/internal/mcp/tools_authoring_test.go
+++ b/internal/mcp/tools_authoring_test.go
@@ -833,6 +833,77 @@ func TestAnalyticalPassTool_UnknownAction(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// author.start_stage tool tests
+// ---------------------------------------------------------------------------
+
+func TestAuthoringStartStageTool(t *testing.T) {
+	c := newComposerClient(defaultConstitutionMock(), defaultSpecMock("test-slug"), defaultGraphMock())
+	reg := NewRegistry()
+	RegisterAuthoringTools(reg, c)
+
+	tool, ok := reg.LookupTool("author.start_stage")
+	require.True(t, ok, "author.start_stage not registered")
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"stage": "shape",
+		"slug":  "test-slug",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError, "expected no error result, got %+v", result)
+	require.NotEmpty(t, result.Content)
+	require.Contains(t, result.Content[0].Text, "# Shape")
+}
+
+func TestAuthoringStartStageTool_MissingStage(t *testing.T) {
+	c := newComposerClient(defaultConstitutionMock(), defaultSpecMock(""), defaultGraphMock())
+	reg := NewRegistry()
+	RegisterAuthoringTools(reg, c)
+
+	tool, ok := reg.LookupTool("author.start_stage")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"slug": "test-slug",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "stage is required")
+}
+
+func TestAuthoringStartStageTool_MissingSlugForNonSpark(t *testing.T) {
+	c := newComposerClient(defaultConstitutionMock(), defaultSpecMock(""), defaultGraphMock())
+	reg := NewRegistry()
+	RegisterAuthoringTools(reg, c)
+
+	tool, ok := reg.LookupTool("author.start_stage")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"stage": "shape",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].Text, "slug is required")
+}
+
+func TestAuthoringStartStageTool_SparkNoSlug(t *testing.T) {
+	c := newComposerClient(defaultConstitutionMock(), defaultSpecMock(""), defaultGraphMock())
+	reg := NewRegistry()
+	RegisterAuthoringTools(reg, c)
+
+	tool, ok := reg.LookupTool("author.start_stage")
+	require.True(t, ok)
+
+	result, err := tool.Handler(context.Background(), map[string]any{
+		"stage": "spark",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError, "spark without slug should succeed, got %+v", result)
+	require.NotEmpty(t, result.Content)
+	require.Contains(t, result.Content[0].Text, "# Persona")
+}
+
+// ---------------------------------------------------------------------------
 // enum helper tests
 // ---------------------------------------------------------------------------
 

--- a/internal/mcp/tools_authoring_test.go
+++ b/internal/mcp/tools_authoring_test.go
@@ -852,6 +852,10 @@ func TestAuthoringStartStageTool(t *testing.T) {
 	require.False(t, result.IsError, "expected no error result, got %+v", result)
 	require.NotEmpty(t, result.Content)
 	require.Contains(t, result.Content[0].Text, "# Shape")
+	// B.6: The dynamic state block must reflect the slug supplied.
+	// defaultSpecMock("test-slug") returns Slug="test-slug", so the composer renders
+	// "**Spec test-slug**" in the current state section.
+	require.Contains(t, result.Content[0].Text, "**Spec test-slug**")
 }
 
 func TestAuthoringStartStageTool_MissingStage(t *testing.T) {

--- a/internal/server/analytical_pass_handler.go
+++ b/internal/server/analytical_pass_handler.go
@@ -71,8 +71,9 @@ func (h *AnalyticalPassHandler) RunAnalyticalPass(ctx context.Context, req *conn
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 
-	stage := spec.Stage
-	offered := authoring.OfferedPasses(stage, authoring.PostureDrive)
+	// Lifecycle stages return empty Stage; OfferedPasses returns nil for unknown.
+	authoringStage, _ := authoring.StageFromStorage(spec.Stage)
+	offered := authoring.OfferedPasses(authoringStage, authoring.PostureDrive)
 
 	return connect.NewResponse(&specv1.RunAnalyticalPassResponse{
 		PassType:       msg.PassType,

--- a/internal/server/authoring_handler.go
+++ b/internal/server/authoring_handler.go
@@ -636,7 +636,9 @@ func (h *AuthoringHandler) GetPrompts(_ context.Context, req *connect.Request[sp
 	if req.Msg.Stage == specv1.AuthoringStage_AUTHORING_STAGE_APPROVED {
 		return connect.NewResponse(&specv1.GetPromptsResponse{}), nil
 	}
-	prompts := promptsToProto(stage)
+	// Direct coercion is safe: stage came from protoToStage, which only
+	// contains valid funnel stage values.
+	prompts := promptsToProto(authoring.Stage(stage))
 	if len(prompts) == 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("no prompts defined for stage %q", stage))
 	}
@@ -1042,7 +1044,10 @@ func decomposeOutputToDomain(p *specv1.DecomposeOutput) (*storage.DecomposeOutpu
 
 // stageToProto delegates to the canonical mapping in authoring_convert.go.
 func stageToProto(stage storage.SpecStage) specv1.AuthoringStage {
-	return authoringStageToProto(stage)
+	// Direct coercion is safe here: stageToProto is only called with values
+	// returned from successful storage.TransitionStage calls, which always
+	// return one of the funnel stages.
+	return authoringStageToProto(authoring.Stage(stage))
 }
 
 var protoToStage = map[specv1.AuthoringStage]storage.SpecStage{


### PR DESCRIPTION
## Summary

Wires the `internal/authoring.Composer` (shipped in Slice 3, PR #922) into the MCP delivery surfaces — prompts, tools, and resources — so MCP clients receive rich composed content instead of thin templates. Also adds the platform-identifier plumbing (`ProfileFromClientInfo` extensions + contract tests) needed for Slice 5's thin-plugin cutover.

This is Phase B Slice 4 of the multi-platform plugin plan (`docs/plans/2026-04-20-multi-platform-plugin-plan.md`, tasks 26–30). It also absorbs the Slice 3 review carry-overs that were deferred until the composer had real callers.

## Tasks shipped

- **Task 26** — composer adapter (`internal/mcp/composer_adapter.go`) + delegate `stagePromptHandler`/`sparkPromptHandler` to the composer. Updates `prompts_test.go` to assert composer markers.
- **Task 27** — `author.start_stage` MCP tool, always registered on the authoring profile. Same composed content as prompts, for clients that don't expose prompts to the LLM (opencode/codex).
- **Task 28** — `specgraph://prime` MCP resource. Markdown digest: constitution summary, spec counts by stage, top 10 ready, findings by severity. Sorted for deterministic output.
- **Task 29** — extend `ProfileFromClientInfo` to map `opencode` and `codex` client names to `ProfileAuthoring`.
- **Task 30** — `TestClientIDContract` documenting expected `clientInfo.name` per platform with a clear migration message on regression.

## Carry-overs from Slice 3 (PR #922) absorbed

- **Typed `Stage` and `Relationship`** at the composer boundary (`ComposeInput.Stage`, `RelatedSpec.Relationship`) — consolidates with the existing `storage.SpecStage` alias rather than introducing a parallel string type.
- **`authoring.ErrSpecNotFound` sentinel** with documented soft-miss contract on `ComposerBackend`. Adapter maps `connect.CodeNotFound` from the underlying `Spec.GetSpec` RPC to the sentinel; composer treats it as soft-miss (compose succeeds, spec block skipped). Other errors still fail compose.
- **Render-branch coverage**: tests for `PriorStageSummary`, multi-related-specs, nil-constitution skip, and invalid-stage error format.

## Review-fix history (in-PR)

Two issues caught in per-task code review and fixed before opening:

- `lsmn` — adapter only mapped the nil-Spec branch on `GetSpec`, but the real server returns `connect.CodeNotFound`. Without the mapping the soft-miss path was dead in production.
- `rlqs` — `TestPrimeResource_FindingsSection` only asserted findings appeared; didn't assert excluded sections were absent. The negative `NotContains` assertions now make the section-tolerance property the test is named for actually verifiable.

## Deferred to Slice 5

These were flagged as low-priority during Slice 3 review and remain deferred (no composer functional impact):

- Drift-test camelCase tightening (Task 25 follow-up)
- Visible truncation marker in prompt body
- Tighter golden-file budgets after truncation is counted
- \`PrimaryLanguage\` polyglot concern
- \`Posture\` wiring into prompt body

## Test plan

- [x] \`task check\` green (build, lint, fmt, license, race-enabled unit tests)
- [ ] \`task pr-prep\` (integration + e2e — being run after PR creation)
- [x] New unit tests pass for each task — composer adapter (4 cases incl. \`CodeNotFound\` mapping), \`author.start_stage\` (4 cases incl. validation paths), \`specgraph://prime\` (2 cases incl. section tolerance), \`ProfileFromClientInfo\` (opencode + codex rows added to existing table), \`TestClientIDContract\` (7 platforms)
- [x] No proto regeneration; no changes under \`gen/\` or \`proto/\`
- [x] DCO trailers present on all 10 commits
- [ ] CodeRabbit + \`/pr-review-toolkit:review-pr\` after creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)