### PR TITLE
chore(spgr-7htb): dogfood — initialize this repo via 'specgraph init'

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,11 +1,11 @@
 {
   "mcpServers": {
     "specgraph": {
-      "url": "http://127.0.0.1:7890/mcp/",
       "headers": {
         "Authorization": "Bearer ${env:SPECGRAPH_API_KEY}",
         "X-Specgraph-Project": "specgraph"
-      }
+      },
+      "url": "http://127.0.0.1:7890/mcp/"
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,12 +1,12 @@
 {
   "mcpServers": {
     "specgraph": {
-      "type": "http",
-      "url": "http://127.0.0.1:7890/mcp/",
       "headers": {
         "Authorization": "Bearer ${SPECGRAPH_API_KEY}",
         "X-Specgraph-Project": "specgraph"
-      }
+      },
+      "type": "http",
+      "url": "http://127.0.0.1:7890/mcp/"
     }
   }
 }

--- a/.specgraph.yaml
+++ b/.specgraph.yaml
@@ -1,0 +1,1 @@
+project: specgraph

--- a/cmd/specgraph/dogfood_test.go
+++ b/cmd/specgraph/dogfood_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/config/mcpconfigs"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDogfood_CheckedInConfigsAreCanonical guards the spgr-7htb dogfood
+// cutover: the three managed MCP config files at the repo root must stay
+// in the canonical form Sync produces from the SpecGraph dogfood slug +
+// server URL. A future change to ManagedConfigs (key shape, env-var syntax,
+// harness-specific fields) or a manual edit that drifts a file from
+// canonical would silently bit-rot the committed configs until someone
+// re-ran specgraph init manually; this test fails loud instead.
+//
+// The slug + URL constants below are the ground truth for this repo and are
+// independent of the contributor's global config — the test must NOT depend
+// on ~/.config/specgraph/config.yaml because CI agents may have a different
+// or absent default. .specgraph.yaml deliberately omits a `server:` field
+// (its presence would break startFakeServer-using tests by overriding the
+// fake server URL via ProjectConfig.Server), so the dogfood URL is pinned
+// here in the test instead.
+//
+// Implementation: copy the three checked-in files into a temp dir and run
+// Sync there. If everything is already canonical, all three actions are
+// no-op. The temp-dir copy keeps Sync read-only against the working tree.
+func TestDogfood_CheckedInConfigsAreCanonical(t *testing.T) {
+	const (
+		dogfoodSlug      = "specgraph"
+		dogfoodServerURL = "http://127.0.0.1:7890"
+	)
+
+	root, err := config.FindProjectRoot(".")
+	require.NoError(t, err, "find project root from cmd/specgraph")
+
+	pc, err := config.LoadProject(root)
+	require.NoError(t, err, "load .specgraph.yaml")
+	require.Equal(t, dogfoodSlug, pc.Slug, ".specgraph.yaml slug should be %q", dogfoodSlug)
+
+	managedPaths := []string{".cursor/mcp.json", ".mcp.json", "opencode.json"}
+	tmp := t.TempDir()
+	for _, p := range managedPaths {
+		src := filepath.Join(root, p)
+		dst := filepath.Join(tmp, p)
+		require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0o755), "mkdir %s", filepath.Dir(dst)) //nolint:gosec // 0755 is intentional for test fixture dirs
+		data, readErr := os.ReadFile(src)
+		require.NoError(t, readErr, "read checked-in %s", p)
+		require.NoError(t, os.WriteFile(dst, data, 0o600), "write fixture %s", dst) //nolint:gosec // dst is t.TempDir() joined with a literal path
+	}
+
+	configs := mcpconfigs.ManagedConfigs(dogfoodSlug, dogfoodServerURL)
+	results, err := mcpconfigs.Sync(tmp, configs)
+	require.NoError(t, err, "Sync against fixture copy")
+
+	// Guard against ManagedConfigs accidentally dropping a managed file —
+	// without this the loop would iterate over fewer results and silently
+	// skip canonical-form checks for the missing path. If this fails,
+	// either managedPaths above is stale or ManagedConfigs lost an entry.
+	require.Len(t, results, len(managedPaths),
+		"expected one result per managed path; ManagedConfigs returned a different set")
+
+	for _, r := range results {
+		if r.Action != mcpconfigs.ActionNoOp {
+			t.Errorf("checked-in %s drifted from canonical form: action = %q, want %q. "+
+				"Run `specgraph init specgraph` from the repo root to re-canonicalize.",
+				r.Path, r.Action, mcpconfigs.ActionNoOp)
+		}
+	}
+}

--- a/cmd/specgraph/lifecycle_test.go
+++ b/cmd/specgraph/lifecycle_test.go
@@ -7,10 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -177,21 +173,11 @@ func TestRunDriftAck_CannotSpecifyBoth(t *testing.T) {
 }
 
 // startFakeLifecycleServer registers handler with a fresh httptest.Server and
-// sets cfgFile to point at it.
+// sets cfgFile to point at it. Mirrors startFakeSpecServer / startFakeGraphServer /
+// etc. — see test_helpers_test.go for the dual-schema cfgFile rationale.
 func startFakeLifecycleServer(t *testing.T, h specgraphv1connect.LifecycleServiceHandler) {
 	t.Helper()
-	mux := http.NewServeMux()
-	path, hnd := specgraphv1connect.NewLifecycleServiceHandler(h)
-	mux.Handle(path, hnd)
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-
-	cfgDir := t.TempDir()
-	cfgPath := filepath.Join(cfgDir, "config.yaml")
-	require.NoError(t, os.WriteFile(cfgPath, []byte(fmt.Sprintf("server:\n  remote: %s\n", srv.URL)), 0o600))
-	old := cfgFile
-	cfgFile = cfgPath
-	t.Cleanup(func() { cfgFile = old })
+	startFakeServer[specgraphv1connect.LifecycleServiceHandler](t, h, specgraphv1connect.NewLifecycleServiceHandler)
 }
 
 // --- happy-path fake handlers ---

--- a/cmd/specgraph/read_mcp_resource_test.go
+++ b/cmd/specgraph/read_mcp_resource_test.go
@@ -34,7 +34,9 @@ func TestReadMCPResource_Prime(t *testing.T) {
 
 	cfgDir := t.TempDir()
 	cfgPath := filepath.Join(cfgDir, "config.yaml")
-	body := fmt.Sprintf("server:\n  remote: %s\n", srv.URL)
+	// Write both the new (client.default_server) and legacy (server.remote)
+	// schemas — see test_helpers_test.go for rationale.
+	body := fmt.Sprintf("client:\n  default_server: %s\nserver:\n  remote: %s\n", srv.URL, srv.URL)
 	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}

--- a/cmd/specgraph/status_test.go
+++ b/cmd/specgraph/status_test.go
@@ -71,7 +71,9 @@ func TestRunStatus_NotRunning(t *testing.T) {
 	// Point at a URL where nothing is listening — triggers the net.Error branch.
 	cfgDir := t.TempDir()
 	cfgPath := filepath.Join(cfgDir, "config.yaml")
-	require.NoError(t, os.WriteFile(cfgPath, []byte("server:\n  remote: http://127.0.0.1:1\n"), 0o600))
+	// Write both the new (client.default_server) and legacy (server.remote)
+	// schemas — see test_helpers_test.go for rationale.
+	require.NoError(t, os.WriteFile(cfgPath, []byte("client:\n  default_server: http://127.0.0.1:1\nserver:\n  remote: http://127.0.0.1:1\n"), 0o600))
 	old := cfgFile
 	cfgFile = cfgPath
 	t.Cleanup(func() { cfgFile = old })

--- a/cmd/specgraph/sync_test.go
+++ b/cmd/specgraph/sync_test.go
@@ -6,6 +6,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -69,14 +71,26 @@ func TestInjectCmd_ToolAliases(t *testing.T) {
 		{"CLAUDE-CODE", false},
 	}
 
+	// Point cfgFile at a dead port so runInject errors with a controlled
+	// "connection refused" rather than dialing the contributor's real
+	// server (post-spgr-7htb dogfood, .specgraph.yaml exists at the repo
+	// root, so resolveBaseURL takes the new path and otherwise reads the
+	// user's ~/.config/specgraph/config.yaml).
+	oldCfgFile := cfgFile
+	cfgDir := t.TempDir()
+	cfgPath := filepath.Join(cfgDir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("client:\n  default_server: http://127.0.0.1:1\nserver:\n  remote: http://127.0.0.1:1\n"), 0o600))
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = oldCfgFile })
+
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			old := injectTool
 			defer func() { injectTool = old }()
 			injectTool = tt.input
 
-			err := runInject(injectCmd, []string{"test-slug"})
-			require.Error(t, err, "runInject should error (no server running)")
+			err := runInject(newCmdWithCtx(), []string{"test-slug"})
+			require.Error(t, err, "runInject should error (no server reachable)")
 			if tt.wantErr {
 				assert.Contains(t, err.Error(), "unsupported tool")
 			} else {

--- a/cmd/specgraph/test_helpers_test.go
+++ b/cmd/specgraph/test_helpers_test.go
@@ -32,7 +32,18 @@ func startFakeServer[H any](t *testing.T, h H, register func(H, ...connect.Handl
 
 	cfgDir := t.TempDir()
 	cfgPath := filepath.Join(cfgDir, "config.yaml")
-	require.NoError(t, os.WriteFile(cfgPath, []byte(fmt.Sprintf("server:\n  remote: %s\n", srv.URL)), 0o600))
+	// Write BOTH the current and legacy global-config schemas to the same
+	// file. resolveBaseURL takes one of two paths depending on whether a
+	// .specgraph.yaml is found upstack:
+	//   - new path: reads client.default_server via loadGlobalCfg.
+	//   - legacy path (no .specgraph.yaml): reads server.remote via
+	//     config.Load(legacyConfigPath()).
+	// Tests that Chdir into a temp dir (e.g. constitution-emit path-traversal)
+	// follow the legacy path; tests that run from the worktree root follow
+	// the new path (this repo ships a .specgraph.yaml at the root). Writing
+	// both keys keeps both paths pointed at srv.URL.
+	cfgYAML := fmt.Sprintf("client:\n  default_server: %s\nserver:\n  remote: %s\n", srv.URL, srv.URL)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgYAML), 0o600))
 	old := cfgFile
 	cfgFile = cfgPath
 	t.Cleanup(func() { cfgFile = old })

--- a/opencode.json
+++ b/opencode.json
@@ -2,13 +2,13 @@
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
     "specgraph": {
-      "type": "remote",
-      "url": "http://127.0.0.1:7890/mcp/",
       "enabled": true,
       "headers": {
         "Authorization": "Bearer {env:SPECGRAPH_API_KEY}",
         "X-Specgraph-Project": "specgraph"
-      }
+      },
+      "type": "remote",
+      "url": "http://127.0.0.1:7890/mcp/"
     }
   }
 }


### PR DESCRIPTION
## Summary

Completes the deferred work referenced in spgr-7htb's design doc as "Task 38 dogfood cutover": runs `specgraph init specgraph` against this repo, retiring the hand-maintained MCP configs in favor of init-generated ones. Two-commit stack:

1. `test(cli): write both new and legacy global-config schemas in fake-server helpers` — prerequisite test-helper fix.
2. `chore(spgr-7htb): dogfood — initialize this repo via 'specgraph init'` — the actual cutover.

## What changed

### Dogfood commit
- `.specgraph.yaml`: new file with `project: specgraph`. Pinning the slug here prevents `specgraph init` from deriving a wrong one from the worktree dirname (e.g. `cursor-plugin` in jj workspaces).
- `.cursor/mcp.json`, `.mcp.json`, `opencode.json`: re-emitted in canonical form (alphabetic key order, 2-space indent, trailing newline). **Data is byte-equivalent** to the prior hand-maintained content; only the order of keys within each `specgraph` server entry changed (canonicalization moves `headers` before `url`, and `type` before `url` for Claude Code and OpenCode).

### Test-helper commit
- `cmd/specgraph/test_helpers_test.go`, `lifecycle_test.go`, `read_mcp_resource_test.go`, `status_test.go`: write both `client.default_server` (new schema) and `server.remote` (legacy schema) to the same `cfgFile`. `resolveBaseURL` takes one of two paths depending on whether `.specgraph.yaml` is found upstack — without `.specgraph.yaml` (pre-cutover) tests took the legacy path; once `.specgraph.yaml` lands every test would silently fall through to the `9090` default and dial-refused.
- `cmd/specgraph/sync_test.go`: `TestInjectCmd_ToolAliases` uses `newCmdWithCtx()` so a refused connection produces a `connection refused` error rather than panicking inside connect on a nil context.

This is a **no-op in isolation** (tests already passed without it) but a prerequisite for the dogfood cutover.

## Verification

- `specgraph init specgraph` first run: three files report `updated`, banner printed.
- `specgraph init specgraph` second run: three files report `no-op`, no banner (`.specgraph.yaml` already exists).
- `task check`: PASS.

## Why two commits

Bisect-safe and review-friendly. The test-helper commit is a no-op against the current main (it just adds redundant schema lines that were never read). The dogfood commit then becomes a clean diff focused on what actually changes for users.

Closes the "Task 38 dogfood cutover" follow-up to spgr-7htb. The Codex (Task 36) follow-up is still independently deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)