### PR TITLE
fix(mcp): friendlier empty-state rendering in prime resource

### DIFF
--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -201,6 +201,11 @@ func primeResourceHandler(c *Client) ResourceHandler {
 
 		conResp, err := c.Constitution.GetConstitution(ctx, connect.NewRequest(&specv1.GetConstitutionRequest{}))
 		switch {
+		case err != nil && connect.CodeOf(err) == connect.CodeNotFound:
+			// Expected empty state on fresh projects: no constitution defined.
+			// Render a heading + hint so the agent knows the slot exists and
+			// how to populate it, rather than treating it as an RPC failure.
+			b.WriteString("## Constitution\n\n_No constitution configured. Run `specgraph constitution set` to define project ground truth._\n\n")
 		case err != nil:
 			slog.WarnContext(ctx, "prime.section_failed",
 				slog.String("section", "constitution"),
@@ -281,6 +286,11 @@ func primeResourceHandler(c *Client) ResourceHandler {
 
 		findingsResp, err := c.AnalyticalPass.ListFindings(ctx, connect.NewRequest(&specv1.ListFindingsRequest{}))
 		switch {
+		case err != nil && connect.CodeOf(err) == connect.CodeInvalidArgument:
+			// ListFindings currently requires a per-spec slug; the prime
+			// composer wants project-wide findings but has no project-scoped
+			// query yet. Skip silently rather than render a confusing "slug
+			// is required" error to the agent. Tracked: spgr-vabz.
 		case err != nil:
 			slog.WarnContext(ctx, "prime.section_failed",
 				slog.String("section", "open_findings"),

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -666,6 +666,62 @@ func TestPrimeResource_EmptyGraphSkipped(t *testing.T) {
 		"Graph Overview heading should not render for empty spec list")
 }
 
+// TestPrimeResource_ConstitutionNotFound_RendersHint verifies that when
+// GetConstitution fails with connect.CodeNotFound (the expected fresh-project
+// state), the prime body renders a heading + actionable hint instead of the
+// loud "_(unable to load: ...)_" marker reserved for genuine RPC failures.
+func TestPrimeResource_ConstitutionNotFound_RendersHint(t *testing.T) {
+	c := &Client{
+		Constitution: &mockConstitutionService{
+			getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+				return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("constitution not found"))
+			},
+		},
+		Spec:           &mockSpecService{listSpecs: func() (*specv1.ListSpecsResponse, error) { return &specv1.ListSpecsResponse{}, nil }},
+		Graph:          &mockGraphService{getReady: func() (*specv1.GetReadyResponse, error) { return &specv1.GetReadyResponse{}, nil }},
+		AnalyticalPass: defaultAnalyticalPassMock(),
+	}
+
+	content, err := primeResourceHandler(c)(context.Background(), "specgraph://prime")
+	require.NoError(t, err)
+	require.NotEmpty(t, content)
+	text := content[0].Text
+
+	require.Contains(t, text, "## Constitution",
+		"Constitution heading should render so the agent knows the slot exists")
+	require.Contains(t, text, "specgraph constitution set",
+		"NotFound state should hint at the command that populates the constitution")
+	require.NotContains(t, text, "unable to load",
+		"NotFound is an expected empty state, not an RPC failure")
+}
+
+// TestPrimeResource_FindingsInvalidArgument_SkippedSilently verifies that the
+// prime body skips the Open Findings section entirely when ListFindings
+// returns InvalidArgument (the current "slug is required" surface — tracked
+// in spgr-vabz). Other RPC failure modes still render the loud marker.
+func TestPrimeResource_FindingsInvalidArgument_SkippedSilently(t *testing.T) {
+	c := &Client{
+		Constitution: defaultConstitutionMock(),
+		Spec:         &mockSpecService{listSpecs: func() (*specv1.ListSpecsResponse, error) { return &specv1.ListSpecsResponse{}, nil }},
+		Graph:        &mockGraphService{getReady: func() (*specv1.GetReadyResponse, error) { return &specv1.GetReadyResponse{}, nil }},
+		AnalyticalPass: &mockAnalyticalPassService{
+			listFindings: func(_ string) (*specv1.ListFindingsResponse, error) {
+				return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("slug is required"))
+			},
+		},
+	}
+
+	content, err := primeResourceHandler(c)(context.Background(), "specgraph://prime")
+	require.NoError(t, err)
+	require.NotEmpty(t, content)
+	text := content[0].Text
+
+	require.NotContains(t, text, "## Open Findings",
+		"InvalidArgument is the spgr-vabz interim state; render nothing rather than a confusing 'slug is required' error")
+	require.NotContains(t, text, "slug is required",
+		"raw error message must not surface to the agent")
+}
+
 // ---------------------------------------------------------------------------
 // extractSlugFromURI tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two cases the prime composer was treating as RPC failures are actually expected empty / interim states. Render them gracefully instead of as loud `_(unable to load: ...)_` markers — what motivated this is opening `specgraph://prime` from a fresh checkout and seeing both messages immediately.

### Constitution NotFound
A fresh project has no constitution; `GetConstitution` returns `connect.CodeNotFound`. Now renders:

```markdown
## Constitution

_No constitution configured. Run `specgraph constitution set` to define project ground truth._
```

The agent sees the slot exists and how to populate it instead of thinking the backend is broken. Other constitution RPC failures still render the loud marker.

### Open Findings InvalidArgument
`ListFindings` currently requires a per-spec slug; the prime composer wants project-wide findings but has no project-scoped query yet (`spgr-vabz`). Now silently skips the section on `connect.CodeInvalidArgument`, matching how Graph Overview and Ready-to-Work skip on empty data. Other findings RPC failures still render the loud marker.

This is purely a rendering improvement — the architectural fix to surface real findings via prime is `spgr-vabz`'s scope (proposed Option A: project-scoped findings RPC).

## Test plan

- [x] `TestPrimeResource_ConstitutionNotFound_RendersHint` pins the constitution heading + hint, no "unable to load" marker.
- [x] `TestPrimeResource_FindingsInvalidArgument_SkippedSilently` pins that the findings section is omitted entirely; no raw "slug is required" leak.
- [x] Existing `TestPrimeResource_RPCFailureRendersErrorMarker` still passes — `connect.CodeOf(fmt.Errorf(...))` returns `CodeUnknown`, so generic errors still hit the loud-marker default branch.
- [x] `task check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)