### PR TITLE
fix(mcp): render constitution empty state nicely

### DIFF
--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -31,6 +31,21 @@ func resourceJSON(uri string, msg proto.Message) ([]ResourceContent, error) {
 	}}, nil
 }
 
+func constitutionEmptyResource(uri string) []ResourceContent {
+	return []ResourceContent{{
+		URI:      uri,
+		MimeType: "text/markdown",
+		Text:     "# SpecGraph Constitution\n\n_No constitution configured. Run `specgraph constitution set` to define project ground truth._\n",
+	}}
+}
+
+func isConstitutionEmptyState(err error) bool {
+	if connect.CodeOf(err) == connect.CodeNotFound {
+		return true
+	}
+	return connect.CodeOf(err) == connect.CodeInvalidArgument && strings.Contains(err.Error(), "slug is required")
+}
+
 // extractSlugFromURI returns the last path segment of a specgraph:// URI.
 // e.g. "specgraph://spec/oauth-refresh" → "oauth-refresh"
 func extractSlugFromURI(uri string) string {
@@ -93,7 +108,13 @@ func constitutionResourceHandler(c *Client) ResourceHandler {
 	return func(ctx context.Context, uri string) ([]ResourceContent, error) {
 		resp, err := c.Constitution.GetConstitution(ctx, connect.NewRequest(&specv1.GetConstitutionRequest{}))
 		if err != nil {
+			if isConstitutionEmptyState(err) {
+				return constitutionEmptyResource(uri), nil
+			}
 			return nil, fmt.Errorf("get constitution: %w", err)
+		}
+		if resp.Msg.GetConstitution() == nil {
+			return constitutionEmptyResource(uri), nil
 		}
 		return resourceJSON(uri, resp.Msg)
 	}

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -147,6 +147,40 @@ func TestConstitutionResource(t *testing.T) {
 	require.Contains(t, contents[0].Text, "project-constitution")
 }
 
+func TestConstitutionResource_NotFoundRendersHint(t *testing.T) {
+	c := &Client{Constitution: &mockConstitutionService{
+		getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("constitution not found"))
+		},
+	}}
+
+	handler := constitutionResourceHandler(c)
+	contents, err := handler(context.Background(), "specgraph://constitution")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+	require.Equal(t, "text/markdown", contents[0].MimeType)
+	require.Equal(t, "specgraph://constitution", contents[0].URI)
+	require.Contains(t, contents[0].Text, "No constitution configured")
+	require.Contains(t, contents[0].Text, "specgraph constitution set")
+}
+
+func TestConstitutionResource_SlugRequiredRendersHint(t *testing.T) {
+	c := &Client{Constitution: &mockConstitutionService{
+		getConstitution: func() (*specv1.GetConstitutionResponse, error) {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("slug is required"))
+		},
+	}}
+
+	handler := constitutionResourceHandler(c)
+	contents, err := handler(context.Background(), "specgraph://constitution")
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+	require.Equal(t, "text/markdown", contents[0].MimeType)
+	require.Equal(t, "specgraph://constitution", contents[0].URI)
+	require.Contains(t, contents[0].Text, "No constitution configured")
+	require.Contains(t, contents[0].Text, "specgraph constitution set")
+}
+
 func TestConstitutionResource_Error(t *testing.T) {
 	c := &Client{Constitution: &mockConstitutionService{
 		getConstitution: func() (*specv1.GetConstitutionResponse, error) {


### PR DESCRIPTION
## Summary
- Render a friendly `specgraph://constitution` empty-state body when no constitution is configured.
- Treat the observed `slug is required` invalid-argument response as the same exact-resource empty state.
- Add MCP resource regressions for both `not_found` and `slug is required` cases.

## Test plan
- [x] `go test ./internal/mcp`
- [x] `task check`

Made with [Cursor](https://cursor.com)