### PR TITLE
fix(mcp): render constitution resource as markdown

### DIFF
--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -13,6 +13,7 @@ import (
 	"connectrpc.com/connect"
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/specgraph/specgraph/internal/authoring"
+	"github.com/specgraph/specgraph/internal/render"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -116,7 +117,11 @@ func constitutionResourceHandler(c *Client) ResourceHandler {
 		if resp.Msg.GetConstitution() == nil {
 			return constitutionEmptyResource(uri), nil
 		}
-		return resourceJSON(uri, resp.Msg)
+		return []ResourceContent{{
+			URI:      uri,
+			MimeType: "text/markdown",
+			Text:     render.Constitution(resp.Msg.GetConstitution()),
+		}}, nil
 	}
 }
 
@@ -388,7 +393,7 @@ func RegisterResources(r *Registry, c *Client) {
 		URI:         "specgraph://constitution",
 		Name:        "constitution",
 		Description: "Merged constitution (all layers).",
-		MimeType:    "application/json",
+		MimeType:    "text/markdown",
 		IsTemplate:  false,
 		Handler:     constitutionResourceHandler(c),
 	})

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -131,8 +131,9 @@ func TestConstitutionResource(t *testing.T) {
 		getConstitution: func() (*specv1.GetConstitutionResponse, error) {
 			return &specv1.GetConstitutionResponse{
 				Constitution: &specv1.Constitution{
-					Name:  "project-constitution",
-					Layer: specv1.ConstitutionLayer_CONSTITUTION_LAYER_PROJECT,
+					Name:        "project-constitution",
+					Layer:       specv1.ConstitutionLayer_CONSTITUTION_LAYER_PROJECT,
+					Constraints: []string{"no circular deps"},
 				},
 			}, nil
 		},
@@ -142,9 +143,11 @@ func TestConstitutionResource(t *testing.T) {
 	contents, err := handler(context.Background(), "specgraph://constitution")
 	require.NoError(t, err)
 	require.Len(t, contents, 1)
-	require.Equal(t, "application/json", contents[0].MimeType)
+	require.Equal(t, "text/markdown", contents[0].MimeType)
 	require.Equal(t, "specgraph://constitution", contents[0].URI)
 	require.Contains(t, contents[0].Text, "project-constitution")
+	require.Contains(t, contents[0].Text, "## Constraints")
+	require.Contains(t, contents[0].Text, "no circular deps")
 }
 
 func TestConstitutionResource_NotFoundRendersHint(t *testing.T) {


### PR DESCRIPTION
## Summary
- Render populated `specgraph://constitution` resources with the existing constitution Markdown renderer.
- Advertise the exact constitution resource as `text/markdown` instead of `application/json`.
- Update the MCP resource regression to assert Markdown MIME type and rendered constraints.

## Test plan
- [x] `go test ./internal/mcp`
- [x] `task check`

Made with [Cursor](https://cursor.com)