### PR TITLE
fix(plugin/opencode): match author tool structurally; add E2E smoke procedure

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -10,5 +10,8 @@
       "type": "remote",
       "url": "http://127.0.0.1:9090/mcp/"
     }
-  }
+  },
+  "plugin": [
+    "./plugin/opencode/.opencode/plugins/specgraph.ts"
+  ]
 }

--- a/plugin/opencode/.opencode/plugins/specgraph.ts
+++ b/plugin/opencode/.opencode/plugins/specgraph.ts
@@ -9,13 +9,23 @@
 //     system prompt so the model starts each turn with the same priming the
 //     Claude Code and Cursor harnesses get. Runs on every turn, which keeps
 //     the priming current rather than going stale after the first message.
-//   - tool.execute.after: when the `mcp__specgraph__author` tool succeeds with
-//     a stage action (spark/shape/specify/decompose/approve), record the stage
-//     so the next system-prompt transform appends a nudge to run the
-//     analytical passes registered for that stage. The cross-harness contract
-//     is "after stage transition, passes are surfaced", not "identical
-//     mechanism" — Claude uses a PostToolUse hook, Cursor uses a rule, we
-//     thread it through the system-prompt transform here.
+//   - tool.execute.after: when an MCP `*_author` tool succeeds with a stage
+//     action (spark/shape/specify/decompose/approve), record the stage so the
+//     next system-prompt transform appends a nudge to run the analytical
+//     passes registered for that stage. The cross-harness contract is "after
+//     stage transition, passes are surfaced", not "identical mechanism" —
+//     Claude uses a PostToolUse hook, Cursor uses a rule, we thread it
+//     through the system-prompt transform here.
+//
+// Tool-name matching is structural, not literal. OpenCode names MCP tools
+// `<server-key>_<tool-name>` (e.g. `specgraph_author` for the default
+// opencode.json key, `specgraph-prod_author` if the user has renamed). The
+// hook matches the `*_author` suffix AND requires args.action to be one of
+// the five SpecGraph stage actions. The action whitelist is the actual
+// identity check — those exact strings as the action arg are uniquely
+// SpecGraph's surface — so the suffix + action gate is strictly more robust
+// than a hardcoded literal across MCP key renames, multiple specgraph
+// instances, or future cross-harness reuse.
 //
 // We use execFile (argv array, no shell) to avoid shell injection if the
 // argument list ever grows beyond the fixed `specgraph://prime` URI.
@@ -78,7 +88,7 @@ const plugin: Plugin = async () => {
       }
     },
     "tool.execute.after": async (input, _output) => {
-      if (input.tool !== "mcp__specgraph__author") return;
+      if (!input.tool.endsWith("_author")) return;
       const action = input.args?.action;
       if (typeof action !== "string" || !STAGE_ACTIONS.has(action)) return;
       pendingStageNudge =

--- a/plugin/opencode/README.md
+++ b/plugin/opencode/README.md
@@ -86,6 +86,17 @@ The plugin matches the `Hooks` interface shipped with `@opencode-ai/plugin`
 The plugin uses `execFile` (argv array, no shell) for the CLI invocation to
 avoid shell-injection footguns if the URI list ever grows.
 
-The OpenCode runtime integration has not yet been validated end-to-end inside
-a running OpenCode session — the structure matches the type definitions, but
-behavior verification is tracked as a follow-up bead.
+Tool-name matching is **structural**, not literal — the `tool.execute.after`
+hook gates on the `*_author` suffix plus the action-arg whitelist (the exact
+five SpecGraph stage actions). This is resilient to MCP-key renames, multiple
+specgraph instances in one config, and harness-naming-convention drift,
+where a hardcoded literal like `mcp__specgraph__author` (the Claude Code
+form) would silently break.
+
+## Smoke test
+
+Manual end-to-end procedure for verifying behavior against a running
+OpenCode session: see [SMOKE_TEST.md](SMOKE_TEST.md). The procedure was
+last walked end-to-end against `opencode 1.14.40` and surfaced the
+tool-name-matching bug fixed in commit history; subsequent reruns should
+reproduce the documented sequence.

--- a/plugin/opencode/SMOKE_TEST.md
+++ b/plugin/opencode/SMOKE_TEST.md
@@ -1,0 +1,144 @@
+# OpenCode plugin smoke test
+
+Manual end-to-end procedure for verifying `plugin/opencode/.opencode/plugins/specgraph.ts`
+against a running OpenCode session. Captures the contract that has no
+automated test coverage today (bead `spgr-f0di`).
+
+## Prereqs
+
+- OpenCode CLI installed (`opencode --version` ≥ 1.14)
+- `specgraph` binary on `PATH` (`task build && ln -sf $(pwd)/specgraph ~/.local/bin/`)
+- specgraph server running (`specgraph serve &`) and reachable
+- `SPECGRAPH_API_KEY` set in environment
+- `opencode.json` in the project root with both an `mcp.specgraph` entry
+  and the plugin path in `plugin`:
+
+  ```json
+  {
+    "$schema": "https://opencode.ai/config.json",
+    "plugin": ["./plugin/opencode/.opencode/plugins/specgraph.ts"],
+    "mcp": {
+      "specgraph": {
+        "type": "remote",
+        "enabled": true,
+        "url": "http://127.0.0.1:7890/mcp/",
+        "headers": {
+          "Authorization": "Bearer {env:SPECGRAPH_API_KEY}",
+          "X-Specgraph-Project": "specgraph"
+        }
+      }
+    }
+  }
+  ```
+
+  The MCP fields are managed by `specgraph init` (idempotent); the `plugin`
+  array is a manual install step today.
+
+## Observation strategy
+
+OpenCode does not expose the assembled system prompt in its logs. To observe
+the plugin's behaviour directly, temporarily add `console.error` calls inside
+the two hooks (`experimental.chat.system.transform`, `tool.execute.after`) —
+they surface in OpenCode's stderr stream when running with
+`--print-logs --log-level INFO` or `DEBUG`. **Strip the instrumentation
+before committing.**
+
+Suggested marker prefix: `[specgraph-smoke]`. Grep for it after each run.
+
+## Test cases
+
+### 1. Plugin loads without import errors
+
+```bash
+opencode run --print-logs --log-level DEBUG -- "Reply: PONG-1" 2>&1 \
+  | grep "loading plugin" | grep specgraph
+```
+
+**Expected:** one `service=plugin path=...specgraph.ts loading plugin` line.
+
+### 2. MCP transport connects
+
+```bash
+opencode run --print-logs --log-level DEBUG -- "Reply: PONG-1" 2>&1 \
+  | grep "service=mcp key=specgraph"
+```
+
+**Expected:** `transport=StreamableHTTP connected` and a non-zero `toolCount`.
+
+### 3. Prime injected into system prompt every turn
+
+With instrumentation in `chat.system.transform`:
+
+```ts
+console.error(`[specgraph-smoke] system.transform fired; prime.len=${prime.length}`);
+```
+
+Run any prompt. The hook should fire at least once per LLM call (so often
+twice per `opencode run`: title-gen + main agent).
+
+**Expected:** `prime.len` non-zero on every fire; first chars `# SpecGraph
+Session Prime`.
+
+### 4. Stage nudge queues on author tool, consumes one-shot on next turn
+
+Drive the author tool from a prompt:
+
+```bash
+opencode run --dangerously-skip-permissions --print-logs --log-level INFO -- \
+  'Use the specgraph_author tool with arguments {"action":"spark","intent":"smoke","problem":"verify nudge","context":"smoke"}. Then reply: SPARK-DONE.'
+```
+
+With instrumentation around the queue/consume points, expect this exact
+sequence per stage transition:
+
+```text
+[specgraph-smoke] tool.execute.after fired tool=specgraph_author
+[specgraph-smoke] queued nudge for stage=spark
+[specgraph-smoke] system.transform fired; prime.len=N pendingNudge=true
+[specgraph-smoke] pushed nudge first40="Run the analytical passes registered for"
+[specgraph-smoke] system.transform fired; ... pendingNudge=false   ← one-shot consumption
+```
+
+### 5. Non-author tools are ignored
+
+The same run typically also fires `tool.execute.after` for `read`, `grep`,
+`specgraph_spec`, `specgraph_author_start_stage`, etc. None should result in
+`queued nudge` lines — the suffix check (`endsWith("_author")`) and the
+action whitelist exclude all of them.
+
+### 6. Soft-fail when CLI is missing or server is unreachable
+
+```bash
+# Stop the server (or temporarily unset the symlink for the CLI)
+pkill -f "specgraph serve"
+opencode run --print-logs --log-level INFO -- "Reply: PONG-OFFLINE"
+```
+
+**Expected:** session completes; `prime.len` is non-zero (the soft-fail
+message length); `first40` starts with `"# specgraph prime unavailable"`.
+The cache holds the failure message, so a server that comes online
+mid-session is **not** retried — this is intentional.
+
+## Known limitations (not fixed here)
+
+- **Multi-stage transitions in a single LLM turn.** `pendingStageNudge` is a
+  single slot; if `tool.execute.after` fires twice for two different stages
+  before any `system.transform` runs, the second overwrites the first. In
+  practice the model issues stage transitions over multiple turns, so the
+  queue depth has been "good enough" — but if we ever want strict ordering,
+  switch to an array.
+- **Long-running session retry.** `loadPrime` caches both success and
+  failure for the lifetime of the plugin instance. A server that comes online
+  mid-session keeps showing the failure message. Acceptable for short
+  sessions; revisit if real users report stale-failure complaints.
+
+## Cleanup
+
+After each run, abandon any specs created during testing:
+
+```bash
+specgraph abandon <slug> --reason="smoke test cleanup"
+```
+
+If you instrumented the plugin with `console.error` statements, revert
+those before committing.


### PR DESCRIPTION
## Summary

End-to-end smoke test against `opencode 1.14.40` (bead `spgr-f0di`)
surfaced that the OpenCode plugin's `tool.execute.after` hook never
fired its stage nudge: the literal check `input.tool === "mcp__specgraph__author"`
is the Claude-Code MCP-naming convention, but OpenCode names MCP tools
`<server-key>_<tool-name>` — so the actual emitted tool name was
`specgraph_author` and the gate always returned early.

Fix is structural rather than a literal swap: the hook now matches any
tool whose name ends with `_author` AND whose `args.action` is one of
the five SpecGraph stage actions. The action whitelist is the actual
identity check; the suffix gates against unrelated tools that happen to
have an action arg. Resilient to MCP-key renames, multiple specgraph
instances in one config, and future cross-harness reuse.

Adds `plugin/opencode/SMOKE_TEST.md` capturing the manual procedure with
known limitations (single-slot nudge queue, no mid-session retry on
soft-fail). Also adds the plugin path to the repo's `opencode.json` so
SpecGraph dev work dogfoods the integration.

## Validated

- Plugin loads, MCP transport connects (`toolCount=21`)
- Prime injected on every `system.transform` call (cached across calls)
- `specgraph_author` action=spark/shape → queues nudge → consumed
  one-shot on next `system.transform` → cleared
- `specgraph_author_start_stage`, `specgraph_spec`, `grep`, `read` —
  correctly ignored (suffix mismatch or action whitelist miss)
- Soft-fail when server is down: prime cache holds failure message,
  session continues, model responds normally

## Test plan

- [x] `task check` (fmt, license, lint, skills, build, race tests)
- [x] Manual smoke against `opencode 1.14.40` per `plugin/opencode/SMOKE_TEST.md`
- [ ] CI green

Closes spgr-f0di.