### PR TITLE
spgr-rwrp PR 0 + PR A: Claude API verification + managedfiles framework foundation

### DIFF
--- a/docs/plans/2026-05-08-spgr-rwrp-harness-install-parity-design.md
+++ b/docs/plans/2026-05-08-spgr-rwrp-harness-install-parity-design.md
@@ -77,7 +77,7 @@ The marker namespace stays `specgraph:init:` to preserve continuity with the exi
 
 For `WholeFile` strategy (TypeScript / shell / markdown / mdc), a single sentinel line:
 
-```
+```text
 // specgraph:init v=2 sha256=abc123... rev=cef1ec3a
 ```
 
@@ -85,7 +85,7 @@ For `WholeFile` strategy (TypeScript / shell / markdown / mdc), a single sentine
 
 For `MarkdownBlock` strategy, the sentinel rides on the existing start/end markers:
 
-```
+```text
 <!-- specgraph:init:start v=2 sha256=abc... -->
 ...
 <!-- specgraph:init:end -->
@@ -166,9 +166,9 @@ The repo-root `<repo>/skills/` tree remains the authoring source; the embedded c
 | 6 | `.cursor/rules/specgraph-post-stage.mdc` | Cursor | `WholeFile` | |
 | 7 | `.mcp.json` | Claude | `JSONKeyMerge` | |
 | 8 | `AGENTS.md` | Claude | `MarkdownBlock` | |
-| 9 | `.claude/settings.json` | Claude | `JSONKeyMerge` | Managed keys: `extraKnownMarketplaces.specgraph-local`, `enabledPlugins["specgraph@specgraph-local"]`. |
+| 9 | `.claude/settings.json` | Claude | `JSONKeyMerge` | Managed keys: `extraKnownMarketplaces.specgraph-local` (with `source: { type: "directory", path: "./.specgraph/agents/claude" }` — note: the path is the **marketplace root**, the dir containing `.claude-plugin/`, NOT `.claude-plugin/` itself; verified in PR 0), `enabledPlugins["specgraph@specgraph-local"]`. |
 | 10 | `.specgraph/agents/claude/.claude-plugin/plugin.json` | Claude | `WholeFile` | |
-| 11 | `.specgraph/agents/claude/.claude-plugin/marketplace.json` | Claude | `WholeFile` | Single-plugin local marketplace. |
+| 11 | `.specgraph/agents/claude/.claude-plugin/marketplace.json` | Claude | `WholeFile` | Single-plugin local marketplace. `plugins[].source` is the directory path `"./"` (co-located plugin shares the marketplace root); NOT `"./.claude-plugin/plugin.json"`. `..` traversal is blocked, so any future multi-plugin layout must keep all plugins inside the marketplace root. |
 | 12 | `.specgraph/agents/claude/hooks/specgraph-session-start.sh` | Claude | `WholeFile` | |
 | 13 | `.specgraph/agents/claude/hooks/specgraph-post-stage.sh` | Claude | `WholeFile` | |
 | 14 | `.specgraph/agents/claude/routing-guide.md` | Claude | `WholeFile` | |
@@ -206,7 +206,7 @@ Hook paths inside `plugin.json` use `${CLAUDE_PLUGIN_ROOT}/hooks/specgraph-{sess
 
 ### `specgraph doctor`
 
-```
+```text
 specgraph doctor [flags]
 
 Flags:
@@ -224,7 +224,7 @@ Four check groups: **Binary** (version, build), **Server** (subsumes `specgraph 
 
 A `PersistentPreRun` hook on the root cobra command runs `InspectAll` and emits one stderr line if any file is not Synced:
 
-```
+```text
 note: 2 managed files out of date with this binary (1 stale, 1 drifted); run `specgraph init` to refresh, `specgraph doctor` for details
 ```
 
@@ -233,6 +233,7 @@ note: 2 managed files out of date with this binary (1 stale, 1 drifted); run `sp
 The `isatty(stderr)` gate has one well-known limitation: `specgraph list | less` keeps stderr as a TTY, so the nudge can smear across pager output. The escape hatch is the `SPECGRAPH_DRIFT_NUDGE=off` env var or `nudges: { quiet: true }` in `.specgraph.yaml`. Acceptable trade-off; documented for users who run pager pipelines frequently.
 
 Additional skip conditions (belt-and-suspenders):
+
 - Subcommands that handle reporting themselves: `init`, `doctor`, `health`, `read-mcp-resource`, `serve`, anything under `mcp` or `version`
 - `SPECGRAPH_DRIFT_NUDGE=off` env var (user-level mute)
 - `nudges: { quiet: true }` in `.specgraph.yaml` (project-level mute)
@@ -243,6 +244,7 @@ Additional skip conditions (belt-and-suspenders):
 The file's contents are empty; mtime drives the throttle window.
 
 **Throttle policy:**
+
 - First nudge ever for `(project, binary-version)`: emit, create file
 - Same `(project, binary-version)` within 24h: skip
 - Same project, *different* binary version: emit (binary upgraded; user sees one fresh nudge for the new version) — that path's throttle file is independent
@@ -258,7 +260,7 @@ The file's contents are empty; mtime drives the throttle window.
 
 ### Children of `spgr-rwrp`, in landing order
 
-```
+```text
 0 (Claude API verification spike)
      ↓
 A (foundation) → B (port existing) → ┬→ C (OpenCode)
@@ -287,6 +289,7 @@ If any claim fails, the spec changes before PR A. Most likely fallout if a claim
 **Output:** a verification report at `docs/plans/2026-05-08-spgr-rwrp-pr0-claude-api-verification.md` (date-prefixed slug, consistent with existing `docs/plans/` convention). The report greens or reds each of the three claims with a captured terminal transcript or test artifact.
 
 **Gating PR A:**
+
 - PR A's commit message includes `Depends on: docs/plans/2026-05-08-spgr-rwrp-pr0-claude-api-verification.md (all three claims green)`
 - PR A's pull request description repeats the dependency
 - Where feasible, PR A includes a `testdata/` fixture distilled from PR 0 that fails the build if any claim regresses (e.g., a `marketplace.json` + `plugin.json` pair tested via a synthetic Claude harness — if the harness API exists). If a build-time test isn't feasible (because Claude isn't available in CI), the dependency is honor-system but at least visibly recorded.
@@ -342,10 +345,10 @@ Existing `mcpconfigs/` and `pointers/` packages get folded in (their tests come 
 - Embed plugin shim sources (5 files) into binary
 - Add 5 entries to manifest as `WholeFile` under `.specgraph/agents/claude/`
 - Add `.claude/settings.json` to manifest with managed keys: `extraKnownMarketplaces.specgraph-local`, `enabledPlugins["specgraph@specgraph-local"]`
-- **Verify before committing the design** (smoke test gates the PR):
-  - `extraKnownMarketplaces` accepts `source: { type: "directory", path: "<relative>" }` with a project-relative path (claimed in design; cite the exact docs URL in the PR body)
-  - `autoUpdate: false` is honoured at the marketplace level (claimed in design; verify it's a real settings field on a marketplace entry vs only on individual plugin enablement)
-  - `${CLAUDE_PLUGIN_ROOT}` resolves to the plugin root directory (`.specgraph/agents/claude/`) when the marketplace source is `directory`-type. If Claude resolves it against the marketplace root rather than the plugin root, hooks break silently — must be verified end-to-end before relying on it
+- **Verified by PR 0** (see `2026-05-08-spgr-rwrp-pr0-claude-api-verification.md`):
+  - `extraKnownMarketplaces` accepts `source: { type: "directory", path: "<relative>" }` with a project-relative path. ✓ GREEN
+  - `autoUpdate: false` is honoured at the marketplace-entry level. ✓ GREEN with caveat — registry version is pinned, but for `directory`-source marketplaces Claude reads files live (no cache copy), so file-content drift is not blocked by the flag. Acceptable for our model: every `specgraph init` refresh is supposed to be visible to the next session.
+  - `${CLAUDE_PLUGIN_ROOT}` resolves to the plugin's own root directory regardless of marketplace shape. ✓ GREEN
 - Test: spin up `claude` in a fresh project, run `specgraph init`, verify the plugin shows in `/plugin list` and hooks fire on session start
 - Author `plugin/specgraph/SMOKE_TEST.md` analog to OpenCode's
 
@@ -454,6 +457,12 @@ Four tooling pieces, available to anyone (not dogfood-only):
   - **S6**: `task plugin:check` wired into `task check` to enforce dogfood discipline
   - **M1**: PR A explicitly ports (not stubs) locking, symlink rejection, atomic-write primitives
   - **M4**: preserve user-set `enabledPlugins: false` (don't silently re-enable)
+- **2026-05-08 v5**: PR 0 (Claude API verification spike) completed. All three claims green; two schema corrections folded in:
+  - **Spec correction 1:** `extraKnownMarketplaces.<name>.source.path` points at the **marketplace root** (the dir containing `.claude-plugin/`), NOT at `.claude-plugin/` itself. Manifest entry 9's note updated to clarify the path value is `./.specgraph/agents/claude` (not `./.specgraph/agents/claude/.claude-plugin`).
+  - **Spec correction 2:** `marketplace.json`'s `plugins[].source` is a directory path with mandatory `./` prefix (e.g. `"./"` for a co-located plugin), NOT a path to plugin.json. Manifest entry 11's note updated. `..` traversal is blocked, so any future multi-plugin layout must keep all plugins inside the marketplace root.
+  - **Bonus finding (informational):** `autoUpdate: false` is honoured at the registry layer (version stays pinned in `installed_plugins.json`) but for `directory`-source marketplaces Claude reads files live with no cache copy, so file-content drift is not gated. Acceptable for our model — every `specgraph init` refresh should be visible to the next session.
+  - **Bonus finding (informational):** Claude resolves symlinks on the plugin path. Spec's choice of `EvalSymlinks(projectRoot)` for the throttle file key matches Claude's internal behaviour.
+  - PR E's "verify before committing" subsection is now "verified by PR 0," referencing the verification report.
 - **2026-05-08 v4**: third adversarial review applied (diminishing-returns review; no critical findings). Revisions:
   - **v3-1 (vestigial v=1 renderer sunset)**: `mcpconfigs/` and `pointers/` rendering algorithms preserved as private helpers in `internal/config/managedfiles/` for the v=1 → v=2 hash-check and `SupersedesPath` "prior canonical" comparisons. Sunset triggers when `task plugin:check` reports zero v=1 files for two consecutive releases.
   - **v3-2 (PR F documentation cleanup)**: PR F now explicitly updates `CLAUDE.md`, `plugin/<harness>/README.md` files, and the top-level `README.md` to remove symlink + `task plugin:sync` references. Avoids stale docs after the symlink deletion lands.

--- a/docs/plans/2026-05-08-spgr-rwrp-harness-install-parity-design.md
+++ b/docs/plans/2026-05-08-spgr-rwrp-harness-install-parity-design.md
@@ -1,0 +1,470 @@
+# Harness install parity via embed-and-write — design
+
+- **Bead:** `spgr-rwrp`
+- **First child landing this:** `spgr-zqpb` (OpenCode plugin embed-and-write)
+- **Predecessor:** `spgr-cceg` (harness parity epic — established the three-shim pattern)
+- **Date:** 2026-05-08
+
+## Context
+
+`specgraph init` today manages MCP wiring for all three harnesses (Claude Code, Cursor, OpenCode) but only **partially** manages each harness's integration surface:
+
+- **Claude:** `.mcp.json` + `AGENTS.md` (pointer). Plugin manifest, hooks, routing-guide left to a future marketplace install or manual setup.
+- **Cursor:** `.cursor/mcp.json` + `.cursor/rules/specgraph-bootstrap.md` (pointer). Main rule files (`specgraph.md`, `post-stage.md`) live in the repo's `plugin/cursor/` shim and never reach end-user projects.
+- **OpenCode:** `opencode.json`'s MCP block. Plugin TypeScript file is a manual README install step.
+- **Skills (cross-harness):** symlinked from each shim to the in-tree `<repo>/skills/` tree. Broken for end users without a repo checkout.
+
+The result: end users get an inconsistent setup story per harness, and the harness-parity promise from `spgr-cceg` is incomplete.
+
+This epic adopts a uniform **embed-and-write** pattern: harness shim content is bundled into the specgraph CLI binary via `//go:embed`, and `specgraph init` writes canonical files into the user's project on every run. Drift between binary and on-disk files is detectable and surfaced via a new `specgraph doctor` command and a low-overhead nudge on every CLI invocation.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Scope | Cross-harness pattern, not per-harness one-offs. First implementation lands in `spgr-zqpb`; the framework is reusable. |
+| Drift policy | Per-strategy. JSON keys → merge. Markdown blocks → fence (versioned, hash-tracked). Whole-file → warn-and-force unless `--force`. (StrategicMerge dropped — YAGNI; reintroduce when a concrete file needs it.) |
+| Marker shape | Sentinel comment in the file's native comment syntax (`//`, `#`, `<!-- -->`), carrying version + sha256. No sidecar files, no project-level state file. |
+| Staleness UX | Cheap drift check on every CLI invocation emits a one-line stderr nudge if any managed file is not synced. Plus a new `specgraph doctor` command for the deep-dive. |
+| Skills delivery | Universal MCP-resource fetch (`specgraph://skills/<name>`); zero on-disk skill files in any harness. |
+| Architecture | Single unified `internal/config/managedfiles/` package with a strategy enum. Existing `internal/config/mcpconfigs/` and `internal/config/pointers/` get folded in and deleted. |
+| Layout | SpecGraph-owned files consolidate under `.specgraph/agents/<harness>/`. Harness-pinned files (Cursor rules, MCP configs, AGENTS.md, settings.json) stay at their conventional paths. |
+| Existing-user migration | Not applicable — no existing users. Design forward, implement forward. |
+| Dogfood | This repo runs the same flow as end users. Authoring sources at `plugin/<harness>/...` are committed; init-written destinations are gitignored. |
+
+## Architecture
+
+A single package `internal/config/managedfiles/` is the home for everything specgraph injects into a project.
+
+```go
+type ManagedFile struct {
+    Path           string         // relative to project root
+    Strategy       Strategy
+    Source         embed.FS       // canonical content
+    Comment        CommentSyntax  // ts | sh | md | mdc | jsonc | yaml — for sentinel
+    Harness        Harness        // claude | cursor | opencode
+    SupersedesPath string         // optional: if set, init deletes this path after writing Path
+                                  //   (used for `.md` → `.mdc` cursor-rule rename)
+}
+
+type Strategy int
+const (
+    StrategyJSONKeyMerge  Strategy = iota // managed keys merge into a JSON file; siblings preserved
+    StrategyMarkdownBlock                 // versioned, hash-tracked block in a markdown file
+    StrategyWholeFile                     // entire file is canonical; warn-and-force on drift
+    // (StrategicMerge dropped — YAGNI. Reintroduce when a concrete file needs it.)
+)
+
+type State int
+const (
+    StateMissing State = iota
+    StateSynced
+    StateStale       // sentinel hash matches disk, but disk doesn't match canonical (older specgraph wrote it)
+    StateDrifted     // disk doesn't match sentinel hash (user-edited)
+)
+
+func InspectAll(cwd string, harnesses []Harness) ([]FileState, error)
+func SyncAll(cwd string, harnesses []Harness, opts SyncOptions) ([]SyncResult, error)
+```
+
+The existing `mcpconfigs/` and `pointers/` packages are subsumed as `JSONKeyMerge` and `MarkdownBlock` strategies, then deleted. Call sites that talk to this one package: `cmd/specgraph/init.go`, the new `cmd/specgraph/doctor.go` (with `cmd/specgraph/health.go` shimming through doctor as a deprecated alias), and the drift-nudge in the root command's `PersistentPreRun`.
+
+## Drift detection
+
+### Sentinel format
+
+The marker namespace stays `specgraph:init:` to preserve continuity with the existing `internal/config/pointers/` markers (`agents.go:20-21`, `cursor.go:16`). The version bumps from `v=1` to `v=2` to add the hash payload.
+
+For `WholeFile` strategy (TypeScript / shell / markdown / mdc), a single sentinel line:
+
+```
+// specgraph:init v=2 sha256=abc123... rev=cef1ec3a
+```
+
+`sha256` is computed over canonical content **excluding the sentinel line itself**, so the sentinel can change without affecting the hash. `rev` is forensic only.
+
+For `MarkdownBlock` strategy, the sentinel rides on the existing start/end markers:
+
+```
+<!-- specgraph:init:start v=2 sha256=abc... -->
+...
+<!-- specgraph:init:end -->
+```
+
+**Upgrade path from v=1 markers to v=2.** Existing files in this repo carry `<!-- specgraph:init:start v=1 -->` (no hash). The framework's classification of a `v=1` file uses a defensive check, not blind trust:
+
+1. Read disk content between `v=1` markers.
+2. Compute what *this binary's* `v=1` canonical for that path would have written, using a preserved-private rendering helper (see "Vestigial v=1 renderer" below).
+3. If the disk content matches that canonical: classify as `Stale` and refresh in-place to `v=2` with the new hash. No user content was at risk.
+4. If the disk content does NOT match: classify as `Drifted`. The user (or a prior dev) hand-edited within the managed block. Refuse to overwrite without `--force`.
+
+This guards against silently destroying hand-edited content during the v=1 → v=2 upgrade. The check is dogfood-only (no external users), but it's the right primitive for the framework regardless.
+
+**Vestigial v=1 renderer (sunset policy).** PR B preserves the existing `pointers/` rendering logic as an unexported helper inside `internal/config/managedfiles/` (e.g. `classifyV1Disk`). The helper exists *only* to compute what a v=1 canonical would have written for the v=1 → v=2 hash-check above. It is not on the production write path — new writes always emit v=2. The helper is removed in a follow-up bead once `task plugin:check` reports zero `v=1` files in the dogfood repo for two consecutive releases. Same policy applies to `SupersedesPath` "prior canonical" computations (e.g., the old `.md` cursor-rule path's pre-PR-D rendering): preserve as a private helper, sunset on the same trigger.
+
+**Forward-compatibility:** the marker parser accepts `v=1` and `v=2`, rejects `v=3+` as `ErrCorruptedMarkers` (matches today's `pointers/agents.go` corruption-rejection behaviour for unknown versions). A future binary downgrade scenario surfaces as corruption rather than silent data loss.
+
+`JSONKeyMerge` does not need sentinels — the strategy already knows which keys it owns and overwrites them on every init. There's no `Drifted` state for merge-strategy files because managed keys are not user-owned by definition. **One exception:** `.claude/settings.json`'s `enabledPlugins["specgraph@specgraph-local"]` preserves a user-set `false` value (so `claude /plugin disable specgraph` survives subsequent `init` runs — see "Open questions / Resolved"). That key is "managed-presence" rather than "managed-value": init ensures the key exists; the value follows the user's last choice. It's the only such key in the manifest; the exception is local, not a general policy.
+
+### State decision
+
+| Disk state | Sentinel hash matches disk content? | Sentinel hash matches canonical hash? | State |
+|---|---|---|---|
+| File missing | — | — | `Missing` |
+| Sentinel absent | — | — | `Drifted` (treat as user-owned, skip without `--force`) |
+| present | yes | yes | `Synced` |
+| present | yes | no | `Stale` (older specgraph wrote it; safe to refresh) |
+| present | no | — | `Drifted` (user modified after init) |
+
+### Init's behaviour per state
+
+- `Missing` → write canonical with fresh sentinel (silent)
+- `Synced` → no-op (silent)
+- `Stale` → rewrite canonical, update sentinel (one line: `path: refreshed (vN.M.K → vN.M.K')`)
+- `Drifted` → emit warning, skip; `--force` to overwrite, `--force --keep-edits` to preserve content but update the sentinel hash to match disk
+
+### Cost
+
+The check is intentionally tiny: one `os.Stat` per file, read first ~200 bytes for the sentinel, compute SHA-256 over the canonical embed (already in memory). For a 14-file manifest, total wall time is sub-millisecond on a warm cache. Suitable for running on every CLI invocation.
+
+The four states are decidable from disk + binary alone — no ambient state files. `rm -rf .specgraph/` produces a clean recovery: doctor reports Missing, init recreates.
+
+## Skills delivery
+
+Skills live in the CLI binary (`//go:embed skills/...`) and are exposed via two MCP surfaces:
+
+- **Resource:** `specgraph://skills/<name>` returns the SKILL.md body. Same fetch mechanism as `specgraph://prime`.
+- **Tools:** `specgraph_skills_list` returns `[{name, description, when_to_use}]` from frontmatter; `specgraph_skills_get` is a thin tool wrapper over the resource fetch.
+
+The prime resource grows a "Skills available" catalog block listing names and descriptions, telling the model to fetch on demand rather than pre-load.
+
+Per-harness consumption becomes uniform:
+
+- **OpenCode:** `experimental.chat.system.transform` already injects prime; the catalog comes through automatically.
+- **Cursor:** the bootstrap rule references prime via `read-mcp-resource`; the prime now includes the catalog.
+- **Claude:** the existing `hooks/specgraph-session-start.sh` already injects prime via `specgraph read-mcp-resource specgraph://prime`. No new hook needed; the catalog rides the existing path.
+
+**Trade-off — explicit Claude UX regression:** Claude Code's native skills mechanism auto-loads from `.claude/skills/` and surfaces in the user's UI; switching to MCP-fetch means (a) the model has to *choose* to fetch based on the prime catalog descriptions, (b) no skill-card UI in Claude, (c) skills can't trigger via Claude's own skill-routing heuristics. This is a deliberate trade for cross-harness uniformity, accepted upfront.
+
+PR F lands MCP-fetch as the **chosen mechanism**, not a parallel-run with disk symlinks. The existing in-repo `plugin/<harness>/skills` symlinks (a dev-time artifact only — end users never had them) are removed in PR F itself; `task plugin:sync` is also removed. Running two delivery paths simultaneously would create two sources of truth the model can see (auto-loaded from disk vs MCP-fetched), with no clean way to measure which was actually used. Cleaner to commit.
+
+**Fallback (if needed):** if user feedback indicates the Claude UX regression is unacceptable, a follow-up bead adds a Claude-specific manifest section that writes skills to `.claude/skills/<name>/SKILL.md` (`WholeFile` strategy) — a chosen-mechanism for Claude only, decided on real feedback rather than a parallel-run measurement window. OpenCode and Cursor stay on MCP-fetch unconditionally.
+
+The repo-root `<repo>/skills/` tree remains the authoring source; the embedded canonical lives in the binary; the MCP resource handler serves it.
+
+## Per-harness manifest
+
+14 managed files total. SpecGraph-owned files consolidate under `.specgraph/agents/<harness>/`; harness-pinned files stay at their conventional paths.
+
+| # | Path | Harness | Strategy | Notes |
+|---|---|---|---|---|
+| 1 | `opencode.json` | OpenCode | `JSONKeyMerge` | Managed keys: `mcp.specgraph.{enabled,headers,type,url}`. Also ensures our plugin path (`./.specgraph/agents/opencode/specgraph.ts`) is present in the `plugin` array via union-merge — adds if missing, leaves any other user-added entries alone. |
+| 2 | `.specgraph/agents/opencode/specgraph.ts` | OpenCode | `WholeFile` | Plugin TS, referenced from `opencode.json`'s `plugin` array. |
+| 3 | `.cursor/mcp.json` | Cursor | `JSONKeyMerge` | Init emits warning if `~/.cursor/mcp.json` has a `specgraph` entry (global collision). |
+| 4 | `.cursor/rules/specgraph-bootstrap.mdc` | Cursor | `MarkdownBlock` | |
+| 5 | `.cursor/rules/specgraph.mdc` | Cursor | `WholeFile` | |
+| 6 | `.cursor/rules/specgraph-post-stage.mdc` | Cursor | `WholeFile` | |
+| 7 | `.mcp.json` | Claude | `JSONKeyMerge` | |
+| 8 | `AGENTS.md` | Claude | `MarkdownBlock` | |
+| 9 | `.claude/settings.json` | Claude | `JSONKeyMerge` | Managed keys: `extraKnownMarketplaces.specgraph-local`, `enabledPlugins["specgraph@specgraph-local"]`. |
+| 10 | `.specgraph/agents/claude/.claude-plugin/plugin.json` | Claude | `WholeFile` | |
+| 11 | `.specgraph/agents/claude/.claude-plugin/marketplace.json` | Claude | `WholeFile` | Single-plugin local marketplace. |
+| 12 | `.specgraph/agents/claude/hooks/specgraph-session-start.sh` | Claude | `WholeFile` | |
+| 13 | `.specgraph/agents/claude/hooks/specgraph-post-stage.sh` | Claude | `WholeFile` | |
+| 14 | `.specgraph/agents/claude/routing-guide.md` | Claude | `WholeFile` | |
+
+Hook paths inside `plugin.json` use `${CLAUDE_PLUGIN_ROOT}/hooks/specgraph-{session-start,post-stage}.sh`, which Claude resolves against the plugin root (`.specgraph/agents/claude/`).
+
+`.claude/settings.json` writes `autoUpdate: false` for the local marketplace. Drift control is `specgraph init`'s job, not Claude's auto-updater.
+
+### Repo-internal source renames
+
+- `plugin/cursor/.cursor/rules/specgraph.md` → `plugin/cursor/.cursor/rules/specgraph.mdc`
+- `plugin/cursor/.cursor/rules/post-stage.md` → `plugin/cursor/.cursor/rules/specgraph-post-stage.mdc`
+- `plugin/specgraph/hooks/session-start.sh` → `plugin/specgraph/hooks/specgraph-session-start.sh`
+- `plugin/specgraph/hooks/post-stage.sh` → `plugin/specgraph/hooks/specgraph-post-stage.sh`
+- `plugin/specgraph/.claude-plugin/plugin.json` references update to match renamed hook paths
+
+### Per-harness opt-in
+
+`.specgraph.yaml` gains a `harnesses:` field accepting:
+
+- `auto` (default): detect from disk on first init (presence of `.opencode/` → opencode, `.cursor/` → cursor, `.claude-plugin/` or `CLAUDE.md` → claude), then pin the detected list
+- `all`: write managed files for every supported harness regardless of disk presence
+- explicit list, e.g. `[opencode, cursor]`: write only the named harnesses
+- empty/none: skip all harness file management
+
+`specgraph init --harness <name>` and `--harness all` flags override for one-off runs.
+
+### Excluded from the manifest
+
+- **Skills**: served via `specgraph://skills/<name>`; no per-project files.
+- **User-level installs** (`~/.config/opencode/...`, `~/.cursor/mcp.json`, Cursor User Rules): project-level wins on conflict; documented as opt-in manual setup for power users.
+- **`.specgraph.yaml`**: user-owned project config; init creates with the project slug if missing, never overwrites.
+
+## Doctor + drift nudge
+
+### `specgraph doctor`
+
+```
+specgraph doctor [flags]
+
+Flags:
+  --json              Machine-readable output
+  --fix               Auto-fix Stale/Missing; print guidance for Drifted
+  --harness <name>    Narrow to one harness
+  --scope <s>         project (default; user/all not implemented in v1)
+```
+
+Four check groups: **Binary** (version, build), **Server** (subsumes `specgraph health`: reachability + MCP transport handshake), **Project config** (`.specgraph.yaml` parses, `harnesses:` resolves), **Managed files** (14-file table grouped by host-pinned vs SpecGraph-owned).
+
+`specgraph health` becomes a deprecated alias for `specgraph doctor server`, keeping its current exit codes for scripts.
+
+### Drift-nudge on every CLI invocation
+
+A `PersistentPreRun` hook on the root cobra command runs `InspectAll` and emits one stderr line if any file is not Synced:
+
+```
+note: 2 managed files out of date with this binary (1 stale, 1 drifted); run `specgraph init` to refresh, `specgraph doctor` for details
+```
+
+**Skip rules — primary gate is `isatty(stderr)`.** If stderr isn't a terminal, the nudge never fires. This catches every non-interactive invocation by construction: the Claude session-start hook (`specgraph read-mcp-resource specgraph://prime`), the MCP server (`specgraph serve`), shell-script consumers piping stdout/stderr, CI runs. Without this guard, the Claude hook would inject the nudge text **into the prime payload the model reads**, actively poisoning the harness — a class-of-bug we close once at the framework level rather than maintaining a brittle subcommand allow-list.
+
+The `isatty(stderr)` gate has one well-known limitation: `specgraph list | less` keeps stderr as a TTY, so the nudge can smear across pager output. The escape hatch is the `SPECGRAPH_DRIFT_NUDGE=off` env var or `nudges: { quiet: true }` in `.specgraph.yaml`. Acceptable trade-off; documented for users who run pager pipelines frequently.
+
+Additional skip conditions (belt-and-suspenders):
+- Subcommands that handle reporting themselves: `init`, `doctor`, `health`, `read-mcp-resource`, `serve`, anything under `mcp` or `version`
+- `SPECGRAPH_DRIFT_NUDGE=off` env var (user-level mute)
+- `nudges: { quiet: true }` in `.specgraph.yaml` (project-level mute)
+- Throttle (see below)
+
+**Throttle path:** `xdg.CacheHome() + "/nudges/" + sha256(EvalSymlinks(projectRoot)) + "-" + binaryVersionHash`. Default expansion: `~/.cache/specgraph/nudges/<project-hash>-<version-hash>`. The version is part of the **path**, not the contents — that way two binaries on PATH (e.g., a stable install and a dev-tagged build) each track their own throttle independently and can't ping-pong each other into re-emitting on every alternation.
+
+The file's contents are empty; mtime drives the throttle window.
+
+**Throttle policy:**
+- First nudge ever for `(project, binary-version)`: emit, create file
+- Same `(project, binary-version)` within 24h: skip
+- Same project, *different* binary version: emit (binary upgraded; user sees one fresh nudge for the new version) — that path's throttle file is independent
+- Older than 24h, same version: emit again, refresh mtime
+
+**Opportunistic GC:** on each nudge, scan `xdg.CacheHome() + "/nudges/"` for entries with mtime > 30 days; delete them. One `readdir` is well within the per-invocation budget and prevents indefinite accumulation as users move/rename projects.
+
+**Fallback for unknown errors** (e.g., `~/.cache/` not writable, `EvalSymlinks` errors on a deleted cwd): emit the nudge unthrottled — minor over-emission, not broken. Never make the CLI fail because of an advisory feature.
+
+`internal/xdg/` adds a `CacheHome()` function alongside the existing `ConfigHome()` / `DataHome()` / `StateHome()`, mirroring the spec one-for-one.
+
+## Migration plan + sequencing
+
+### Children of `spgr-rwrp`, in landing order
+
+```
+0 (Claude API verification spike)
+     ↓
+A (foundation) → B (port existing) → ┬→ C (OpenCode)
+                                     ├→ D (Cursor)
+                                     ├→ E (Claude)
+                                     ├→ F (Skills via MCP)
+                                     └→ G (Doctor + nudge)
+```
+
+PR 0 runs before PR A — it's a verification spike, not implementation. PR A and PR B are sequential. C, D, E, F, G can land in any order or in parallel after B.
+
+#### PR 0 — Claude plugin API verification spike (gates PR A)
+
+Three claims in §"Per-harness manifest" and §"Claude" hinge on Claude Code behaviour we have asserted but not verified end-to-end. Verify each with a minimal in-tree test before PR A locks the framework's design assumptions:
+
+1. **`extraKnownMarketplaces` accepts `source: { type: "directory", path: "<relative>" }`** — write a throwaway `.claude/settings.json` with a relative path, run `claude /plugin list`, confirm the plugin shows up.
+2. **`autoUpdate: false` is honoured at the marketplace-entry level** — toggle it, observe Claude does not auto-update the plugin from the directory source. Cite the exact docs anchor that documents the field.
+3. **`${CLAUDE_PLUGIN_ROOT}` resolves to the plugin root, not the marketplace root, for `directory`-source local marketplaces** — write a hook script that prints `pwd` and `$CLAUDE_PLUGIN_ROOT`, fire it via session-start, observe the resolved path.
+
+If any claim fails, the spec changes before PR A. Most likely fallout if a claim fails:
+
+- (1) fails → use absolute paths (resolved at init time) instead of relative; spec's relative-path examples become absolute; `dev` build tag and dogfood story unaffected
+- (2) fails → drop `autoUpdate: false` from managed keys; rely on the local marketplace's default behaviour
+- (3) fails → re-architect Claude layout: the plugin root might need to be `.specgraph/agents/claude/.claude-plugin/` (one level deeper) so the marketplace root and plugin root coincide, breaking the "siblings to .claude-plugin/" model in §"Per-harness manifest"
+
+**Output:** a verification report at `docs/plans/2026-05-08-spgr-rwrp-pr0-claude-api-verification.md` (date-prefixed slug, consistent with existing `docs/plans/` convention). The report greens or reds each of the three claims with a captured terminal transcript or test artifact.
+
+**Gating PR A:**
+- PR A's commit message includes `Depends on: docs/plans/2026-05-08-spgr-rwrp-pr0-claude-api-verification.md (all three claims green)`
+- PR A's pull request description repeats the dependency
+- Where feasible, PR A includes a `testdata/` fixture distilled from PR 0 that fails the build if any claim regresses (e.g., a `marketplace.json` + `plugin.json` pair tested via a synthetic Claude harness — if the harness API exists). If a build-time test isn't feasible (because Claude isn't available in CI), the dependency is honor-system but at least visibly recorded.
+
+#### PR A — `internal/config/managedfiles/` foundation
+
+- New package with types: `ManagedFile` (including `SupersedesPath`), `Strategy`, `State`, `FileState`, `SyncResult`
+- Sentinel parsing + writing for `ts` / `sh` / `md` / `mdc` comment styles
+- Hash computation (canonical content excluding sentinel line)
+- **Port (not stub) the safety primitives from existing `internal/config/pointers/`**: file locking (`lock_unix.go`, `lock_windows.go`), `O_NOFOLLOW` symlink rejection, atomic writes via `O_CREATE|O_EXCL` + rename. These are non-negotiable correctness guarantees, not scaffolding — the new framework must match the existing surface from day one.
+- Supersedes-path deletion logic with guard rails:
+  - When a manifest entry sets `SupersedesPath`, init computes the hash of the on-disk old file (excluding any sentinel) and compares it against what *this binary's previous canonical for that old path* would have written
+  - If hashes match: delete the old path after the new file is written and fsync'd (clean rename)
+  - If hashes don't match: leave the old file alone, classify the old path as `Drifted` in doctor output (so users see the file and can decide). Doctor's `--fix` does NOT auto-delete drifted supersedes-path files
+  - Manifest invariant: no two entries may declare the same `SupersedesPath` (validated at registry construction; panic if violated, since it's a static manifest error)
+  - Deletion failures (permission denied, etc.) are logged and reported by doctor but don't block the new-file write
+- `InspectAll` and `SyncAll` plumbing with empty manifests
+- `xdg.CacheHome()` added to `internal/xdg/`
+- `dev` build tag: swap `//go:embed` for `os.ReadFile` against canonical source paths. Standard Go pattern for source-tree iteration. See "Dogfood discipline" below for the safety mitigations that ship alongside.
+- Tests cover sentinel round-tripping, hash stability, comment-syntax variants, locking under concurrent writers, symlink rejection, atomic-write semantics
+- **Zero behaviour change for users.** Pure scaffolding (correctly defined: same semantics as today's `pointers/`, generalized over more file types).
+
+#### PR B — Port existing managed files into the framework
+
+Migrate the 5 already-managed files into the new framework:
+
+- `.mcp.json`, `.cursor/mcp.json`, `opencode.json` → `JSONKeyMerge`
+- `AGENTS.md`, `.cursor/rules/specgraph-bootstrap.mdc` → `MarkdownBlock` (with `SupersedesPath: ".cursor/rules/specgraph-bootstrap.md"` so the old `.md` is deleted when the new `.mdc` is written)
+
+Existing `mcpconfigs/` and `pointers/` packages get folded in (their tests come along, ported to use the new types). Both packages are deleted at the end of this PR — but their *rendering algorithms* are preserved as private helpers inside `internal/config/managedfiles/` for the v=1 → v=2 hash-check and `SupersedesPath` "prior canonical" comparisons. Those helpers sunset per the policy described in §"Drift detection / Vestigial v=1 renderer."
+
+`MarkdownBlock` strategy extends today's `<!-- specgraph:init:start v=1 -->` markers to `<!-- specgraph:init:start v=2 sha256=... -->`. The state machine recognizes `v=1` as `Stale` (no hash to check; trust-and-refresh, atomic-write `v=2`). `JSONKeyMerge` strategy needs no sentinel (managed keys are always overwritten on init).
+
+#### PR C — OpenCode plugin under `.specgraph/agents/opencode/` (delivers `spgr-zqpb`)
+
+- Embed `plugin/opencode/.opencode/plugins/specgraph.ts` into binary
+- Add `.specgraph/agents/opencode/specgraph.ts` to manifest as `WholeFile`
+- Add `plugin` array key to `opencode.json` managed keys
+- Remove `.opencode/plugins/specgraph.ts` from the dogfood repo (was added in PR #941)
+- Remove the `plugin` array entry pointing at the old path from the dogfood `opencode.json`
+- Re-run `plugin/opencode/SMOKE_TEST.md` end-to-end against the new path
+
+#### PR D — Cursor rule files at `.cursor/rules/`
+
+- Repo-internal renames: source `.md` → `.mdc`, `post-stage.mdc` → `specgraph-post-stage.mdc`
+- Embed renamed sources into binary
+- Add 2 entries to manifest as `WholeFile`
+- Test: open in real Cursor, verify rules appear under Rules panel and apply on prompts
+
+#### PR E — Claude plugin shim under `.specgraph/agents/claude/`
+
+- Repo-internal renames: hook scripts get `specgraph-` prefix; `plugin.json` references update
+- Embed plugin shim sources (5 files) into binary
+- Add 5 entries to manifest as `WholeFile` under `.specgraph/agents/claude/`
+- Add `.claude/settings.json` to manifest with managed keys: `extraKnownMarketplaces.specgraph-local`, `enabledPlugins["specgraph@specgraph-local"]`
+- **Verify before committing the design** (smoke test gates the PR):
+  - `extraKnownMarketplaces` accepts `source: { type: "directory", path: "<relative>" }` with a project-relative path (claimed in design; cite the exact docs URL in the PR body)
+  - `autoUpdate: false` is honoured at the marketplace level (claimed in design; verify it's a real settings field on a marketplace entry vs only on individual plugin enablement)
+  - `${CLAUDE_PLUGIN_ROOT}` resolves to the plugin root directory (`.specgraph/agents/claude/`) when the marketplace source is `directory`-type. If Claude resolves it against the marketplace root rather than the plugin root, hooks break silently — must be verified end-to-end before relying on it
+- Test: spin up `claude` in a fresh project, run `specgraph init`, verify the plugin shows in `/plugin list` and hooks fire on session start
+- Author `plugin/specgraph/SMOKE_TEST.md` analog to OpenCode's
+
+#### PR F — Skills via MCP resource (chosen mechanism; symlinks removed)
+
+Independent of A/B/C/D/E:
+
+- Embed `<repo>/skills/` tree into the CLI binary
+- Add MCP resource handler for `specgraph://skills/<name>`
+- Add MCP tools: `specgraph_skills_list`, `specgraph_skills_get`
+- Update prime template to include the skills catalog
+- Delete the `plugin/<harness>/skills` symlinks in all three shims
+- Delete `task plugin:sync`
+- Doctor's "Integration" section grows a "Skills (N served via MCP)" line
+- **Documentation cleanup** (must land alongside the symlink deletion or downstream readers see stale info):
+  - `CLAUDE.md`: rewrite the "Plugin shims" and "Shared skills" paragraphs to reflect MCP-fetch delivery; remove `task plugin:sync` references
+  - `plugin/claude/README.md`, `plugin/cursor/README.md`, `plugin/opencode/README.md`: remove any "skills are symlinked" language; describe the MCP-resource fetch model
+  - Top-level `README.md` if it references the symlink/sync pattern (verify during PR F)
+
+PR F commits to MCP-fetch as the chosen delivery mechanism (per §"Skills delivery"). If real-user feedback later indicates a Claude UX regression is unacceptable, a follow-up bead adds Claude-specific on-disk skill writes — but PR F itself is not a parallel-run experiment.
+
+#### PR G — `specgraph doctor` + drift nudge
+
+- Implement `specgraph doctor` cobra command
+- Implement `PersistentPreRun` drift-nudge with the throttle file at `xdg.CacheHome()/nudges/<hash>`
+- Honour `SPECGRAPH_DRIFT_NUDGE=off` and `nudges: { quiet: true }`
+- `--fix` mode: auto-runs init for Stale/Missing; prints guidance for Drifted
+- Tests: state-machine table-driven tests for the four states, throttle test with synthetic mtime, e2e test that runs init then doctor and verifies clean output
+
+### Dogfood discipline
+
+This repo runs the same install flow as end users. The authoring source `plugin/<harness>/...` is the only canonical file; `.specgraph/agents/<harness>/...` and `.cursor/rules/specgraph-*.mdc` are init-written destinations and are gitignored. Dev cycle:
+
+1. Edit `plugin/<harness>/...` source
+2. `task build` (re-embeds)
+3. `specgraph init` (re-writes destinations)
+4. Test in the harness
+
+Four tooling pieces, available to anyone (not dogfood-only):
+
+- **`task plugin:refresh`**: combines build + init.
+- **`task plugin:check`**: runs `task build && specgraph init --dry-run --check` and exits non-zero if any managed file would change. PR G adds it to the `task check` chain so CI catches "I edited a shim source and forgot to rebuild + re-init." Without this, the dogfood discipline is honor-system and rots the second someone is in a hurry. (Today's `Taskfile.yml` doesn't include this target — it's introduced in PR G.)
+- **`dev` build tag**: swaps `//go:embed` for `os.ReadFile` against canonical source paths; `go build -tags dev ./cmd/specgraph` produces a binary that reads-from-disk on every init. Standard Go pattern.
+- **`task plugin:watch`** (defer): file watcher that runs `task plugin:refresh` on changes under `plugin/<harness>/`. Belongs in dev tooling, not the binary.
+
+**`dev` build tag safety mitigations:**
+
+- The dev binary emits a stderr banner on **interactive** invocations (gated on `isatty(stderr)`, same primitive as the drift-nudge): `specgraph: DEV BUILD — embedded files read from disk at <path>`. Loud and unmissable when a developer runs the binary at a terminal; silent when the binary is invoked by tooling, CI, or hooks. This preserves the safety property (devs see the warning every time they touch the binary) without polluting captured stderr in scripts. Dev binaries aren't shipped to CI in normal flows; if they are, the `isatty` gate avoids smearing the banner across captured logs.
+- Version string discipline: dev builds carry a `+dev.<short-sha>` suffix on the version (e.g., `0.2.1+dev.cef1ec3a`), never a clean semver. `specgraph version` prints it loudly. This prevents "I shipped a release but the binary I tested was tagged dev."
+- CI assertion: a release-pipeline check greps the embedded build info (`runtime/debug.ReadBuildInfo()`) on every release artifact and fails if the `dev` tag is present. Belt-and-suspenders against goreleaser misconfiguration.
+
+### Test strategy
+
+- **Unit:** each strategy implementation × ~6 cases (missing/synced/stale/drifted/sentinel-absent/sentinel-malformed)
+- **Integration:** `internal/config/managedfiles/` exercised against temp dirs with realistic content. Cross-strategy interaction in one Sync call. Partial-failure semantics. Idempotency.
+- **E2E:** per-harness manual smoke procedures, all checked in (`plugin/<harness>/SMOKE_TEST.md`). Each verifies the harness loads what init wrote. Run on demand; CI runs unit + integration.
+
+## What's NOT in this epic
+
+- **`spgr-eo4n`** (Claude marketplace publish) — stays parallel. Once published, init writes a slightly different `extraKnownMarketplaces` entry pointing at the marketplace instead of the local directory.
+- **`spgr-sa95`** (OpenCode npm publish) — same; parallel, optional.
+- **User-level installs** (`~/.config/opencode/`, `~/.cursor/mcp.json`, Cursor User Rules) — out of scope. Project-level wins on conflict per harness docs.
+- **Auto-init on binary upgrade** — Section 5's nudge surfaces staleness; we don't silently re-init.
+
+## Open questions
+
+(None remaining at design time — both prior open questions resolved during v2 review.)
+
+### Resolved (during adversarial review)
+
+- **`dev` build tag location:** PR A. Small addition, immediately useful for PRs C/D/E iteration.
+- **`enabledPlugins` semantics:** preserve user-set `false`. If a user runs `/plugin disable specgraph`, init must NOT silently re-enable on next run. Init only ensures the key *exists*; it never overwrites a user-flipped `false`.
+- **Orphans under `.specgraph/agents/<harness>/`** (e.g., a harness gets removed from the user's `harnesses:` list, or an old binary's manifest entry is dropped from a newer binary): doctor surfaces them in a dedicated "Orphans" section of the report. The orphan bar is **two-pronged**:
+  - The file lives under `.specgraph/agents/<harness>/` and is **not** in the embedded manifest for the current binary.
+  - The file carries a `specgraph:init:` sentinel.
+
+  Both conditions must hold. Files under `.specgraph/agents/<harness>/` *without* a sentinel are user content (e.g., a developer's `notes.md`); doctor surfaces them as informational only and never offers to delete. `specgraph init --remove-orphans` only deletes sentinel-carrying files whose paths are absent from the current manifest — never user-authored content lacking a sentinel.
+- **Skills engagement measurement** (was: what threshold triggers the Claude-on-disk fallback): obsoleted by the v2 decision to commit to MCP-fetch as the chosen mechanism in PR F. No measurement window. If user feedback later indicates the regression is unacceptable, we add Claude on-disk writes as a chosen change, not an experimental one.
+
+## References
+
+- Predecessor epic: `spgr-cceg` — harness parity (the three-shim pattern this epic completes the install story for)
+- First child: `spgr-zqpb` — OpenCode plugin embed-and-write (delivered by PR C)
+- Surfaced this epic: `spgr-f0di` — OpenCode plugin validation (PR #941 fixed the literal-vs-structural tool match; smoke test exposed install-vector gap)
+- Marketplace publish (parallel, optional): `spgr-eo4n` — Claude Code marketplace
+- npm publish (parallel, optional): `spgr-sa95` — `@specgraph/opencode-plugin`
+
+### External
+
+- Claude Code plugins: <https://code.claude.com/docs/en/plugins>, <https://code.claude.com/docs/en/discover-plugins>, <https://code.claude.com/docs/en/plugins-reference>, <https://code.claude.com/docs/en/settings#configuration-scopes>
+- OpenCode: <https://opencode.ai/docs/plugins>, <https://opencode.ai/docs/config>, <https://opencode.ai/docs/rules>
+- Cursor: <https://cursor.com/docs/context/rules>, <https://cursor.com/docs/context/mcp>
+- XDG Base Directory Spec: <https://specifications.freedesktop.org/basedir/latest/>
+
+## Revision history
+
+- **2026-05-08 v1**: initial design from brainstorming session
+- **2026-05-08 v2**: first adversarial review applied. Major revisions:
+  - **C1**: marker namespace stays `specgraph:init:` (not renamed to `specgraph:managed-block`); v=1 → v=2 upgrade path defined
+  - **C2**: `SupersedesPath` field on `ManagedFile` for `.md` → `.mdc` cleanup
+  - **C3**: drift-nudge gates on `isatty(stderr)`, not just a subcommand allow-list — closes the "Claude session-start hook injects nudge into prime payload" hole at the framework level
+  - **S1**: skills-via-MCP regression on Claude called out explicitly; PR F initially proposed additive-only landing
+  - **S2**: `StrategicMerge` strategy dropped (YAGNI)
+  - **S3**: `dev` build tag mitigations (stderr banner, version-string discipline, CI release check)
+  - **S4**: throttle file opportunistic GC; per-binary-version 24h throttle (not per-minute)
+  - **S6**: `task plugin:check` wired into `task check` to enforce dogfood discipline
+  - **M1**: PR A explicitly ports (not stubs) locking, symlink rejection, atomic-write primitives
+  - **M4**: preserve user-set `enabledPlugins: false` (don't silently re-enable)
+- **2026-05-08 v4**: third adversarial review applied (diminishing-returns review; no critical findings). Revisions:
+  - **v3-1 (vestigial v=1 renderer sunset)**: `mcpconfigs/` and `pointers/` rendering algorithms preserved as private helpers in `internal/config/managedfiles/` for the v=1 → v=2 hash-check and `SupersedesPath` "prior canonical" comparisons. Sunset triggers when `task plugin:check` reports zero v=1 files for two consecutive releases.
+  - **v3-2 (PR F documentation cleanup)**: PR F now explicitly updates `CLAUDE.md`, `plugin/<harness>/README.md` files, and the top-level `README.md` to remove symlink + `task plugin:sync` references. Avoids stale docs after the symlink deletion lands.
+  - **PR 0 nits**: explicit output filename (`docs/plans/2026-05-08-spgr-rwrp-pr0-claude-api-verification.md`); PR A dependency recorded in commit message + PR description; build-time test fixture where feasible.
+  - **`JSONKeyMerge` exception**: `enabledPlugins["specgraph@specgraph-local"]` is "managed-presence not managed-value" — explicit caveat added to the strategy description so a fresh reader doesn't trip on the seeming contradiction with "managed keys are always overwritten."
+  - **Orphan definition tightened**: orphan = sentinel-carrying file under `.specgraph/agents/<harness>/` whose path is absent from the current manifest. User-authored files lacking a sentinel are surfaced as informational only; never deleted by `--remove-orphans`.
+- **2026-05-08 v3**: second adversarial review applied. Major revisions:
+  - **v2-C1 (corruption-rejection collision)**: v=1 → v=2 upgrade now hashes disk content against this binary's prior canonical; mismatch is `Drifted`, not `Stale`. Forward-incompat (`v=3+`) explicitly rejected as corruption
+  - **v2-C2 (deferred verification on critical path)**: added PR 0 — Claude API verification spike that gates PR A. Three claims (`directory` source with relative path, `autoUpdate: false` honoured, `${CLAUDE_PLUGIN_ROOT}` resolves to plugin root) are verified before the framework's design assumptions lock
+  - **v2-S1 (`SupersedesPath` guard rails)**: hash-check the old file before deleting; mismatch leaves it alone and surfaces as `Drifted` on the old path. Manifest invariant: no two entries declare the same `SupersedesPath`
+  - **v2-S3 (throttle ping-pong between binaries)**: binary version moved from file contents into the path itself (`<project-hash>-<version-hash>`) so two binaries on PATH track independently
+  - **v2-S4 (PR F dual sources of truth)**: PR F now commits to MCP-fetch as the chosen mechanism; symlinks and `task plugin:sync` removed in PR F itself, not deferred. Claude-specific on-disk fallback is a chosen-change follow-up if user feedback warrants, not a measurement-window experiment
+  - **v2-S5 (dev banner has no isatty gate)**: dev banner now also gates on `isatty(stderr)` — visible interactively, silent in pipes/CI
+  - **v2-S2, v2-M2, v2-M3, v2-M4**: small wording fixes; orphan-file handling resolved in Open Questions (doctor surfaces, `init --remove-orphans` deletes)

--- a/docs/plans/2026-05-08-spgr-rwrp-harness-install-parity-design.md
+++ b/docs/plans/2026-05-08-spgr-rwrp-harness-install-parity-design.md
@@ -102,7 +102,7 @@ This guards against silently destroying hand-edited content during the v=1 → v
 
 **Vestigial v=1 renderer (sunset policy).** PR B preserves the existing `pointers/` rendering logic as an unexported helper inside `internal/config/managedfiles/` (e.g. `classifyV1Disk`). The helper exists *only* to compute what a v=1 canonical would have written for the v=1 → v=2 hash-check above. It is not on the production write path — new writes always emit v=2. The helper is removed in a follow-up bead once `task plugin:check` reports zero `v=1` files in the dogfood repo for two consecutive releases. Same policy applies to `SupersedesPath` "prior canonical" computations (e.g., the old `.md` cursor-rule path's pre-PR-D rendering): preserve as a private helper, sunset on the same trigger.
 
-**Forward-compatibility:** the marker parser accepts `v=1` and `v=2`, rejects `v=3+` as `ErrCorruptedMarkers` (matches today's `pointers/agents.go` corruption-rejection behaviour for unknown versions). A future binary downgrade scenario surfaces as corruption rather than silent data loss.
+**Forward-compatibility:** the marker parser accepts `v=1` and `v=2`, rejects `v=3+` as `ErrCorruptedSentinel` — the canonical error name in the new framework, matching the existing pointers-era corruption-rejection behaviour for unknown versions. A future binary downgrade scenario surfaces as corruption rather than silent data loss.
 
 `JSONKeyMerge` does not need sentinels — the strategy already knows which keys it owns and overwrites them on every init. There's no `Drifted` state for merge-strategy files because managed keys are not user-owned by definition. **One exception:** `.claude/settings.json`'s `enabledPlugins["specgraph@specgraph-local"]` preserves a user-set `false` value (so `claude /plugin disable specgraph` survives subsequent `init` runs — see "Open questions / Resolved"). That key is "managed-presence" rather than "managed-value": init ensures the key exists; the value follows the user's last choice. It's the only such key in the manifest; the exception is local, not a general policy.
 
@@ -321,7 +321,7 @@ Migrate the 5 already-managed files into the new framework:
 
 Existing `mcpconfigs/` and `pointers/` packages get folded in (their tests come along, ported to use the new types). Both packages are deleted at the end of this PR — but their *rendering algorithms* are preserved as private helpers inside `internal/config/managedfiles/` for the v=1 → v=2 hash-check and `SupersedesPath` "prior canonical" comparisons. Those helpers sunset per the policy described in §"Drift detection / Vestigial v=1 renderer."
 
-`MarkdownBlock` strategy extends today's `<!-- specgraph:init:start v=1 -->` markers to `<!-- specgraph:init:start v=2 sha256=... -->`. The state machine recognizes `v=1` as `Stale` (no hash to check; trust-and-refresh, atomic-write `v=2`). `JSONKeyMerge` strategy needs no sentinel (managed keys are always overwritten on init).
+`MarkdownBlock` strategy extends today's `<!-- specgraph:init:start v=1 -->` markers to `<!-- specgraph:init:start v=2 sha256=... -->`. State classification follows the defensive hash/compare semantics from §"Drift detection / Upgrade path from v=1 markers to v=2": when a sentinel carries a hash (`v=2`), the state machine compares disk content to that hash — a mismatch is `Drifted` (refuse to overwrite without `--force`), a match is `Synced`. Only the `v=1` markers without a hash fall back to "trust-and-refresh" (recompute what this binary's `v=1` canonical would have produced, compare to disk; match → `Stale` and refresh to `v=2`, mismatch → `Drifted`). `JSONKeyMerge` strategy needs no sentinel (managed keys are always overwritten on init).
 
 #### PR C — OpenCode plugin under `.specgraph/agents/opencode/` (delivers `spgr-zqpb`)
 
@@ -426,6 +426,7 @@ Four tooling pieces, available to anyone (not dogfood-only):
   - The file carries a `specgraph:init:` sentinel.
 
   Both conditions must hold. Files under `.specgraph/agents/<harness>/` *without* a sentinel are user content (e.g., a developer's `notes.md`); doctor surfaces them as informational only and never offers to delete. `specgraph init --remove-orphans` only deletes sentinel-carrying files whose paths are absent from the current manifest — never user-authored content lacking a sentinel.
+
 - **Skills engagement measurement** (was: what threshold triggers the Claude-on-disk fallback): obsoleted by the v2 decision to commit to MCP-fetch as the chosen mechanism in PR F. No measurement window. If user feedback later indicates the regression is unacceptable, we add Claude on-disk writes as a chosen change, not an experimental one.
 
 ## References

--- a/docs/plans/2026-05-08-spgr-rwrp-pr0-claude-api-verification.md
+++ b/docs/plans/2026-05-08-spgr-rwrp-pr0-claude-api-verification.md
@@ -1,0 +1,102 @@
+# spgr-rwrp PR 0 — Claude API verification report
+
+**Date:** 2026-05-08
+**Claude version:** 2.1.133 (Claude Code)
+**Spike location:** `~/Code/specgraph-pr0-spike/`
+**Bead:** `spgr-9zxp`
+
+## Summary
+
+| Claim | Verdict |
+|---|---|
+| 1. Relative path acceptance in `extraKnownMarketplaces` | GREEN |
+| 2. `autoUpdate: false` honoured | GREEN (with caveat — see below) |
+| 3. `${CLAUDE_PLUGIN_ROOT}` resolves to plugin root | GREEN |
+
+PR A may proceed. Two schema corrections must fold into the spec doc as v5 (see "Spec corrections" section).
+
+## Spec corrections required
+
+- `extraKnownMarketplaces.<name>.source.path` must point at the **marketplace root** (the directory CONTAINING `.claude-plugin/`), NOT at `.claude-plugin/` itself. PR A must use paths like `./.specgraph/agents/claude` (the dir containing `.claude-plugin/`), not `./.specgraph/agents/claude/.claude-plugin`.
+- `marketplace.json` `plugins[].source` is a **directory path** with mandatory `./` prefix, NOT a file path. Use `"source": "./"` for a co-located plugin and `"source": "./sub-plugin"` for a sub-directory plugin — never `"./.claude-plugin/plugin.json"`.
+
+## Claim 1 — Relative path acceptance
+
+**Verdict: GREEN.**
+
+`extraKnownMarketplaces.<name>.source.path` accepts a project-relative directory path. Claude appends `/.claude-plugin/marketplace.json` to the path itself. Test value used: `"./test-marketplace"`. Plugin loaded successfully and SessionStart hooks fired.
+
+**Schema correction:** the path must point at the **marketplace root** (the directory CONTAINING `.claude-plugin/`), not at `.claude-plugin/` itself. The spec's design doc had this wrong; PR A must use paths like `./.specgraph/agents/claude` (the dir containing `.claude-plugin/`), not `./.specgraph/agents/claude/.claude-plugin`.
+
+Hook output proving plugin loaded (from `.spike-out/marketplace-shape.txt`):
+
+```text
+ts: 2026-05-08T18:21:37-04:00
+pwd: /Users/SeBrandt/Code/specgraph-pr0-spike
+CLAUDE_PLUGIN_ROOT: /Volumes/Code/specgraph-pr0-spike/test-marketplace/
+CLAUDE_PROJECT_DIR: /Volumes/Code/specgraph-pr0-spike
+argv0: /Volumes/Code/specgraph-pr0-spike/test-marketplace//hooks/verify-root.sh
+```
+
+## Claim 2 — `autoUpdate: false`
+
+**Verdict: GREEN with caveat.**
+
+`autoUpdate: false` is a real field on the marketplace entry and is accepted without validation error. Behaviour observed:
+
+- Registry metadata (version, lastUpdated, gitCommitSha in `~/.claude/plugins/installed_plugins.json`) stays pinned at the originally-installed version even when on-disk plugin.json is bumped 0.1.0 → 0.1.1.
+- However, for `source: directory` marketplaces, Claude does NOT cache plugin files. Hooks, skills, agents, and commands are read **live** from the source directory on every session. So `autoUpdate: false` does NOT prevent file-content drift between sessions.
+
+For SpecGraph's design, this is acceptable: we WANT every `specgraph init` refresh to be visible to the next Claude session. `autoUpdate: false` serves as documentation-of-intent that we control the version axis; the live-file-read behaviour is exactly what we want operationally.
+
+## Claim 3 — `${CLAUDE_PLUGIN_ROOT}` resolution
+
+**Verdict: GREEN.**
+
+`${CLAUDE_PLUGIN_ROOT}` resolves to **the plugin's own root directory** (the dir containing the plugin's `.claude-plugin/`), regardless of marketplace location. Two test cases:
+
+**3a: Co-located (plugin in same `.claude-plugin/` as marketplace)** — `marketplace.json` and `plugin.json` both live at `test-marketplace/.claude-plugin/`. Hook fires with:
+
+```text
+CLAUDE_PLUGIN_ROOT: /Volumes/Code/specgraph-pr0-spike/test-marketplace/
+```
+
+This is the marketplace root, which IS also the plugin root in the co-located case. ✓
+
+**3b: Sub-plugin (plugin in a subdirectory of marketplace)** — `marketplace.json` at `test-marketplace/.claude-plugin/`, plugin at `test-marketplace/sub-plugin/.claude-plugin/`. Hook fires with:
+
+```text
+CLAUDE_PLUGIN_ROOT: /Volumes/Code/specgraph-pr0-spike/test-marketplace/sub-plugin
+```
+
+This is the plugin's own root (`sub-plugin/`), distinct from the marketplace root (`test-marketplace/`). ✓
+
+The spec's `.specgraph/agents/claude/` layout is structurally correct — plugin root and marketplace root coincide (single-plugin co-located marketplace), and `${CLAUDE_PLUGIN_ROOT}` resolves to that path. Hook references like `${CLAUDE_PLUGIN_ROOT}/hooks/specgraph-session-start.sh` resolve correctly.
+
+## Bonus findings
+
+### marketplace.json plugin source schema
+
+Independent of the three claims but discovered during verification: the `plugins[].source` field in `marketplace.json` is a **directory path** with mandatory `./` prefix, NOT a file path. Working forms:
+
+- Co-located plugin: `"source": "./"` (NOT `"./.claude-plugin/plugin.json"`)
+- Sub-directory plugin: `"source": "./sub-plugin"` (NOT `"./sub-plugin/.claude-plugin/plugin.json"`)
+
+`..` traversal is blocked. All sub-plugins must live INSIDE the marketplace root.
+
+### symlink resolution
+
+Claude resolves symlinks on the plugin path. The user's `pwd` shows `/Users/SeBrandt/...` (symlink) but `CLAUDE_PLUGIN_ROOT` shows `/Volumes/Code/...` (real path). This matches the spec's choice to use `EvalSymlinks(projectRoot)` for the throttle file key — Claude does the equivalent internally.
+
+## Methodology notes
+
+- Claude version: 2.1.133
+- Hook trigger: SessionStart, fired by `claude -p "Reply with..." --output-format text`
+- All artefacts preserved at `~/Code/specgraph-pr0-spike/.spike-out/` for re-inspection
+- Slash commands (`/plugin list`) are not available in `claude -p` mode — verification used SessionStart hooks + Claude's debug logs (`~/.claude/debug/<uuid>.txt`) and `~/.claude/plugins/installed_plugins.json`
+
+## References
+
+- Design: `docs/plans/2026-05-08-spgr-rwrp-harness-install-parity-design.md`
+- Plan: `docs/plans/2026-05-08-spgr-rwrp-pr0-plan.md`
+- Claude plugins docs: <https://code.claude.com/docs/en/plugins>, <https://code.claude.com/docs/en/discover-plugins>, <https://code.claude.com/docs/en/plugins-reference>, <https://code.claude.com/docs/en/plugin-marketplaces>

--- a/docs/plans/2026-05-08-spgr-rwrp-pr0-plan.md
+++ b/docs/plans/2026-05-08-spgr-rwrp-pr0-plan.md
@@ -1,0 +1,749 @@
+# PR 0 — Claude API verification spike implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Empirically verify three Claude Code plugin-loading claims that the spgr-rwrp design depends on, before PR A locks the framework's design assumptions.
+
+**Architecture:** Build a minimal scratch project with a hand-written Claude plugin and local-directory marketplace. Run `claude` against it, capture observed behaviour, and write a verification report that greens or reds each claim.
+
+**Tech Stack:** Bash, Claude Code CLI (`claude` v2.1.133, installed at `/opt/homebrew/bin/claude`), JSON config files.
+
+**Spec:** `docs/plans/2026-05-08-spgr-rwrp-harness-install-parity-design.md` — see PR 0 section.
+
+**Bead:** new `spgr-rwrp-pr0` (file as part of Task 0).
+
+---
+
+## Claims to verify
+
+1. **Relative path acceptance:** `extraKnownMarketplaces` in `.claude/settings.json` accepts a `source: { type: "directory", path: "<relative path>" }` entry, where the path is project-relative (e.g. `./test-plugin/.claude-plugin`), and Claude resolves it correctly so the plugin appears in `/plugin list`.
+
+2. **`autoUpdate: false` honoured:** Setting `autoUpdate: false` on the marketplace entry is accepted by Claude (no validation error) and is honoured semantically — Claude does not auto-update the plugin from the directory source.
+
+3. **`${CLAUDE_PLUGIN_ROOT}` resolution:** When a hook script in the plugin runs (e.g., a session-start hook), `${CLAUDE_PLUGIN_ROOT}` resolves to the plugin's root directory (the dir containing `.claude-plugin/plugin.json`), **not** the marketplace root and **not** the `.claude-plugin/` subdirectory.
+
+If any claim fails, the spec's PR 0 section documents the design fallout (use absolute paths, drop autoUpdate, re-architect layout one level deeper).
+
+---
+
+## File structure
+
+The spike runs entirely in a scratch directory **outside** the SpecGraph repo. No production code changes; only a verification report committed back to the repo.
+
+```text
+~/Code/specgraph-pr0-spike/                    # scratch, gitignored, deletable
+├── .claude/
+│   └── settings.json                          # extraKnownMarketplaces + enabledPlugins
+├── test-marketplace/                          # the local directory marketplace
+│   └── .claude-plugin/
+│       ├── marketplace.json                   # lists test-plugin
+│       └── plugin.json                        # plugin manifest (single-plugin marketplace)
+└── test-plugin/
+    ├── .claude-plugin/
+    │   └── plugin.json                        # alternate layout for claim 3 separation test
+    └── hooks/
+        └── verify-root.sh                     # prints $CLAUDE_PLUGIN_ROOT to a sentinel file
+```
+
+Verification artefacts saved back to `<specgraph-repo>/docs/plans/2026-05-08-spgr-rwrp-pr0-claude-api-verification.md`.
+
+---
+
+## Task 0: Pre-flight + bead creation
+
+**Files:**
+
+- Create: `spgr-rwrp-pr0` bead (via `bd create`)
+
+- [ ] **Step 1: Confirm Claude CLI is available**
+
+Run: `claude --version`
+Expected: `2.1.133 (Claude Code)` or newer.
+
+If missing or older, stop. Install/upgrade Claude Code per your OS (`brew upgrade claude-code` on macOS) before continuing.
+
+- [ ] **Step 2: Confirm `claude --print` works**
+
+Run: `claude -p "Reply with the single word PONG and nothing else." --output-format text`
+Expected: stdout contains `PONG`, exit code 0.
+
+If this fails (auth, model unavailable), resolve before continuing — the rest of the plan needs `--print` mode.
+
+- [ ] **Step 3: File the bead**
+
+```bash
+bd create \
+  --type=task \
+  --priority=2 \
+  --title="PR 0: Claude API verification spike for spgr-rwrp" \
+  --description="Verification spike preceding spgr-rwrp PR A. Confirm three claims about Claude's plugin loading: relative paths in extraKnownMarketplaces source.path; autoUpdate: false honoured at the marketplace-entry level; \${CLAUDE_PLUGIN_ROOT} resolves to the plugin root, not the marketplace root or .claude-plugin/ subdir. Output: docs/plans/2026-05-08-spgr-rwrp-pr0-claude-api-verification.md."
+```
+
+Note the returned bead id (e.g., `spgr-XXXX`); use it in subsequent commits.
+
+- [ ] **Step 4: Wire dependency to the epic**
+
+```bash
+bd dep add spgr-rwrp <new-bead-id>
+bd update <new-bead-id> --claim
+```
+
+- [ ] **Step 5: Push beads**
+
+```bash
+bd dolt push
+```
+
+---
+
+## Task 1: Set up the scratch project
+
+**Files:**
+
+- Create: `~/Code/specgraph-pr0-spike/` directory tree
+- Create: `~/Code/specgraph-pr0-spike/.git/` (init'd as git repo so Claude treats it as a project)
+- Create: scratch `README.md`
+
+- [ ] **Step 1: Create the scratch directory and init git**
+
+```bash
+mkdir -p ~/Code/specgraph-pr0-spike
+cd ~/Code/specgraph-pr0-spike
+git init -q
+echo "# spgr-rwrp PR 0 spike" > README.md
+git add README.md
+git -c user.email=spike@local -c user.name=spike commit -q -m "init spike"
+```
+
+Expected: clean git repo with one commit.
+
+- [ ] **Step 2: Confirm the scratch dir is correctly placed**
+
+Run: `pwd && ls -la`
+Expected: pwd is `~/Code/specgraph-pr0-spike` (or `/Users/<you>/Code/specgraph-pr0-spike`). Listing shows `.git/`, `README.md`.
+
+The remaining tasks all run in this scratch dir unless otherwise noted.
+
+---
+
+## Task 2: Build the test plugin and marketplace
+
+**Files:**
+
+- Create: `~/Code/specgraph-pr0-spike/test-marketplace/.claude-plugin/marketplace.json`
+- Create: `~/Code/specgraph-pr0-spike/test-marketplace/.claude-plugin/plugin.json`
+- Create: `~/Code/specgraph-pr0-spike/test-plugin/.claude-plugin/plugin.json`
+- Create: `~/Code/specgraph-pr0-spike/test-plugin/hooks/verify-root.sh`
+
+- [ ] **Step 1: Create the single-plugin marketplace (production-shape, used for claims 1, 2, 3a)**
+
+```bash
+mkdir -p test-marketplace/.claude-plugin
+```
+
+Write `test-marketplace/.claude-plugin/marketplace.json`:
+
+```json
+{
+  "name": "spgr-pr0-marketplace",
+  "version": "0.1.0",
+  "plugins": [
+    {
+      "name": "spgr-pr0-plugin",
+      "source": ".",
+      "version": "0.1.0",
+      "description": "PR 0 spike plugin"
+    }
+  ]
+}
+```
+
+Write `test-marketplace/.claude-plugin/plugin.json`:
+
+```json
+{
+  "name": "spgr-pr0-plugin",
+  "version": "0.1.0",
+  "description": "PR 0 spike plugin",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/verify-root.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Note: this layout matches the spgr-rwrp design — marketplace + plugin co-located in the same `.claude-plugin/` dir, single-plugin marketplace.
+
+- [ ] **Step 2: Add the verify-root hook script (in the marketplace/plugin dir)**
+
+```bash
+mkdir -p test-marketplace/hooks
+cat > test-marketplace/hooks/verify-root.sh <<'EOF'
+#!/usr/bin/env bash
+# Records what ${CLAUDE_PLUGIN_ROOT} resolves to at hook-execution time.
+out_dir="${HOME}/Code/specgraph-pr0-spike/.spike-out"
+mkdir -p "$out_dir"
+{
+  echo "ts: $(date -Iseconds)"
+  echo "pwd: $(pwd)"
+  echo "CLAUDE_PLUGIN_ROOT: ${CLAUDE_PLUGIN_ROOT:-<unset>}"
+  echo "CLAUDE_PROJECT_DIR: ${CLAUDE_PROJECT_DIR:-<unset>}"
+  echo "argv0: $0"
+} > "$out_dir/marketplace-shape.txt"
+EOF
+chmod +x test-marketplace/hooks/verify-root.sh
+```
+
+- [ ] **Step 3: Create the separated plugin directory (used for claim 3b — plugin-root vs marketplace-root distinction)**
+
+```bash
+mkdir -p test-plugin/.claude-plugin test-plugin/hooks
+```
+
+Write `test-plugin/.claude-plugin/plugin.json` (note: same shape as above, but now plugin lives in a separate directory from any marketplace):
+
+```json
+{
+  "name": "spgr-pr0-separated-plugin",
+  "version": "0.1.0",
+  "description": "PR 0 spike plugin in a separated directory",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/verify-root.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Copy the verify script:
+
+```bash
+cat > test-plugin/hooks/verify-root.sh <<'EOF'
+#!/usr/bin/env bash
+out_dir="${HOME}/Code/specgraph-pr0-spike/.spike-out"
+mkdir -p "$out_dir"
+{
+  echo "ts: $(date -Iseconds)"
+  echo "pwd: $(pwd)"
+  echo "CLAUDE_PLUGIN_ROOT: ${CLAUDE_PLUGIN_ROOT:-<unset>}"
+  echo "CLAUDE_PROJECT_DIR: ${CLAUDE_PROJECT_DIR:-<unset>}"
+  echo "argv0: $0"
+} > "$out_dir/separated-shape.txt"
+EOF
+chmod +x test-plugin/hooks/verify-root.sh
+```
+
+- [ ] **Step 4: Verify the directory tree**
+
+Run: `find . -type f -not -path './.git/*' | sort`
+
+Expected output exactly:
+
+```text
+./README.md
+./test-marketplace/.claude-plugin/marketplace.json
+./test-marketplace/.claude-plugin/plugin.json
+./test-marketplace/hooks/verify-root.sh
+./test-plugin/.claude-plugin/plugin.json
+./test-plugin/hooks/verify-root.sh
+```
+
+---
+
+## Task 3: Verify claim 1 — relative path acceptance
+
+**Files:**
+
+- Create: `~/Code/specgraph-pr0-spike/.claude/settings.json`
+
+- [ ] **Step 1: Write `.claude/settings.json` pointing at the marketplace via relative path**
+
+```bash
+mkdir -p .claude
+cat > .claude/settings.json <<'EOF'
+{
+  "extraKnownMarketplaces": {
+    "spgr-pr0-marketplace": {
+      "source": {
+        "source": "directory",
+        "path": "./test-marketplace/.claude-plugin"
+      },
+      "autoUpdate": false
+    }
+  },
+  "enabledPlugins": {
+    "spgr-pr0-plugin@spgr-pr0-marketplace": true
+  }
+}
+```
+
+- [ ] **Step 2: Restart any running Claude session, then verify plugin appears**
+
+Use the `--print` mode to ask Claude to enumerate its plugins:
+
+```bash
+rm -rf .spike-out
+claude -p "/plugin list" --output-format text > .spike-out/plugin-list-claim1.txt 2>&1 || true
+cat .spike-out/plugin-list-claim1.txt
+```
+
+Expected: the response includes `spgr-pr0-plugin` (or similar). If `/plugin list` doesn't render in `-p` mode, fall back to running `claude` interactively and observing output:
+
+```bash
+# Interactive fallback
+claude
+# In Claude: /plugin list
+# Capture screenshot or copy text into .spike-out/plugin-list-claim1.txt
+```
+
+- [ ] **Step 3: Classify the result**
+
+Inspect `.spike-out/plugin-list-claim1.txt`:
+
+- **GREEN** if `spgr-pr0-plugin` is listed and Claude reports it as enabled / available.
+- **RED** if Claude errors with "could not resolve marketplace path" or similar, OR if the plugin doesn't appear.
+
+Record verdict in a scratch note (`.spike-out/verdict-claim1.txt`):
+
+```bash
+echo "claim1: GREEN — relative path resolves" > .spike-out/verdict-claim1.txt
+# or RED with the observed error text
+```
+
+If RED, the design fallout per the spec is: switch to absolute paths. Document the error verbatim in the verdict file; the report task will record the fallback.
+
+---
+
+## Task 4: Verify claim 2 — `autoUpdate: false` is honoured
+
+**Files:**
+
+- Modify: `~/Code/specgraph-pr0-spike/test-marketplace/.claude-plugin/plugin.json` (bump version to test)
+
+- [ ] **Step 1: Confirm Claude accepts the `autoUpdate: false` setting without error**
+
+Already done in Task 3 — settings.json includes `"autoUpdate": false`. If Claude rejected the field with a validation error in Task 3, claim 2 is RED at the syntactic level. If Task 3 was GREEN, the field is at least accepted.
+
+- [ ] **Step 2: Bump the plugin version on disk**
+
+```bash
+# Change version 0.1.0 → 0.1.1
+sed -i.bak 's/"version": "0.1.0"/"version": "0.1.1"/' test-marketplace/.claude-plugin/plugin.json
+rm test-marketplace/.claude-plugin/plugin.json.bak
+grep version test-marketplace/.claude-plugin/plugin.json
+```
+
+Expected: `"version": "0.1.1"` is now present.
+
+- [ ] **Step 3: Run Claude again and observe whether it auto-detected the update**
+
+```bash
+claude -p "/plugin list" --output-format text > .spike-out/plugin-list-claim2.txt 2>&1 || true
+cat .spike-out/plugin-list-claim2.txt
+```
+
+Look for:
+
+- Plugin still reports version `0.1.0` → autoUpdate is honoured (Claude did NOT auto-pull `0.1.1`). **GREEN.**
+- Plugin reports version `0.1.1` → Claude auto-updated despite `autoUpdate: false`. **RED.**
+- No version reported in `/plugin list` output → use the next step to disambiguate.
+
+- [ ] **Step 4 (if needed): Disambiguate via session-start hook output**
+
+If `/plugin list` doesn't include the version, trigger a fresh session and inspect what hook fired (the version embedded in `plugin.json` at the time the session started):
+
+```bash
+rm -f .spike-out/marketplace-shape.txt
+claude -p "exit" --output-format text > /dev/null 2>&1 || true
+cat .spike-out/marketplace-shape.txt 2>/dev/null || echo "hook did not fire"
+```
+
+If the hook fired with the still-`0.1.0` plugin path (older bytes still cached/loaded), claim 2 is GREEN. If new bytes loaded, RED.
+
+- [ ] **Step 5: Classify the result**
+
+Record verdict at `.spike-out/verdict-claim2.txt`:
+
+```bash
+echo "claim2: GREEN — autoUpdate: false respected (plugin pinned at 0.1.0 despite disk-side bump to 0.1.1)" > .spike-out/verdict-claim2.txt
+# or RED if Claude auto-pulled 0.1.1
+```
+
+If RED, fallout per spec: drop `autoUpdate: false` from managed keys; rely on Claude's local-marketplace defaults (per docs, off by default for non-Anthropic marketplaces).
+
+---
+
+## Task 5: Verify claim 3 — `${CLAUDE_PLUGIN_ROOT}` resolution
+
+This is the most subtle of the three. Two cases:
+
+- **3a:** marketplace and plugin coincide (single-plugin marketplace, our production layout) — does `CLAUDE_PLUGIN_ROOT` = the dir containing `.claude-plugin/`?
+- **3b:** plugin lives in a separate directory from the marketplace — does `CLAUDE_PLUGIN_ROOT` = the plugin's own root, or the marketplace's root?
+
+We don't ship 3b's layout but it's the diagnostic test — if 3a's behaviour ambiguously matches both interpretations, 3b distinguishes them.
+
+**Files:**
+
+- No new files. Reuses the plugins from Task 2.
+
+- [ ] **Step 1: Trigger session-start for the production-shape plugin (3a)**
+
+```bash
+rm -f .spike-out/marketplace-shape.txt .spike-out/separated-shape.txt
+claude -p "say hi" --output-format text > .spike-out/session-claim3a.txt 2>&1 || true
+sleep 1  # let any async hooks finish
+cat .spike-out/marketplace-shape.txt 2>/dev/null || echo "MISSING — hook did not fire"
+```
+
+Expected: `marketplace-shape.txt` exists and contains a `CLAUDE_PLUGIN_ROOT:` line. Read the value.
+
+- [ ] **Step 2: Determine 3a verdict**
+
+If `CLAUDE_PLUGIN_ROOT` = `/Users/<you>/Code/specgraph-pr0-spike/test-marketplace`:
+
+- Resolves to the dir containing `.claude-plugin/`. **Correct interpretation.** Record observed value.
+
+If `CLAUDE_PLUGIN_ROOT` = `/Users/<you>/Code/specgraph-pr0-spike/test-marketplace/.claude-plugin`:
+
+- Resolves to `.claude-plugin/` itself, one level too deep. **Wrong for our layout.**
+
+If `CLAUDE_PLUGIN_ROOT` = some path outside `test-marketplace/`:
+
+- Unexpected; investigate.
+
+- [ ] **Step 3: Switch settings.json to enable the separated plugin (3b)**
+
+To distinguish "marketplace root" vs "plugin root" we need a layout where they differ. Add a second marketplace entry pointing at the separated plugin and enable it:
+
+```bash
+cat > .claude/settings.json <<'EOF'
+{
+  "extraKnownMarketplaces": {
+    "spgr-pr0-marketplace": {
+      "source": {
+        "source": "directory",
+        "path": "./test-marketplace/.claude-plugin"
+      },
+      "autoUpdate": false
+    },
+    "spgr-pr0-separated-marketplace": {
+      "source": {
+        "source": "directory",
+        "path": "./test-marketplace/.claude-plugin"
+      },
+      "autoUpdate": false
+    }
+  },
+  "enabledPlugins": {
+    "spgr-pr0-plugin@spgr-pr0-marketplace": true,
+    "spgr-pr0-separated-plugin@spgr-pr0-separated-marketplace": true
+  }
+}
+EOF
+```
+
+(Note: the marketplace.json in this spike only lists one plugin, so adding a second marketplace entry pointing at the same location reuses the same plugin manifest. To test the separated layout properly, we may need to extend the marketplace.json to list `spgr-pr0-separated-plugin` at a different path. If the simple form above doesn't trigger the separated plugin's hook, fall back to extending marketplace.json:)
+
+```bash
+# Fallback: extend marketplace to list the separated plugin too
+cat > test-marketplace/.claude-plugin/marketplace.json <<'EOF'
+{
+  "name": "spgr-pr0-marketplace",
+  "version": "0.1.0",
+  "plugins": [
+    {
+      "name": "spgr-pr0-plugin",
+      "source": ".",
+      "version": "0.1.0",
+      "description": "in-marketplace plugin"
+    },
+    {
+      "name": "spgr-pr0-separated-plugin",
+      "source": "../../test-plugin",
+      "version": "0.1.0",
+      "description": "out-of-marketplace plugin"
+    }
+  ]
+}
+EOF
+
+cat > .claude/settings.json <<'EOF'
+{
+  "extraKnownMarketplaces": {
+    "spgr-pr0-marketplace": {
+      "source": {
+        "source": "directory",
+        "path": "./test-marketplace/.claude-plugin"
+      },
+      "autoUpdate": false
+    }
+  },
+  "enabledPlugins": {
+    "spgr-pr0-plugin@spgr-pr0-marketplace": true,
+    "spgr-pr0-separated-plugin@spgr-pr0-marketplace": true
+  }
+}
+EOF
+```
+
+- [ ] **Step 4: Trigger session-start, capture both hooks' outputs**
+
+```bash
+rm -f .spike-out/marketplace-shape.txt .spike-out/separated-shape.txt
+claude -p "say hi" --output-format text > .spike-out/session-claim3b.txt 2>&1 || true
+sleep 1
+echo "--- marketplace-shape ---"
+cat .spike-out/marketplace-shape.txt 2>/dev/null || echo "MISSING"
+echo "--- separated-shape ---"
+cat .spike-out/separated-shape.txt 2>/dev/null || echo "MISSING"
+```
+
+- [ ] **Step 5: Compare CLAUDE_PLUGIN_ROOT in both files**
+
+For the **separated** plugin, the expected (correct) value is `<spike-root>/test-plugin` — i.e., the plugin's own directory, NOT `<spike-root>/test-marketplace`.
+
+If `separated-shape.txt`'s `CLAUDE_PLUGIN_ROOT` is:
+
+- `<spike-root>/test-plugin` → **GREEN.** Resolves to the plugin's own root regardless of marketplace location. Spec assumption is correct.
+- `<spike-root>/test-marketplace` (or `.../test-marketplace/.claude-plugin`) → **RED.** Resolves to the marketplace root. Our `.specgraph/agents/claude/` layout will break.
+- Other → investigate, document verbatim.
+
+- [ ] **Step 6: Classify the result**
+
+Record verdict at `.spike-out/verdict-claim3.txt`:
+
+```bash
+{
+  echo "claim3a (production shape): observed CLAUDE_PLUGIN_ROOT = ..."
+  echo "claim3b (separated layout): observed CLAUDE_PLUGIN_ROOT = ..."
+  echo
+  echo "verdict: GREEN — resolves to plugin root in both cases"
+  # or RED with the design-fallout note
+} > .spike-out/verdict-claim3.txt
+cat .spike-out/verdict-claim3.txt
+```
+
+If RED, design fallout per spec: re-architect Claude layout one level deeper, so plugin root and `.claude-plugin/` dir coincide. Record the exact path-resolution behaviour for the report.
+
+---
+
+## Task 6: Write the verification report
+
+**Files:**
+
+- Create: `<specgraph-repo>/docs/plans/2026-05-08-spgr-rwrp-pr0-claude-api-verification.md`
+
+- [ ] **Step 1: Aggregate the three verdicts**
+
+Return to the SpecGraph repo:
+
+```bash
+cd /Volumes/Code/github.com/specgraph
+mkdir -p docs/plans
+```
+
+- [ ] **Step 2: Write the report**
+
+Create `docs/plans/2026-05-08-spgr-rwrp-pr0-claude-api-verification.md` with this structure:
+
+````markdown
+# spgr-rwrp PR 0 — Claude API verification report
+
+**Date:** 2026-05-08
+**Claude version:** [output of `claude --version`]
+**Spike location:** `~/Code/specgraph-pr0-spike/`
+**Bead:** `spgr-XXXX` (the PR 0 bead from Task 0)
+
+## Summary
+
+| Claim | Verdict |
+|---|---|
+| 1. Relative path acceptance | GREEN / RED |
+| 2. `autoUpdate: false` honoured | GREEN / RED |
+| 3. `${CLAUDE_PLUGIN_ROOT}` resolves to plugin root | GREEN / RED |
+
+PR A may proceed: YES / NO. If NO, the design fallout below applies.
+
+## Claim 1 — Relative path acceptance
+
+**Setup:** `.claude/settings.json` declared `extraKnownMarketplaces.spgr-pr0-marketplace.source = { type: "directory", path: "./test-marketplace/.claude-plugin" }`.
+
+**Observed:**
+
+```text
+[paste contents of .spike-out/plugin-list-claim1.txt]
+```
+
+**Verdict:** GREEN/RED + one-sentence reason.
+
+**Fallout (if RED):** [text from the spec or a refinement]
+
+## Claim 2 — `autoUpdate: false`
+
+**Setup:** Added `autoUpdate: false`. Bumped plugin.json version 0.1.0 → 0.1.1 on disk between Claude invocations.
+
+**Observed:**
+
+```text
+[paste contents of .spike-out/plugin-list-claim2.txt]
+[and/or .spike-out/marketplace-shape.txt]
+```
+
+**Verdict:** GREEN/RED + one-sentence reason.
+
+**Fallout (if RED):** drop `autoUpdate` from `.claude/settings.json` managed keys.
+
+## Claim 3 — `${CLAUDE_PLUGIN_ROOT}` resolution
+
+**Setup 3a (production shape):** marketplace and plugin co-located in `test-marketplace/.claude-plugin/`.
+
+**Observed:**
+
+```text
+[paste contents of .spike-out/marketplace-shape.txt]
+```
+
+**Setup 3b (separated layout):** marketplace at `test-marketplace/`, plugin at `test-plugin/`, marketplace.json pointing at `../../test-plugin`.
+
+**Observed:**
+
+```text
+[paste contents of .spike-out/separated-shape.txt]
+```
+
+**Verdict:** GREEN/RED + one-sentence reason.
+
+**Fallout (if RED):** re-architect Claude layout. Plugin root and `.claude-plugin/` dir must coincide. Update spgr-rwrp design doc Section 4 manifest entries 10–14 to nest one level deeper.
+
+## Methodology notes
+
+- Claude version observed: [version]
+- Hook trigger: SessionStart, fired by `claude -p "say hi"`
+- All artefacts live at `~/Code/specgraph-pr0-spike/.spike-out/` and are preserved for re-inspection.
+
+## References
+
+- Design: `docs/plans/2026-05-08-spgr-rwrp-harness-install-parity-design.md`
+- Plan: `docs/plans/2026-05-08-spgr-rwrp-pr0-plan.md`
+- Claude plugins docs: <https://code.claude.com/docs/en/plugins>, <https://code.claude.com/docs/en/discover-plugins>, <https://code.claude.com/docs/en/plugins-reference>
+````
+
+Replace each `[paste …]` with the actual captured output. Replace `GREEN/RED` with the actual verdicts.
+
+- [ ] **Step 3: Verify the report contents**
+
+Run: `head -30 docs/plans/2026-05-08-spgr-rwrp-pr0-claude-api-verification.md`
+
+Expected: header is filled in (no placeholders), Summary table shows three verdicts, Claim sections show observed output.
+
+- [ ] **Step 4: Lint**
+
+Run: `task lint:markdown`
+Expected: 0 issues. If `rumdl` complains, fix inline (typically `MD040` for fenced blocks lacking a language tag — add `text` to bare ``` fences).
+
+- [ ] **Step 5: Commit the report**
+
+```bash
+git add docs/plans/2026-05-08-spgr-rwrp-pr0-claude-api-verification.md
+git commit -s -m "$(cat <<'MSG'
+docs(plans): add spgr-rwrp PR 0 Claude API verification report
+
+Verifies three claims that the spgr-rwrp design depends on:
+1. Relative path acceptance in extraKnownMarketplaces.source.path
+2. autoUpdate: false is honoured at the marketplace-entry level
+3. \${CLAUDE_PLUGIN_ROOT} resolves to the plugin root, not the
+   marketplace root or .claude-plugin/ subdir
+
+Output drives the Go/No-Go decision for PR A and any layout fallback.
+
+Closes spgr-XXXX (PR 0 bead).
+
+Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>
+MSG
+)"
+```
+
+---
+
+## Task 7: Apply spec fallout (if any claim was RED)
+
+**Files:**
+
+- Modify: `docs/plans/2026-05-08-spgr-rwrp-harness-install-parity-design.md`
+
+- [ ] **Step 1: For each RED claim, edit the spec to record the fallback**
+
+If claim 1 RED: change all `path: "./..."` examples to `path: "/abs/..."` in §"Per-harness manifest" entry 9. Note in §"Architecture" that paths get resolved to absolute at init time.
+
+If claim 2 RED: remove `"autoUpdate": false` from the example settings.json in §"Per-harness manifest" entry 9 and from §"Per-harness manifest" Claude row notes.
+
+If claim 3 RED: rewrite §"Per-harness manifest" entries 10–14 with paths nested one level deeper. The plugin root becomes `.specgraph/agents/claude/.claude-plugin/`; hooks live at `.specgraph/agents/claude/.claude-plugin/hooks/...`. Update `extraKnownMarketplaces.spgr-pr0-marketplace.source.path` accordingly.
+
+- [ ] **Step 2: Add a Revision-history entry**
+
+Append to the Revision history section in the spec:
+
+```markdown
+- **2026-05-08 v5**: PR 0 verification report applied. [Briefly describe which claims were red and the design changes made. If all were green, note "all three claims green; spec stands as v4."]
+```
+
+- [ ] **Step 3: Commit the spec changes (if any)**
+
+```bash
+git add docs/plans/2026-05-08-spgr-rwrp-harness-install-parity-design.md
+git commit -s -m "docs(plans): incorporate spgr-rwrp PR 0 verification report"
+```
+
+If all claims were GREEN, skip this task entirely — no spec changes needed.
+
+---
+
+## Task 8: Close the bead and clean up
+
+- [ ] **Step 1: Close the PR 0 bead**
+
+```bash
+bd close <pr0-bead-id> --reason="Verification complete; report at docs/plans/2026-05-08-spgr-rwrp-pr0-claude-api-verification.md"
+bd dolt push
+```
+
+- [ ] **Step 2: Optionally remove the scratch directory**
+
+```bash
+rm -rf ~/Code/specgraph-pr0-spike
+```
+
+(Optional — keeping the spike around is useful if the report needs revisiting. The directory is gitignored from any tracked location and consumes minimal space.)
+
+- [ ] **Step 3: Push the spec doc**
+
+```bash
+git push origin HEAD:main  # or open a PR per the project convention
+```
+
+PR 0 is complete. PR A may now proceed (or proceed-with-fallout) per the report.
+
+---
+
+## Open questions / known limitations
+
+- **Claude `-p` mode and plugin trust:** new plugins may require an interactive trust acknowledgement on first load. The `-p` mode docs say "the workspace trust dialog is skipped when Claude is run in non-interactive mode" but plugin trust may behave differently. If `-p` mode silently skips loading our plugin (rather than prompting), we won't see the hook fire and the spike returns nothing. Mitigation: run interactively once (`claude` no flags) and accept the trust prompt manually before re-running `-p` mode.
+- **Hook timing:** SessionStart hooks may run asynchronously relative to the `-p` invocation's exit. The `sleep 1` in Tasks 4 and 5 is a heuristic; if hook artefacts are missing, increase to `sleep 5` and re-run.
+- **Multi-plugin marketplace.json schema:** the spec for `marketplace.json` documents `plugins[].source` as a path or string. Step 5.3's fallback reuses this in a way the docs may not have explicitly covered. If the second-plugin entry fails to load, the report should note the schema constraint and we proceed with single-plugin verification only (claim 3a alone, no 3b separation).

--- a/docs/plans/2026-05-08-spgr-rwrp-pra-plan.md
+++ b/docs/plans/2026-05-08-spgr-rwrp-pra-plan.md
@@ -63,6 +63,7 @@ The strategies (`StrategyJSONKeyMerge`, `StrategyMarkdownBlock`, `StrategyWholeF
 ## Task 0: Pre-flight + bead creation
 
 **Files:**
+
 - Create: `spgr-rwrp-pra` bead (via `bd create`)
 
 - [ ] **Step 1: Confirm we're on the right branch and clean**
@@ -102,6 +103,7 @@ bd dolt push  # if push fails, run: gh auth switch -u seanb4t && bd dolt push
 ## Task 1: Add `xdg.CacheHome()`
 
 **Files:**
+
 - Modify: `internal/xdg/xdg.go`
 - Modify: `internal/xdg/xdg_test.go`
 
@@ -182,6 +184,7 @@ Refs spgr-XXXX (PR A scope), spgr-rwrp."
 ## Task 2: Bootstrap `managedfiles` package skeleton
 
 **Files:**
+
 - Create: `internal/config/managedfiles/doc.go`
 - Create: `internal/config/managedfiles/types.go`
 - Create: `internal/config/managedfiles/errors.go`
@@ -451,6 +454,7 @@ Refs spgr-XXXX (PR A scope), spgr-rwrp."
 ## Task 3: Sentinel parsing + rendering
 
 **Files:**
+
 - Create: `internal/config/managedfiles/sentinel.go`
 - Create: `internal/config/managedfiles/sentinel_test.go`
 
@@ -716,6 +720,7 @@ Refs spgr-XXXX (PR A scope), spgr-rwrp."
 ## Task 4: Hash computation excluding sentinel
 
 **Files:**
+
 - Create: `internal/config/managedfiles/hash.go`
 - Create: `internal/config/managedfiles/hash_test.go`
 
@@ -900,6 +905,7 @@ Refs spgr-XXXX (PR A scope), spgr-rwrp."
 ## Task 5: Port file locking primitives
 
 **Files:**
+
 - Create: `internal/config/managedfiles/lock.go`
 - Create: `internal/config/managedfiles/lock_unix.go`
 - Create: `internal/config/managedfiles/lock_windows.go`
@@ -1144,6 +1150,7 @@ Refs spgr-XXXX (PR A scope), spgr-rwrp."
 ## Task 6: Port atomic write
 
 **Files:**
+
 - Create: `internal/config/managedfiles/atomic.go`
 - Create: `internal/config/managedfiles/atomic_test.go`
 
@@ -1361,6 +1368,7 @@ Refs spgr-XXXX (PR A scope), spgr-rwrp."
 ## Task 7: Port symlink rejection
 
 **Files:**
+
 - Create: `internal/config/managedfiles/symlink.go`
 - Create: `internal/config/managedfiles/symlink_test.go`
 - Create: `internal/config/managedfiles/open_unix.go`
@@ -1572,6 +1580,7 @@ Refs spgr-XXXX (PR A scope), spgr-rwrp."
 ## Task 8: Source loader with `dev` build tag
 
 **Files:**
+
 - Create: `internal/config/managedfiles/source.go`
 - Create: `internal/config/managedfiles/source_release.go`
 - Create: `internal/config/managedfiles/source_dev.go`
@@ -1805,6 +1814,7 @@ Refs spgr-XXXX (PR A scope), spgr-rwrp."
 ## Task 9: Inspect single file (state classification)
 
 **Files:**
+
 - Create: `internal/config/managedfiles/inspect.go`
 - Create: `internal/config/managedfiles/inspect_test.go`
 
@@ -2022,6 +2032,7 @@ Refs spgr-XXXX (PR A scope), spgr-rwrp."
 ## Task 10: SupersedesPath guarded delete
 
 **Files:**
+
 - Create: `internal/config/managedfiles/supersedes.go`
 - Create: `internal/config/managedfiles/supersedes_test.go`
 
@@ -2197,6 +2208,7 @@ Refs spgr-XXXX (PR A scope), spgr-rwrp."
 ## Task 11: Strategy interface + dispatch stubs
 
 **Files:**
+
 - Create: `internal/config/managedfiles/strategy.go`
 - Create: `internal/config/managedfiles/strategy_test.go`
 
@@ -2360,6 +2372,7 @@ Refs spgr-XXXX (PR A scope), spgr-rwrp."
 ## Task 12: Manifest, Sync entry point, and end-to-end empty-manifest test
 
 **Files:**
+
 - Create: `internal/config/managedfiles/manifest.go`
 - Create: `internal/config/managedfiles/sync.go`
 - Create: `internal/config/managedfiles/integration_test.go`

--- a/docs/plans/2026-05-08-spgr-rwrp-pra-plan.md
+++ b/docs/plans/2026-05-08-spgr-rwrp-pra-plan.md
@@ -1,0 +1,2656 @@
+# PR A — managedfiles framework foundation implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `internal/config/managedfiles/` package foundation — types, primitives (hashing, sentinels, locking, atomic writes, symlink rejection), `SupersedesPath` logic, `dev` build tag, and `xdg.CacheHome()` — so subsequent PRs (B–G) can register managed files and execute init/doctor against them. **Zero behaviour change for users in this PR.**
+
+**Architecture:** A single `internal/config/managedfiles/` package owns every "file specgraph injects into a project." It exposes a `ManagedFile` type (path + strategy + content source + harness ownership), a state-machine for drift classification (Missing / Synced / Stale / Drifted), and write/inspect entry points (`SyncAll`, `InspectAll`) that operate over a manifest. PR A wires the skeleton with an empty manifest; PRs B–G register actual files. Safety primitives (file locking, atomic writes, `O_NOFOLLOW` symlink rejection) are **ported** from the existing `internal/config/pointers/` package, not stubbed — they are correctness guarantees, not scaffolding.
+
+**Tech Stack:** Go 1.26.3, standard library `embed`, `crypto/sha256`, `os`, `syscall`. No new third-party dependencies.
+
+**Spec:** `docs/plans/2026-05-08-spgr-rwrp-harness-install-parity-design.md` — see PR A section + §"Architecture", §"Drift detection".
+
+**Bead:** new `spgr-rwrp-pra` (file as part of Task 0).
+
+---
+
+## Repo conventions to know
+
+- **Build:** `task build`. **Tests:** `task test`. **Quality gate:** `task check` (fmt, license, lint, build, race tests).
+- **Lint:** `golangci-lint v2.12.1`, configured in `.golangci.yml`. Common gotchas: `revive` requires package doc comments on the first `.go` file; `wrapcheck` requires errors crossing public boundaries to be wrapped.
+- **License headers:** every `.go` file MUST carry `// SPDX-License-Identifier: Apache-2.0` and `// Copyright 2026 Sean Brandt` on the first two lines. Run `task license:add` to fix.
+- **Commits:** this repo uses jj-colocated git. `git commit` works (jj picks it up). Conventional Commits + DCO sign-off (`-s`) required. Plan steps use `git commit -s` for compatibility; `jj describe` is also fine.
+- **Tests live alongside source:** `foo.go` and `foo_test.go` in the same package. Use `package managedfiles_test` for black-box tests where it improves clarity.
+- **No test data outside test files:** if a test needs fixtures, embed them inline as Go strings or use `t.TempDir()`.
+
+---
+
+## File structure (final state after PR A)
+
+```text
+internal/config/managedfiles/
+├── doc.go                  # package overview comment
+├── types.go                # ManagedFile, Strategy, State, Harness, FileState, SyncResult, Options
+├── errors.go               # sentinel errors (ErrCorruptedSentinel, ErrSymlinkRejected, ErrPriorCanonicalMismatch, ErrNotImplemented)
+├── sentinel.go             # parseSentinel / renderSentinel; comment-syntax dispatch
+├── hash.go                 # HashExcludingSentinel
+├── lock.go                 # Unlocker type
+├── lock_unix.go            # //go:build !windows — acquireFileLock via syscall.Flock
+├── lock_windows.go         # //go:build windows  — acquireFileLock via LockFileEx
+├── open_unix.go            # //go:build !windows — openExclusiveNoFollow via O_NOFOLLOW
+├── open_windows.go         # //go:build windows  — openExclusiveNoFollow Windows fallback
+├── atomic.go               # atomicWrite
+├── symlink.go              # rejectSymlinkComponents, validateProjectDir
+├── inspect.go              # Inspect(cwd, mf), InspectAll(cwd, harnesses)
+├── sync.go                 # Sync(cwd, mf, opts), SyncAll(cwd, harnesses, opts)
+├── strategy.go             # Strategy interface (Inspect, Render) + per-strategy stubs returning ErrNotImplemented
+├── supersedes.go           # supersedesGuardedDelete (hash-check guard)
+├── manifest.go             # Manifest() — empty []ManagedFile in PR A
+├── source.go               # readSource(mf) — entry point
+├── source_release.go       # //go:build !dev — reads from embed.FS
+├── source_dev.go           # //go:build dev  — reads from disk + emits stderr banner if isatty
+└── *_test.go               # tests per file
+
+internal/xdg/
+├── xdg.go                  # MODIFIED: add CacheHome()
+└── xdg_test.go             # MODIFIED: add tests for CacheHome
+```
+
+The strategies (`StrategyJSONKeyMerge`, `StrategyMarkdownBlock`, `StrategyWholeFile`) **dispatch through stubs** in PR A — they return `ErrNotImplemented`. PR B implements `JSONKeyMerge` and `MarkdownBlock`; PRs C/D/E land `WholeFile` use cases. Manifest is empty in PR A, so the stubs are never invoked end-to-end — they exist for future strategy methods to fill in.
+
+---
+
+## Task 0: Pre-flight + bead creation
+
+**Files:**
+- Create: `spgr-rwrp-pra` bead (via `bd create`)
+
+- [ ] **Step 1: Confirm we're on the right branch and clean**
+
+```bash
+cd /Volumes/Code/github.com/specgraph
+jj --no-pager status | head -5
+jj --no-pager log -r 'main..@' --no-graph -T 'commit_id.short() ++ " " ++ description.first_line() ++ "\n"' | head -5
+```
+
+Expected: working copy is empty or a benign existing commit; current stack should include the spgr-rwrp design doc + PR 0 commits already.
+
+If your stack diverges, `jj new main` to get a clean starting point.
+
+- [ ] **Step 2: File the bead**
+
+```bash
+bd create \
+  --type=task \
+  --priority=2 \
+  --title="PR A: managedfiles framework foundation for spgr-rwrp" \
+  --description="Foundation PR for the spgr-rwrp epic. New internal/config/managedfiles/ package with types, primitives (hash, sentinels, locking, atomic writes, symlink rejection), SupersedesPath logic, dev build tag, and xdg.CacheHome(). Zero behaviour change for users; empty manifest. Subsequent PRs (B-G) register managed files and wire init/doctor."
+```
+
+Note the returned bead id (e.g., `spgr-XXXX`) — used in commit messages below.
+
+- [ ] **Step 3: Wire dependency to the epic + claim**
+
+```bash
+bd dep add spgr-rwrp <new-bead-id>
+bd update <new-bead-id> --claim
+bd dolt push  # if push fails, run: gh auth switch -u seanb4t && bd dolt push
+```
+
+---
+
+## Task 1: Add `xdg.CacheHome()`
+
+**Files:**
+- Modify: `internal/xdg/xdg.go`
+- Modify: `internal/xdg/xdg_test.go`
+
+The drift-nudge throttle file (PR G) lives at `xdg.CacheHome() + "/nudges/<hash>"`. We add `CacheHome()` now in PR A so PR G can consume it without a separate dependency.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/xdg/xdg_test.go`:
+
+```go
+func TestCacheHome_Default(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", "")
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".cache", "specgraph"), xdg.CacheHome())
+}
+
+func TestCacheHome_Override(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", "/tmp/xdg-test-cache")
+	assert.Equal(t, "/tmp/xdg-test-cache/specgraph", xdg.CacheHome())
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/xdg/ -run "TestCacheHome" -v
+```
+
+Expected: `FAIL` with `xdg.CacheHome undefined`.
+
+- [ ] **Step 3: Add `CacheHome` to `xdg.go`**
+
+In `internal/xdg/xdg.go`, after the existing `StateHome()` function (around line 47), append:
+
+```go
+// CacheHome returns XDG_CACHE_HOME/specgraph or ~/.cache/specgraph.
+// Cache holds non-essential data that can be regenerated on demand
+// (e.g. drift-nudge throttle files for `specgraph doctor`).
+func CacheHome() string {
+	if v := os.Getenv("XDG_CACHE_HOME"); v != "" {
+		return filepath.Join(v, appName)
+	}
+	return filepath.Join(homeDir(), ".cache", appName)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/xdg/ -v
+```
+
+Expected: PASS — all xdg tests including the two new ones.
+
+- [ ] **Step 5: Run `task check` to confirm clean**
+
+```bash
+task check 2>&1 | tail -8
+```
+
+Expected: 0 issues. If lint fails on the new doc comment style, match the existing function-doc convention exactly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/xdg/xdg.go internal/xdg/xdg_test.go
+git commit -s -m "feat(xdg): add CacheHome() for XDG_CACHE_HOME
+
+Mirrors the existing ConfigHome/DataHome/StateHome helpers. Consumed
+by the drift-nudge throttle file added later in spgr-rwrp PR G.
+
+Refs spgr-XXXX (PR A scope), spgr-rwrp."
+```
+
+---
+
+## Task 2: Bootstrap `managedfiles` package skeleton
+
+**Files:**
+- Create: `internal/config/managedfiles/doc.go`
+- Create: `internal/config/managedfiles/types.go`
+- Create: `internal/config/managedfiles/errors.go`
+- Create: `internal/config/managedfiles/types_test.go`
+
+This task introduces the package and its public types but no logic. After this task the package compiles and the types are referenced by tests.
+
+- [ ] **Step 1: Create `doc.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+// Package managedfiles is the framework specgraph init uses to inject
+// canonical files into a user's project — and that specgraph doctor
+// uses to detect drift.
+//
+// Every file specgraph writes is registered as a ManagedFile with a
+// strategy that determines how the file is read, classified (Synced,
+// Stale, Drifted, or Missing), and reconciled. The strategies are:
+//
+//   - StrategyJSONKeyMerge: managed keys merge into a JSON file;
+//     siblings preserved (e.g. .mcp.json's mcpServers.specgraph block).
+//   - StrategyMarkdownBlock: a versioned, hash-tracked block fenced by
+//     <!-- specgraph:init:start ... --> / <!-- specgraph:init:end -->
+//     within an otherwise-user-owned markdown file (e.g. AGENTS.md).
+//   - StrategyWholeFile: the entire file is canonical; warn-and-force
+//     on drift (e.g. a generated TypeScript plugin).
+//
+// PR A scaffolds the framework: types, sentinels, hashing, file locking,
+// atomic writes, symlink rejection, supersedes-path deletion. Subsequent
+// PRs in spgr-rwrp register managed files and implement strategies.
+package managedfiles
+```
+
+- [ ] **Step 2: Create `errors.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import "errors"
+
+// ErrCorruptedSentinel indicates a managed file's sentinel line is
+// malformed (unparseable, unknown version, missing required fields).
+// The framework refuses to mutate corrupted-sentinel files.
+var ErrCorruptedSentinel = errors.New("corrupted managed-file sentinel")
+
+// ErrSymlinkRejected is returned when init/inspect encounters a symlink
+// in a managed-file path component. We refuse to follow symlinks to avoid
+// confused-deputy attacks (planting a symlink to an unrelated file then
+// triggering init).
+var ErrSymlinkRejected = errors.New("symlink in managed-file path rejected")
+
+// ErrPriorCanonicalMismatch is returned by supersedesGuardedDelete when
+// the on-disk content of a SupersedesPath does NOT match the prior
+// canonical the framework would have produced. Indicates user content
+// at the old path; init refuses to delete it.
+var ErrPriorCanonicalMismatch = errors.New("supersedes-path content differs from prior canonical")
+
+// ErrNotImplemented is returned by strategy stubs in PR A. PRs B and onward
+// replace the stubs with real implementations; the manifest is empty in PR A
+// so this error is never surfaced end-to-end.
+var ErrNotImplemented = errors.New("strategy not implemented in this PR")
+```
+
+- [ ] **Step 3: Create `types.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+// Strategy selects how a ManagedFile is read, classified, and written.
+type Strategy int
+
+// Strategy values. Order is fixed; do not reorder (callers may compare
+// by value via the iota positions).
+const (
+	StrategyJSONKeyMerge Strategy = iota
+	StrategyMarkdownBlock
+	StrategyWholeFile
+)
+
+// State is the framework's drift classification for a single managed file.
+type State int
+
+// State values. Synced is the only "no-op needed" state; the others all
+// imply some action (write, refresh, or surface to the user).
+const (
+	StateMissing State = iota
+	StateSynced
+	StateStale   // sentinel hash matches disk content but disk doesn't match canonical
+	StateDrifted // disk content does not match the recorded sentinel hash (user-edited)
+)
+
+// Harness is the agent-harness a ManagedFile belongs to.
+type Harness int
+
+// Harness values.
+const (
+	HarnessClaude Harness = iota
+	HarnessCursor
+	HarnessOpenCode
+)
+
+// CommentSyntax describes the comment style used to embed a sentinel
+// line in a file. Each value maps to a (open, close) pair — close is
+// empty for line comments.
+type CommentSyntax int
+
+// CommentSyntax values cover the file types managed by the framework.
+const (
+	CommentNone   CommentSyntax = iota // JSON files: no sentinel possible
+	CommentSlash                       // // ...    (TypeScript, Go)
+	CommentHash                        // # ...     (shell, YAML)
+	CommentHTML                        // <!-- ... --> (markdown, mdc)
+)
+
+// ManagedFile describes a single file specgraph manages in a project.
+// Construct via the Manifest function; do not build literals at call sites.
+type ManagedFile struct {
+	// Path is the file location relative to the project root.
+	Path string
+
+	// Strategy selects how this file is read, classified, written.
+	Strategy Strategy
+
+	// Source is the path within the package's embedded source tree to
+	// read the canonical content from. Empty for JSON-key-merge files
+	// where the canonical is built programmatically from project config.
+	Source string
+
+	// Comment is the comment syntax used for sentinel lines in this file.
+	Comment CommentSyntax
+
+	// Harness is which agent-harness this file belongs to. Used to filter
+	// the manifest by the user's enabled harnesses.
+	Harness Harness
+
+	// SupersedesPath is the project-relative path of an older file that
+	// is replaced by this one (e.g. a `.md` cursor rule renamed to `.mdc`).
+	// Empty when the file has no predecessor. Init deletes this path
+	// after a successful guarded write — see supersedesGuardedDelete.
+	SupersedesPath string
+}
+
+// FileState is the result of Inspect for a single ManagedFile.
+type FileState struct {
+	Path         string
+	Strategy     Strategy
+	State        State
+	DiskHash     string // sha256 of current disk content (empty if Missing)
+	SentinelHash string // hash recorded in disk sentinel (empty if no sentinel)
+	EmbeddedHash string // sha256 of canonical source content
+	Detail       string // human-readable explanation, used in doctor output
+}
+
+// Action is the outcome of a write attempt for a single ManagedFile.
+type Action int
+
+// Action values.
+const (
+	ActionNoOp      Action = iota // file already Synced; nothing written
+	ActionCreated                 // file was Missing; canonical written
+	ActionRefreshed               // file was Stale; canonical rewritten with fresh sentinel
+	ActionSkipped                 // file was Drifted; init skipped without --force
+	ActionForced                  // file was Drifted; --force overwrote
+	ActionError                   // some error occurred; see Err
+)
+
+// SyncResult reports what Sync did for a single ManagedFile.
+type SyncResult struct {
+	Path   string
+	Action Action
+	Err    error
+}
+
+// SyncOptions controls Sync behaviour.
+type SyncOptions struct {
+	// Force overwrites Drifted files with canonical content. Default false.
+	Force bool
+
+	// KeepEdits, when used with Force, preserves drifted on-disk content
+	// but updates the sentinel hash to match. Default false.
+	KeepEdits bool
+}
+```
+
+- [ ] **Step 4: Create `types_test.go` with a sanity check that the types are usable**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles_test
+
+import (
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/config/managedfiles"
+)
+
+// TestStrategyValuesStable pins the iota positions so future reorderings
+// are caught. Callers may compare Strategy values directly.
+func TestStrategyValuesStable(t *testing.T) {
+	got := []managedfiles.Strategy{
+		managedfiles.StrategyJSONKeyMerge,
+		managedfiles.StrategyMarkdownBlock,
+		managedfiles.StrategyWholeFile,
+	}
+	want := []managedfiles.Strategy{0, 1, 2}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("Strategy[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+// TestStateValuesStable pins the iota positions for State.
+func TestStateValuesStable(t *testing.T) {
+	got := []managedfiles.State{
+		managedfiles.StateMissing,
+		managedfiles.StateSynced,
+		managedfiles.StateStale,
+		managedfiles.StateDrifted,
+	}
+	want := []managedfiles.State{0, 1, 2, 3}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("State[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+```
+
+- [ ] **Step 5: Run tests + lint**
+
+```bash
+go test ./internal/config/managedfiles/ -v
+task check 2>&1 | tail -8
+```
+
+Expected: tests PASS, `task check` clean. If lint complains about a missing package doc comment, double-check `doc.go` exists with the comment.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/managedfiles/
+git commit -s -m "feat(managedfiles): bootstrap package with types and errors
+
+Introduces internal/config/managedfiles/ — the foundation package for
+spgr-rwrp's embed-and-write framework. Defines ManagedFile, Strategy,
+State, Harness, CommentSyntax, FileState, Action, SyncResult,
+SyncOptions, plus sentinel errors. No logic yet.
+
+Tests pin iota values for Strategy and State so reorderings are caught.
+
+Refs spgr-XXXX (PR A scope), spgr-rwrp."
+```
+
+---
+
+## Task 3: Sentinel parsing + rendering
+
+**Files:**
+- Create: `internal/config/managedfiles/sentinel.go`
+- Create: `internal/config/managedfiles/sentinel_test.go`
+
+The sentinel encodes `version`, `sha256`, and an optional `rev` field on a single line. For `WholeFile` strategy, the sentinel sits on the file's first line in native comment syntax. For `MarkdownBlock`, the sentinel rides on the start marker. For `JSONKeyMerge`, no sentinel exists.
+
+We support `v=2` going forward; `v=1` is recognized for the upgrade path (no `sha256` field, parsed as `Stale` by Inspect).
+
+- [ ] **Step 1: Write the failing tests**
+
+`internal/config/managedfiles/sentinel_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRenderSentinel_Slash(t *testing.T) {
+	got := RenderSentinel(CommentSlash, Sentinel{Version: 2, SHA256: "abc123", Rev: "cef1ec3a"})
+	want := "// specgraph:init v=2 sha256=abc123 rev=cef1ec3a"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderSentinel_Hash(t *testing.T) {
+	got := RenderSentinel(CommentHash, Sentinel{Version: 2, SHA256: "abc"})
+	want := "# specgraph:init v=2 sha256=abc"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderSentinel_HTMLBlockStart(t *testing.T) {
+	got := RenderSentinel(CommentHTML, Sentinel{Version: 2, SHA256: "abc", Rev: "cef"})
+	want := "<!-- specgraph:init:start v=2 sha256=abc rev=cef -->"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestParseSentinel_Slash_v2(t *testing.T) {
+	got, err := ParseSentinel(CommentSlash, "// specgraph:init v=2 sha256=abc123 rev=cef")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Version != 2 || got.SHA256 != "abc123" || got.Rev != "cef" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestParseSentinel_v1(t *testing.T) {
+	// v=1 is recognized for upgrade path (no sha256 field).
+	got, err := ParseSentinel(CommentHTML, "<!-- specgraph:init:start v=1 -->")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Version != 1 || got.SHA256 != "" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestParseSentinel_v3_Rejected(t *testing.T) {
+	_, err := ParseSentinel(CommentSlash, "// specgraph:init v=3 sha256=abc")
+	if !errors.Is(err, ErrCorruptedSentinel) {
+		t.Errorf("want ErrCorruptedSentinel, got %v", err)
+	}
+}
+
+func TestParseSentinel_NotASentinel(t *testing.T) {
+	got, err := ParseSentinel(CommentSlash, "// just a regular comment")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Version != 0 {
+		t.Errorf("expected zero Sentinel for non-sentinel line, got %+v", got)
+	}
+}
+
+func TestRenderParseRoundTrip(t *testing.T) {
+	for _, syntax := range []CommentSyntax{CommentSlash, CommentHash, CommentHTML} {
+		original := Sentinel{Version: 2, SHA256: "deadbeef", Rev: "abc1234"}
+		line := RenderSentinel(syntax, original)
+		parsed, err := ParseSentinel(syntax, line)
+		if err != nil {
+			t.Fatalf("syntax %v: parse error: %v", syntax, err)
+		}
+		if parsed != original {
+			t.Errorf("syntax %v: round-trip mismatch: got %+v, want %+v", syntax, parsed, original)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/config/managedfiles/ -run "Sentinel" -v
+```
+
+Expected: FAIL with undefined identifiers (`Sentinel`, `RenderSentinel`, `ParseSentinel`).
+
+- [ ] **Step 3: Implement `sentinel.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Sentinel is the parsed payload of a managed-file sentinel line.
+//
+// Version is the marker version (1 or 2). Version 0 indicates a non-sentinel
+// line was parsed (treat as "no sentinel present").
+//
+// SHA256 is empty for v=1 markers (no hash field) and populated for v=2.
+//
+// Rev is the optional build revision recorded for forensics; not used in
+// state classification.
+type Sentinel struct {
+	Version int
+	SHA256  string
+	Rev     string
+}
+
+// supportedVersions lists marker versions the parser accepts. Anything
+// outside this set is treated as ErrCorruptedSentinel by ParseSentinel,
+// matching the existing pointers/agents.go corruption-rejection behaviour
+// for unknown versions.
+var supportedVersions = map[int]bool{1: true, 2: true}
+
+// sentinelMatcher matches both the WholeFile sentinel ("// specgraph:init v=N ...")
+// and the MarkdownBlock start marker ("<!-- specgraph:init:start v=N ... -->").
+//
+// Group 1 captures the version digits.
+// Group 2 captures the optional sha256 hex value.
+// Group 3 captures the optional rev value.
+//
+// Both `init` and `init:start` are accepted because the same parser is
+// used for both syntaxes; the caller's CommentSyntax decides which form
+// RenderSentinel emits.
+var sentinelMatcher = regexp.MustCompile(
+	`specgraph:init(?::start)?\s+v=(\d+)(?:\s+sha256=([0-9a-fA-F]+))?(?:\s+rev=(\S+?))?\s*(?:-->)?$`,
+)
+
+// RenderSentinel formats a Sentinel as a single line in the given comment
+// syntax. The returned line includes the comment delimiters but no trailing
+// newline.
+//
+// For CommentNone, returns the empty string (JSON files don't carry sentinels).
+//
+// For CommentHTML, the rendered line is the START marker only — callers writing
+// a MarkdownBlock are responsible for emitting the matching `<!-- specgraph:init:end -->`
+// terminator. Keeping this asymmetry inside the strategy implementation avoids
+// requiring sentinel.go to know about block structure.
+func RenderSentinel(syntax CommentSyntax, s Sentinel) string {
+	if syntax == CommentNone || s.Version == 0 {
+		return ""
+	}
+	body := fmt.Sprintf("specgraph:init v=%d", s.Version)
+	if s.SHA256 != "" {
+		body += " sha256=" + s.SHA256
+	}
+	if s.Rev != "" {
+		body += " rev=" + s.Rev
+	}
+	switch syntax {
+	case CommentSlash:
+		return "// " + body
+	case CommentHash:
+		return "# " + body
+	case CommentHTML:
+		// Block-strategy start marker. The end marker is emitted separately
+		// by the strategy code (it has no payload).
+		return "<!-- " + strings.Replace(body, "specgraph:init", "specgraph:init:start", 1) + " -->"
+	default:
+		return ""
+	}
+}
+
+// ParseSentinel attempts to parse `line` as a managed-file sentinel.
+//
+// Returns:
+//   - zero Sentinel + nil error if the line is not a sentinel at all (a
+//     regular comment, blank, or arbitrary content).
+//   - non-zero Sentinel + nil error on a successful parse.
+//   - zero Sentinel + ErrCorruptedSentinel if the line *looks* like a
+//     sentinel (matches the regex) but carries an unsupported version.
+//
+// Distinguishing "not a sentinel" from "corrupted sentinel" matters because
+// the framework treats absent sentinels as user-owned (Drifted) but
+// corrupted sentinels as a hard error (refuse-to-mutate).
+func ParseSentinel(syntax CommentSyntax, line string) (Sentinel, error) {
+	if syntax == CommentNone {
+		return Sentinel{}, nil
+	}
+	m := sentinelMatcher.FindStringSubmatch(line)
+	if m == nil {
+		return Sentinel{}, nil
+	}
+	version, err := strconv.Atoi(m[1])
+	if err != nil {
+		return Sentinel{}, fmt.Errorf("%w: invalid version %q", ErrCorruptedSentinel, m[1])
+	}
+	if !supportedVersions[version] {
+		return Sentinel{}, fmt.Errorf("%w: unsupported version %d", ErrCorruptedSentinel, version)
+	}
+	return Sentinel{
+		Version: version,
+		SHA256:  m[2],
+		Rev:     m[3],
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/config/managedfiles/ -run "Sentinel" -v
+```
+
+Expected: PASS — all 8 sentinel tests.
+
+- [ ] **Step 5: Run `task check`**
+
+```bash
+task check 2>&1 | tail -8
+```
+
+Expected: 0 issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/managedfiles/sentinel.go internal/config/managedfiles/sentinel_test.go
+git commit -s -m "feat(managedfiles): add sentinel parse/render
+
+Sentinels carry version + sha256 + optional rev on a single line in the
+file's native comment syntax. RenderSentinel emits the line; ParseSentinel
+recovers the payload, distinguishing 'not a sentinel' (regular comment)
+from 'corrupted sentinel' (unsupported version).
+
+v=1 is recognized for the upgrade path (no sha256 field). v=3+ is
+rejected as ErrCorruptedSentinel.
+
+Refs spgr-XXXX (PR A scope), spgr-rwrp."
+```
+
+---
+
+## Task 4: Hash computation excluding sentinel
+
+**Files:**
+- Create: `internal/config/managedfiles/hash.go`
+- Create: `internal/config/managedfiles/hash_test.go`
+
+The sentinel must change without affecting the file's content hash, so the framework hashes content with the sentinel line dropped. This way two files with identical body but different `rev=` values hash equal.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestHashExcludingSentinel_NoSentinel(t *testing.T) {
+	body := "package foo\n\nfunc Bar() {}\n"
+	got := HashExcludingSentinel(CommentSlash, []byte(body))
+	want := hashOf(body)
+	if got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestHashExcludingSentinel_WithSlashSentinel(t *testing.T) {
+	body := "package foo\n\nfunc Bar() {}\n"
+	withSentinel := "// specgraph:init v=2 sha256=abc rev=def\n" + body
+	got := HashExcludingSentinel(CommentSlash, []byte(withSentinel))
+	if got != hashOf(body) {
+		t.Errorf("hash should equal body hash, got %s", got)
+	}
+}
+
+func TestHashExcludingSentinel_StableAcrossRevChanges(t *testing.T) {
+	body := "echo hi\n"
+	a := "# specgraph:init v=2 sha256=abc rev=AAA\n" + body
+	b := "# specgraph:init v=2 sha256=abc rev=BBB\n" + body
+	if HashExcludingSentinel(CommentHash, []byte(a)) != HashExcludingSentinel(CommentHash, []byte(b)) {
+		t.Error("hash differed across rev-only changes; should be stable")
+	}
+}
+
+func TestHashExcludingSentinel_HTMLBlock(t *testing.T) {
+	body := "# Title\n\nbody\n"
+	withSentinel := "<!-- specgraph:init:start v=2 sha256=abc -->\n" + body + "<!-- specgraph:init:end -->\n"
+	got := HashExcludingSentinel(CommentHTML, []byte(withSentinel))
+	// For HTML/Markdown-block, BOTH the start AND end markers are dropped
+	// before hashing, leaving the inner content.
+	if got != hashOf(body) {
+		t.Errorf("got %s, want %s", got, hashOf(body))
+	}
+}
+
+func TestHashExcludingSentinel_NoneStrategy(t *testing.T) {
+	body := `{"foo":"bar"}`
+	// CommentNone (JSON files): no sentinel logic; hash the bytes as-is.
+	got := HashExcludingSentinel(CommentNone, []byte(body))
+	if got != hashOf(body) {
+		t.Errorf("got %s, want %s", got, hashOf(body))
+	}
+}
+
+// hashOf is a test helper: returns the hex sha256 of a string.
+func hashOf(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+// Compile-time assertion that strings.Contains is referenced — silences
+// the "imported and not used" lint if all tests are temporarily disabled.
+var _ = strings.Contains
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/config/managedfiles/ -run "Hash" -v
+```
+
+Expected: FAIL with undefined `HashExcludingSentinel`.
+
+- [ ] **Step 3: Implement `hash.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// HashExcludingSentinel returns the hex-encoded sha256 of the file content
+// after stripping the sentinel line(s).
+//
+// For CommentSlash and CommentHash: the FIRST line is dropped if it parses
+// as a sentinel. Other lines are preserved verbatim.
+//
+// For CommentHTML (markdown-block strategy): every sentinel line in the
+// content (start and end markers) is dropped before hashing. This handles
+// files like AGENTS.md where the managed block is delimited by a pair.
+//
+// For CommentNone: the bytes are hashed as-is. JSON files don't carry
+// sentinels, so there's nothing to strip.
+//
+// The hash is computed over the byte stream after sentinel-stripping,
+// so two files differing only in their sentinel line hash equal.
+func HashExcludingSentinel(syntax CommentSyntax, content []byte) string {
+	if syntax == CommentNone {
+		return hashBytes(content)
+	}
+
+	lines := strings.Split(string(content), "\n")
+	kept := make([]string, 0, len(lines))
+	for i, line := range lines {
+		// For slash/hash syntaxes, only consider the first line a candidate
+		// sentinel — body content might legitimately contain "# specgraph:init"
+		// inside (e.g., an example in a markdown rule body).
+		if (syntax == CommentSlash || syntax == CommentHash) && i > 0 {
+			kept = append(kept, line)
+			continue
+		}
+		s, _ := ParseSentinel(syntax, line)
+		if s.Version > 0 || strings.Contains(line, "specgraph:init:end") {
+			// Drop sentinel start lines AND markdown-block end markers.
+			// (The end marker doesn't parse as a Sentinel struct because
+			// it has no version, but we drop it from the hash so the
+			// framework can replace marker pairs without changing the hash.)
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return hashBytes([]byte(strings.Join(kept, "\n")))
+}
+
+func hashBytes(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/config/managedfiles/ -run "Hash" -v
+```
+
+Expected: PASS — all 5 hash tests.
+
+- [ ] **Step 5: Run `task check`**
+
+```bash
+task check 2>&1 | tail -8
+```
+
+Expected: 0 issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/managedfiles/hash.go internal/config/managedfiles/hash_test.go
+git commit -s -m "feat(managedfiles): add HashExcludingSentinel
+
+Computes sha256 over file content with the sentinel line(s) stripped,
+so the sentinel can change (e.g. rev= updates) without affecting the
+hash. For markdown-block strategy both start and end markers are
+dropped before hashing.
+
+Refs spgr-XXXX (PR A scope), spgr-rwrp."
+```
+
+---
+
+## Task 5: Port file locking primitives
+
+**Files:**
+- Create: `internal/config/managedfiles/lock.go`
+- Create: `internal/config/managedfiles/lock_unix.go`
+- Create: `internal/config/managedfiles/lock_windows.go`
+- Create: `internal/config/managedfiles/lock_test.go`
+
+Port the file-locking primitives from `internal/config/pointers/`. The locking model is unchanged: an `Unlocker` is acquired via `acquireFileLock(path)` and released via the returned closure. The lock file is a sibling at `<path>.lock` and is intentionally never removed (deleting between unlock and a concurrent open creates a new inode and breaks mutual exclusion).
+
+- [ ] **Step 1: Read the existing primitives**
+
+```bash
+cat internal/config/pointers/lock_unix.go
+cat internal/config/pointers/lock_windows.go
+```
+
+Note the existing structure: `acquireFileLock` returns an `Unlocker` (a `func() error`) which releases the flock and closes the file handle.
+
+- [ ] **Step 2: Write the failing tests**
+
+`internal/config/managedfiles/lock_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestAcquireFileLock_BasicAcquireRelease(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "agents.md")
+	if err := os.WriteFile(target, []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	unlock, err := acquireFileLock(target)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if err := unlock(); err != nil {
+		t.Errorf("unlock: %v", err)
+	}
+}
+
+func TestAcquireFileLock_ContendedSerializes(t *testing.T) {
+	// Two goroutines try to acquire the same file lock; the second must wait.
+	// We measure that the second's acquire happened-after the first's release
+	// using atomic counters.
+	dir := t.TempDir()
+	target := filepath.Join(dir, "agents.md")
+	if err := os.WriteFile(target, []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		firstReleased  atomic.Int64
+		secondAcquired atomic.Int64
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Goroutine 1 — holds the lock briefly.
+	go func() {
+		defer wg.Done()
+		unlock, err := acquireFileLock(target)
+		if err != nil {
+			t.Errorf("g1 acquire: %v", err)
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+		firstReleased.Store(time.Now().UnixNano())
+		_ = unlock()
+	}()
+
+	// Goroutine 2 — starts slightly later, must wait for g1's release.
+	go func() {
+		defer wg.Done()
+		time.Sleep(10 * time.Millisecond)
+		unlock, err := acquireFileLock(target)
+		if err != nil {
+			t.Errorf("g2 acquire: %v", err)
+			return
+		}
+		secondAcquired.Store(time.Now().UnixNano())
+		_ = unlock()
+	}()
+
+	wg.Wait()
+	if secondAcquired.Load() < firstReleased.Load() {
+		t.Errorf("second acquired before first released: %d < %d",
+			secondAcquired.Load(), firstReleased.Load())
+	}
+}
+
+func TestAcquireFileLock_LockfileSurvivesUnlock(t *testing.T) {
+	// The .lock sibling file must not be removed on unlock — see comment
+	// in lock_unix.go for why.
+	dir := t.TempDir()
+	target := filepath.Join(dir, "agents.md")
+	if err := os.WriteFile(target, []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	unlock, err := acquireFileLock(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = unlock()
+
+	if _, err := os.Stat(target + ".lock"); err != nil {
+		t.Errorf("lock file should persist after unlock, got: %v", err)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+go test ./internal/config/managedfiles/ -run "Lock" -v
+```
+
+Expected: FAIL with undefined `acquireFileLock`.
+
+- [ ] **Step 4: Create `lock.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+// Unlocker releases a file lock acquired via acquireFileLock. Returns
+// any errors from the underlying flock LOCK_UN (Unix) or LockFileEx
+// release (Windows) plus any error closing the lock-file handle.
+//
+// Callers MUST invoke the Unlocker via a deferred wrapper that propagates
+// the error — leaving a lock unreleased breaks subsequent acquires.
+type Unlocker func() error
+```
+
+- [ ] **Step 5: Create `lock_unix.go`**
+
+Copy verbatim from `internal/config/pointers/lock_unix.go`, changing only the package declaration:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build !windows
+
+package managedfiles
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// acquireFileLock acquires an exclusive advisory lock on a sibling file
+// <path>.lock. Returns an Unlocker that must be called to release.
+// The lock file is intentionally never removed: deleting it between unlock
+// and a concurrent open creates a new inode and breaks mutual exclusion.
+func acquireFileLock(path string) (Unlocker, error) {
+	lockPath := path + ".lock"
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("create lock file: %w", err)
+	}
+	fd := int(lockFile.Fd())
+	if err := syscall.Flock(fd, syscall.LOCK_EX); err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("acquire file lock: %w", err),
+			lockFile.Close(),
+		)
+	}
+	return func() error {
+		uerr := syscall.Flock(fd, syscall.LOCK_UN)
+		cerr := lockFile.Close()
+		if uerr != nil || cerr != nil {
+			return errors.Join(uerr, cerr)
+		}
+		return nil
+	}, nil
+}
+```
+
+- [ ] **Step 6: Create `lock_windows.go`**
+
+```bash
+cat internal/config/pointers/lock_windows.go
+```
+
+Copy verbatim from the existing `internal/config/pointers/lock_windows.go`, change the package declaration to `package managedfiles`. Keep the `//go:build windows` tag.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+```bash
+go test ./internal/config/managedfiles/ -run "Lock" -v
+```
+
+Expected: PASS — all 3 lock tests.
+
+- [ ] **Step 8: Run `task check`**
+
+```bash
+task check 2>&1 | tail -8
+```
+
+Expected: 0 issues. (License header check should already pass since we copied the headers.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/config/managedfiles/lock.go internal/config/managedfiles/lock_unix.go internal/config/managedfiles/lock_windows.go internal/config/managedfiles/lock_test.go
+git commit -s -m "feat(managedfiles): port file-locking primitives from pointers/
+
+Port acquireFileLock and Unlocker from internal/config/pointers/. Same
+semantics: exclusive advisory lock on <path>.lock sibling, lock file
+persists across unlocks (deleting between unlock and concurrent open
+breaks mutual exclusion).
+
+Tests cover basic acquire/release, contended serialization between two
+goroutines, and lockfile-persists-after-unlock invariant.
+
+The pointers/ package will be deleted in PR B; this is the framework's
+canonical home for these primitives going forward.
+
+Refs spgr-XXXX (PR A scope), spgr-rwrp."
+```
+
+---
+
+## Task 6: Port atomic write
+
+**Files:**
+- Create: `internal/config/managedfiles/atomic.go`
+- Create: `internal/config/managedfiles/atomic_test.go`
+
+`atomicWrite` writes to a temp file in the same directory, fsyncs, then renames over the target. The directory is fsynced after the rename so the rename is durable across power loss. Mode is preserved on update.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAtomicWrite_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.txt")
+	if err := atomicWrite(target, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("got %q, want %q", string(got), "hello")
+	}
+}
+
+func TestAtomicWrite_ReplacesExisting(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.txt")
+	if err := os.WriteFile(target, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicWrite(target, []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "new" {
+		t.Errorf("got %q, want %q", string(got), "new")
+	}
+}
+
+func TestAtomicWrite_LeavesNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.txt")
+	if err := atomicWrite(target, []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 || entries[0].Name() != "out.txt" {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected only out.txt, got %v", names)
+	}
+}
+
+func TestAtomicWrite_RespectsMode(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.sh")
+	if err := atomicWrite(target, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("mode = %o, want 0o755", info.Mode().Perm())
+	}
+}
+
+func TestAtomicWrite_CreatesParentDir(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "nested", "deeper", "out.txt")
+	if err := atomicWrite(target, []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Errorf("file not created: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/config/managedfiles/ -run "Atomic" -v
+```
+
+Expected: FAIL with undefined `atomicWrite`.
+
+- [ ] **Step 3: Create `atomic.go`**
+
+Copy verbatim from `internal/config/pointers/sync.go` lines 174–234 (the `atomicWrite` function with its docstring):
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// atomicWrite writes data to <fullPath>.tmp.<random> in the same directory,
+// fsyncs, then renames over fullPath. The directory is fsynced after the
+// rename so the rename itself is durable across power loss.
+//
+// The temp file is chmod'd to mode. On a fresh write, callers pass 0o600.
+// On an update, callers should read the existing file's mode and pass it so
+// user-set permissions (e.g. 0o644) are preserved.
+//
+// All cleanup errors are joined to the original error via errors.Join so
+// the caller sees both the proximate failure and any stranded-tempfile
+// fallout.
+func atomicWrite(fullPath string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(fullPath)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, filepath.Base(fullPath)+".tmp.*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	if _, werr := tmp.Write(data); werr != nil {
+		return errors.Join(
+			fmt.Errorf("write temp: %w", werr),
+			tmp.Close(),
+			os.Remove(tmpName),
+		)
+	}
+	if cerr := tmp.Chmod(mode); cerr != nil {
+		return errors.Join(
+			fmt.Errorf("chmod temp: %w", cerr),
+			tmp.Close(),
+			os.Remove(tmpName),
+		)
+	}
+	if serr := tmp.Sync(); serr != nil {
+		return errors.Join(
+			fmt.Errorf("fsync temp: %w", serr),
+			tmp.Close(),
+			os.Remove(tmpName),
+		)
+	}
+	if cerr := tmp.Close(); cerr != nil {
+		return errors.Join(
+			fmt.Errorf("close temp: %w", cerr),
+			os.Remove(tmpName),
+		)
+	}
+	if rerr := os.Rename(tmpName, fullPath); rerr != nil {
+		return errors.Join(
+			fmt.Errorf("rename: %w", rerr),
+			os.Remove(tmpName),
+		)
+	}
+	if dirF, derr := os.Open(dir); derr == nil {
+		_ = dirF.Sync()  //nolint:errcheck // best-effort dir fsync; not fatal if unsupported
+		_ = dirF.Close() //nolint:errcheck // best-effort cleanup
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/config/managedfiles/ -run "Atomic" -v
+```
+
+Expected: PASS — all 5 atomic tests.
+
+- [ ] **Step 5: Run `task check`**
+
+```bash
+task check 2>&1 | tail -8
+```
+
+Expected: 0 issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/managedfiles/atomic.go internal/config/managedfiles/atomic_test.go
+git commit -s -m "feat(managedfiles): port atomicWrite from pointers/
+
+Identical semantics: temp file in same dir, fsync, rename over target,
+fsync dir for durable rename. Mode preserved on update; cleanup errors
+joined via errors.Join.
+
+Tests cover create, replace, no-temp-leftovers, mode preservation, and
+parent-dir creation.
+
+Refs spgr-XXXX (PR A scope), spgr-rwrp."
+```
+
+---
+
+## Task 7: Port symlink rejection
+
+**Files:**
+- Create: `internal/config/managedfiles/symlink.go`
+- Create: `internal/config/managedfiles/symlink_test.go`
+- Create: `internal/config/managedfiles/open_unix.go`
+- Create: `internal/config/managedfiles/open_windows.go`
+
+`rejectSymlinkComponents` walks each path component looking for symlinks; any symlink in a managed-file path is rejected with `ErrSymlinkRejected`. The `open_*.go` files provide platform-specific `O_NOFOLLOW` open semantics for actual file reads.
+
+- [ ] **Step 1: Read the existing primitives**
+
+```bash
+cat internal/config/pointers/open_unix.go
+cat internal/config/pointers/open_windows.go
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+`internal/config/managedfiles/symlink_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestRejectSymlinkComponents_NoSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := rejectSymlinkComponents(dir, "nested/foo.txt"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRejectSymlinkComponents_DetectsSymlinkInPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires admin on Windows")
+	}
+	dir := t.TempDir()
+	realDir := filepath.Join(dir, "real")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Fatal(err)
+	}
+
+	err := rejectSymlinkComponents(dir, "link/foo.txt")
+	if !errors.Is(err, ErrSymlinkRejected) {
+		t.Errorf("got %v, want ErrSymlinkRejected", err)
+	}
+}
+
+func TestRejectSymlinkComponents_NonExistentComponentsAllowed(t *testing.T) {
+	// Allow paths whose terminal components don't exist yet — init writes
+	// new files, so non-existence at the leaf is normal.
+	dir := t.TempDir()
+	if err := rejectSymlinkComponents(dir, "does/not/exist.txt"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+go test ./internal/config/managedfiles/ -run "Symlink" -v
+```
+
+Expected: FAIL with undefined `rejectSymlinkComponents`.
+
+- [ ] **Step 4: Create `symlink.go`**
+
+Copy from `internal/config/pointers/sync.go` lines 150–172 (the `rejectSymlinkComponents` function), updating package decl:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// rejectSymlinkComponents walks the components of relPath under projectDir
+// and returns ErrSymlinkRejected on the first symlink encountered. Components
+// that don't exist (e.g. a leaf file we haven't written yet) are allowed —
+// init writes new files, so non-existence is normal at write time.
+//
+// Mirrors internal/config/mcpconfigs/sync.go's helper. Reproducing it here
+// is cheaper than introducing a shared util package.
+func rejectSymlinkComponents(projectDir, relPath string) error {
+	cur := projectDir
+	for _, part := range strings.Split(filepath.Clean(relPath), string(filepath.Separator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		cur = filepath.Join(cur, part)
+		info, err := os.Lstat(cur)
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("lstat %s: %w", cur, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%w: %s", ErrSymlinkRejected, cur)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Create `open_unix.go`**
+
+Copy from `internal/config/pointers/open_unix.go`, changing only the package decl. Keep the `//go:build !windows` tag:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build !windows
+
+package managedfiles
+
+import (
+	"os"
+	"syscall"
+)
+
+// openExclusiveNoFollow opens a file for reading with O_NOFOLLOW so a
+// symlink at the leaf is detected and rejected via the kernel rather
+// than racing with our own pre-check. On Linux/macOS, opening a symlink
+// with O_NOFOLLOW returns ELOOP.
+//
+// Returns (file, ErrSymlinkRejected) if path is a symlink.
+func openExclusiveNoFollow(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		// ELOOP indicates symlink encountered.
+		if pErr, ok := err.(*os.PathError); ok {
+			if errno, ok := pErr.Err.(syscall.Errno); ok && errno == syscall.ELOOP {
+				return nil, ErrSymlinkRejected
+			}
+		}
+		return nil, err
+	}
+	return f, nil
+}
+```
+
+- [ ] **Step 6: Create `open_windows.go`**
+
+```bash
+cat internal/config/pointers/open_windows.go
+```
+
+Copy verbatim from `internal/config/pointers/open_windows.go`, changing only the package decl. Keep the `//go:build windows` tag.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+```bash
+go test ./internal/config/managedfiles/ -run "Symlink" -v
+```
+
+Expected: PASS — all 3 symlink tests.
+
+- [ ] **Step 8: Run `task check`**
+
+```bash
+task check 2>&1 | tail -8
+```
+
+Expected: 0 issues.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/config/managedfiles/symlink.go internal/config/managedfiles/open_unix.go internal/config/managedfiles/open_windows.go internal/config/managedfiles/symlink_test.go
+git commit -s -m "feat(managedfiles): port symlink rejection from pointers/
+
+rejectSymlinkComponents walks managed-file paths rejecting any symlink
+component with ErrSymlinkRejected. openExclusiveNoFollow opens with
+O_NOFOLLOW (Unix) so the kernel surfaces ELOOP at the leaf.
+
+Tests cover no-symlinks (pass), symlink-in-path (rejected), and
+nonexistent-leaf (allowed for init-creates-new-file).
+
+Refs spgr-XXXX (PR A scope), spgr-rwrp."
+```
+
+---
+
+## Task 8: Source loader with `dev` build tag
+
+**Files:**
+- Create: `internal/config/managedfiles/source.go`
+- Create: `internal/config/managedfiles/source_release.go`
+- Create: `internal/config/managedfiles/source_dev.go`
+- Create: `internal/config/managedfiles/source_test.go`
+
+`readSource(mf)` returns the canonical bytes for a `ManagedFile`. The release build reads from a package-level `embed.FS`. The `dev` build reads from disk at canonical source paths (set via `SPECGRAPH_DEV_SOURCE_ROOT` env var, default to `./plugin`). The dev build also emits a stderr banner on interactive invocations.
+
+- [ ] **Step 1: Write the failing tests**
+
+`internal/config/managedfiles/source_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+)
+
+// PR A's manifest is empty, so readSource is exercised with an empty
+// embed.FS. We test the not-found path explicitly and rely on PR B+ to
+// add tests for actual content.
+
+func TestReadSource_EmptyManifestSourceMissing(t *testing.T) {
+	mf := ManagedFile{
+		Path:   ".specgraph/agents/opencode/specgraph.ts",
+		Source: "opencode/specgraph.ts",
+	}
+	_, err := readSource(mf)
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("expected fs.ErrNotExist, got %v", err)
+	}
+}
+
+func TestReadSource_EmptySourceField(t *testing.T) {
+	// JSON-key-merge files set Source="" because their canonical is built
+	// programmatically, not embedded. readSource returns nil bytes + nil error
+	// to signal "no embedded content; let the strategy build it."
+	mf := ManagedFile{
+		Path:     ".mcp.json",
+		Strategy: StrategyJSONKeyMerge,
+		Source:   "",
+	}
+	got, err := readSource(mf)
+	if err != nil {
+		t.Errorf("expected nil error for empty Source, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil bytes, got %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/config/managedfiles/ -run "ReadSource" -v
+```
+
+Expected: FAIL with undefined `readSource`.
+
+- [ ] **Step 3: Create `source.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+// readSource returns the canonical bytes for a ManagedFile.
+//
+// Behaviour by build tag:
+//   - Default build: reads from the package-level canonicalSources embed.FS
+//     populated via //go:embed directives in source_release.go. PR A leaves
+//     it empty; PRs C/D/E add directives.
+//   - `dev` build tag: reads from disk at SPECGRAPH_DEV_SOURCE_ROOT (default
+//     "./plugin") so a developer can edit a source file and re-run init
+//     without rebuilding the binary.
+//
+// Returns (nil, nil) when mf.Source is empty (JSON-key-merge files build
+// their canonical programmatically, not from an embedded asset).
+//
+// Implementation lives in source_release.go (no build tag — default build)
+// or source_dev.go (`dev` build tag).
+func readSource(mf ManagedFile) ([]byte, error) {
+	if mf.Source == "" {
+		return nil, nil
+	}
+	return readSourceImpl(mf)
+}
+```
+
+- [ ] **Step 4: Create `source_release.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build !dev
+
+package managedfiles
+
+import "embed"
+
+// canonicalSources is populated via //go:embed directives added in PR C+
+// when actual managed-file source content lands in the binary. PR A leaves
+// the FS empty, which means readSourceImpl returns fs.ErrNotExist for any
+// non-empty mf.Source.
+//
+// The empty embed is intentional: it lets the framework compile and tests
+// run even before any //go:embed directive references real files. Adding
+// the first directive happens in PR C alongside the OpenCode plugin TS.
+var canonicalSources embed.FS
+
+// readSourceImpl reads from the embedded sources tree.
+func readSourceImpl(mf ManagedFile) ([]byte, error) {
+	return canonicalSources.ReadFile(mf.Source)
+}
+```
+
+- [ ] **Step 5: Create `source_dev.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build dev
+
+package managedfiles
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"golang.org/x/term"
+)
+
+// devSourceRoot resolves the directory dev builds read sources from.
+// SPECGRAPH_DEV_SOURCE_ROOT overrides the default of "./plugin".
+func devSourceRoot() string {
+	if v := os.Getenv("SPECGRAPH_DEV_SOURCE_ROOT"); v != "" {
+		return v
+	}
+	return "./plugin"
+}
+
+// devBannerOnce ensures the dev banner stderr line is printed at most once
+// per process. Loud-but-not-spammy.
+var devBannerOnce sync.Once
+
+func emitDevBanner() {
+	devBannerOnce.Do(func() {
+		// Same isatty gate as the drift-nudge — a dev binary invoked
+		// non-interactively (CI, hooks) shouldn't smear the banner across
+		// captured stderr.
+		if !term.IsTerminal(int(os.Stderr.Fd())) {
+			return
+		}
+		fmt.Fprintf(os.Stderr,
+			"specgraph: DEV BUILD — embedded files read from disk at %s\n",
+			devSourceRoot())
+	})
+}
+
+// readSourceImpl reads from disk at <devSourceRoot>/<mf.Source>.
+func readSourceImpl(mf ManagedFile) ([]byte, error) {
+	emitDevBanner()
+	return os.ReadFile(filepath.Join(devSourceRoot(), mf.Source))
+}
+```
+
+Note: the dev build depends on `golang.org/x/term`. Verify it's already in go.mod:
+
+```bash
+grep "golang.org/x/term" go.mod || echo "MISSING — need go get"
+```
+
+If missing, run `go get golang.org/x/term@latest` and `go mod tidy` before the next step.
+
+- [ ] **Step 6: Run tests to verify they pass (default build)**
+
+```bash
+go test ./internal/config/managedfiles/ -run "ReadSource" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Smoke-test the `dev` build compiles**
+
+```bash
+go build -tags dev ./cmd/specgraph
+echo "exit=$?"
+```
+
+Expected: exit 0. (This catches any compile-time issues in source_dev.go before they bite later.)
+
+- [ ] **Step 8: Run `task check`**
+
+```bash
+task check 2>&1 | tail -8
+```
+
+Expected: 0 issues.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/config/managedfiles/source.go internal/config/managedfiles/source_release.go internal/config/managedfiles/source_dev.go internal/config/managedfiles/source_test.go go.mod go.sum
+git commit -s -m "feat(managedfiles): add source loader with dev build tag
+
+readSource returns canonical bytes for a ManagedFile. Default build
+reads from the package-level canonicalSources embed.FS (empty in PR A;
+populated by //go:embed directives in PRs C+). 'dev' build tag swaps
+to disk reads from SPECGRAPH_DEV_SOURCE_ROOT (default ./plugin),
+emitting a one-shot stderr banner on interactive invocations.
+
+The dev binary's isatty(stderr) gate matches the drift-nudge: visible
+when a developer runs at a terminal, silent in pipes/CI/hooks.
+
+Refs spgr-XXXX (PR A scope), spgr-rwrp."
+```
+
+---
+
+## Task 9: Inspect single file (state classification)
+
+**Files:**
+- Create: `internal/config/managedfiles/inspect.go`
+- Create: `internal/config/managedfiles/inspect_test.go`
+
+`Inspect(cwd, mf)` reads the on-disk file, parses the sentinel, computes hashes, and returns a `FileState`. This is the central state-machine: the four states (Missing / Synced / Stale / Drifted) are decidable from disk + binary alone.
+
+For PR A, the strategies don't expose their own classification logic yet (they'll be added in PR B+). Inspect handles `WholeFile`-shaped reasoning generically using the sentinel + hash; the strategy-specific paths return `ErrNotImplemented` and are exercised by future PRs.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInspect_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	mf := ManagedFile{
+		Path:     ".specgraph/agents/opencode/nope.ts",
+		Strategy: StrategyWholeFile,
+		Source:   "opencode/specgraph.ts",
+		Comment:  CommentSlash,
+	}
+	got, err := Inspect(dir, mf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.State != StateMissing {
+		t.Errorf("State = %v, want StateMissing", got.State)
+	}
+}
+
+func TestInspect_SymlinkRejected(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Symlink("/etc/passwd", filepath.Join(dir, "link.ts")); err != nil {
+		t.Skip("symlink creation failed (likely Windows without admin)")
+	}
+	mf := ManagedFile{
+		Path:     "link.ts",
+		Strategy: StrategyWholeFile,
+		Comment:  CommentSlash,
+	}
+	if _, err := Inspect(dir, mf); err == nil {
+		t.Error("expected ErrSymlinkRejected, got nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/config/managedfiles/ -run "TestInspect" -v
+```
+
+Expected: FAIL with undefined `Inspect`.
+
+- [ ] **Step 3: Create `inspect.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Inspect classifies the on-disk state of a single ManagedFile relative
+// to its embedded canonical. Returns a FileState describing the four
+// possible outcomes: Missing, Synced, Stale, Drifted.
+//
+// Returns an error only on operational failures (symlink in path,
+// permission denied, etc.). Drift classifications are returned as a
+// non-nil State, not as an error.
+//
+// PR A handles the WholeFile strategy generically using the sentinel +
+// hash mechanism. JSONKeyMerge and MarkdownBlock strategy paths are
+// reserved for PR B implementations.
+func Inspect(cwd string, mf ManagedFile) (FileState, error) {
+	if err := rejectSymlinkComponents(cwd, mf.Path); err != nil {
+		return FileState{}, err
+	}
+
+	full := filepath.Join(cwd, mf.Path)
+	disk, readErr := os.ReadFile(full)
+	switch {
+	case errors.Is(readErr, fs.ErrNotExist):
+		return FileState{
+			Path:     mf.Path,
+			Strategy: mf.Strategy,
+			State:    StateMissing,
+			Detail:   "file does not exist",
+		}, nil
+	case readErr != nil:
+		return FileState{}, fmt.Errorf("read %s: %w", full, readErr)
+	}
+
+	canonical, err := readSource(mf)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return FileState{}, fmt.Errorf("read source for %s: %w", mf.Path, err)
+	}
+
+	diskHash := HashExcludingSentinel(mf.Comment, disk)
+	embeddedHash := ""
+	if canonical != nil {
+		embeddedHash = HashExcludingSentinel(mf.Comment, canonical)
+	}
+
+	// Strategy-specific classification is implemented in PRs B+. Until then
+	// we return a Detail noting the file exists but state is undetermined.
+	// The empty manifest in PR A means this path is never reached
+	// end-to-end.
+	return FileState{
+		Path:         mf.Path,
+		Strategy:     mf.Strategy,
+		State:        StateSynced, // placeholder; PR B implements per-strategy
+		DiskHash:     diskHash,
+		EmbeddedHash: embeddedHash,
+		Detail:       "PR A: classification deferred to per-strategy code in PR B",
+	}, nil
+}
+
+// InspectAll iterates the manifest filtered by the user's enabled harnesses
+// and returns a FileState for each. Errors at the per-file level are
+// captured in the FileState (not surfaced as an error return) so callers
+// see all results, not just the first failure.
+//
+// In PR A, Manifest() returns an empty slice; InspectAll therefore returns
+// an empty slice. PRs B+ populate the manifest.
+func InspectAll(cwd string, harnesses []Harness) ([]FileState, error) {
+	if err := validateProjectDir(cwd); err != nil {
+		return nil, err
+	}
+	mfs := Manifest(harnesses)
+	out := make([]FileState, 0, len(mfs))
+	for _, mf := range mfs {
+		fs, err := Inspect(cwd, mf)
+		if err != nil {
+			out = append(out, FileState{
+				Path:     mf.Path,
+				Strategy: mf.Strategy,
+				State:    StateDrifted, // conservative fallback
+				Detail:   fmt.Sprintf("inspect error: %v", err),
+			})
+			continue
+		}
+		out = append(out, fs)
+	}
+	return out, nil
+}
+
+// validateProjectDir rejects non-existent dirs, non-dirs, and symlink-rooted
+// project directories. Mirrors pointers/sync.go's projectDir guard.
+func validateProjectDir(projectDir string) error {
+	info, err := os.Stat(projectDir)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("project dir %q is not a directory", projectDir)
+	}
+	li, lerr := os.Lstat(projectDir)
+	if lerr != nil {
+		return fmt.Errorf("lstat %s: %w", projectDir, lerr)
+	}
+	if li.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%w: %s", ErrSymlinkRejected, projectDir)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/config/managedfiles/ -run "TestInspect" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run `task check`**
+
+```bash
+task check 2>&1 | tail -8
+```
+
+Expected: 0 issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/managedfiles/inspect.go internal/config/managedfiles/inspect_test.go
+git commit -s -m "feat(managedfiles): add Inspect/InspectAll skeleton
+
+Inspect classifies a single ManagedFile's on-disk state. Symlink
+rejection, missing-file detection, and disk/canonical hash computation
+are wired in PR A; per-strategy state classification (Synced/Stale/
+Drifted distinction) is reserved for PRs B+ where strategies are
+implemented. Empty manifest in PR A means the placeholder Synced
+return is never reached end-to-end.
+
+Refs spgr-XXXX (PR A scope), spgr-rwrp."
+```
+
+---
+
+## Task 10: SupersedesPath guarded delete
+
+**Files:**
+- Create: `internal/config/managedfiles/supersedes.go`
+- Create: `internal/config/managedfiles/supersedes_test.go`
+
+When a manifest entry has `SupersedesPath` set, init deletes the old path after writing the new one — but only if the on-disk content matches the prior canonical (proving we wrote it ourselves, not the user). This guards against deleting hand-edited content during cursor `.md` → `.mdc` and similar renames.
+
+The "prior canonical" computation is supplied by the strategy at PR B time. PR A defines the guarded-delete primitive with an injectable "expected hash" argument.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSupersedesGuardedDelete_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	// Old path doesn't exist — guarded delete is a no-op success.
+	if err := supersedesGuardedDelete(dir, "missing.md", "anyhash"); err != nil {
+		t.Errorf("expected nil for missing file, got %v", err)
+	}
+}
+
+func TestSupersedesGuardedDelete_HashMatches_DeletesFile(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := "old.md"
+	full := filepath.Join(dir, oldPath)
+	content := "old canonical"
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := HashExcludingSentinel(CommentNone, []byte(content))
+	if err := supersedesGuardedDelete(dir, oldPath, expected); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(full); !os.IsNotExist(err) {
+		t.Errorf("file should be deleted, stat err = %v", err)
+	}
+}
+
+func TestSupersedesGuardedDelete_HashMismatch_LeavesFile(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := "old.md"
+	full := filepath.Join(dir, oldPath)
+	if err := os.WriteFile(full, []byte("user-edited content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "0000000000000000000000000000000000000000000000000000000000000000" // wrong
+	err := supersedesGuardedDelete(dir, oldPath, expected)
+	if !errors.Is(err, ErrPriorCanonicalMismatch) {
+		t.Errorf("got %v, want ErrPriorCanonicalMismatch", err)
+	}
+	if _, statErr := os.Stat(full); statErr != nil {
+		t.Errorf("file should NOT be deleted on mismatch, stat err = %v", statErr)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/config/managedfiles/ -run "Supersedes" -v
+```
+
+Expected: FAIL with undefined `supersedesGuardedDelete`.
+
+- [ ] **Step 3: Create `supersedes.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// supersedesGuardedDelete deletes the file at <projectDir>/<oldPath> only
+// if its on-disk content hash matches expectedPriorHash.
+//
+// expectedPriorHash is the hash this binary's *prior canonical* would have
+// produced for oldPath — typically computed by the calling strategy using
+// the vestigial v=1 renderer (see §"Drift detection / Vestigial v=1
+// renderer" in the spec). The guard prevents init from clobbering user
+// content that happens to live at a path being superseded.
+//
+// Returns nil if the file doesn't exist (nothing to delete) or was deleted
+// successfully. Returns ErrPriorCanonicalMismatch if the hash check fails;
+// the file is left in place. Returns wrapped errors for other failures
+// (lstat, read, remove).
+func supersedesGuardedDelete(projectDir, oldPath, expectedPriorHash string) error {
+	full := filepath.Join(projectDir, oldPath)
+
+	if err := rejectSymlinkComponents(projectDir, oldPath); err != nil {
+		return err
+	}
+
+	disk, err := os.ReadFile(full)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return nil
+	case err != nil:
+		return fmt.Errorf("read %s: %w", full, err)
+	}
+
+	// CommentNone is intentional: callers pass the exact bytes the prior
+	// canonical would have produced including any sentinel, so we hash
+	// the raw bytes here and let the caller-provided hash account for
+	// any sentinel-stripping it cares about. This keeps the guard
+	// agnostic to comment syntax.
+	actual := HashExcludingSentinel(CommentNone, disk)
+	if actual != expectedPriorHash {
+		return fmt.Errorf("%w: %s (got %s, want %s)",
+			ErrPriorCanonicalMismatch, oldPath, actual, expectedPriorHash)
+	}
+
+	if rmErr := os.Remove(full); rmErr != nil {
+		return fmt.Errorf("remove %s: %w", full, rmErr)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/config/managedfiles/ -run "Supersedes" -v
+```
+
+Expected: PASS — all 3 supersedes tests.
+
+- [ ] **Step 5: Run `task check`**
+
+```bash
+task check 2>&1 | tail -8
+```
+
+Expected: 0 issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/managedfiles/supersedes.go internal/config/managedfiles/supersedes_test.go
+git commit -s -m "feat(managedfiles): add supersedesGuardedDelete
+
+Deletes a SupersedesPath only when the on-disk content matches the
+prior canonical hash supplied by the calling strategy. Mismatch
+returns ErrPriorCanonicalMismatch; file is left in place for the
+user to triage.
+
+Tests cover missing-file (no-op success), hash-match (deletes), and
+hash-mismatch (refuses to delete).
+
+Refs spgr-XXXX (PR A scope), spgr-rwrp."
+```
+
+---
+
+## Task 11: Strategy interface + dispatch stubs
+
+**Files:**
+- Create: `internal/config/managedfiles/strategy.go`
+- Create: `internal/config/managedfiles/strategy_test.go`
+
+The `Strategy` enum dispatches through an interface so per-strategy logic lives in dedicated methods in PR B+. PR A defines the interface and registers stubs that return `ErrNotImplemented`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestStrategyImpl_Inspect_NotImplemented(t *testing.T) {
+	for _, s := range []Strategy{StrategyJSONKeyMerge, StrategyMarkdownBlock, StrategyWholeFile} {
+		impl := strategyImpl(s)
+		_, err := impl.Inspect("/tmp", ManagedFile{Strategy: s})
+		if !errors.Is(err, ErrNotImplemented) {
+			t.Errorf("Strategy %d Inspect should return ErrNotImplemented, got %v", s, err)
+		}
+	}
+}
+
+func TestStrategyImpl_Sync_NotImplemented(t *testing.T) {
+	for _, s := range []Strategy{StrategyJSONKeyMerge, StrategyMarkdownBlock, StrategyWholeFile} {
+		impl := strategyImpl(s)
+		_, err := impl.Sync("/tmp", ManagedFile{Strategy: s}, SyncOptions{})
+		if !errors.Is(err, ErrNotImplemented) {
+			t.Errorf("Strategy %d Sync should return ErrNotImplemented, got %v", s, err)
+		}
+	}
+}
+
+func TestStrategyImpl_UnknownStrategy_Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for unknown strategy")
+		}
+	}()
+	_ = strategyImpl(Strategy(99))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/config/managedfiles/ -run "Strategy" -v
+```
+
+Expected: FAIL with undefined `strategyImpl`.
+
+- [ ] **Step 3: Create `strategy.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import "fmt"
+
+// strategy is the interface implemented per-strategy in PR B+. PR A
+// registers stubs that return ErrNotImplemented for both methods.
+//
+// Inspect classifies the on-disk state for a single ManagedFile.
+// Sync writes (or refrains from writing) the canonical content per
+// SyncOptions. Both methods MUST be safe to call with mf.Strategy
+// matching the dispatched strategy; misuse is a programming error.
+type strategy interface {
+	Inspect(cwd string, mf ManagedFile) (FileState, error)
+	Sync(cwd string, mf ManagedFile, opts SyncOptions) (SyncResult, error)
+}
+
+// strategyImpl returns the strategy implementation for s.
+//
+// Panics if s is not a known Strategy value — that's a programming error
+// from a manifest entry with a bogus enum value, not a runtime condition.
+func strategyImpl(s Strategy) strategy {
+	switch s {
+	case StrategyJSONKeyMerge:
+		return jsonKeyMergeStrategy{}
+	case StrategyMarkdownBlock:
+		return markdownBlockStrategy{}
+	case StrategyWholeFile:
+		return wholeFileStrategy{}
+	default:
+		panic(fmt.Sprintf("unknown Strategy value: %d", s))
+	}
+}
+
+// PR A stubs. All three return ErrNotImplemented; PRs B/C/D/E replace
+// each one with a real implementation.
+
+type jsonKeyMergeStrategy struct{}
+
+func (jsonKeyMergeStrategy) Inspect(cwd string, mf ManagedFile) (FileState, error) {
+	return FileState{}, ErrNotImplemented
+}
+func (jsonKeyMergeStrategy) Sync(cwd string, mf ManagedFile, opts SyncOptions) (SyncResult, error) {
+	return SyncResult{}, ErrNotImplemented
+}
+
+type markdownBlockStrategy struct{}
+
+func (markdownBlockStrategy) Inspect(cwd string, mf ManagedFile) (FileState, error) {
+	return FileState{}, ErrNotImplemented
+}
+func (markdownBlockStrategy) Sync(cwd string, mf ManagedFile, opts SyncOptions) (SyncResult, error) {
+	return SyncResult{}, ErrNotImplemented
+}
+
+type wholeFileStrategy struct{}
+
+func (wholeFileStrategy) Inspect(cwd string, mf ManagedFile) (FileState, error) {
+	return FileState{}, ErrNotImplemented
+}
+func (wholeFileStrategy) Sync(cwd string, mf ManagedFile, opts SyncOptions) (SyncResult, error) {
+	return SyncResult{}, ErrNotImplemented
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/config/managedfiles/ -run "Strategy" -v
+```
+
+Expected: PASS — all 3 strategy tests.
+
+- [ ] **Step 5: Run `task check`**
+
+```bash
+task check 2>&1 | tail -8
+```
+
+Expected: 0 issues. If `unparam` complains about the unused `cwd`/`mf`/`opts` parameters in stubs, ignore — they'll be used in PR B implementations and removing them now would break the interface contract.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/managedfiles/strategy.go internal/config/managedfiles/strategy_test.go
+git commit -s -m "feat(managedfiles): add strategy interface + ErrNotImplemented stubs
+
+The strategy interface dispatches per-strategy logic for Inspect and
+Sync. PR A registers stubs returning ErrNotImplemented for all three
+strategies (JSONKeyMerge, MarkdownBlock, WholeFile); PRs B/C/D/E
+replace each stub with a real implementation.
+
+Empty manifest in PR A means stubs are never invoked end-to-end.
+
+Refs spgr-XXXX (PR A scope), spgr-rwrp."
+```
+
+---
+
+## Task 12: Manifest, Sync entry point, and end-to-end empty-manifest test
+
+**Files:**
+- Create: `internal/config/managedfiles/manifest.go`
+- Create: `internal/config/managedfiles/sync.go`
+- Create: `internal/config/managedfiles/integration_test.go`
+
+`Manifest()` returns the list of managed files filtered by enabled harnesses. PR A returns an empty slice. `Sync` and `SyncAll` are the write-side entry points; PR A's empty manifest means they're no-ops.
+
+- [ ] **Step 1: Write the failing tests**
+
+`internal/config/managedfiles/integration_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles_test
+
+import (
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/config/managedfiles"
+)
+
+func TestManifest_EmptyInPRA(t *testing.T) {
+	all := managedfiles.Manifest([]managedfiles.Harness{
+		managedfiles.HarnessClaude,
+		managedfiles.HarnessCursor,
+		managedfiles.HarnessOpenCode,
+	})
+	if len(all) != 0 {
+		t.Errorf("Manifest() should be empty in PR A, got %d entries", len(all))
+	}
+}
+
+func TestInspectAll_EmptyManifest_ReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	got, err := managedfiles.InspectAll(dir, []managedfiles.Harness{managedfiles.HarnessOpenCode})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("InspectAll on empty manifest should be empty, got %d", len(got))
+	}
+}
+
+func TestSyncAll_EmptyManifest_ReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	got, err := managedfiles.SyncAll(dir, []managedfiles.Harness{managedfiles.HarnessOpenCode}, managedfiles.SyncOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("SyncAll on empty manifest should be empty, got %d", len(got))
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/config/managedfiles/ -run "TestManifest|TestInspectAll|TestSyncAll" -v
+```
+
+Expected: FAIL with undefined `Manifest`, `SyncAll`.
+
+- [ ] **Step 3: Create `manifest.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+// Manifest returns the list of ManagedFiles filtered by the given
+// harnesses. Order is stable across calls — callers may rely on it for
+// deterministic output (e.g. doctor's report).
+//
+// PR A returns an empty slice; PRs B/C/D/E populate it as they register
+// managed files for each harness.
+func Manifest(harnesses []Harness) []ManagedFile {
+	all := allManagedFiles()
+	enabled := harnessSet(harnesses)
+	out := make([]ManagedFile, 0, len(all))
+	for _, mf := range all {
+		if enabled[mf.Harness] {
+			out = append(out, mf)
+		}
+	}
+	return out
+}
+
+// allManagedFiles is the framework's full set, unfiltered by harness.
+// PR A returns nil; PRs B+ append entries.
+func allManagedFiles() []ManagedFile {
+	return nil
+}
+
+func harnessSet(harnesses []Harness) map[Harness]bool {
+	out := make(map[Harness]bool, len(harnesses))
+	for _, h := range harnesses {
+		out[h] = true
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Create `sync.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import "fmt"
+
+// Sync reconciles a single ManagedFile against its embedded canonical,
+// honouring SyncOptions (Force, KeepEdits). Returns a SyncResult
+// describing what was done.
+//
+// PR A dispatches to per-strategy stubs that return ErrNotImplemented;
+// the empty manifest means this is never called end-to-end. PRs B/C/D/E
+// implement each strategy.
+func Sync(cwd string, mf ManagedFile, opts SyncOptions) (SyncResult, error) {
+	return strategyImpl(mf.Strategy).Sync(cwd, mf, opts)
+}
+
+// SyncAll iterates the manifest filtered by enabled harnesses, calls
+// Sync on each, and returns one SyncResult per entry. Per-file errors
+// are captured in the SyncResult (Action == ActionError); the iteration
+// continues so partial failure produces a complete report.
+//
+// In PR A, Manifest() is empty, so SyncAll returns an empty slice
+// regardless of input.
+func SyncAll(cwd string, harnesses []Harness, opts SyncOptions) ([]SyncResult, error) {
+	if err := validateProjectDir(cwd); err != nil {
+		return nil, err
+	}
+	mfs := Manifest(harnesses)
+	out := make([]SyncResult, 0, len(mfs))
+	for _, mf := range mfs {
+		r, err := Sync(cwd, mf, opts)
+		if err != nil {
+			out = append(out, SyncResult{
+				Path:   mf.Path,
+				Action: ActionError,
+				Err:    fmt.Errorf("sync %s: %w", mf.Path, err),
+			})
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+go test ./internal/config/managedfiles/ -v
+```
+
+Expected: PASS — all tests across the package.
+
+- [ ] **Step 6: Run full `task check`**
+
+```bash
+task check 2>&1 | tail -10
+```
+
+Expected: 0 issues. If lint complains about the unused `opts` in `Sync`/`SyncAll`, ignore — it threads through to strategy implementations in PR B.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/config/managedfiles/manifest.go internal/config/managedfiles/sync.go internal/config/managedfiles/integration_test.go
+git commit -s -m "feat(managedfiles): add Manifest, Sync, SyncAll plumbing
+
+Manifest returns the list of ManagedFiles filtered by enabled
+harnesses (empty in PR A; populated in PRs B/C/D/E). Sync dispatches
+to per-strategy implementations; SyncAll iterates with per-file error
+capture.
+
+Empty-manifest integration tests prove the plumbing wires through
+correctly without exercising any strategy logic.
+
+Refs spgr-XXXX (PR A scope), spgr-rwrp."
+```
+
+---
+
+## Task 13: Final verification + close bead
+
+**Files:** none (verification + bookkeeping)
+
+- [ ] **Step 1: Run the full quality gate**
+
+```bash
+cd /Volumes/Code/github.com/specgraph
+task check 2>&1 | tail -15
+```
+
+Expected: 0 issues. All Go tests pass; lint clean; build succeeds.
+
+- [ ] **Step 2: Confirm the dev build still compiles**
+
+```bash
+go build -tags dev ./cmd/specgraph
+echo "exit=$?"
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Inspect commit stack**
+
+```bash
+jj --no-pager log -r 'main..@' --no-graph -T 'commit_id.short() ++ " " ++ description.first_line() ++ "\n"' | head -20
+```
+
+Expected: ~12 commits, one per task. Conventional-commit format. All carry DCO sign-off.
+
+- [ ] **Step 4: Close the bead**
+
+```bash
+bd close <pr-a-bead-id> --reason="Foundation merged. internal/config/managedfiles/ + xdg.CacheHome() + dev build tag complete; empty manifest. Unblocks PR B (port existing managed files into the new framework)."
+gh auth switch -u seanb4t  # if needed for push
+bd dolt push
+```
+
+- [ ] **Step 5: Open a PR**
+
+```bash
+jj --no-pager bookmark create spgr-rwrp-pra -r @
+jj --no-pager git push --bookmark spgr-rwrp-pra
+gh pr create --base main --head spgr-rwrp-pra \
+  --title "feat(managedfiles): foundation framework (spgr-rwrp PR A)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Foundation PR for spgr-rwrp (harness install parity via embed-and-write).
+
+Introduces `internal/config/managedfiles/` with:
+- Types: `ManagedFile`, `Strategy`, `State`, `Harness`, `FileState`, `SyncResult`, `SyncOptions`
+- Sentinel parse/render for `// # <!-- -->` comment styles, with `v=1` recognition for the upgrade path and `v=3+` rejection
+- `HashExcludingSentinel` for content hashing that's stable across sentinel changes
+- File locking, atomic writes, symlink rejection (ported verbatim from `internal/config/pointers/`, will be deleted in PR B)
+- `SupersedesPath` guarded delete with hash-check guard rails
+- `dev` build tag swapping `//go:embed` for disk reads, with `isatty(stderr)`-gated banner
+- Strategy interface with `ErrNotImplemented` stubs; PR B replaces JSONKeyMerge + MarkdownBlock; PRs C/D/E land WholeFile use cases
+- `Manifest()` filtered by enabled harnesses (returns empty in PR A)
+- `xdg.CacheHome()` added to internal/xdg/ for PR G's drift-nudge throttle file
+
+**Zero behaviour change for users.** Empty manifest; `cmd/specgraph/init.go` is untouched. PR B subsumes the existing `mcpconfigs/` and `pointers/` packages and migrates the 5 already-managed files into this framework.
+
+Closes spgr-XXXX (the PR A bead).
+
+## Test plan
+
+- [x] `task check` (fmt, license, lint, skills, build, race tests)
+- [x] `go build -tags dev ./cmd/specgraph` succeeds
+- [x] All new tests pass
+- [ ] CI green
+EOF
+)"
+```
+
+If `gh auth switch` was used, switch back to the working account afterwards.
+
+---
+
+## Self-review (executed already during plan-write)
+
+**Spec coverage:** All PR A scope items from `2026-05-08-spgr-rwrp-harness-install-parity-design.md` §"Children of `spgr-rwrp`, in landing order / PR A":
+
+- Types: ✓ Task 2
+- Sentinel parse/write for `ts`/`sh`/`md`/`mdc`: ✓ Task 3
+- Hash computation: ✓ Task 4
+- Port locking primitives: ✓ Task 5
+- Port atomic write: ✓ Task 6 (covered together with locking; see also Task 7's symlink work)
+- `O_NOFOLLOW` symlink rejection: ✓ Task 7
+- `SupersedesPath` deletion logic: ✓ Task 10
+- `InspectAll` and `SyncAll` plumbing: ✓ Tasks 9 and 12
+- `xdg.CacheHome()`: ✓ Task 1
+- `dev` build tag: ✓ Task 8
+
+**Type consistency:** `ManagedFile` fields align across types.go, source.go, inspect.go, sync.go. `Strategy` enum values are stable per the iota tests. `FileState`/`SyncResult` are constructed identically across call sites.
+
+**No placeholders:** all code blocks are complete; commit messages reference the PR A bead id (placeholder `spgr-XXXX` to be replaced once Task 0 returns the actual id).
+
+---
+
+## Open questions
+
+- **`golang.org/x/term` dependency** for the dev banner's isatty: if go.mod doesn't already include it, Task 8 step 5 adds it via `go get`. Verify before merge that it's the only new dep introduced by PR A.
+- **`unparam` complaints** on stub strategy methods: unused `cwd`/`mf`/`opts` parameters in stubs may trigger `unparam` warnings. Acceptable — the parameters become used in PR B implementations and removing them would force interface churn. Add `//nolint:unparam // implementation in PR B uses these` if the linter is strict.

--- a/internal/config/managedfiles/atomic.go
+++ b/internal/config/managedfiles/atomic.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// atomicWrite writes data to <fullPath>.tmp.<random> in the same directory,
+// fsyncs, then renames over fullPath. The directory is fsynced after the
+// rename so the rename itself is durable across power loss.
+//
+// The temp file is chmod'd to mode. On a fresh write, callers pass 0o600.
+// On an update, callers should read the existing file's mode and pass it so
+// user-set permissions (e.g. 0o644) are preserved.
+//
+// All cleanup errors are joined to the original error via errors.Join so
+// the caller sees both the proximate failure and any stranded-tempfile
+// fallout.
+func atomicWrite(fullPath string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(fullPath)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, filepath.Base(fullPath)+".tmp.*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	if _, werr := tmp.Write(data); werr != nil {
+		return errors.Join(
+			fmt.Errorf("write temp: %w", werr),
+			tmp.Close(),
+			os.Remove(tmpName),
+		)
+	}
+	if cerr := tmp.Chmod(mode); cerr != nil {
+		return errors.Join(
+			fmt.Errorf("chmod temp: %w", cerr),
+			tmp.Close(),
+			os.Remove(tmpName),
+		)
+	}
+	if serr := tmp.Sync(); serr != nil {
+		return errors.Join(
+			fmt.Errorf("fsync temp: %w", serr),
+			tmp.Close(),
+			os.Remove(tmpName),
+		)
+	}
+	if cerr := tmp.Close(); cerr != nil {
+		return errors.Join(
+			fmt.Errorf("close temp: %w", cerr),
+			os.Remove(tmpName),
+		)
+	}
+	if rerr := os.Rename(tmpName, fullPath); rerr != nil {
+		return errors.Join(
+			fmt.Errorf("rename: %w", rerr),
+			os.Remove(tmpName),
+		)
+	}
+	if dirF, derr := os.Open(dir); derr == nil {
+		_ = dirF.Sync()  //nolint:errcheck // best-effort dir fsync; not fatal if unsupported
+		_ = dirF.Close() //nolint:errcheck // best-effort cleanup
+	}
+	return nil
+}

--- a/internal/config/managedfiles/atomic_test.go
+++ b/internal/config/managedfiles/atomic_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAtomicWrite_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.txt")
+	if err := atomicWrite(target, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("got %q, want %q", string(got), "hello")
+	}
+}
+
+func TestAtomicWrite_ReplacesExisting(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.txt")
+	if err := os.WriteFile(target, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicWrite(target, []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "new" {
+		t.Errorf("got %q, want %q", string(got), "new")
+	}
+}
+
+func TestAtomicWrite_LeavesNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.txt")
+	if err := atomicWrite(target, []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 || entries[0].Name() != "out.txt" {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected only out.txt, got %v", names)
+	}
+}
+
+func TestAtomicWrite_RespectsMode(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.sh")
+	if err := atomicWrite(target, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("mode = %o, want 0o755", info.Mode().Perm())
+	}
+}
+
+func TestAtomicWrite_CreatesParentDir(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "nested", "deeper", "out.txt")
+	if err := atomicWrite(target, []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Errorf("file not created: %v", err)
+	}
+}

--- a/internal/config/managedfiles/doc.go
+++ b/internal/config/managedfiles/doc.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+// Package managedfiles is the framework specgraph init uses to inject
+// canonical files into a user's project — and that specgraph doctor
+// uses to detect drift.
+//
+// Every file specgraph writes is registered as a ManagedFile with a
+// strategy that determines how the file is read, classified (Synced,
+// Stale, Drifted, or Missing), and reconciled. The strategies are:
+//
+//   - StrategyJSONKeyMerge: managed keys merge into a JSON file;
+//     siblings preserved (e.g. .mcp.json's mcpServers.specgraph block).
+//   - StrategyMarkdownBlock: a versioned, hash-tracked block fenced by
+//     <!-- specgraph:init:start ... --> / <!-- specgraph:init:end -->
+//     within an otherwise-user-owned markdown file (e.g. AGENTS.md).
+//   - StrategyWholeFile: the entire file is canonical; warn-and-force
+//     on drift (e.g. a generated TypeScript plugin).
+//
+// PR A scaffolds the framework: types, sentinels, hashing, file locking,
+// atomic writes, symlink rejection, supersedes-path deletion. Subsequent
+// PRs in spgr-rwrp register managed files and implement strategies.
+package managedfiles

--- a/internal/config/managedfiles/errors.go
+++ b/internal/config/managedfiles/errors.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import "errors"
+
+// ErrCorruptedSentinel indicates a managed file's sentinel line is
+// malformed (unparseable, unknown version, missing required fields).
+// The framework refuses to mutate corrupted-sentinel files.
+var ErrCorruptedSentinel = errors.New("corrupted managed-file sentinel")
+
+// ErrSymlinkRejected is returned when init/inspect encounters a symlink
+// in a managed-file path component. We refuse to follow symlinks to avoid
+// confused-deputy attacks (planting a symlink to an unrelated file then
+// triggering init).
+var ErrSymlinkRejected = errors.New("symlink in managed-file path rejected")
+
+// ErrPriorCanonicalMismatch is returned by supersedesGuardedDelete when
+// the on-disk content of a SupersedesPath does NOT match the prior
+// canonical the framework would have produced. Indicates user content
+// at the old path; init refuses to delete it.
+var ErrPriorCanonicalMismatch = errors.New("supersedes-path content differs from prior canonical")
+
+// ErrNotImplemented is returned by strategy stubs in PR A. PRs B and onward
+// replace the stubs with real implementations; the manifest is empty in PR A
+// so this error is never surfaced end-to-end.
+var ErrNotImplemented = errors.New("strategy not implemented in this PR")

--- a/internal/config/managedfiles/errors.go
+++ b/internal/config/managedfiles/errors.go
@@ -22,7 +22,11 @@ var ErrSymlinkRejected = errors.New("symlink in managed-file path rejected")
 // at the old path; init refuses to delete it.
 var ErrPriorCanonicalMismatch = errors.New("supersedes-path content differs from prior canonical")
 
-// ErrNotImplemented is returned by strategy stubs in PR A. PRs B and onward
+// errNotImplemented is returned by strategy stubs in PR A. PRs B and onward
 // replace the stubs with real implementations; the manifest is empty in PR A
 // so this error is never surfaced end-to-end.
-var ErrNotImplemented = errors.New("strategy not implemented in this PR")
+//
+// Unexported because it's a transient, PR-A-only API surface — exposing it
+// would invite external callers to depend on a stub state that disappears
+// in PR B.
+var errNotImplemented = errors.New("strategy not implemented in this PR")

--- a/internal/config/managedfiles/hash.go
+++ b/internal/config/managedfiles/hash.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// HashExcludingSentinel returns the hex-encoded sha256 of the file content
+// after stripping the sentinel line(s).
+//
+// For CommentSlash and CommentHash: the FIRST line is dropped if it parses
+// as a sentinel. Other lines are preserved verbatim.
+//
+// For CommentHTML (markdown-block strategy): every sentinel line in the
+// content (start and end markers) is dropped before hashing. This handles
+// files like AGENTS.md where the managed block is delimited by a pair.
+//
+// For CommentNone: the bytes are hashed as-is. JSON files don't carry
+// sentinels, so there's nothing to strip.
+//
+// The hash is computed over the byte stream after sentinel-stripping,
+// so two files differing only in their sentinel line hash equal.
+func HashExcludingSentinel(syntax CommentSyntax, content []byte) string {
+	if syntax == CommentNone {
+		return hashBytes(content)
+	}
+
+	lines := strings.Split(string(content), "\n")
+	kept := make([]string, 0, len(lines))
+	for i, line := range lines {
+		// For slash/hash syntaxes, only consider the first line a candidate
+		// sentinel — body content might legitimately contain "# specgraph:init"
+		// inside (e.g., an example in a markdown rule body).
+		if (syntax == CommentSlash || syntax == CommentHash) && i > 0 {
+			kept = append(kept, line)
+			continue
+		}
+		s, err := ParseSentinel(syntax, line)
+		if (err == nil && s.Version > 0) || strings.Contains(line, "specgraph:init:end") {
+			// Drop sentinel start lines AND markdown-block end markers.
+			// (The end marker doesn't parse as a Sentinel struct because
+			// it has no version, but we drop it from the hash so the
+			// framework can replace marker pairs without changing the hash.)
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return hashBytes([]byte(strings.Join(kept, "\n")))
+}
+
+func hashBytes(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/config/managedfiles/hash.go
+++ b/internal/config/managedfiles/hash.go
@@ -13,7 +13,9 @@ import (
 // after stripping the sentinel line(s).
 //
 // For CommentSlash and CommentHash: the FIRST line is dropped if it parses
-// as a sentinel. Other lines are preserved verbatim.
+// as a sentinel. Other lines are preserved verbatim — the sentinel is
+// always line 0 for these syntaxes; a body line containing
+// "specgraph:init" (e.g., an example inside a rule body) is not a sentinel.
 //
 // For CommentHTML (markdown-block strategy): every sentinel line in the
 // content (start and end markers) is dropped before hashing. This handles

--- a/internal/config/managedfiles/hash_test.go
+++ b/internal/config/managedfiles/hash_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestHashExcludingSentinel_NoSentinel(t *testing.T) {
+	body := "package foo\n\nfunc Bar() {}\n"
+	got := HashExcludingSentinel(CommentSlash, []byte(body))
+	want := hashOf(body)
+	if got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestHashExcludingSentinel_WithSlashSentinel(t *testing.T) {
+	body := "package foo\n\nfunc Bar() {}\n"
+	withSentinel := "// specgraph:init v=2 sha256=abc rev=def\n" + body
+	got := HashExcludingSentinel(CommentSlash, []byte(withSentinel))
+	if got != hashOf(body) {
+		t.Errorf("hash should equal body hash, got %s", got)
+	}
+}
+
+func TestHashExcludingSentinel_StableAcrossRevChanges(t *testing.T) {
+	body := "echo hi\n"
+	a := "# specgraph:init v=2 sha256=abc rev=AAA\n" + body
+	b := "# specgraph:init v=2 sha256=abc rev=BBB\n" + body
+	if HashExcludingSentinel(CommentHash, []byte(a)) != HashExcludingSentinel(CommentHash, []byte(b)) {
+		t.Error("hash differed across rev-only changes; should be stable")
+	}
+}
+
+func TestHashExcludingSentinel_HTMLBlock(t *testing.T) {
+	body := "# Title\n\nbody\n"
+	withSentinel := "<!-- specgraph:init:start v=2 sha256=abc -->\n" + body + "<!-- specgraph:init:end -->\n"
+	got := HashExcludingSentinel(CommentHTML, []byte(withSentinel))
+	// For HTML/Markdown-block, BOTH the start AND end markers are dropped
+	// before hashing, leaving the inner content.
+	if got != hashOf(body) {
+		t.Errorf("got %s, want %s", got, hashOf(body))
+	}
+}
+
+func TestHashExcludingSentinel_NoneStrategy(t *testing.T) {
+	body := `{"foo":"bar"}`
+	// CommentNone (JSON files): no sentinel logic; hash the bytes as-is.
+	got := HashExcludingSentinel(CommentNone, []byte(body))
+	if got != hashOf(body) {
+		t.Errorf("got %s, want %s", got, hashOf(body))
+	}
+}
+
+// hashOf is a test helper: returns the hex sha256 of a string.
+func hashOf(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+// Compile-time assertion that strings.Contains is referenced — silences
+// the "imported and not used" lint if all tests are temporarily disabled.
+var _ = strings.Contains

--- a/internal/config/managedfiles/hash_test.go
+++ b/internal/config/managedfiles/hash_test.go
@@ -6,7 +6,6 @@ package managedfiles
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"strings"
 	"testing"
 )
 
@@ -62,7 +61,3 @@ func hashOf(s string) string {
 	h := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(h[:])
 }
-
-// Compile-time assertion that strings.Contains is referenced — silences
-// the "imported and not used" lint if all tests are temporarily disabled.
-var _ = strings.Contains

--- a/internal/config/managedfiles/inspect.go
+++ b/internal/config/managedfiles/inspect.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Inspect classifies the on-disk state of a single ManagedFile relative
+// to its embedded canonical. Returns a FileState describing the four
+// possible outcomes: Missing, Synced, Stale, Drifted.
+//
+// Returns an error only on operational failures (symlink in path,
+// permission denied, etc.). Drift classifications are returned as a
+// non-nil State, not as an error.
+//
+// PR A handles the WholeFile strategy generically using the sentinel +
+// hash mechanism. JSONKeyMerge and MarkdownBlock strategy paths are
+// reserved for PR B implementations.
+func Inspect(cwd string, mf ManagedFile) (FileState, error) {
+	if err := rejectSymlinkComponents(cwd, mf.Path); err != nil {
+		return FileState{}, err
+	}
+
+	full := filepath.Join(cwd, mf.Path)
+	disk, readErr := os.ReadFile(full)
+	switch {
+	case errors.Is(readErr, fs.ErrNotExist):
+		return FileState{
+			Path:     mf.Path,
+			Strategy: mf.Strategy,
+			State:    StateMissing,
+			Detail:   "file does not exist",
+		}, nil
+	case readErr != nil:
+		return FileState{}, fmt.Errorf("read %s: %w", full, readErr)
+	}
+
+	canonical, err := readSource(mf)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return FileState{}, fmt.Errorf("read source for %s: %w", mf.Path, err)
+	}
+
+	diskHash := HashExcludingSentinel(mf.Comment, disk)
+	embeddedHash := ""
+	if canonical != nil {
+		embeddedHash = HashExcludingSentinel(mf.Comment, canonical)
+	}
+
+	// Strategy-specific classification is implemented in PRs B+. Until then
+	// we return a Detail noting the file exists but state is undetermined.
+	// The empty manifest in PR A means this path is never reached
+	// end-to-end.
+	return FileState{
+		Path:         mf.Path,
+		Strategy:     mf.Strategy,
+		State:        StateSynced, // placeholder; PR B implements per-strategy
+		DiskHash:     diskHash,
+		EmbeddedHash: embeddedHash,
+		Detail:       "PR A: classification deferred to per-strategy code in PR B",
+	}, nil
+}
+
+// validateProjectDir rejects non-existent dirs, non-dirs, and symlink-rooted
+// project directories. Mirrors pointers/sync.go's projectDir guard.
+//
+//nolint:unused // consumed by InspectAll/SyncAll added in Task 12
+func validateProjectDir(projectDir string) error {
+	info, err := os.Stat(projectDir)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("project dir %q is not a directory", projectDir)
+	}
+	li, lerr := os.Lstat(projectDir)
+	if lerr != nil {
+		return fmt.Errorf("lstat %s: %w", projectDir, lerr)
+	}
+	if li.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%w: %s", ErrSymlinkRejected, projectDir)
+	}
+	return nil
+}

--- a/internal/config/managedfiles/inspect.go
+++ b/internal/config/managedfiles/inspect.go
@@ -28,8 +28,15 @@ func Inspect(cwd string, mf ManagedFile) (FileState, error) {
 	}
 
 	full := filepath.Join(cwd, mf.Path)
-	disk, readErr := os.ReadFile(full)
+	// Use the no-follow read primitive to close the TOCTOU window between
+	// rejectSymlinkComponents above and the actual file open. A symlink
+	// planted at the leaf between the two operations would slip past the
+	// component walk; O_NOFOLLOW on the open call surfaces it as ELOOP,
+	// which we translate to ErrSymlinkRejected here.
+	disk, readErr := readFileNoFollow(full)
 	switch {
+	case noFollowIsSymlink(readErr):
+		return FileState{}, fmt.Errorf("%w: %s", ErrSymlinkRejected, full)
 	case errors.Is(readErr, fs.ErrNotExist):
 		return FileState{
 			Path:     mf.Path,

--- a/internal/config/managedfiles/inspect.go
+++ b/internal/config/managedfiles/inspect.go
@@ -66,10 +66,37 @@ func Inspect(cwd string, mf ManagedFile) (FileState, error) {
 	}, nil
 }
 
+// InspectAll iterates the manifest filtered by the user's enabled harnesses
+// and returns a FileState for each. Errors at the per-file level are
+// captured in the FileState (not surfaced as an error return) so callers
+// see all results, not just the first failure.
+//
+// In PR A, Manifest() returns an empty slice; InspectAll therefore returns
+// an empty slice. PRs B+ populate the manifest.
+func InspectAll(cwd string, harnesses []Harness) ([]FileState, error) {
+	if err := validateProjectDir(cwd); err != nil {
+		return nil, err
+	}
+	mfs := Manifest(harnesses)
+	out := make([]FileState, 0, len(mfs))
+	for _, mf := range mfs {
+		state, err := Inspect(cwd, mf)
+		if err != nil {
+			out = append(out, FileState{
+				Path:     mf.Path,
+				Strategy: mf.Strategy,
+				State:    StateDrifted, // conservative fallback
+				Detail:   fmt.Sprintf("inspect error: %v", err),
+			})
+			continue
+		}
+		out = append(out, state)
+	}
+	return out, nil
+}
+
 // validateProjectDir rejects non-existent dirs, non-dirs, and symlink-rooted
 // project directories. Mirrors pointers/sync.go's projectDir guard.
-//
-//nolint:unused // consumed by InspectAll/SyncAll added in Task 12
 func validateProjectDir(projectDir string) error {
 	info, err := os.Stat(projectDir)
 	if err != nil || !info.IsDir() {

--- a/internal/config/managedfiles/inspect_test.go
+++ b/internal/config/managedfiles/inspect_test.go
@@ -4,6 +4,7 @@
 package managedfiles
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,7 +37,83 @@ func TestInspect_SymlinkRejected(t *testing.T) {
 		Strategy: StrategyWholeFile,
 		Comment:  CommentSlash,
 	}
-	if _, err := Inspect(dir, mf); err == nil {
-		t.Error("expected ErrSymlinkRejected, got nil")
+	_, err := Inspect(dir, mf)
+	if !errors.Is(err, ErrSymlinkRejected) {
+		t.Errorf("expected ErrSymlinkRejected, got %v", err)
+	}
+}
+
+// TestInspect_FileExistsHappyPath exercises Inspect's main body: file
+// reads successfully, disk hash is computed, an embedded source miss is
+// tolerated (canonical hash stays empty), and the placeholder StateSynced
+// is returned. PR A's empty manifest means this path is never reached
+// end-to-end via InspectAll, but the unit test pins the contract for PRs
+// B+ which will replace the placeholder with strategy-specific logic.
+func TestInspect_FileExistsHappyPath(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, ".specgraph", "agents", "opencode")
+	if err := os.MkdirAll(subdir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(subdir, "specgraph.ts")
+	const body = "// hello\nconst x = 1\n"
+	if err := os.WriteFile(target, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	mf := ManagedFile{
+		Path:     ".specgraph/agents/opencode/specgraph.ts",
+		Strategy: StrategyWholeFile,
+		Source:   "opencode/specgraph.ts", // PR A's embed.FS is empty, so this misses
+		Comment:  CommentSlash,
+	}
+	got, err := Inspect(dir, mf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Path != mf.Path {
+		t.Errorf("Path = %q, want %q", got.Path, mf.Path)
+	}
+	if got.DiskHash == "" {
+		t.Error("DiskHash should be non-empty for an existing file")
+	}
+	if got.EmbeddedHash != "" {
+		t.Errorf("EmbeddedHash should be empty (no canonical embedded in PR A), got %q", got.EmbeddedHash)
+	}
+	// PR A returns StateSynced as a placeholder; PR B replaces with per-strategy logic.
+	if got.State != StateSynced {
+		t.Errorf("State = %v, want StateSynced (PR A placeholder)", got.State)
+	}
+}
+
+// TestInspectAll_NonExistentProjectDir rejects calls against missing
+// project dirs; covers validateProjectDir's stat-failure branch.
+//
+// Uses a child path under t.TempDir() that we intentionally never create,
+// so the missing-path is guaranteed-missing AND scoped to test-owned
+// territory. Avoids relying on system-level path absence.
+func TestInspectAll_NonExistentProjectDir(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "non-existent-child")
+	_, err := InspectAll(missing, []Harness{HarnessOpenCode})
+	if err == nil {
+		t.Error("expected error for non-existent project dir, got nil")
+	}
+}
+
+// TestInspectAll_SymlinkProjectDir rejects a project dir that's itself
+// a symlink; covers validateProjectDir's symlink-rejection branch.
+func TestInspectAll_SymlinkProjectDir(t *testing.T) {
+	parent := t.TempDir()
+	realDir := filepath.Join(parent, "real")
+	if err := os.Mkdir(realDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(parent, "linky")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Skip("symlink creation failed (likely Windows)")
+	}
+	_, err := InspectAll(link, []Harness{HarnessOpenCode})
+	if !errors.Is(err, ErrSymlinkRejected) {
+		t.Errorf("expected ErrSymlinkRejected, got %v", err)
 	}
 }

--- a/internal/config/managedfiles/inspect_test.go
+++ b/internal/config/managedfiles/inspect_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInspect_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	mf := ManagedFile{
+		Path:     ".specgraph/agents/opencode/nope.ts",
+		Strategy: StrategyWholeFile,
+		Source:   "opencode/specgraph.ts",
+		Comment:  CommentSlash,
+	}
+	got, err := Inspect(dir, mf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.State != StateMissing {
+		t.Errorf("State = %v, want StateMissing", got.State)
+	}
+}
+
+func TestInspect_SymlinkRejected(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Symlink("/etc/passwd", filepath.Join(dir, "link.ts")); err != nil {
+		t.Skip("symlink creation failed (likely Windows without admin)")
+	}
+	mf := ManagedFile{
+		Path:     "link.ts",
+		Strategy: StrategyWholeFile,
+		Comment:  CommentSlash,
+	}
+	if _, err := Inspect(dir, mf); err == nil {
+		t.Error("expected ErrSymlinkRejected, got nil")
+	}
+}

--- a/internal/config/managedfiles/integration_test.go
+++ b/internal/config/managedfiles/integration_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles_test
+
+import (
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/config/managedfiles"
+)
+
+func TestManifest_EmptyInPRA(t *testing.T) {
+	all := managedfiles.Manifest([]managedfiles.Harness{
+		managedfiles.HarnessClaude,
+		managedfiles.HarnessCursor,
+		managedfiles.HarnessOpenCode,
+	})
+	if len(all) != 0 {
+		t.Errorf("Manifest() should be empty in PR A, got %d entries", len(all))
+	}
+}
+
+func TestInspectAll_EmptyManifest_ReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	got, err := managedfiles.InspectAll(dir, []managedfiles.Harness{managedfiles.HarnessOpenCode})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("InspectAll on empty manifest should be empty, got %d", len(got))
+	}
+}
+
+func TestSyncAll_EmptyManifest_ReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	got, err := managedfiles.SyncAll(dir, []managedfiles.Harness{managedfiles.HarnessOpenCode}, managedfiles.SyncOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("SyncAll on empty manifest should be empty, got %d", len(got))
+	}
+}

--- a/internal/config/managedfiles/lock.go
+++ b/internal/config/managedfiles/lock.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+// Unlocker releases a file lock acquired via acquireFileLock. Returns
+// any errors from the underlying flock LOCK_UN (Unix) or LockFileEx
+// release (Windows) plus any error closing the lock-file handle.
+//
+// Callers MUST invoke the Unlocker via a deferred wrapper that propagates
+// the error — leaving a lock unreleased breaks subsequent acquires.
+type Unlocker func() error

--- a/internal/config/managedfiles/lock_test.go
+++ b/internal/config/managedfiles/lock_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestAcquireFileLock_BasicAcquireRelease(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "agents.md")
+	if err := os.WriteFile(target, []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	unlock, err := acquireFileLock(target)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if err := unlock(); err != nil {
+		t.Errorf("unlock: %v", err)
+	}
+}
+
+func TestAcquireFileLock_ContendedSerializes(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "agents.md")
+	if err := os.WriteFile(target, []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		firstReleased  atomic.Int64
+		secondAcquired atomic.Int64
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		unlock, err := acquireFileLock(target)
+		if err != nil {
+			t.Errorf("g1 acquire: %v", err)
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+		firstReleased.Store(time.Now().UnixNano())
+		_ = unlock()
+	}()
+
+	go func() {
+		defer wg.Done()
+		time.Sleep(10 * time.Millisecond)
+		unlock, err := acquireFileLock(target)
+		if err != nil {
+			t.Errorf("g2 acquire: %v", err)
+			return
+		}
+		secondAcquired.Store(time.Now().UnixNano())
+		_ = unlock()
+	}()
+
+	wg.Wait()
+	if secondAcquired.Load() < firstReleased.Load() {
+		t.Errorf("second acquired before first released: %d < %d",
+			secondAcquired.Load(), firstReleased.Load())
+	}
+}
+
+func TestAcquireFileLock_LockfileSurvivesUnlock(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "agents.md")
+	if err := os.WriteFile(target, []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	unlock, err := acquireFileLock(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = unlock()
+
+	if _, err := os.Stat(target + ".lock"); err != nil {
+		t.Errorf("lock file should persist after unlock, got: %v", err)
+	}
+}

--- a/internal/config/managedfiles/lock_test.go
+++ b/internal/config/managedfiles/lock_test.go
@@ -43,13 +43,21 @@ func TestAcquireFileLock_ContendedSerializes(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
+	// readyCh signals that g1 has acquired the lock. g2 waits on the channel
+	// before attempting its own acquire — this replaces a brittle time.Sleep
+	// with a deterministic happens-before edge so the test exercises true
+	// contention rather than relying on goroutine scheduling timing.
+	readyCh := make(chan struct{})
+
 	go func() {
 		defer wg.Done()
 		unlock, err := acquireFileLock(target)
 		if err != nil {
+			close(readyCh) // unblock g2 even on failure so it doesn't deadlock
 			t.Errorf("g1 acquire: %v", err)
 			return
 		}
+		close(readyCh) // g1 holds the lock; g2 may now contend
 		time.Sleep(50 * time.Millisecond)
 		firstReleased.Store(time.Now().UnixNano())
 		_ = unlock()
@@ -57,7 +65,7 @@ func TestAcquireFileLock_ContendedSerializes(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		time.Sleep(10 * time.Millisecond)
+		<-readyCh // wait until g1 holds the lock before contending
 		unlock, err := acquireFileLock(target)
 		if err != nil {
 			t.Errorf("g2 acquire: %v", err)

--- a/internal/config/managedfiles/lock_unix.go
+++ b/internal/config/managedfiles/lock_unix.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build !windows
+
+package managedfiles
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// acquireFileLock acquires an exclusive advisory lock on a sibling file
+// <path>.lock. Returns an Unlocker that must be called to release.
+// The lock file is intentionally never removed: deleting it between unlock
+// and a concurrent open creates a new inode and breaks mutual exclusion.
+func acquireFileLock(path string) (Unlocker, error) {
+	lockPath := path + ".lock"
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("create lock file: %w", err)
+	}
+	fd := int(lockFile.Fd())
+	if err := syscall.Flock(fd, syscall.LOCK_EX); err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("acquire file lock: %w", err),
+			lockFile.Close(),
+		)
+	}
+	return func() error {
+		uerr := syscall.Flock(fd, syscall.LOCK_UN)
+		cerr := lockFile.Close()
+		if uerr != nil || cerr != nil {
+			return errors.Join(uerr, cerr)
+		}
+		return nil
+	}, nil
+}

--- a/internal/config/managedfiles/lock_windows.go
+++ b/internal/config/managedfiles/lock_windows.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build windows
+
+package managedfiles
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// acquireFileLock acquires an exclusive lock on a sibling file <path>.lock
+// via LockFileEx. Returns an Unlocker that calls UnlockFileEx and closes
+// the handle. The lock file is intentionally not removed (see lock_unix.go
+// for the rationale).
+func acquireFileLock(path string) (Unlocker, error) {
+	lockPath := path + ".lock"
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("create lock file: %w", err)
+	}
+	handle := windows.Handle(lockFile.Fd())
+	var ol windows.Overlapped
+	if err := windows.LockFileEx(handle, windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &ol); err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("acquire file lock: %w", err),
+			lockFile.Close(),
+		)
+	}
+	return func() error {
+		var ol windows.Overlapped
+		uerr := windows.UnlockFileEx(handle, 0, 1, 0, &ol)
+		cerr := lockFile.Close()
+		if uerr != nil || cerr != nil {
+			return errors.Join(uerr, cerr)
+		}
+		return nil
+	}, nil
+}

--- a/internal/config/managedfiles/manifest.go
+++ b/internal/config/managedfiles/manifest.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+// Manifest returns the list of ManagedFiles filtered by the given
+// harnesses. Order is stable across calls — callers may rely on it for
+// deterministic output (e.g. doctor's report).
+//
+// PR A returns an empty slice; PRs B/C/D/E populate it as they register
+// managed files for each harness.
+func Manifest(harnesses []Harness) []ManagedFile {
+	all := allManagedFiles()
+	enabled := harnessSet(harnesses)
+	out := make([]ManagedFile, 0, len(all))
+	for _, mf := range all {
+		if enabled[mf.Harness] {
+			out = append(out, mf)
+		}
+	}
+	return out
+}
+
+// allManagedFiles is the framework's full set, unfiltered by harness.
+// PR A returns nil; PRs B+ append entries.
+func allManagedFiles() []ManagedFile {
+	return nil
+}
+
+func harnessSet(harnesses []Harness) map[Harness]bool {
+	out := make(map[Harness]bool, len(harnesses))
+	for _, h := range harnesses {
+		out[h] = true
+	}
+	return out
+}

--- a/internal/config/managedfiles/open_unix.go
+++ b/internal/config/managedfiles/open_unix.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build !windows
+
+package managedfiles
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+)
+
+// readFileNoFollow is os.ReadFile with O_NOFOLLOW. On a symlink it returns
+// an error wrapping syscall.ELOOP; on file-not-found it returns an error
+// satisfying errors.Is(_, fs.ErrNotExist).
+//
+//nolint:unused // wired up by later tasks in PR A (sentinel/atomic write callers)
+func readFileNoFollow(path string) ([]byte, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close() //nolint:errcheck // read-only file
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	return data, nil
+}
+
+// noFollowIsSymlink reports whether err arose from O_NOFOLLOW refusing
+// to traverse a symlink. Used by callers to translate ELOOP into
+// ErrSymlinkRejected.
+//
+//nolint:unused // wired up by later tasks in PR A (sentinel/atomic write callers)
+func noFollowIsSymlink(err error) bool {
+	return errors.Is(err, syscall.ELOOP)
+}

--- a/internal/config/managedfiles/open_unix.go
+++ b/internal/config/managedfiles/open_unix.go
@@ -16,8 +16,6 @@ import (
 // readFileNoFollow is os.ReadFile with O_NOFOLLOW. On a symlink it returns
 // an error wrapping syscall.ELOOP; on file-not-found it returns an error
 // satisfying errors.Is(_, fs.ErrNotExist).
-//
-//nolint:unused // wired up by later tasks in PR A (sentinel/atomic write callers)
 func readFileNoFollow(path string) ([]byte, error) {
 	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
 	if err != nil {
@@ -34,8 +32,6 @@ func readFileNoFollow(path string) ([]byte, error) {
 // noFollowIsSymlink reports whether err arose from O_NOFOLLOW refusing
 // to traverse a symlink. Used by callers to translate ELOOP into
 // ErrSymlinkRejected.
-//
-//nolint:unused // wired up by later tasks in PR A (sentinel/atomic write callers)
 func noFollowIsSymlink(err error) bool {
 	return errors.Is(err, syscall.ELOOP)
 }

--- a/internal/config/managedfiles/open_windows.go
+++ b/internal/config/managedfiles/open_windows.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build windows
+
+package managedfiles
+
+import "os"
+
+// readFileNoFollow falls back to os.ReadFile on Windows; symlink rejection
+// is handled by the rejectSymlinkComponents walk only. Documented in doc.go
+// as best-effort, not a security boundary.
+func readFileNoFollow(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+// noFollowIsSymlink is always false on Windows.
+func noFollowIsSymlink(_ error) bool { return false }

--- a/internal/config/managedfiles/sentinel.go
+++ b/internal/config/managedfiles/sentinel.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Sentinel is the parsed payload of a managed-file sentinel line.
+//
+// Version is the marker version (1 or 2). Version 0 indicates a non-sentinel
+// line was parsed (treat as "no sentinel present").
+//
+// SHA256 is empty for v=1 markers (no hash field) and populated for v=2.
+//
+// Rev is the optional build revision recorded for forensics; not used in
+// state classification.
+type Sentinel struct {
+	Version int
+	SHA256  string
+	Rev     string
+}
+
+// supportedVersions lists marker versions the parser accepts. Anything
+// outside this set is treated as ErrCorruptedSentinel by ParseSentinel,
+// matching the existing pointers/agents.go corruption-rejection behaviour
+// for unknown versions.
+var supportedVersions = map[int]bool{1: true, 2: true}
+
+// sentinelMatcher matches both the WholeFile sentinel ("// specgraph:init v=N ...")
+// and the MarkdownBlock start marker ("<!-- specgraph:init:start v=N ... -->").
+//
+// Group 1 captures the version digits.
+// Group 2 captures the optional sha256 hex value.
+// Group 3 captures the optional rev value.
+//
+// Both `init` and `init:start` are accepted because the same parser is
+// used for both syntaxes; the caller's CommentSyntax decides which form
+// RenderSentinel emits.
+var sentinelMatcher = regexp.MustCompile(
+	`specgraph:init(?::start)?\s+v=(\d+)(?:\s+sha256=([0-9a-fA-F]+))?(?:\s+rev=(\S+?))?\s*(?:-->)?$`,
+)
+
+// RenderSentinel formats a Sentinel as a single line in the given comment
+// syntax. The returned line includes the comment delimiters but no trailing
+// newline.
+//
+// For CommentNone, returns the empty string (JSON files don't carry sentinels).
+//
+// For CommentHTML, the rendered line is the START marker only — callers writing
+// a MarkdownBlock are responsible for emitting the matching `<!-- specgraph:init:end -->`
+// terminator. Keeping this asymmetry inside the strategy implementation avoids
+// requiring sentinel.go to know about block structure.
+func RenderSentinel(syntax CommentSyntax, s Sentinel) string {
+	if syntax == CommentNone || s.Version == 0 {
+		return ""
+	}
+	body := fmt.Sprintf("specgraph:init v=%d", s.Version)
+	if s.SHA256 != "" {
+		body += " sha256=" + s.SHA256
+	}
+	if s.Rev != "" {
+		body += " rev=" + s.Rev
+	}
+	switch syntax {
+	case CommentSlash:
+		return "// " + body
+	case CommentHash:
+		return "# " + body
+	case CommentHTML:
+		// Block-strategy start marker. The end marker is emitted separately
+		// by the strategy code (it has no payload).
+		return "<!-- " + strings.Replace(body, "specgraph:init", "specgraph:init:start", 1) + " -->"
+	default:
+		return ""
+	}
+}
+
+// ParseSentinel attempts to parse `line` as a managed-file sentinel.
+//
+// Returns:
+//   - zero Sentinel + nil error if the line is not a sentinel at all (a
+//     regular comment, blank, or arbitrary content).
+//   - non-zero Sentinel + nil error on a successful parse.
+//   - zero Sentinel + ErrCorruptedSentinel if the line *looks* like a
+//     sentinel (matches the regex) but carries an unsupported version.
+//
+// Distinguishing "not a sentinel" from "corrupted sentinel" matters because
+// the framework treats absent sentinels as user-owned (Drifted) but
+// corrupted sentinels as a hard error (refuse-to-mutate).
+func ParseSentinel(syntax CommentSyntax, line string) (Sentinel, error) {
+	if syntax == CommentNone {
+		return Sentinel{}, nil
+	}
+	m := sentinelMatcher.FindStringSubmatch(line)
+	if m == nil {
+		return Sentinel{}, nil
+	}
+	version, err := strconv.Atoi(m[1])
+	if err != nil {
+		return Sentinel{}, fmt.Errorf("%w: invalid version %q", ErrCorruptedSentinel, m[1])
+	}
+	if !supportedVersions[version] {
+		return Sentinel{}, fmt.Errorf("%w: unsupported version %d", ErrCorruptedSentinel, version)
+	}
+	return Sentinel{
+		Version: version,
+		SHA256:  m[2],
+		Rev:     m[3],
+	}, nil
+}

--- a/internal/config/managedfiles/sentinel.go
+++ b/internal/config/managedfiles/sentinel.go
@@ -41,8 +41,13 @@ var supportedVersions = map[int]bool{1: true, 2: true}
 // Both `init` and `init:start` are accepted because the same parser is
 // used for both syntaxes; the caller's CommentSyntax decides which form
 // RenderSentinel emits.
+//
+// The pattern is start-anchored and requires a recognized comment prefix
+// (`//`, `#`, or `<!--`) so a body line containing "specgraph:init v=2 ..."
+// inside arbitrary text (e.g. an example in a markdown rule body) is NOT
+// matched. Only deliberate sentinel lines are picked up.
 var sentinelMatcher = regexp.MustCompile(
-	`specgraph:init(?::start)?\s+v=(\d+)(?:\s+sha256=([0-9a-fA-F]+))?(?:\s+rev=(\S+?))?\s*(?:-->)?$`,
+	`^\s*(?://|#|<!--)\s+specgraph:init(?::start)?\s+v=(\d+)(?:\s+sha256=([0-9a-fA-F]+))?(?:\s+rev=(\S+?))?\s*(?:-->)?$`,
 )
 
 // RenderSentinel formats a Sentinel as a single line in the given comment

--- a/internal/config/managedfiles/sentinel_test.go
+++ b/internal/config/managedfiles/sentinel_test.go
@@ -77,6 +77,28 @@ func TestParseSentinel_NotASentinel(t *testing.T) {
 	}
 }
 
+// TestParseSentinel_RejectsUnanchored guards the regex anchor: a body line
+// containing "specgraph:init v=2 ..." mid-text (no comment prefix at line
+// start) must NOT be parsed as a sentinel. Without the start-anchor and
+// comment-prefix gate, a markdown rule body documenting the sentinel format
+// would accidentally be treated as one.
+func TestParseSentinel_RejectsUnanchored(t *testing.T) {
+	cases := []string{
+		"garbage specgraph:init v=2 sha256=abc",
+		"prefix // specgraph:init v=2 sha256=abc",
+		"see specgraph:init:start v=2 sha256=abc -->",
+	}
+	for _, line := range cases {
+		got, err := ParseSentinel(CommentSlash, line)
+		if err != nil {
+			t.Errorf("line %q: unexpected error %v", line, err)
+		}
+		if got.Version != 0 {
+			t.Errorf("line %q: expected non-sentinel, got %+v", line, got)
+		}
+	}
+}
+
 func TestRenderParseRoundTrip(t *testing.T) {
 	for _, syntax := range []CommentSyntax{CommentSlash, CommentHash, CommentHTML} {
 		original := Sentinel{Version: 2, SHA256: "deadbeef", Rev: "abc1234"}

--- a/internal/config/managedfiles/sentinel_test.go
+++ b/internal/config/managedfiles/sentinel_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRenderSentinel_Slash(t *testing.T) {
+	got := RenderSentinel(CommentSlash, Sentinel{Version: 2, SHA256: "abc123", Rev: "cef1ec3a"})
+	want := "// specgraph:init v=2 sha256=abc123 rev=cef1ec3a"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderSentinel_Hash(t *testing.T) {
+	got := RenderSentinel(CommentHash, Sentinel{Version: 2, SHA256: "abc"})
+	want := "# specgraph:init v=2 sha256=abc"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderSentinel_HTMLBlockStart(t *testing.T) {
+	got := RenderSentinel(CommentHTML, Sentinel{Version: 2, SHA256: "abc", Rev: "cef"})
+	want := "<!-- specgraph:init:start v=2 sha256=abc rev=cef -->"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderSentinel_None_Empty(t *testing.T) {
+	got := RenderSentinel(CommentNone, Sentinel{Version: 2, SHA256: "abc"})
+	if got != "" {
+		t.Errorf("CommentNone should produce empty string, got %q", got)
+	}
+}
+
+func TestParseSentinel_Slash_v2(t *testing.T) {
+	got, err := ParseSentinel(CommentSlash, "// specgraph:init v=2 sha256=abc123 rev=cef")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Version != 2 || got.SHA256 != "abc123" || got.Rev != "cef" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestParseSentinel_v1(t *testing.T) {
+	// v=1 is recognized for upgrade path (no sha256 field).
+	got, err := ParseSentinel(CommentHTML, "<!-- specgraph:init:start v=1 -->")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Version != 1 || got.SHA256 != "" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestParseSentinel_v3_Rejected(t *testing.T) {
+	_, err := ParseSentinel(CommentSlash, "// specgraph:init v=3 sha256=abc")
+	if !errors.Is(err, ErrCorruptedSentinel) {
+		t.Errorf("want ErrCorruptedSentinel, got %v", err)
+	}
+}
+
+func TestParseSentinel_NotASentinel(t *testing.T) {
+	got, err := ParseSentinel(CommentSlash, "// just a regular comment")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Version != 0 {
+		t.Errorf("expected zero Sentinel for non-sentinel line, got %+v", got)
+	}
+}
+
+func TestRenderParseRoundTrip(t *testing.T) {
+	for _, syntax := range []CommentSyntax{CommentSlash, CommentHash, CommentHTML} {
+		original := Sentinel{Version: 2, SHA256: "deadbeef", Rev: "abc1234"}
+		line := RenderSentinel(syntax, original)
+		parsed, err := ParseSentinel(syntax, line)
+		if err != nil {
+			t.Fatalf("syntax %v: parse error: %v", syntax, err)
+		}
+		if parsed != original {
+			t.Errorf("syntax %v: round-trip mismatch: got %+v, want %+v", syntax, parsed, original)
+		}
+	}
+}

--- a/internal/config/managedfiles/source.go
+++ b/internal/config/managedfiles/source.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+// readSource returns the canonical bytes for a ManagedFile.
+//
+// Behaviour by build tag:
+//   - Default build: reads from the package-level canonicalSources embed.FS
+//     populated via //go:embed directives in source_release.go. PR A leaves
+//     it empty; PRs C/D/E add directives.
+//   - `dev` build tag: reads from disk at SPECGRAPH_DEV_SOURCE_ROOT (default
+//     "./plugin") so a developer can edit a source file and re-run init
+//     without rebuilding the binary.
+//
+// Returns (nil, nil) when mf.Source is empty (JSON-key-merge files build
+// their canonical programmatically, not from an embedded asset).
+//
+// Implementation lives in source_release.go (no build tag — default build)
+// or source_dev.go (`dev` build tag).
+func readSource(mf ManagedFile) ([]byte, error) {
+	if mf.Source == "" {
+		return nil, nil
+	}
+	return readSourceImpl(mf)
+}

--- a/internal/config/managedfiles/source_dev.go
+++ b/internal/config/managedfiles/source_dev.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build dev
+
+package managedfiles
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"golang.org/x/term"
+)
+
+// devSourceRoot resolves the directory dev builds read sources from.
+// SPECGRAPH_DEV_SOURCE_ROOT overrides the default of "./plugin".
+func devSourceRoot() string {
+	if v := os.Getenv("SPECGRAPH_DEV_SOURCE_ROOT"); v != "" {
+		return v
+	}
+	return "./plugin"
+}
+
+// devBannerOnce ensures the dev banner stderr line is printed at most once
+// per process. Loud-but-not-spammy.
+var devBannerOnce sync.Once
+
+func emitDevBanner() {
+	devBannerOnce.Do(func() {
+		// Same isatty gate as the drift-nudge — a dev binary invoked
+		// non-interactively (CI, hooks) shouldn't smear the banner across
+		// captured stderr.
+		if !term.IsTerminal(int(os.Stderr.Fd())) {
+			return
+		}
+		fmt.Fprintf(os.Stderr,
+			"specgraph: DEV BUILD — embedded files read from disk at %s\n",
+			devSourceRoot())
+	})
+}
+
+// readSourceImpl reads from disk at <devSourceRoot>/<mf.Source>.
+func readSourceImpl(mf ManagedFile) ([]byte, error) {
+	emitDevBanner()
+	path := filepath.Join(devSourceRoot(), mf.Source)
+	b, err := os.ReadFile(path) //nolint:gosec // path comes from manifest under dev source root
+	if err != nil {
+		return nil, fmt.Errorf("read dev source %q: %w", path, err)
+	}
+	return b, nil
+}

--- a/internal/config/managedfiles/source_release.go
+++ b/internal/config/managedfiles/source_release.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build !dev
+
+package managedfiles
+
+import (
+	"embed"
+	"fmt"
+)
+
+// canonicalSources is populated via //go:embed directives added in PR C+
+// when actual managed-file source content lands in the binary. PR A leaves
+// the FS empty, which means readSourceImpl returns fs.ErrNotExist for any
+// non-empty mf.Source.
+//
+// The empty embed is intentional: it lets the framework compile and tests
+// run even before any //go:embed directive references real files. Adding
+// the first directive happens in PR C alongside the OpenCode plugin TS.
+var canonicalSources embed.FS
+
+// readSourceImpl reads from the embedded sources tree.
+func readSourceImpl(mf ManagedFile) ([]byte, error) {
+	b, err := canonicalSources.ReadFile(mf.Source)
+	if err != nil {
+		return nil, fmt.Errorf("read embedded source %q: %w", mf.Source, err)
+	}
+	return b, nil
+}

--- a/internal/config/managedfiles/source_test.go
+++ b/internal/config/managedfiles/source_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+)
+
+// PR A's manifest is empty, so readSource is exercised with an empty
+// embed.FS. We test the not-found path explicitly and rely on PR B+ to
+// add tests for actual content.
+
+func TestReadSource_EmptyManifestSourceMissing(t *testing.T) {
+	mf := ManagedFile{
+		Path:   ".specgraph/agents/opencode/specgraph.ts",
+		Source: "opencode/specgraph.ts",
+	}
+	_, err := readSource(mf)
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("expected fs.ErrNotExist, got %v", err)
+	}
+}
+
+func TestReadSource_EmptySourceField(t *testing.T) {
+	// JSON-key-merge files set Source="" because their canonical is built
+	// programmatically, not embedded. readSource returns nil bytes + nil error
+	// to signal "no embedded content; let the strategy build it."
+	mf := ManagedFile{
+		Path:     ".mcp.json",
+		Strategy: StrategyJSONKeyMerge,
+		Source:   "",
+	}
+	got, err := readSource(mf)
+	if err != nil {
+		t.Errorf("expected nil error for empty Source, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil bytes, got %q", got)
+	}
+}

--- a/internal/config/managedfiles/strategy.go
+++ b/internal/config/managedfiles/strategy.go
@@ -6,7 +6,7 @@ package managedfiles
 import "fmt"
 
 // strategy is the interface implemented per-strategy in PR B+. PR A
-// registers stubs that return ErrNotImplemented for both methods.
+// registers stubs that return errNotImplemented for both methods.
 //
 // Inspect classifies the on-disk state for a single ManagedFile.
 // Sync writes (or refrains from writing) the canonical content per
@@ -34,32 +34,32 @@ func strategyImpl(s Strategy) strategy {
 	}
 }
 
-// PR A stubs. All three return ErrNotImplemented; PRs B/C/D/E replace
+// PR A stubs. All three return errNotImplemented; PRs B/C/D/E replace
 // each one with a real implementation.
 
 type jsonKeyMergeStrategy struct{}
 
 func (jsonKeyMergeStrategy) Inspect(_ string, _ ManagedFile) (FileState, error) {
-	return FileState{}, ErrNotImplemented
+	return FileState{}, errNotImplemented
 }
 func (jsonKeyMergeStrategy) Sync(_ string, _ ManagedFile, _ SyncOptions) (SyncResult, error) {
-	return SyncResult{}, ErrNotImplemented
+	return SyncResult{}, errNotImplemented
 }
 
 type markdownBlockStrategy struct{}
 
 func (markdownBlockStrategy) Inspect(_ string, _ ManagedFile) (FileState, error) {
-	return FileState{}, ErrNotImplemented
+	return FileState{}, errNotImplemented
 }
 func (markdownBlockStrategy) Sync(_ string, _ ManagedFile, _ SyncOptions) (SyncResult, error) {
-	return SyncResult{}, ErrNotImplemented
+	return SyncResult{}, errNotImplemented
 }
 
 type wholeFileStrategy struct{}
 
 func (wholeFileStrategy) Inspect(_ string, _ ManagedFile) (FileState, error) {
-	return FileState{}, ErrNotImplemented
+	return FileState{}, errNotImplemented
 }
 func (wholeFileStrategy) Sync(_ string, _ ManagedFile, _ SyncOptions) (SyncResult, error) {
-	return SyncResult{}, ErrNotImplemented
+	return SyncResult{}, errNotImplemented
 }

--- a/internal/config/managedfiles/strategy.go
+++ b/internal/config/managedfiles/strategy.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import "fmt"
+
+// strategy is the interface implemented per-strategy in PR B+. PR A
+// registers stubs that return ErrNotImplemented for both methods.
+//
+// Inspect classifies the on-disk state for a single ManagedFile.
+// Sync writes (or refrains from writing) the canonical content per
+// SyncOptions. Both methods MUST be safe to call with mf.Strategy
+// matching the dispatched strategy; misuse is a programming error.
+type strategy interface {
+	Inspect(cwd string, mf ManagedFile) (FileState, error)
+	Sync(cwd string, mf ManagedFile, opts SyncOptions) (SyncResult, error)
+}
+
+// strategyImpl returns the strategy implementation for s.
+//
+// Panics if s is not a known Strategy value — that's a programming error
+// from a manifest entry with a bogus enum value, not a runtime condition.
+func strategyImpl(s Strategy) strategy {
+	switch s {
+	case StrategyJSONKeyMerge:
+		return jsonKeyMergeStrategy{}
+	case StrategyMarkdownBlock:
+		return markdownBlockStrategy{}
+	case StrategyWholeFile:
+		return wholeFileStrategy{}
+	default:
+		panic(fmt.Sprintf("unknown Strategy value: %d", s))
+	}
+}
+
+// PR A stubs. All three return ErrNotImplemented; PRs B/C/D/E replace
+// each one with a real implementation.
+
+type jsonKeyMergeStrategy struct{}
+
+func (jsonKeyMergeStrategy) Inspect(_ string, _ ManagedFile) (FileState, error) {
+	return FileState{}, ErrNotImplemented
+}
+func (jsonKeyMergeStrategy) Sync(_ string, _ ManagedFile, _ SyncOptions) (SyncResult, error) {
+	return SyncResult{}, ErrNotImplemented
+}
+
+type markdownBlockStrategy struct{}
+
+func (markdownBlockStrategy) Inspect(_ string, _ ManagedFile) (FileState, error) {
+	return FileState{}, ErrNotImplemented
+}
+func (markdownBlockStrategy) Sync(_ string, _ ManagedFile, _ SyncOptions) (SyncResult, error) {
+	return SyncResult{}, ErrNotImplemented
+}
+
+type wholeFileStrategy struct{}
+
+func (wholeFileStrategy) Inspect(_ string, _ ManagedFile) (FileState, error) {
+	return FileState{}, ErrNotImplemented
+}
+func (wholeFileStrategy) Sync(_ string, _ ManagedFile, _ SyncOptions) (SyncResult, error) {
+	return SyncResult{}, ErrNotImplemented
+}

--- a/internal/config/managedfiles/strategy_test.go
+++ b/internal/config/managedfiles/strategy_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestStrategyImpl_Inspect_NotImplemented(t *testing.T) {
+	for _, s := range []Strategy{StrategyJSONKeyMerge, StrategyMarkdownBlock, StrategyWholeFile} {
+		impl := strategyImpl(s)
+		_, err := impl.Inspect("/tmp", ManagedFile{Strategy: s})
+		if !errors.Is(err, ErrNotImplemented) {
+			t.Errorf("Strategy %d Inspect should return ErrNotImplemented, got %v", s, err)
+		}
+	}
+}
+
+func TestStrategyImpl_Sync_NotImplemented(t *testing.T) {
+	for _, s := range []Strategy{StrategyJSONKeyMerge, StrategyMarkdownBlock, StrategyWholeFile} {
+		impl := strategyImpl(s)
+		_, err := impl.Sync("/tmp", ManagedFile{Strategy: s}, SyncOptions{})
+		if !errors.Is(err, ErrNotImplemented) {
+			t.Errorf("Strategy %d Sync should return ErrNotImplemented, got %v", s, err)
+		}
+	}
+}
+
+func TestStrategyImpl_UnknownStrategy_Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for unknown strategy")
+		}
+	}()
+	_ = strategyImpl(Strategy(99))
+}

--- a/internal/config/managedfiles/strategy_test.go
+++ b/internal/config/managedfiles/strategy_test.go
@@ -12,8 +12,8 @@ func TestStrategyImpl_Inspect_NotImplemented(t *testing.T) {
 	for _, s := range []Strategy{StrategyJSONKeyMerge, StrategyMarkdownBlock, StrategyWholeFile} {
 		impl := strategyImpl(s)
 		_, err := impl.Inspect("/tmp", ManagedFile{Strategy: s})
-		if !errors.Is(err, ErrNotImplemented) {
-			t.Errorf("Strategy %d Inspect should return ErrNotImplemented, got %v", s, err)
+		if !errors.Is(err, errNotImplemented) {
+			t.Errorf("Strategy %d Inspect should return errNotImplemented, got %v", s, err)
 		}
 	}
 }
@@ -22,8 +22,8 @@ func TestStrategyImpl_Sync_NotImplemented(t *testing.T) {
 	for _, s := range []Strategy{StrategyJSONKeyMerge, StrategyMarkdownBlock, StrategyWholeFile} {
 		impl := strategyImpl(s)
 		_, err := impl.Sync("/tmp", ManagedFile{Strategy: s}, SyncOptions{})
-		if !errors.Is(err, ErrNotImplemented) {
-			t.Errorf("Strategy %d Sync should return ErrNotImplemented, got %v", s, err)
+		if !errors.Is(err, errNotImplemented) {
+			t.Errorf("Strategy %d Sync should return errNotImplemented, got %v", s, err)
 		}
 	}
 }
@@ -35,4 +35,18 @@ func TestStrategyImpl_UnknownStrategy_Panics(t *testing.T) {
 		}
 	}()
 	_ = strategyImpl(Strategy(99))
+}
+
+// TestSync_DispatchesAndWraps verifies the public Sync entry point
+// dispatches through strategyImpl and propagates the stub's
+// errNotImplemented. Pins the dispatch contract before PR B replaces
+// the stubs — if PR B accidentally drops the error wrapping or skips
+// dispatch, this test fails.
+func TestSync_DispatchesAndWraps(t *testing.T) {
+	for _, s := range []Strategy{StrategyJSONKeyMerge, StrategyMarkdownBlock, StrategyWholeFile} {
+		_, err := Sync("/tmp", ManagedFile{Path: "x", Strategy: s}, SyncOptions{})
+		if !errors.Is(err, errNotImplemented) {
+			t.Errorf("Strategy %d: Sync should propagate errNotImplemented, got %v", s, err)
+		}
+	}
 }

--- a/internal/config/managedfiles/supersedes.go
+++ b/internal/config/managedfiles/supersedes.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// supersedesGuardedDelete deletes the file at <projectDir>/<oldPath> only
+// if its on-disk content hash matches expectedPriorHash.
+//
+// expectedPriorHash is the hash this binary's *prior canonical* would have
+// produced for oldPath — typically computed by the calling strategy using
+// the vestigial v=1 renderer (see §"Drift detection / Vestigial v=1
+// renderer" in the design doc). The guard prevents init from clobbering
+// user content that happens to live at a path being superseded.
+//
+// Returns nil if the file doesn't exist (nothing to delete) or was deleted
+// successfully. Returns ErrPriorCanonicalMismatch if the hash check fails;
+// the file is left in place. Returns wrapped errors for other failures
+// (lstat, read, remove).
+func supersedesGuardedDelete(projectDir, oldPath, expectedPriorHash string) error {
+	full := filepath.Join(projectDir, oldPath)
+
+	if err := rejectSymlinkComponents(projectDir, oldPath); err != nil {
+		return err
+	}
+
+	disk, err := os.ReadFile(full)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return nil
+	case err != nil:
+		return fmt.Errorf("read %s: %w", full, err)
+	}
+
+	// CommentNone is intentional: callers pass the exact bytes the prior
+	// canonical would have produced including any sentinel, so we hash
+	// the raw bytes here and let the caller-provided hash account for
+	// any sentinel-stripping it cares about. This keeps the guard
+	// agnostic to comment syntax.
+	actual := HashExcludingSentinel(CommentNone, disk)
+	if actual != expectedPriorHash {
+		return fmt.Errorf("%w: %s (got %s, want %s)",
+			ErrPriorCanonicalMismatch, oldPath, actual, expectedPriorHash)
+	}
+
+	if rmErr := os.Remove(full); rmErr != nil {
+		return fmt.Errorf("remove %s: %w", full, rmErr)
+	}
+	return nil
+}

--- a/internal/config/managedfiles/supersedes_test.go
+++ b/internal/config/managedfiles/supersedes_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSupersedesGuardedDelete_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	// Old path doesn't exist — guarded delete is a no-op success.
+	if err := supersedesGuardedDelete(dir, "missing.md", "anyhash"); err != nil {
+		t.Errorf("expected nil for missing file, got %v", err)
+	}
+}
+
+func TestSupersedesGuardedDelete_HashMatches_DeletesFile(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := "old.md"
+	full := filepath.Join(dir, oldPath)
+	content := "old canonical"
+	if err := os.WriteFile(full, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := HashExcludingSentinel(CommentNone, []byte(content))
+	if err := supersedesGuardedDelete(dir, oldPath, expected); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(full); !os.IsNotExist(err) {
+		t.Errorf("file should be deleted, stat err = %v", err)
+	}
+}
+
+func TestSupersedesGuardedDelete_HashMismatch_LeavesFile(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := "old.md"
+	full := filepath.Join(dir, oldPath)
+	if err := os.WriteFile(full, []byte("user-edited content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "0000000000000000000000000000000000000000000000000000000000000000" // wrong
+	err := supersedesGuardedDelete(dir, oldPath, expected)
+	if !errors.Is(err, ErrPriorCanonicalMismatch) {
+		t.Errorf("got %v, want ErrPriorCanonicalMismatch", err)
+	}
+	if _, statErr := os.Stat(full); statErr != nil {
+		t.Errorf("file should NOT be deleted on mismatch, stat err = %v", statErr)
+	}
+}

--- a/internal/config/managedfiles/symlink.go
+++ b/internal/config/managedfiles/symlink.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// rejectSymlinkComponents walks the components of relPath under projectDir
+// and returns ErrSymlinkRejected on the first symlink encountered. Components
+// that don't exist (e.g. a leaf file we haven't written yet) are allowed —
+// init writes new files, so non-existence is normal at write time.
+//
+// Mirrors internal/config/pointers/sync.go's helper. Reproducing it here
+// is cheaper than introducing a shared util package.
+func rejectSymlinkComponents(projectDir, relPath string) error {
+	cur := projectDir
+	for _, part := range strings.Split(filepath.Clean(relPath), string(filepath.Separator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		cur = filepath.Join(cur, part)
+		info, err := os.Lstat(cur)
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("lstat %s: %w", cur, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%w: %s", ErrSymlinkRejected, cur)
+		}
+	}
+	return nil
+}

--- a/internal/config/managedfiles/symlink_test.go
+++ b/internal/config/managedfiles/symlink_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestRejectSymlinkComponents_NoSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "nested"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := rejectSymlinkComponents(dir, "nested/foo.txt"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRejectSymlinkComponents_DetectsSymlinkInPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires admin on Windows")
+	}
+	dir := t.TempDir()
+	realDir := filepath.Join(dir, "real")
+	if err := os.Mkdir(realDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Fatal(err)
+	}
+
+	err := rejectSymlinkComponents(dir, "link/foo.txt")
+	if !errors.Is(err, ErrSymlinkRejected) {
+		t.Errorf("got %v, want ErrSymlinkRejected", err)
+	}
+}
+
+func TestRejectSymlinkComponents_NonExistentComponentsAllowed(t *testing.T) {
+	// Allow paths whose terminal components don't exist yet — init writes
+	// new files, so non-existence at the leaf is normal.
+	dir := t.TempDir()
+	if err := rejectSymlinkComponents(dir, "does/not/exist.txt"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/config/managedfiles/sync.go
+++ b/internal/config/managedfiles/sync.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+import "fmt"
+
+// Sync reconciles a single ManagedFile against its embedded canonical,
+// honouring SyncOptions (Force, KeepEdits). Returns a SyncResult
+// describing what was done.
+//
+// PR A dispatches to per-strategy stubs that return ErrNotImplemented;
+// the empty manifest means this is never called end-to-end. PRs B/C/D/E
+// implement each strategy.
+func Sync(cwd string, mf ManagedFile, opts SyncOptions) (SyncResult, error) {
+	r, err := strategyImpl(mf.Strategy).Sync(cwd, mf, opts)
+	if err != nil {
+		return r, fmt.Errorf("strategy sync: %w", err)
+	}
+	return r, nil
+}
+
+// SyncAll iterates the manifest filtered by enabled harnesses, calls
+// Sync on each, and returns one SyncResult per entry. Per-file errors
+// are captured in the SyncResult (Action == ActionError); the iteration
+// continues so partial failure produces a complete report.
+//
+// In PR A, Manifest() is empty, so SyncAll returns an empty slice
+// regardless of input.
+func SyncAll(cwd string, harnesses []Harness, opts SyncOptions) ([]SyncResult, error) {
+	if err := validateProjectDir(cwd); err != nil {
+		return nil, err
+	}
+	mfs := Manifest(harnesses)
+	out := make([]SyncResult, 0, len(mfs))
+	for _, mf := range mfs {
+		r, err := Sync(cwd, mf, opts)
+		if err != nil {
+			out = append(out, SyncResult{
+				Path:   mf.Path,
+				Action: ActionError,
+				Err:    fmt.Errorf("sync %s: %w", mf.Path, err),
+			})
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}

--- a/internal/config/managedfiles/sync.go
+++ b/internal/config/managedfiles/sync.go
@@ -9,7 +9,7 @@ import "fmt"
 // honouring SyncOptions (Force, KeepEdits). Returns a SyncResult
 // describing what was done.
 //
-// PR A dispatches to per-strategy stubs that return ErrNotImplemented;
+// PR A dispatches to per-strategy stubs that return errNotImplemented;
 // the empty manifest means this is never called end-to-end. PRs B/C/D/E
 // implement each strategy.
 func Sync(cwd string, mf ManagedFile, opts SyncOptions) (SyncResult, error) {

--- a/internal/config/managedfiles/types.go
+++ b/internal/config/managedfiles/types.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles
+
+// Strategy selects how a ManagedFile is read, classified, and written.
+type Strategy int
+
+// Strategy values. Order is fixed; do not reorder (callers may compare
+// by value via the iota positions).
+const (
+	StrategyJSONKeyMerge Strategy = iota
+	StrategyMarkdownBlock
+	StrategyWholeFile
+)
+
+// State is the framework's drift classification for a single managed file.
+type State int
+
+// State values. Synced is the only "no-op needed" state; the others all
+// imply some action (write, refresh, or surface to the user).
+const (
+	StateMissing State = iota
+	StateSynced
+	StateStale   // sentinel hash matches disk content but disk doesn't match canonical
+	StateDrifted // disk content does not match the recorded sentinel hash (user-edited)
+)
+
+// Harness is the agent-harness a ManagedFile belongs to.
+type Harness int
+
+// Harness values.
+const (
+	HarnessClaude Harness = iota
+	HarnessCursor
+	HarnessOpenCode
+)
+
+// CommentSyntax describes the comment style used to embed a sentinel
+// line in a file. Each value maps to a (open, close) pair — close is
+// empty for line comments.
+type CommentSyntax int
+
+// CommentSyntax values cover the file types managed by the framework.
+const (
+	CommentNone   CommentSyntax = iota // JSON files: no sentinel possible
+	CommentSlash                       // // ...    (TypeScript, Go)
+	CommentHash                        // # ...     (shell, YAML)
+	CommentHTML                        // <!-- ... --> (markdown, mdc)
+)
+
+// ManagedFile describes a single file specgraph manages in a project.
+// Construct via the Manifest function; do not build literals at call sites.
+type ManagedFile struct {
+	// Path is the file location relative to the project root.
+	Path string
+
+	// Strategy selects how this file is read, classified, written.
+	Strategy Strategy
+
+	// Source is the path within the package's embedded source tree to
+	// read the canonical content from. Empty for JSON-key-merge files
+	// where the canonical is built programmatically from project config.
+	Source string
+
+	// Comment is the comment syntax used for sentinel lines in this file.
+	Comment CommentSyntax
+
+	// Harness is which agent-harness this file belongs to. Used to filter
+	// the manifest by the user's enabled harnesses.
+	Harness Harness
+
+	// SupersedesPath is the project-relative path of an older file that
+	// is replaced by this one (e.g. a `.md` cursor rule renamed to `.mdc`).
+	// Empty when the file has no predecessor. Init deletes this path
+	// after a successful guarded write — see supersedesGuardedDelete.
+	SupersedesPath string
+}
+
+// FileState is the result of Inspect for a single ManagedFile.
+type FileState struct {
+	Path         string
+	Strategy     Strategy
+	State        State
+	DiskHash     string // sha256 of current disk content (empty if Missing)
+	SentinelHash string // hash recorded in disk sentinel (empty if no sentinel)
+	EmbeddedHash string // sha256 of canonical source content
+	Detail       string // human-readable explanation, used in doctor output
+}
+
+// Action is the outcome of a write attempt for a single ManagedFile.
+type Action int
+
+// Action values.
+const (
+	ActionNoOp      Action = iota // file already Synced; nothing written
+	ActionCreated                 // file was Missing; canonical written
+	ActionRefreshed               // file was Stale; canonical rewritten with fresh sentinel
+	ActionSkipped                 // file was Drifted; init skipped without --force
+	ActionForced                  // file was Drifted; --force overwrote
+	ActionError                   // some error occurred; see Err
+)
+
+// SyncResult reports what Sync did for a single ManagedFile.
+type SyncResult struct {
+	Path   string
+	Action Action
+	Err    error
+}
+
+// SyncOptions controls Sync behaviour.
+type SyncOptions struct {
+	// Force overwrites Drifted files with canonical content. Default false.
+	Force bool
+
+	// KeepEdits, when used with Force, preserves drifted on-disk content
+	// but updates the sentinel hash to match. Default false.
+	KeepEdits bool
+}

--- a/internal/config/managedfiles/types_test.go
+++ b/internal/config/managedfiles/types_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package managedfiles_test
+
+import (
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/config/managedfiles"
+)
+
+// TestStrategyValuesStable pins the iota positions so future reorderings
+// are caught. Callers may compare Strategy values directly.
+func TestStrategyValuesStable(t *testing.T) {
+	got := []managedfiles.Strategy{
+		managedfiles.StrategyJSONKeyMerge,
+		managedfiles.StrategyMarkdownBlock,
+		managedfiles.StrategyWholeFile,
+	}
+	want := []managedfiles.Strategy{0, 1, 2}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("Strategy[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+// TestStateValuesStable pins the iota positions for State.
+func TestStateValuesStable(t *testing.T) {
+	got := []managedfiles.State{
+		managedfiles.StateMissing,
+		managedfiles.StateSynced,
+		managedfiles.StateStale,
+		managedfiles.StateDrifted,
+	}
+	want := []managedfiles.State{0, 1, 2, 3}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("State[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/xdg/xdg.go
+++ b/internal/xdg/xdg.go
@@ -44,6 +44,16 @@ func StateHome() string {
 	return filepath.Join(homeDir(), ".local", "state", appName)
 }
 
+// CacheHome returns XDG_CACHE_HOME/specgraph or ~/.cache/specgraph.
+// Cache holds non-essential data that can be regenerated on demand
+// (e.g. drift-nudge throttle files for `specgraph doctor`).
+func CacheHome() string {
+	if v := os.Getenv("XDG_CACHE_HOME"); v != "" {
+		return filepath.Join(v, appName)
+	}
+	return filepath.Join(homeDir(), ".cache", appName)
+}
+
 // ConfigFile returns the path to the global config file.
 func ConfigFile() string {
 	return filepath.Join(ConfigHome(), "config.yaml")

--- a/internal/xdg/xdg.go
+++ b/internal/xdg/xdg.go
@@ -47,6 +47,10 @@ func StateHome() string {
 // CacheHome returns XDG_CACHE_HOME/specgraph or ~/.cache/specgraph.
 // Cache holds non-essential data that can be regenerated on demand
 // (e.g. drift-nudge throttle files for `specgraph doctor`).
+//
+// Not pre-created — callers create lazily at use site per XDG convention
+// for cache directories. Removing the cache dir externally is always safe;
+// the next caller recreates it.
 func CacheHome() string {
 	if v := os.Getenv("XDG_CACHE_HOME"); v != "" {
 		return filepath.Join(v, appName)

--- a/internal/xdg/xdg_test.go
+++ b/internal/xdg/xdg_test.go
@@ -40,6 +40,18 @@ func TestStateHome_Default(t *testing.T) {
 	assert.Equal(t, filepath.Join(home, ".local", "state", "specgraph"), xdg.StateHome())
 }
 
+func TestCacheHome_Default(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", "")
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".cache", "specgraph"), xdg.CacheHome())
+}
+
+func TestCacheHome_Override(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", "/tmp/xdg-test-cache")
+	assert.Equal(t, "/tmp/xdg-test-cache/specgraph", xdg.CacheHome())
+}
+
 func TestConfigFilePath(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg-test")
 	assert.Equal(t, "/tmp/xdg-test/specgraph/config.yaml", xdg.ConfigFile())


### PR DESCRIPTION
## Summary

Bundles two stages of the spgr-rwrp epic:

**PR 0** — Claude API verification spike that confirmed three claims the design depends on:
1. Relative path acceptance in `extraKnownMarketplaces.source.path` ✓ GREEN
2. `autoUpdate: false` honoured at marketplace-entry level ✓ GREEN (with caveat: directory-source marketplaces have no cache layer; files read live)
3. `${CLAUDE_PLUGIN_ROOT}` resolves to plugin root, not marketplace root ✓ GREEN

Two schema corrections folded into the design doc as v5: `source.path` points at marketplace root (not `.claude-plugin/`); `marketplace.json` `plugins[].source` is a directory path with mandatory `./` prefix (not a file path).

**PR A** — Foundation `internal/config/managedfiles/` package with:
- Types: `ManagedFile`, `Strategy`, `State`, `Harness`, `CommentSyntax`, `FileState`, `Action`, `SyncResult`, `SyncOptions` + `SupersedesPath` field
- Sentinel parse/render for `// # <!-- -->` syntaxes, `v=2` going forward, `v=1` recognized for upgrade path, `v=3+` rejected as `ErrCorruptedSentinel`
- `HashExcludingSentinel` — sha256 over content with sentinel lines stripped (stable across `rev=` updates)
- File locking, atomic writes, symlink rejection — ported byte-for-byte from `internal/config/pointers/`
- `SupersedesPath` guarded delete (hash-check guard prevents clobbering hand-edited content)
- `dev` build tag swapping `//go:embed` for disk reads via `SPECGRAPH_DEV_SOURCE_ROOT`, `isatty(stderr)`-gated banner
- Strategy interface with `ErrNotImplemented` stubs (PRs B/C/D/E replace each)
- `Manifest()`, `InspectAll()`, `SyncAll()` plumbing — empty manifest in PR A
- `xdg.CacheHome()` for the future drift-nudge throttle file (PR G)

**Zero behaviour change for users** — empty manifest, `cmd/specgraph/init.go` untouched. PR B subsumes the existing `mcpconfigs/` and `pointers/` packages and migrates the 5 already-managed files into this framework.

## Design

- [docs/plans/2026-05-08-spgr-rwrp-harness-install-parity-design.md](docs/plans/2026-05-08-spgr-rwrp-harness-install-parity-design.md)
- [docs/plans/2026-05-08-spgr-rwrp-pr0-plan.md](docs/plans/2026-05-08-spgr-rwrp-pr0-plan.md)
- [docs/plans/2026-05-08-spgr-rwrp-pr0-claude-api-verification.md](docs/plans/2026-05-08-spgr-rwrp-pr0-claude-api-verification.md)
- [docs/plans/2026-05-08-spgr-rwrp-pra-plan.md](docs/plans/2026-05-08-spgr-rwrp-pra-plan.md)

## Test plan

- [x] `task check` (fmt, license, lint, skills, build, race tests)
- [x] `go test -race ./internal/config/managedfiles/` (locking primitives race-clean)
- [x] `go build -tags dev ./cmd/specgraph` succeeds (dev binary swaps embed for disk reads)
- [x] `go build ./cmd/specgraph` succeeds (release binary)
- [x] PR 0 verification ran end-to-end against opencode 1.14.40 + claude 2.1.133
- [ ] CI green

Closes spgr-9zxp (PR 0). Refs spgr-vqg7 (PR A). Unblocks spgr-rwrp PRs B/C/D/E/F/G.