### PR TITLE
fix(mcp): pass conversation_exchanges through author tool

### DIFF
--- a/internal/mcp/skills/embedded_test.go
+++ b/internal/mcp/skills/embedded_test.go
@@ -10,17 +10,18 @@ import (
 	"testing"
 )
 
-// Expected names match the six embedded canonicals (relocated in commit 1).
+// Expected names match the embedded canonicals.
 var wantNames = []string{
 	"specgraph-analytical-passes",
 	"specgraph-authoring",
+	"specgraph-constitution",
 	"specgraph-conventions",
 	"specgraph-drift",
 	"specgraph-graph-query",
 	"specgraph-troubleshooting",
 }
 
-func TestNewEmbedded_LoadsAllSixSkills(t *testing.T) {
+func TestNewEmbedded_LoadsAllEmbeddedSkills(t *testing.T) {
 	src, err := NewEmbedded()
 	if err != nil {
 		t.Fatalf("NewEmbedded: %v", err)

--- a/internal/mcp/tools_authoring.go
+++ b/internal/mcp/tools_authoring.go
@@ -63,6 +63,23 @@ func authoringStartStageHandler(c *Client) ToolHandler {
 	}
 }
 
+// parseOptionalExchanges parses the "exchanges" param as a JSON array of
+// ConversationExchange objects. Returns nil exchanges and nil errResult if the
+// param is absent (caller decides whether that is acceptable for the stage).
+// Returns an errResult on malformed JSON.
+func parseOptionalExchanges(params map[string]any) ([]*specv1.ConversationExchange, *ToolResult) {
+	raw := stringParam(params, "exchanges")
+	if raw == "" {
+		return nil, nil
+	}
+	// Parse exchanges array in isolation to prevent JSON injection.
+	var wrapper specv1.RecordConversationRequest
+	if err := protojson.Unmarshal([]byte(`{"exchanges":`+raw+`}`), &wrapper); err != nil {
+		return nil, errResult(fmt.Sprintf("invalid exchanges JSON: %v", err))
+	}
+	return wrapper.Exchanges, nil
+}
+
 // validateOptionalPosture checks that a non-empty posture string maps to a known enum.
 // Returns the parsed posture and nil, or zero and an errResult if invalid.
 func validateOptionalPosture(params map[string]any) (specv1.Posture, *ToolResult) {
@@ -115,6 +132,7 @@ func (t *authorTool) def() ToolDef {
 					"spark", "shape", "specify", "decompose", "approve", "amend", "supersede"),
 				"slug":         stringProp("Spec slug (required for all actions)"),
 				"output":       stringProp("Stage output as a JSON string (required for spark/shape/specify/decompose)"),
+				"exchanges":    stringProp("JSON array of ConversationExchange objects (required for shape/specify/decompose; optional for spark)"),
 				"posture":      stringProp("AI collaboration posture: drive, partner, support"),
 				"reason":       stringProp("Reason for amend or supersede"),
 				"target_stage": stringProp("Target stage for amend: spark, shape, specify, decompose"),
@@ -193,10 +211,15 @@ func (t *authorTool) handleShape(ctx context.Context, params map[string]any) (*T
 	if posErr != nil {
 		return posErr, nil
 	}
+	exchanges, exErr := parseOptionalExchanges(params)
+	if exErr != nil {
+		return exErr, nil
+	}
 	resp, err := t.client.Authoring.Shape(ctx, connect.NewRequest(&specv1.ShapeRequest{
-		Slug:    slug,
-		Output:  &out,
-		Posture: posture,
+		Slug:                  slug,
+		Output:                &out,
+		Posture:               posture,
+		ConversationExchanges: exchanges,
 	}))
 	if err != nil {
 		return connectErrResult(err)
@@ -221,10 +244,15 @@ func (t *authorTool) handleSpecify(ctx context.Context, params map[string]any) (
 	if posErr != nil {
 		return posErr, nil
 	}
+	exchanges, exErr := parseOptionalExchanges(params)
+	if exErr != nil {
+		return exErr, nil
+	}
 	resp, err := t.client.Authoring.Specify(ctx, connect.NewRequest(&specv1.SpecifyRequest{
-		Slug:    slug,
-		Output:  &out,
-		Posture: posture,
+		Slug:                  slug,
+		Output:                &out,
+		Posture:               posture,
+		ConversationExchanges: exchanges,
 	}))
 	if err != nil {
 		return connectErrResult(err)
@@ -249,10 +277,15 @@ func (t *authorTool) handleDecompose(ctx context.Context, params map[string]any)
 	if posErr != nil {
 		return posErr, nil
 	}
+	exchanges, exErr := parseOptionalExchanges(params)
+	if exErr != nil {
+		return exErr, nil
+	}
 	resp, err := t.client.Authoring.Decompose(ctx, connect.NewRequest(&specv1.DecomposeRequest{
-		Slug:    slug,
-		Output:  &out,
-		Posture: posture,
+		Slug:                  slug,
+		Output:                &out,
+		Posture:               posture,
+		ConversationExchanges: exchanges,
 	}))
 	if err != nil {
 		return connectErrResult(err)


### PR DESCRIPTION
## Summary

- **MCP fix:** the `author` tool's `handleShape`/`handleSpecify`/`handleDecompose` handlers built ConnectRPC requests with only `Slug + Output + Posture`, silently dropping `ConversationExchanges`. The server requires at least one exchange per the RPC contract, so every Shape/Specify/Decompose call via MCP failed with `conversation_exchanges: at least one exchange required` regardless of the conversation history the client intended to record. Adds an `exchanges` schema param, a `parseOptionalExchanges` helper, and wires exchanges through all three affected handlers. Spark is unaffected (server treats exchanges as optional for spark); Approve has a different request shape (see follow-on note below).
- **Test fix (stacked commit):** `TestNewEmbedded_LoadsAllSixSkills` had a stale expected count (6) after #950 restored `specgraph-constitution` as the seventh embedded skill. Updates `wantNames` and renames the test to `LoadsAllEmbeddedSkills` so the count is no longer hard-coded into the test name.

## Test plan

- [x] `task check` passes locally (without this branch, fails on the stale skill-count test)
- [x] End-to-end: MCP `author` tool with `action: shape` and an `exchanges` array now persists shape output + conversation atomically (verified live against a real spec during the session that produced this fix)
- [ ] `task pr-prep` (integration + e2e under Docker) — **skipped by author**; this is a SHOULD per CLAUDE.md, not a MUST, and the change is confined to MCP parameter passthrough with no storage or wire changes
- [ ] CI runs the full gate

## Follow-on

\`handleApprove\` also drops \`conversation_exchanges\` (see \`ApproveRequest.conversation_exchanges\` — required when \`action == APPROVE_ACTION_REJECT\`). Same pattern, different request shape. Left out of this PR to keep the patch scoped to the actively-blocked stages.