### PR TITLE
feat!: replace SpecLifecycle with SpecProvenance model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [Unreleased]
+
+### Changed (BREAKING)
+
+- **Replaced `SpecLifecycle` (task/living) with `SpecProvenance`** (AUTHORED / RETROACTIVE_FROM_PR / DECLARED). Wire-break at proto field 10 plus a new `provenance_detail` oneof. Postgres column `lifecycle` removed; `provenance_type` and `provenance_detail` columns added. See `docs/decisions/ADR-006-spec-provenance-model.md`.
+- **`specgraph ready` now requires `stage=approved` AND `provenance=authored`**. Previously surfaced any spec at `stage <> done`, including mid-design and superseded/abandoned specs.
+- **`claim` and `report-completion` reject non-AUTHORED specs** with `ErrClaimRequiresAuthored` / `ErrCompletionRequiresAuthored`.
 
 ### Fixed (post-PR-940 hardening)
 

--- a/cmd/specgraph/lifecycle.go
+++ b/cmd/specgraph/lifecycle.go
@@ -56,7 +56,7 @@ func runAmend(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("amend: %w", err)
 	}
 	s := resp.Msg.GetSpec()
-	fmt.Printf("Amended: %s (stage=%s, lifecycle=%s, version=%d)\n", s.GetSlug(), s.GetStage(), s.GetLifecycle().String(), s.GetVersion())
+	fmt.Printf("Amended: %s (stage=%s, provenance=%s, version=%d)\n", s.GetSlug(), s.GetStage(), s.GetProvenanceType().String(), s.GetVersion())
 	return nil
 }
 
@@ -85,8 +85,8 @@ func runSupersede(cmd *cobra.Command, args []string) error {
 	}
 	old := resp.Msg.GetOldSpec()
 	newSpec := resp.Msg.GetNewSpec()
-	fmt.Printf("Superseded: %s (lifecycle=%s)\n", old.GetSlug(), old.GetLifecycle().String())
-	fmt.Printf("Created:    %s (lifecycle=%s, stage=%s)\n", newSpec.GetSlug(), newSpec.GetLifecycle().String(), newSpec.GetStage())
+	fmt.Printf("Superseded: %s (provenance=%s)\n", old.GetSlug(), old.GetProvenanceType().String())
+	fmt.Printf("Created:    %s (provenance=%s, stage=%s)\n", newSpec.GetSlug(), newSpec.GetProvenanceType().String(), newSpec.GetStage())
 	return nil
 }
 
@@ -114,7 +114,7 @@ func runAbandon(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("abandon: %w", err)
 	}
 	s := resp.Msg.GetSpec()
-	fmt.Printf("Abandoned: %s (lifecycle=%s, version=%d)\n", s.GetSlug(), s.GetLifecycle().String(), s.GetVersion())
+	fmt.Printf("Abandoned: %s (provenance=%s, version=%d)\n", s.GetSlug(), s.GetProvenanceType().String(), s.GetVersion())
 	return nil
 }
 

--- a/cmd/specgraph/lifecycle_test.go
+++ b/cmd/specgraph/lifecycle_test.go
@@ -188,7 +188,7 @@ type fakeAmendHandler struct {
 
 func (fakeAmendHandler) TransitionAmend(_ context.Context, _ *connect.Request[specv1.TransitionAmendRequest]) (*connect.Response[specv1.TransitionAmendResponse], error) {
 	return connect.NewResponse(&specv1.TransitionAmendResponse{
-		Spec: &specv1.Spec{Slug: "my-spec", Stage: "shape", Lifecycle: specv1.SpecLifecycle_SPEC_LIFECYCLE_LIVING, Version: 2},
+		Spec: &specv1.Spec{Slug: "my-spec", Stage: "shape", ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED, Version: 2},
 	}), nil
 }
 
@@ -207,8 +207,8 @@ type fakeSupersedeHandler struct {
 
 func (fakeSupersedeHandler) TransitionSupersede(_ context.Context, _ *connect.Request[specv1.TransitionSupersedeRequest]) (*connect.Response[specv1.TransitionSupersedeResponse], error) {
 	return connect.NewResponse(&specv1.TransitionSupersedeResponse{
-		OldSpec: &specv1.Spec{Slug: "old-spec", Lifecycle: specv1.SpecLifecycle_SPEC_LIFECYCLE_TASK},
-		NewSpec: &specv1.Spec{Slug: "new-spec", Stage: "spark", Lifecycle: specv1.SpecLifecycle_SPEC_LIFECYCLE_LIVING},
+		OldSpec: &specv1.Spec{Slug: "old-spec", ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED},
+		NewSpec: &specv1.Spec{Slug: "new-spec", Stage: "spark", ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED},
 	}), nil
 }
 
@@ -227,7 +227,7 @@ type fakeAbandonHandler struct {
 
 func (fakeAbandonHandler) TransitionAbandon(_ context.Context, _ *connect.Request[specv1.TransitionAbandonRequest]) (*connect.Response[specv1.TransitionAbandonResponse], error) {
 	return connect.NewResponse(&specv1.TransitionAbandonResponse{
-		Spec: &specv1.Spec{Slug: "my-spec", Stage: "abandoned", Lifecycle: specv1.SpecLifecycle_SPEC_LIFECYCLE_TASK, Version: 1},
+		Spec: &specv1.Spec{Slug: "my-spec", Stage: "abandoned", ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED, Version: 1},
 	}), nil
 }
 

--- a/cmd/specgraph/spec.go
+++ b/cmd/specgraph/spec.go
@@ -5,12 +5,15 @@ package main
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
 	"github.com/specgraph/specgraph/internal/render"
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func specClient() (specgraphv1connect.SpecServiceClient, error) {
@@ -36,17 +39,148 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.CreateSpec(cmd.Context(), connect.NewRequest(&specv1.CreateSpecRequest{
-		Slug:     args[0],
-		Intent:   createIntent,
-		Priority: createPriority,
-	}))
+
+	provFlag, err := cmd.Flags().GetString("provenance")
+	if err != nil {
+		return fmt.Errorf("get --provenance flag: %w", err)
+	}
+	var provEnum specv1.SpecProvenance
+	switch strings.ToLower(provFlag) {
+	case "", "authored":
+		provEnum = specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED
+	case "retroactive_from_pr", "retroactive-from-pr", "retroactive":
+		provEnum = specv1.SpecProvenance_SPEC_PROVENANCE_RETROACTIVE_FROM_PR
+	case "declared":
+		provEnum = specv1.SpecProvenance_SPEC_PROVENANCE_DECLARED
+	default:
+		return fmt.Errorf("invalid --provenance %q (valid: authored, retroactive_from_pr, declared)", provFlag)
+	}
+
+	req := &specv1.CreateSpecRequest{
+		Slug:           args[0],
+		Intent:         createIntent,
+		Priority:       createPriority,
+		ProvenanceType: provEnum,
+	}
+
+	switch provEnum {
+	case specv1.SpecProvenance_SPEC_PROVENANCE_RETROACTIVE_FROM_PR:
+		if setErr := setRetroactiveProvenance(cmd, req); setErr != nil {
+			return setErr
+		}
+	case specv1.SpecProvenance_SPEC_PROVENANCE_DECLARED:
+		if setErr := setDeclaredProvenance(cmd, req); setErr != nil {
+			return setErr
+		}
+	}
+
+	if provEnum != specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED {
+		if loadErr := loadStageOutputs(cmd, req); loadErr != nil {
+			return loadErr
+		}
+	}
+
+	resp, err := client.CreateSpec(cmd.Context(), connect.NewRequest(req))
 	if err != nil {
 		return fmt.Errorf("create spec: %w", err)
 	}
 	fmt.Printf("Created: %s (%s)\n", resp.Msg.GetSpec().GetSlug(), resp.Msg.GetSpec().GetId())
 	return nil
 }
+
+func setRetroactiveProvenance(cmd *cobra.Command, req *specv1.CreateSpecRequest) error {
+	prURL, err := cmd.Flags().GetString("pr-url")
+	if err != nil {
+		return fmt.Errorf("get --pr-url flag: %w", err)
+	}
+	prSHA, err := cmd.Flags().GetString("pr-sha")
+	if err != nil {
+		return fmt.Errorf("get --pr-sha flag: %w", err)
+	}
+	prTitle, err := cmd.Flags().GetString("pr-title")
+	if err != nil {
+		return fmt.Errorf("get --pr-title flag: %w", err)
+	}
+	prMergedAtStr, err := cmd.Flags().GetString("pr-merged-at")
+	if err != nil {
+		return fmt.Errorf("get --pr-merged-at flag: %w", err)
+	}
+	var mergedAtPB *timestamppb.Timestamp
+	if prMergedAtStr != "" {
+		parsed, parseErr := time.Parse(time.RFC3339, prMergedAtStr)
+		if parseErr != nil {
+			return fmt.Errorf("invalid --pr-merged-at: %w", parseErr)
+		}
+		mergedAtPB = timestamppb.New(parsed)
+	}
+	req.ProvenanceDetail = &specv1.CreateSpecRequest_RetroactiveFromPr{
+		RetroactiveFromPr: &specv1.RetroactiveFromPrProvenance{
+			Url: prURL, Sha: prSHA, Title: prTitle, MergedAt: mergedAtPB,
+		},
+	}
+	return nil
+}
+
+func setDeclaredProvenance(cmd *cobra.Command, req *specv1.CreateSpecRequest) error {
+	declaredBy, err := cmd.Flags().GetString("declared-by")
+	if err != nil {
+		return fmt.Errorf("get --declared-by flag: %w", err)
+	}
+	note, err := cmd.Flags().GetString("declared-note")
+	if err != nil {
+		return fmt.Errorf("get --declared-note flag: %w", err)
+	}
+	req.ProvenanceDetail = &specv1.CreateSpecRequest_Declared{
+		Declared: &specv1.DeclaredProvenance{DeclaredBy: declaredBy, Note: note},
+	}
+	return nil
+}
+
+func loadStageOutputs(cmd *cobra.Command, req *specv1.CreateSpecRequest) error {
+	sparkPath, err := cmd.Flags().GetString("spark-json")
+	if err != nil {
+		return fmt.Errorf("get --spark-json flag: %w", err)
+	}
+	shapePath, err := cmd.Flags().GetString("shape-json")
+	if err != nil {
+		return fmt.Errorf("get --shape-json flag: %w", err)
+	}
+	specifyPath, err := cmd.Flags().GetString("specify-json")
+	if err != nil {
+		return fmt.Errorf("get --specify-json flag: %w", err)
+	}
+	decomposePath, err := cmd.Flags().GetString("decompose-json")
+	if err != nil {
+		return fmt.Errorf("get --decompose-json flag: %w", err)
+	}
+
+	if sparkPath != "" {
+		req.SparkOutput = &specv1.SparkOutput{}
+		if loadErr := loadJSONFile(sparkPath, req.SparkOutput); loadErr != nil {
+			return loadErr
+		}
+	}
+	if shapePath != "" {
+		req.ShapeOutput = &specv1.ShapeOutput{}
+		if loadErr := loadJSONFile(shapePath, req.ShapeOutput); loadErr != nil {
+			return loadErr
+		}
+	}
+	if specifyPath != "" {
+		req.SpecifyOutput = &specv1.SpecifyOutput{}
+		if loadErr := loadJSONFile(specifyPath, req.SpecifyOutput); loadErr != nil {
+			return loadErr
+		}
+	}
+	if decomposePath != "" {
+		req.DecomposeOutput = &specv1.DecomposeOutput{}
+		if loadErr := loadJSONFile(decomposePath, req.DecomposeOutput); loadErr != nil {
+			return loadErr
+		}
+	}
+	return nil
+}
+
 
 // --- update ---
 
@@ -141,9 +275,26 @@ var (
 	listJSON bool
 )
 
+// registerCreateFlags adds all flags for the create subcommand to cmd.
+// Extracted so tests can call it on a bare cobra.Command.
+func registerCreateFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&createIntent, "intent", "", "intent for the spec (required)")
+	cmd.Flags().StringVar(&createPriority, "priority", "p2", "priority (p0-p3)")
+	cmd.Flags().String("provenance", "authored", "provenance type: authored | retroactive_from_pr | declared")
+	cmd.Flags().String("pr-url", "", "PR URL (required when --provenance=retroactive_from_pr)")
+	cmd.Flags().String("pr-sha", "", "merge commit SHA (required when --provenance=retroactive_from_pr)")
+	cmd.Flags().String("pr-title", "", "PR title at import time (optional, retroactive_from_pr only)")
+	cmd.Flags().String("pr-merged-at", "", "RFC3339 timestamp of PR merge (optional, retroactive_from_pr only)")
+	cmd.Flags().String("declared-by", "", "human or system identifier (required when --provenance=declared)")
+	cmd.Flags().String("declared-note", "", "free-text rationale (optional, declared only)")
+	cmd.Flags().String("spark-json", "", "path to spark_output JSON file (required for non-AUTHORED)")
+	cmd.Flags().String("shape-json", "", "path to shape_output JSON file (required for non-AUTHORED)")
+	cmd.Flags().String("specify-json", "", "path to specify_output JSON file (required for non-AUTHORED)")
+	cmd.Flags().String("decompose-json", "", "path to decompose_output JSON file (required for non-AUTHORED)")
+}
+
 func init() {
-	createCmd.Flags().StringVar(&createIntent, "intent", "", "intent for the spec (required)")
-	createCmd.Flags().StringVar(&createPriority, "priority", "p2", "priority (p0-p3)")
+	registerCreateFlags(createCmd)
 	cobra.CheckErr(createCmd.MarkFlagRequired("intent"))
 	rootCmd.AddCommand(createCmd)
 

--- a/cmd/specgraph/spec_test.go
+++ b/cmd/specgraph/spec_test.go
@@ -117,7 +117,9 @@ func (fakeGetSpecErrHandler) GetSpec(_ context.Context, _ *connect.Request[specv
 
 func TestRunCreate_HappyPath(t *testing.T) {
 	startFakeSpecServer(t, fakeCreateSpecHandler{})
-	err := runCreate(newCmdWithCtx(), []string{"my-spec"})
+	cmd := newCmdWithCtx()
+	registerCreateFlags(cmd)
+	err := runCreate(cmd, []string{"my-spec"})
 	require.NoError(t, err)
 }
 
@@ -201,7 +203,9 @@ func TestRunShow_HappyPath_JSON(t *testing.T) {
 
 func TestRunCreate_RPCError(t *testing.T) {
 	startFakeSpecServer(t, fakeCreateSpecErrHandler{})
-	err := runCreate(newCmdWithCtx(), []string{"my-spec"})
+	cmd := newCmdWithCtx()
+	registerCreateFlags(cmd)
+	err := runCreate(cmd, []string{"my-spec"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "create spec")
 }

--- a/docs/decisions/ADR-006-spec-provenance-model.md
+++ b/docs/decisions/ADR-006-spec-provenance-model.md
@@ -1,0 +1,20 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# ADR-006: Spec Provenance Model
+
+- **Status:** Proposed
+- **Date:** 2026-05-20
+- **Supersedes:** SpecLifecycle enum (task/living)
+- **Implementation:** see docs/superpowers/specs/2026-05-20-spec-provenance-model-design.md
+
+## Context
+
+*(to be finalized in Task 8.3 after implementation)*
+
+## Decision
+
+Replace the `SpecLifecycle` enum + field with `SpecProvenance` (AUTHORED / RETROACTIVE_FROM_PR / DECLARED) plus a structured `provenance_detail` oneof. See design doc for full rationale.
+
+## Consequences
+
+*(to be finalized in Task 8.3)*

--- a/docs/decisions/ADR-006-spec-provenance-model.md
+++ b/docs/decisions/ADR-006-spec-provenance-model.md
@@ -2,19 +2,28 @@
 
 # ADR-006: Spec Provenance Model
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-20
-- **Supersedes:** SpecLifecycle enum (task/living)
-- **Implementation:** see docs/superpowers/specs/2026-05-20-spec-provenance-model-design.md
 
 ## Context
 
-*(to be finalized in Task 8.3 after implementation)*
+SpecGraph specs previously carried a `lifecycle` field with values `task` and `living`. The intent was to distinguish one-time work (task) from ongoing contracts (living). The actual implementation encoded only the type tag — `GetReady` never consulted it, drift detection ignored it, and the conceptual boundary between `task`/`living`/`done` was vestigial after `done`.
+
+Adding a `retroactive` lifecycle value (an early proposal) would have created a third value behaviorally identical to LIVING, distinguished only by provenance.
 
 ## Decision
 
-Replace the `SpecLifecycle` enum + field with `SpecProvenance` (AUTHORED / RETROACTIVE_FROM_PR / DECLARED) plus a structured `provenance_detail` oneof. See design doc for full rationale.
+Replace `SpecLifecycle` with `SpecProvenance` — an enum capturing **how a spec entered the graph**, not how the funnel should treat it after `done`. Values: `AUTHORED`, `RETROACTIVE_FROM_PR`, `DECLARED`. Per-variant structured payload via a `provenance_detail` oneof at proto fields 22–24.
+
+Stage drives funnel behavior; provenance drives the forward-vs-imported axis. Done specs of any provenance share drift, dependency, and supersession semantics.
+
+See `docs/superpowers/specs/2026-05-20-spec-provenance-model-design.md` for full design rationale, alternatives considered, and adversarial review trail.
 
 ## Consequences
 
-*(to be finalized in Task 8.3)*
+- Wire-break at proto field 10 (pre-1.0, no production data).
+- `specgraph ready` semantics tightened: only AUTHORED specs at `stage=approved` with no active claim.
+- `claim` and `report-completion` reject non-AUTHORED specs (sentinels `ErrClaimRequiresAuthored` / `ErrCompletionRequiresAuthored`).
+- Drift detection unified on `stage=done`.
+- Provenance is immutable through amend; supersede creates a fresh spec with fresh provenance.
+- Adding new provenance values (e.g. `IMPORTED_FROM_BACKUP`) later is wire-compatible per proto enum evolution rules.

--- a/docs/superpowers/plans/2026-05-20-spec-provenance-model.md
+++ b/docs/superpowers/plans/2026-05-20-spec-provenance-model.md
@@ -60,6 +60,7 @@ The proto change is first because every other layer compiles against the new typ
 ### Task 1.1: Add new sentinel errors
 
 **Files:**
+
 - Modify: `internal/storage/errors.go`
 
 Adding sentinels first so handler code in later phases can reference them without forward declarations.
@@ -120,6 +121,7 @@ Adding sentinels first so handler code in later phases can reference them withou
 ### Task 1.2: Add ADR-006 stub
 
 **Files:**
+
 - Create: `docs/decisions/ADR-006-spec-provenance-model.md`
 
 Stub now so the touch surface is complete; finalize content in Task 8.3.
@@ -164,6 +166,7 @@ Stub now so the touch surface is complete; finalize content in Task 8.3.
 ### Task 1.3: Update the proto schema
 
 **Files:**
+
 - Modify: `proto/specgraph/v1/spec.proto`
 
 - [ ] **Step 1: Replace the SpecLifecycle enum block with SpecProvenance**
@@ -273,6 +276,7 @@ Stub now so the touch surface is complete; finalize content in Task 8.3.
 ### Task 2.1: Update storage domain types
 
 **Files:**
+
 - Modify: `internal/storage/spec_domain.go`
 
 - [ ] **Step 1: Remove the SpecLifecycle type and constants**
@@ -393,6 +397,7 @@ Stub now so the touch surface is complete; finalize content in Task 8.3.
 ### Task 2.2: Update server convert layer
 
 **Files:**
+
 - Modify: `internal/server/convert_spec.go`
 
 - [ ] **Step 1: Remove the lifecycle conversion**
@@ -540,6 +545,7 @@ Stub now so the touch surface is complete; finalize content in Task 8.3.
 ### Task 3.1: Postgres migration 007
 
 **Files:**
+
 - Create: `internal/storage/postgres/migrations/007_spec_provenance.sql`
 
 - [ ] **Step 1: Write the migration**
@@ -589,6 +595,7 @@ Stub now so the touch surface is complete; finalize content in Task 8.3.
 ### Task 3.2: Update postgres spec.go insert/select
 
 **Files:**
+
 - Modify: `internal/storage/postgres/spec.go`
 
 - [ ] **Step 1: Update the insert in CreateSpec**
@@ -757,6 +764,7 @@ Stub now so the touch surface is complete; finalize content in Task 8.3.
 ### Task 3.3: Rewrite GetReady query
 
 **Files:**
+
 - Modify: `internal/storage/postgres/graph.go` (function `GetReady` at line 358)
 
 - [ ] **Step 1: Replace the GetReady query body**
@@ -833,6 +841,7 @@ Stub now so the touch surface is complete; finalize content in Task 8.3.
 ### Task 4.1: Spec_handler create validation
 
 **Files:**
+
 - Modify: `internal/server/spec_handler.go`
 
 The existing `CreateSpec` RPC takes only slug + intent + priority + complexity. The new design requires extending it to optionally accept provenance + provenance_detail + all four stage outputs (for non-AUTHORED creates).
@@ -965,6 +974,7 @@ The existing `CreateSpec` RPC takes only slug + intent + priority + complexity. 
 ### Task 4.2: Claim and completion gating
 
 **Files:**
+
 - Modify: `internal/server/claim_handler.go`, `internal/server/execution_handler.go`
 
 - [ ] **Step 1: Gate Claim on provenance**
@@ -1006,6 +1016,7 @@ The existing `CreateSpec` RPC takes only slug + intent + priority + complexity. 
 ### Task 5.1: CLI lifecycle.go output
 
 **Files:**
+
 - Modify: `cmd/specgraph/lifecycle.go`
 
 The CLI subcommands for amend/supersede/abandon print `lifecycle=...` in their output. Replace with `provenance=...`.
@@ -1040,6 +1051,7 @@ The CLI subcommands for amend/supersede/abandon print `lifecycle=...` in their o
 ### Task 5.2: CLI spec create flags
 
 **Files:**
+
 - Modify: `cmd/specgraph/spec.go` (or `cmd/specgraph/create.go` — search first)
 
 - [ ] **Step 1: Locate the create command and any existing --lifecycle flag**
@@ -1084,6 +1096,7 @@ The CLI subcommands for amend/supersede/abandon print `lifecycle=...` in their o
 ### Task 5.3: MCP tools_spec.go
 
 **Files:**
+
 - Modify: `internal/mcp/tools_spec.go`
 
 - [ ] **Step 1: Update the MCP spec tool's create-action schema**
@@ -1114,6 +1127,7 @@ The CLI subcommands for amend/supersede/abandon print `lifecycle=...` in their o
 ### Task 5.4: Render layer
 
 **Files:**
+
 - Modify: `internal/render/spec.go`
 
 The existing `lifecycleString` function (line 57-66) is dead code after this change. Replace with a provenance-aware render.
@@ -1192,6 +1206,7 @@ The existing `lifecycleString` function (line 57-66) is dead code after this cha
 ### Task 6.1: Linter schema.go
 
 **Files:**
+
 - Modify: `internal/linter/schema.go`
 
 - [ ] **Step 1: Replace the lifecycle validation block**
@@ -1245,6 +1260,7 @@ The existing `lifecycleString` function (line 57-66) is dead code after this cha
 ### Task 6.2: Export engine
 
 **Files:**
+
 - Modify: `internal/export/engine.go`
 
 - [ ] **Step 1: Replace lifecycle handling in the export path**
@@ -1281,6 +1297,7 @@ The existing `lifecycleString` function (line 57-66) is dead code after this cha
 ### Task 7.1: Provenance creation-path integration tests
 
 **Files:**
+
 - Create: `internal/server/spec_handler_provenance_test.go`
 
 - [ ] **Step 1: Write the AUTHORED-create test**
@@ -1404,6 +1421,7 @@ The existing `lifecycleString` function (line 57-66) is dead code after this cha
 ### Task 7.2: GetReady mixed-seed integration test
 
 **Files:**
+
 - Create: `internal/storage/postgres/graph_ready_provenance_test.go`
 
 - [ ] **Step 1: Write the seed-and-assert test**
@@ -1466,6 +1484,7 @@ The existing `lifecycleString` function (line 57-66) is dead code after this cha
 ### Task 7.3: Migration precondition test
 
 **Files:**
+
 - Create: `internal/storage/postgres/migration_007_test.go`
 
 - [ ] **Step 1: Write the precondition test**
@@ -1524,6 +1543,7 @@ The existing `lifecycleString` function (line 57-66) is dead code after this cha
 ### Task 7.4: Update existing tests that referenced lifecycle
 
 **Files:**
+
 - Modify: any `*_test.go` file currently referencing `Lifecycle`, `SpecLifecycle`, `LIFECYCLE_TASK`, `LIFECYCLE_LIVING`, etc.
 
 - [ ] **Step 1: Find all stragglers**
@@ -1570,6 +1590,7 @@ The existing `lifecycleString` function (line 57-66) is dead code after this cha
 ### Task 8.1: CHANGELOG entry
 
 **Files:**
+
 - Modify: `CHANGELOG.md`
 
 - [ ] **Step 1: Add a breaking-change entry**
@@ -1597,6 +1618,7 @@ The existing `lifecycleString` function (line 57-66) is dead code after this cha
 ### Task 8.2: Concept doc
 
 **Files:**
+
 - Modify: `site/docs/concepts/spec-graph.md`
 
 - [ ] **Step 1: Find and update the lifecycle row**
@@ -1626,6 +1648,7 @@ The existing `lifecycleString` function (line 57-66) is dead code after this cha
 ### Task 8.3: Finalize ADR-006
 
 **Files:**
+
 - Modify: `docs/decisions/ADR-006-spec-provenance-model.md`
 
 - [ ] **Step 1: Replace the stub with full content**

--- a/docs/superpowers/plans/2026-05-20-spec-provenance-model.md
+++ b/docs/superpowers/plans/2026-05-20-spec-provenance-model.md
@@ -1,0 +1,1834 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Spec Provenance Model Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `SpecLifecycle` field (task/living) with a `SpecProvenance` axis (AUTHORED/RETROACTIVE_FROM_PR/DECLARED) end-to-end across proto, storage, server, CLI, MCP, render, linter, and export — landing as a single PR.
+
+**Architecture:** Wire-break at proto field 10 (`SpecLifecycle lifecycle` → `SpecProvenance provenance_type`) plus a `oneof provenance_detail` at fields 22/23/24 carrying type-specific structured payload. Storage domain types mirror the shape with a string-typed discriminator and optional variant pointers. Postgres migration 007 drops `lifecycle` column and adds `provenance_type TEXT NOT NULL` + `provenance_detail JSONB NOT NULL`, with a precondition guard refusing to run on a non-empty `specs` table. Stage progressions diverge by provenance: AUTHORED walks the funnel; RETROACTIVE_FROM_PR and DECLARED are born at `done`. `GetReady` gains provenance + claim filters. Claim and report-completion are gated to `provenance_type = AUTHORED`.
+
+**Tech Stack:** Go 1.26.3, protobuf via `buf` (`task proto`), ConnectRPC, pgx v5 + pgxpool, goose SQL migrations, Cobra CLI, mark3labs/mcp-go for MCP tools, testify (unit) + ginkgo/gomega (e2e), murmur3 content hashing, jj-colocated git, Taskfile.dev for orchestration.
+
+**Source design:** `docs/superpowers/specs/2026-05-20-spec-provenance-model-design.md` (merged in PR #953)
+
+**Single PR constraint:** All tasks below land as one branch and one PR (`fix/spec-provenance-model` or similar). Commits are separated by task for review clarity, but the PR is monolithic.
+
+**Mid-PR build state:** The proto change in Phase 1 intentionally breaks the build. `task check` will not pass again until Phase 7. This is the cost of the clean break and is documented in the design's risks section.
+
+---
+
+## Phase 0 — Setup
+
+### Task 0.1: Confirm working state and create branch
+
+**Files:** none — working-copy state check only.
+
+- [ ] **Step 1: Confirm clean working copy**
+
+  ```bash
+  jj --no-pager status
+  ```
+
+  Expected output: `Working copy changes: ...` (any drift from `specgraph init` is fine — those files will be `jj restore`d before `task check`); `Parent commit (@-): ... main | <recent commit>`. If unrelated files are modified beyond the init-managed ones (`.claude/settings.json`, `.cursor/mcp.json`, `.mcp.json`, `opencode.json`), stop and investigate.
+
+- [ ] **Step 2: Fetch + ensure main is up to date**
+
+  ```bash
+  jj --no-pager git fetch
+  jj --no-pager log -r 'ancestors(@-, 3)' --no-graph
+  ```
+
+  Expected: most recent commit on `main` is at or after the design-doc merge (PR #953).
+
+- [ ] **Step 3: Create a working change off main**
+
+  ```bash
+  jj --no-pager new main -m '(wip) spec-provenance model implementation'
+  ```
+
+  Expected: `Working copy ... (empty) ...`. We'll squash this WIP message later when we structure individual task commits.
+
+---
+
+## Phase 1 — Foundation (proto, sentinels, ADR stub)
+
+The proto change is first because every other layer compiles against the new types. The build will break immediately and stay broken until Phase 7. This is intentional — the type checker becomes the find-every-caller tool.
+
+### Task 1.1: Add new sentinel errors
+
+**Files:**
+- Modify: `internal/storage/errors.go`
+
+Adding sentinels first so handler code in later phases can reference them without forward declarations.
+
+- [ ] **Step 1: Append sentinels at the end of the file**
+
+  Open `internal/storage/errors.go` and append after the existing sentinel block:
+
+  ```go
+  // --- Provenance ---
+
+  // ErrProvenanceMismatch is returned when provenance_type and provenance_detail are inconsistent.
+  var ErrProvenanceMismatch = errors.New("provenance_type does not match populated provenance_detail variant")
+
+  // ErrAuthoredRequiresSparkOnly is returned when an AUTHORED spec create includes stage outputs beyond spark.
+  var ErrAuthoredRequiresSparkOnly = errors.New("AUTHORED provenance: only spark_output may be set at create")
+
+  // ErrRetroactiveRequiresAllOutputs is returned when a RETROACTIVE_FROM_PR create is missing one or more funnel outputs.
+  var ErrRetroactiveRequiresAllOutputs = errors.New("RETROACTIVE_FROM_PR provenance: spark/shape/specify/decompose outputs all required")
+
+  // ErrRetroactiveRequiresPRRef is returned when a RETROACTIVE_FROM_PR create is missing url or sha.
+  var ErrRetroactiveRequiresPRRef = errors.New("RETROACTIVE_FROM_PR provenance: url and sha are required")
+
+  // ErrDeclaredRequiresAllOutputs is returned when a DECLARED create is missing one or more funnel outputs.
+  var ErrDeclaredRequiresAllOutputs = errors.New("DECLARED provenance: spark/shape/specify/decompose outputs all required")
+
+  // ErrDeclaredRequiresDeclaredBy is returned when a DECLARED create is missing declared_by.
+  var ErrDeclaredRequiresDeclaredBy = errors.New("DECLARED provenance: declared_by is required")
+
+  // ErrClaimRequiresAuthored is returned when claim is invoked on a non-AUTHORED spec.
+  var ErrClaimRequiresAuthored = errors.New("claim requires provenance_type = AUTHORED")
+
+  // ErrCompletionRequiresAuthored is returned when report-completion is invoked on a non-AUTHORED spec.
+  var ErrCompletionRequiresAuthored = errors.New("report-completion requires provenance_type = AUTHORED")
+  ```
+
+- [ ] **Step 2: Run a focused build to verify the errors package compiles**
+
+  ```bash
+  go build ./internal/storage/
+  ```
+
+  Expected: no output (success). If it fails, fix the syntax before proceeding.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(storage): add provenance sentinel errors
+
+  Eight new sentinels for the upcoming provenance model: mismatch
+  validation, per-provenance create-time invariants, and claim/completion
+  gating. Defined ahead of the proto change so subsequent layers can
+  reference them.
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" internal/storage/errors.go
+  ```
+
+### Task 1.2: Add ADR-006 stub
+
+**Files:**
+- Create: `docs/decisions/ADR-006-spec-provenance-model.md`
+
+Stub now so the touch surface is complete; finalize content in Task 8.3.
+
+- [ ] **Step 1: Create the ADR stub**
+
+  ```bash
+  cat > docs/decisions/ADR-006-spec-provenance-model.md <<'EOF'
+  <!-- SPDX-License-Identifier: Apache-2.0 -->
+
+  # ADR-006: Spec Provenance Model
+
+  - **Status:** Proposed
+  - **Date:** 2026-05-20
+  - **Supersedes:** SpecLifecycle enum (task/living)
+  - **Implementation:** see docs/superpowers/specs/2026-05-20-spec-provenance-model-design.md
+
+  ## Context
+
+  *(to be finalized in Task 8.3 after implementation)*
+
+  ## Decision
+
+  Replace the `SpecLifecycle` enum + field with `SpecProvenance` (AUTHORED / RETROACTIVE_FROM_PR / DECLARED) plus a structured `provenance_detail` oneof. See design doc for full rationale.
+
+  ## Consequences
+
+  *(to be finalized in Task 8.3)*
+  EOF
+  ```
+
+- [ ] **Step 2: Commit the stub**
+
+  ```bash
+  jj --no-pager commit -m "docs(adr): ADR-006 stub for spec provenance model
+
+  Stub placeholder; finalized after implementation lands.
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" docs/decisions/ADR-006-spec-provenance-model.md
+  ```
+
+### Task 1.3: Update the proto schema
+
+**Files:**
+- Modify: `proto/specgraph/v1/spec.proto`
+
+- [ ] **Step 1: Replace the SpecLifecycle enum block with SpecProvenance**
+
+  In `proto/specgraph/v1/spec.proto`, find lines 13-19 (the existing `SpecLifecycle` enum) and replace with:
+
+  ```proto
+  // --- Enums ---
+
+  // SpecProvenance records how a spec entered the graph. Replaces the
+  // earlier SpecLifecycle field (task/living) at pre-1.0 with a clean
+  // wire-break — see docs/superpowers/specs/2026-05-20-spec-provenance-model-design.md.
+  enum SpecProvenance {
+    SPEC_PROVENANCE_UNSPECIFIED         = 0;
+    SPEC_PROVENANCE_AUTHORED            = 1; // forward-authored via the funnel
+    SPEC_PROVENANCE_RETROACTIVE_FROM_PR = 2; // imported from a merged PR/commit
+    SPEC_PROVENANCE_DECLARED            = 3; // human-declared as describing existing reality
+  }
+
+  // AuthoredProvenance is the empty payload variant for AUTHORED specs.
+  // The audit trail for AUTHORED specs lives in stage outputs and conversation logs.
+  message AuthoredProvenance {}
+
+  message RetroactiveFromPrProvenance {
+    string url       = 1; // PR URL
+    string sha       = 2; // merge commit SHA
+    google.protobuf.Timestamp merged_at = 3;
+    string title     = 4; // PR title at import time
+  }
+
+  message DeclaredProvenance {
+    string declared_by = 1; // human or system identifier
+    string note        = 2; // free-text rationale
+  }
+  ```
+
+- [ ] **Step 2: Update the Spec message — replace field 10 and add the oneof**
+
+  In the same file, find the `Spec` message. Replace line 33 (`SpecLifecycle lifecycle = 10; // task (default) | living`) with:
+
+  ```proto
+    // WIRE-BREAK: field 10 was `SpecLifecycle lifecycle`. Repurposed at
+    // pre-1.0 (no production data); semantic intent preserved — it's still
+    // "how should the funnel treat this spec," with cleaner axes.
+    SpecProvenance provenance_type = 10;
+  ```
+
+  After the `conversation_count` field (line 45) and before the closing brace of the `Spec` message, add:
+
+  ```proto
+    // provenance_detail carries the type-specific payload for non-AUTHORED specs.
+    // The populated variant MUST match provenance_type — enforced server-side
+    // with storage.ErrProvenanceMismatch.
+    oneof provenance_detail {
+      AuthoredProvenance          authored             = 22;
+      RetroactiveFromPrProvenance retroactive_from_pr  = 23;
+      DeclaredProvenance          declared             = 24;
+    }
+  ```
+
+- [ ] **Step 3: Update the `Spec.stage` doc comment**
+
+  Find line 27 (currently `string stage = 4;        // spark | shape | specify | decompose | approved | in_progress | done`) and update the inline comment to enumerate all stages:
+
+  ```proto
+    string stage = 4;        // spark | shape | specify | decompose | approved | in_progress | review | done | superseded | abandoned
+  ```
+
+- [ ] **Step 4: Regenerate proto code**
+
+  ```bash
+  task proto
+  ```
+
+  Expected: regeneration runs; `gen/specgraph/v1/spec.pb.go` is updated. If `task proto` reports "no changes" the fingerprint is stale — delete `.task/checksum/proto*` and retry.
+
+- [ ] **Step 5: Verify build breakage as expected**
+
+  ```bash
+  go build ./... 2>&1 | head -30
+  ```
+
+  Expected: many compile errors referencing `SpecLifecycle`, `Lifecycle` field on `Spec`, `lifecycleToProtoMap`, etc. This is the intended state — every caller of the removed type now needs an update.
+
+- [ ] **Step 6: Commit (build intentionally broken)**
+
+  ```bash
+  jj --no-pager commit -m "feat(proto)!: replace SpecLifecycle with SpecProvenance
+
+  Wire-break at field 10 (lifecycle → provenance_type) plus oneof
+  provenance_detail at fields 22-24. Stage doc-string updated to
+  enumerate all 8 stages (was missing review/superseded/abandoned).
+
+  Build intentionally broken; subsequent tasks chase callers via the
+  type checker. See docs/superpowers/plans/2026-05-20-spec-provenance-model.md
+  for the full task ordering.
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" proto/specgraph/v1/spec.proto gen/
+  ```
+
+  Note the `!` after `feat(proto)` indicates a breaking change per Conventional Commits.
+
+---
+
+## Phase 2 — Domain + conversion layer
+
+### Task 2.1: Update storage domain types
+
+**Files:**
+- Modify: `internal/storage/spec_domain.go`
+
+- [ ] **Step 1: Remove the SpecLifecycle type and constants**
+
+  In `internal/storage/spec_domain.go`, find the `SpecLifecycle` block (lines 134-151) and delete it entirely:
+
+  ```go
+  // DELETE this block:
+  // SpecLifecycle represents the lifecycle model of a spec.
+  type SpecLifecycle string
+  // ... and the IsValid method
+  ```
+
+- [ ] **Step 2: Add the new provenance domain types in the same location**
+
+  Replace the removed block with:
+
+  ```go
+  // SpecProvenanceType is the string-typed discriminator for how a spec
+  // entered the graph. Mirrors the SpecProvenance proto enum.
+  type SpecProvenanceType string
+
+  // Spec provenance discriminator values.
+  const (
+      SpecProvenanceAuthored          SpecProvenanceType = "authored"
+      SpecProvenanceRetroactiveFromPR SpecProvenanceType = "retroactive_from_pr"
+      SpecProvenanceDeclared          SpecProvenanceType = "declared"
+  )
+
+  // IsValid reports whether p is a known spec provenance type.
+  func (p SpecProvenanceType) IsValid() bool {
+      switch p {
+      case SpecProvenanceAuthored, SpecProvenanceRetroactiveFromPR, SpecProvenanceDeclared:
+          return true
+      default:
+          return false
+      }
+  }
+
+  // SpecProvenanceDetail is the structured payload for non-AUTHORED specs.
+  // Exactly one of the embedded pointers is non-nil; both nil is valid (AUTHORED).
+  // The populated variant must match the Spec.Provenance discriminator —
+  // enforced at the server boundary with storage.ErrProvenanceMismatch.
+  type SpecProvenanceDetail struct {
+      RetroactiveFromPR *RetroactivePRProvenance // populated when type == retroactive_from_pr
+      Declared          *DeclaredProvenance      // populated when type == declared
+  }
+
+  // RetroactivePRProvenance carries PR metadata for retroactive-import specs.
+  type RetroactivePRProvenance struct {
+      URL      string
+      SHA      string
+      MergedAt time.Time
+      Title    string
+  }
+
+  // DeclaredProvenance carries declaration metadata for human-declared specs.
+  type DeclaredProvenance struct {
+      DeclaredBy string
+      Note       string
+  }
+  ```
+
+- [ ] **Step 3: Update the Spec struct**
+
+  Find the `Spec` struct (line 174-196). Remove the `Lifecycle SpecLifecycle` line and add provenance fields:
+
+  ```go
+  type Spec struct {
+      ID                string
+      Slug              string
+      Intent            string
+      Stage             SpecStage
+      Priority          SpecPriority
+      Complexity        SpecComplexity
+      Version           int32
+      CreatedAt         time.Time
+      UpdatedAt         time.Time
+      Provenance        SpecProvenanceType
+      ProvenanceDetail  SpecProvenanceDetail
+      SupersededBy      string
+      Supersedes        string
+      Notes             string
+      ContentHash       string
+      ConversationLogs  []*ConversationLogEntry
+      SparkOutput       *SparkOutput
+      ShapeOutput       *ShapeOutput
+      SpecifyOutput     *SpecifyOutput
+      DecomposeOutput   *DecomposeOutput
+      ConversationCount int
+  }
+  ```
+
+- [ ] **Step 4: Verify package compiles**
+
+  ```bash
+  go build ./internal/storage/
+  ```
+
+  Expected: success. If failures reference SpecLifecycle, search for stragglers:
+
+  ```bash
+  grep -rn 'SpecLifecycle' internal/storage/ | grep -v _test
+  ```
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(storage): provenance domain types
+
+  Replace SpecLifecycle string + Spec.Lifecycle field with
+  SpecProvenanceType + Spec.Provenance + Spec.ProvenanceDetail
+  (string discriminator + struct with optional variant pointers).
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" internal/storage/spec_domain.go
+  ```
+
+### Task 2.2: Update server convert layer
+
+**Files:**
+- Modify: `internal/server/convert_spec.go`
+
+- [ ] **Step 1: Remove the lifecycle conversion**
+
+  In `internal/server/convert_spec.go`, delete lines 70-86 (the `// --- Lifecycle ---` section, the `lifecycleToProtoMap`, and the `lifecycleToProto` function).
+
+- [ ] **Step 2: Remove the lifecycle call site in specToProto**
+
+  Find the call `lc, err := lifecycleToProto(s.Lifecycle)` near line 16-18 of `specToProto` and the `Lifecycle: lc,` line in the struct literal (~line 30). Delete both.
+
+- [ ] **Step 3: Add provenance conversion**
+
+  At the bottom of `convert_spec.go`, add:
+
+  ```go
+  // --- Provenance ---
+
+  // provenanceToProtoMap maps storage provenance values to proto enums.
+  var provenanceToProtoMap = map[storage.SpecProvenanceType]specv1.SpecProvenance{
+      storage.SpecProvenanceAuthored:          specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED,
+      storage.SpecProvenanceRetroactiveFromPR: specv1.SpecProvenance_SPEC_PROVENANCE_RETROACTIVE_FROM_PR,
+      storage.SpecProvenanceDeclared:          specv1.SpecProvenance_SPEC_PROVENANCE_DECLARED,
+  }
+
+  func provenanceToProto(p storage.SpecProvenanceType) (specv1.SpecProvenance, error) {
+      if v, ok := provenanceToProtoMap[p]; ok {
+          return v, nil
+      }
+      return specv1.SpecProvenance_SPEC_PROVENANCE_UNSPECIFIED, fmt.Errorf("unknown provenance: %q", p)
+  }
+
+  // provenanceDetailToProto packages the storage-side detail struct into the
+  // proto oneof. The returned value should be assigned to Spec.ProvenanceDetail
+  // (a oneof in proto, which generates a sum-type interface in Go).
+  func provenanceDetailToProto(d storage.SpecProvenanceDetail) specv1.IsSpec_ProvenanceDetail {
+      switch {
+      case d.RetroactiveFromPR != nil:
+          return &specv1.Spec_RetroactiveFromPr{
+              RetroactiveFromPr: &specv1.RetroactiveFromPrProvenance{
+                  Url:      d.RetroactiveFromPR.URL,
+                  Sha:      d.RetroactiveFromPR.SHA,
+                  MergedAt: timeToProto(d.RetroactiveFromPR.MergedAt),
+                  Title:    d.RetroactiveFromPR.Title,
+              },
+          }
+      case d.Declared != nil:
+          return &specv1.Spec_Declared{
+              Declared: &specv1.DeclaredProvenance{
+                  DeclaredBy: d.Declared.DeclaredBy,
+                  Note:       d.Declared.Note,
+              },
+          }
+      default:
+          // AUTHORED — empty payload.
+          return &specv1.Spec_Authored{Authored: &specv1.AuthoredProvenance{}}
+      }
+  }
+
+  // proto-side back to domain (used by handler validation).
+  func provenanceFromProto(p specv1.SpecProvenance) (storage.SpecProvenanceType, error) {
+      for domainVal, protoVal := range provenanceToProtoMap {
+          if protoVal == p {
+              return domainVal, nil
+          }
+      }
+      return "", fmt.Errorf("unknown provenance enum: %q", p.String())
+  }
+
+  func provenanceDetailFromProto(pb specv1.IsSpec_ProvenanceDetail) storage.SpecProvenanceDetail {
+      switch v := pb.(type) {
+      case *specv1.Spec_RetroactiveFromPr:
+          return storage.SpecProvenanceDetail{
+              RetroactiveFromPR: &storage.RetroactivePRProvenance{
+                  URL:      v.RetroactiveFromPr.GetUrl(),
+                  SHA:      v.RetroactiveFromPr.GetSha(),
+                  MergedAt: v.RetroactiveFromPr.GetMergedAt().AsTime(),
+                  Title:    v.RetroactiveFromPr.GetTitle(),
+              },
+          }
+      case *specv1.Spec_Declared:
+          return storage.SpecProvenanceDetail{
+              Declared: &storage.DeclaredProvenance{
+                  DeclaredBy: v.Declared.GetDeclaredBy(),
+                  Note:       v.Declared.GetNote(),
+              },
+          }
+      case *specv1.Spec_Authored:
+          return storage.SpecProvenanceDetail{}
+      default:
+          return storage.SpecProvenanceDetail{}
+      }
+  }
+  ```
+
+  Note: the exact generated type names (`Spec_RetroactiveFromPr`, `IsSpec_ProvenanceDetail`) depend on how protoc-gen-go names oneof variants. Run `task proto` and `grep '^type Spec_' gen/specgraph/v1/spec.pb.go` to confirm names if compilation fails.
+
+- [ ] **Step 4: Wire provenance into specToProto**
+
+  Near the top of `specToProto`, replace the deleted lifecycle assignment with:
+
+  ```go
+      pv, err := provenanceToProto(s.Provenance)
+      if err != nil {
+          return nil, fmt.Errorf("spec %q: %w", s.Slug, err)
+      }
+  ```
+
+  In the struct literal where `Lifecycle: lc,` was, add:
+
+  ```go
+          ProvenanceType:   pv,
+          ProvenanceDetail: provenanceDetailToProto(s.ProvenanceDetail),
+  ```
+
+- [ ] **Step 5: Verify**
+
+  ```bash
+  go build ./internal/server/
+  ```
+
+  Expected: success. If failures reference generated oneof type names, run:
+
+  ```bash
+  grep '^type Spec_' gen/specgraph/v1/spec.pb.go
+  ```
+
+  and adjust the type assertion names in `provenanceDetailToProto` accordingly.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(server): provenance proto↔domain conversion
+
+  Replace lifecycleToProto with provenanceToProto/FromProto and
+  provenanceDetailToProto/FromProto. Generated oneof-variant type
+  names referenced explicitly.
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" internal/server/convert_spec.go
+  ```
+
+---
+
+## Phase 3 — Storage (migration + queries)
+
+### Task 3.1: Postgres migration 007
+
+**Files:**
+- Create: `internal/storage/postgres/migrations/007_spec_provenance.sql`
+
+- [ ] **Step 1: Write the migration**
+
+  ```bash
+  cat > internal/storage/postgres/migrations/007_spec_provenance.sql <<'EOF'
+  -- SPDX-License-Identifier: Apache-2.0
+  -- Copyright 2026 Sean Brandt
+
+  -- +goose Up
+
+  -- Precondition guard: this migration is a clean-break replacement.
+  -- It refuses to run if any rows exist in specs to prevent accidental
+  -- data loss in environments where the clean-break assumption is wrong.
+  DO $$
+  BEGIN
+    IF (SELECT count(*) FROM specs) > 0 THEN
+      RAISE EXCEPTION 'migration 007 refuses to run on a non-empty specs table; clean-break design assumes no data — see docs/superpowers/specs/2026-05-20-spec-provenance-model-design.md';
+    END IF;
+  END
+  $$;
+
+  ALTER TABLE specs DROP COLUMN lifecycle;
+  ALTER TABLE specs ADD COLUMN provenance_type TEXT NOT NULL;
+  ALTER TABLE specs ADD COLUMN provenance_detail JSONB NOT NULL;
+
+  -- +goose Down
+  ALTER TABLE specs DROP COLUMN provenance_detail;
+  ALTER TABLE specs DROP COLUMN provenance_type;
+  ALTER TABLE specs ADD COLUMN lifecycle TEXT NOT NULL DEFAULT 'task';
+  EOF
+  ```
+
+- [ ] **Step 2: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(postgres): migration 007 drops lifecycle, adds provenance columns
+
+  Clean-break replacement with a precondition guard refusing to run on a
+  non-empty specs table. provenance_type TEXT NOT NULL + provenance_detail
+  JSONB NOT NULL. Down migration restores the lifecycle column for
+  reversibility.
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" internal/storage/postgres/migrations/007_spec_provenance.sql
+  ```
+
+### Task 3.2: Update postgres spec.go insert/select
+
+**Files:**
+- Modify: `internal/storage/postgres/spec.go`
+
+- [ ] **Step 1: Update the insert in CreateSpec**
+
+  Find the `INSERT INTO specs` query (around lines 49-59) and replace the column list + values:
+
+  ```go
+  row := s.queryRow(txCtx,
+      `INSERT INTO specs
+          (id, slug, project_slug, intent, stage, priority, complexity,
+           provenance_type, provenance_detail, notes,
+           content_hash, version, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, '', $10, 1, $11, $11)
+       RETURNING id, slug, project_slug, intent, stage, priority, complexity,
+                 provenance_type, provenance_detail,
+                 superseded_by, supersedes, notes, content_hash, version,
+                 spark_output, shape_output, specify_output, decompose_output,
+                 created_at, updated_at`,
+      specID, slug, s.project, intent, defaultInitialStage, priority, complexity,
+      string(storage.SpecProvenanceAuthored), `{"type":"authored","data":null}`,
+      ch, now,
+  )
+  ```
+
+  Also: remove the `defaultLifecycle` reference; if `defaultInitialStage` and `defaultLifecycle` are constants in this file, leave `defaultInitialStage` but delete `defaultLifecycle`.
+
+- [ ] **Step 2: Update the GetSpec SELECT**
+
+  Find the SELECT in `GetSpec` (line ~110-117) and replace `s.lifecycle` with `s.provenance_type, s.provenance_detail`. Update the corresponding `scanSpec` helper or the inline Scan call to read both columns. The provenance_detail JSONB needs to be scanned into a `[]byte` or `*json.RawMessage`, then unmarshalled into `storage.SpecProvenanceDetail`.
+
+  Approach: write a helper `func decodeProvenanceDetail(raw []byte) (storage.SpecProvenanceDetail, error)` that switches on the envelope `{"type": "...", "data": {...}}` shape and populates the right pointer.
+
+  ```go
+  // decodeProvenanceDetail parses the JSONB envelope into a domain detail struct.
+  func decodeProvenanceDetail(raw []byte) (storage.SpecProvenanceDetail, error) {
+      if len(raw) == 0 {
+          return storage.SpecProvenanceDetail{}, nil
+      }
+      var env struct {
+          Type string          `json:"type"`
+          Data json.RawMessage `json:"data"`
+      }
+      if err := json.Unmarshal(raw, &env); err != nil {
+          return storage.SpecProvenanceDetail{}, fmt.Errorf("decode provenance_detail envelope: %w", err)
+      }
+      switch storage.SpecProvenanceType(env.Type) {
+      case storage.SpecProvenanceAuthored:
+          return storage.SpecProvenanceDetail{}, nil
+      case storage.SpecProvenanceRetroactiveFromPR:
+          var d struct {
+              URL      string    `json:"url"`
+              SHA      string    `json:"sha"`
+              MergedAt time.Time `json:"merged_at"`
+              Title    string    `json:"title"`
+          }
+          if err := json.Unmarshal(env.Data, &d); err != nil {
+              return storage.SpecProvenanceDetail{}, fmt.Errorf("decode retroactive_from_pr: %w", err)
+          }
+          return storage.SpecProvenanceDetail{
+              RetroactiveFromPR: &storage.RetroactivePRProvenance{
+                  URL: d.URL, SHA: d.SHA, MergedAt: d.MergedAt, Title: d.Title,
+              },
+          }, nil
+      case storage.SpecProvenanceDeclared:
+          var d struct {
+              DeclaredBy string `json:"declared_by"`
+              Note       string `json:"note"`
+          }
+          if err := json.Unmarshal(env.Data, &d); err != nil {
+              return storage.SpecProvenanceDetail{}, fmt.Errorf("decode declared: %w", err)
+          }
+          return storage.SpecProvenanceDetail{
+              Declared: &storage.DeclaredProvenance{DeclaredBy: d.DeclaredBy, Note: d.Note},
+          }, nil
+      default:
+          return storage.SpecProvenanceDetail{}, fmt.Errorf("unknown provenance type %q in detail envelope", env.Type)
+      }
+  }
+
+  // encodeProvenanceDetail produces the JSONB envelope for storage.
+  func encodeProvenanceDetail(p storage.SpecProvenanceType, d storage.SpecProvenanceDetail) ([]byte, error) {
+      var data any
+      switch p {
+      case storage.SpecProvenanceAuthored:
+          data = nil
+      case storage.SpecProvenanceRetroactiveFromPR:
+          if d.RetroactiveFromPR == nil {
+              return nil, storage.ErrProvenanceMismatch
+          }
+          data = d.RetroactiveFromPR
+      case storage.SpecProvenanceDeclared:
+          if d.Declared == nil {
+              return nil, storage.ErrProvenanceMismatch
+          }
+          data = d.Declared
+      default:
+          return nil, fmt.Errorf("unknown provenance type %q", p)
+      }
+      env := struct {
+          Type string `json:"type"`
+          Data any    `json:"data"`
+      }{Type: string(p), Data: data}
+      return json.Marshal(env)
+  }
+  ```
+
+  Add these helpers to `spec.go` (or a new `provenance_jsonb.go` in the same package if file size warrants).
+
+- [ ] **Step 3: Update scanSpec to decode provenance_detail**
+
+  Find `scanSpec` (in the same file or wherever it's defined; search via `grep -n 'func scanSpec' internal/storage/postgres/spec.go`). Update the column list and Scan targets. Replace `lifecycle` parsing with `provenanceType` and `provenanceDetail`:
+
+  ```go
+  var (
+      // ... existing scan targets ...
+      provenanceType   string
+      provenanceDetail []byte
+      // ...
+  )
+  // Scan in the new column order:
+  err := row.Scan(
+      // ... existing ...,
+      &provenanceType, &provenanceDetail,
+      // ... existing ...,
+  )
+
+  detail, err := decodeProvenanceDetail(provenanceDetail)
+  if err != nil {
+      return nil, err
+  }
+  spec.Provenance = storage.SpecProvenanceType(provenanceType)
+  spec.ProvenanceDetail = detail
+  ```
+
+  Whatever the exact `scanSpec` shape is, the pattern is: pull two columns instead of one, populate two Spec fields instead of one.
+
+- [ ] **Step 4: Verify build**
+
+  ```bash
+  go build ./internal/storage/postgres/
+  ```
+
+  Expected: success. If `lifecycle` is still referenced elsewhere in this package, grep:
+
+  ```bash
+  grep -n 'lifecycle' internal/storage/postgres/spec.go
+  ```
+
+  and remove all occurrences (column names, scan targets, struct field references).
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(postgres): provenance read/write in spec.go
+
+  - INSERT writes provenance_type + provenance_detail columns
+  - SELECT reads them and decodes the JSONB envelope via
+    decodeProvenanceDetail into storage.SpecProvenanceDetail
+  - New helpers encodeProvenanceDetail / decodeProvenanceDetail
+    enforce envelope type ↔ discriminator invariant
+  - defaultLifecycle constant removed
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" internal/storage/postgres/spec.go
+  ```
+
+### Task 3.3: Rewrite GetReady query
+
+**Files:**
+- Modify: `internal/storage/postgres/graph.go` (function `GetReady` at line 358)
+
+- [ ] **Step 1: Replace the GetReady query body**
+
+  Find `func (s *Store) GetReady` (line 358) and replace the query string:
+
+  ```go
+  func (s *Store) GetReady(ctx context.Context) ([]storage.NodeRef, error) {
+      rows, err := s.query(ctx,
+          `SELECT s.slug, 'Spec' AS label, s.stage
+           FROM specs s
+           WHERE s.project_slug = $1
+             AND s.stage = 'approved'
+             AND s.provenance_type = 'authored'
+             AND NOT EXISTS (
+                 -- Active claim
+                 SELECT 1 FROM claims c
+                 WHERE c.project_slug = $1 AND c.spec_slug = s.slug
+                   AND (c.expires_at IS NULL OR c.expires_at > NOW())
+             )
+             AND NOT EXISTS (
+                 SELECT 1 FROM edges e
+                 JOIN specs dep ON dep.slug = e.to_slug AND dep.project_slug = $1
+                 WHERE e.from_slug = s.slug AND e.edge_type = 'DEPENDS_ON' AND e.project_slug = $1
+                   AND dep.stage <> 'done'
+             )
+             AND NOT EXISTS (
+                 SELECT 1 FROM edges e
+                 JOIN specs blocker ON blocker.slug = e.from_slug AND blocker.project_slug = $1
+                 WHERE e.to_slug = s.slug AND e.edge_type = 'BLOCKS' AND e.project_slug = $1
+                   AND blocker.stage <> 'done'
+             )`,
+          s.project,
+      )
+      // ... existing scan loop unchanged ...
+  }
+  ```
+
+  Note: the active-claim check assumes the `claims` table has `project_slug`, `spec_slug`, `expires_at`. Verify with:
+
+  ```bash
+  grep -n 'CREATE TABLE.*claims' internal/storage/postgres/migrations/*.sql
+  ```
+
+  Adjust the claim subquery to match the actual schema if columns differ.
+
+- [ ] **Step 2: Verify build**
+
+  ```bash
+  go build ./internal/storage/postgres/
+  ```
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(postgres): GetReady filters by provenance + active claim
+
+  Query rewritten per design doc Section 3:
+  - stage = 'approved' (was stage <> 'done')
+  - provenance_type = 'authored' (explicit predicate; design Section 3)
+  - no active claim
+  - dependency + blocker checks unchanged
+
+  Effect: design-stage and execution-stage specs no longer appear in
+  ready; LIVING (now DECLARED/RETROACTIVE) specs naturally excluded.
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" internal/storage/postgres/graph.go
+  ```
+
+---
+
+## Phase 4 — Server handlers
+
+### Task 4.1: Spec_handler create validation
+
+**Files:**
+- Modify: `internal/server/spec_handler.go`
+
+The existing `CreateSpec` RPC takes only slug + intent + priority + complexity. The new design requires extending it to optionally accept provenance + provenance_detail + all four stage outputs (for non-AUTHORED creates).
+
+- [ ] **Step 1: Read the existing CreateSpec handler**
+
+  ```bash
+  grep -n 'func.*CreateSpec' internal/server/spec_handler.go
+  ```
+
+  Note the handler signature and the path through validation + storage.
+
+- [ ] **Step 2: Add a provenance validation helper**
+
+  Add to `spec_handler.go` (or a new file `internal/server/provenance_validate.go`):
+
+  ```go
+  // validateProvenance enforces the create-time invariants per design.
+  // - AUTHORED: only spark_output may be set; no provenance_detail
+  // - RETROACTIVE_FROM_PR: all 4 outputs + retroactive_from_pr detail with url+sha
+  // - DECLARED: all 4 outputs + declared detail with declared_by
+  func validateProvenance(
+      pt storage.SpecProvenanceType,
+      pd storage.SpecProvenanceDetail,
+      spark *storage.SparkOutput,
+      shape *storage.ShapeOutput,
+      specify *storage.SpecifyOutput,
+      decompose *storage.DecomposeOutput,
+  ) error {
+      switch pt {
+      case storage.SpecProvenanceAuthored:
+          if shape != nil || specify != nil || decompose != nil {
+              return storage.ErrAuthoredRequiresSparkOnly
+          }
+          if pd.RetroactiveFromPR != nil || pd.Declared != nil {
+              return storage.ErrProvenanceMismatch
+          }
+      case storage.SpecProvenanceRetroactiveFromPR:
+          if spark == nil || shape == nil || specify == nil || decompose == nil {
+              return storage.ErrRetroactiveRequiresAllOutputs
+          }
+          if pd.RetroactiveFromPR == nil {
+              return storage.ErrProvenanceMismatch
+          }
+          if pd.RetroactiveFromPR.URL == "" || pd.RetroactiveFromPR.SHA == "" {
+              return storage.ErrRetroactiveRequiresPRRef
+          }
+          if pd.Declared != nil {
+              return storage.ErrProvenanceMismatch
+          }
+      case storage.SpecProvenanceDeclared:
+          if spark == nil || shape == nil || specify == nil || decompose == nil {
+              return storage.ErrDeclaredRequiresAllOutputs
+          }
+          if pd.Declared == nil {
+              return storage.ErrProvenanceMismatch
+          }
+          if pd.Declared.DeclaredBy == "" {
+              return storage.ErrDeclaredRequiresDeclaredBy
+          }
+          if pd.RetroactiveFromPR != nil {
+              return storage.ErrProvenanceMismatch
+          }
+      default:
+          return fmt.Errorf("unknown provenance type %q", pt)
+      }
+      return nil
+  }
+  ```
+
+- [ ] **Step 3: Wire validation into CreateSpec**
+
+  In the `CreateSpec` handler, after slug/intent/priority validation but before the storage call, decode the request's provenance from proto, decode the four stage outputs (if present in the request), call `validateProvenance`, and pass the validated values through to the storage layer.
+
+  Note: this requires extending `CreateSpecRequest` proto to carry the new fields. Per the design "extend existing CreateSpec to accept all four funnel outputs in a single call." Update the proto:
+
+  ```proto
+  message CreateSpecRequest {
+    string slug = 1;
+    string intent = 2;
+    string priority = 3;
+    string complexity = 4;
+    SpecProvenance provenance_type = 5;
+    oneof provenance_detail {
+      AuthoredProvenance          authored             = 6;
+      RetroactiveFromPrProvenance retroactive_from_pr  = 7;
+      DeclaredProvenance          declared             = 8;
+    }
+    SparkOutput     spark_output     = 9;
+    ShapeOutput     shape_output     = 10;
+    SpecifyOutput   specify_output   = 11;
+    DecomposeOutput decompose_output = 12;
+  }
+  ```
+
+  Add these fields to `proto/specgraph/v1/spec.proto` in the `CreateSpecRequest` message (the existing fields are at 1-4). Run `task proto` again to regenerate.
+
+- [ ] **Step 4: Extend the storage CreateSpec to accept the new arguments**
+
+  Open `internal/storage/postgres/spec.go` `CreateSpec` and add parameters: `provenance storage.SpecProvenanceType`, `detail storage.SpecProvenanceDetail`, `spark *storage.SparkOutput`, `shape *storage.ShapeOutput`, `specify *storage.SpecifyOutput`, `decompose *storage.DecomposeOutput`.
+
+  Logic:
+  - If `provenance == AUTHORED`, initial stage = `spark`, only spark_output is inserted.
+  - If `provenance == RETROACTIVE_FROM_PR` or `DECLARED`, initial stage = `done`, all four stage outputs are inserted, content_hash is pre-computed.
+
+  Pre-compute content_hash by calling `contenthash.Spec(intent, "done", priority, complexity, outputsMap)` where `outputsMap` contains marshaled stage outputs.
+
+  Persist the JSONB envelope via `encodeProvenanceDetail(provenance, detail)`.
+
+- [ ] **Step 5: Verify build**
+
+  ```bash
+  go build ./internal/server/ ./internal/storage/postgres/
+  ```
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(server): provenance validation in CreateSpec
+
+  - CreateSpecRequest proto extended with provenance_type, provenance_detail,
+    and all four stage outputs
+  - validateProvenance enforces the three create-time invariants
+  - Storage CreateSpec accepts the new arguments and pre-computes
+    content_hash for born-at-done flows
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" proto/specgraph/v1/spec.proto gen/ internal/server/spec_handler.go internal/storage/postgres/spec.go
+  ```
+
+### Task 4.2: Claim and completion gating
+
+**Files:**
+- Modify: `internal/server/claim_handler.go`, `internal/server/execution_handler.go`
+
+- [ ] **Step 1: Gate Claim on provenance**
+
+  In `claim_handler.go`, find the Claim handler. After fetching the spec but before issuing the claim, add:
+
+  ```go
+  if spec.Provenance != storage.SpecProvenanceAuthored {
+      return nil, connect.NewError(connect.CodeInvalidArgument, storage.ErrClaimRequiresAuthored)
+  }
+  ```
+
+- [ ] **Step 2: Gate RecordCompletion on provenance**
+
+  Same pattern in `execution_handler.go` for the `RecordCompletion` RPC. Fetch spec, check `spec.Provenance == AUTHORED`, return `ErrCompletionRequiresAuthored` otherwise.
+
+- [ ] **Step 3: Verify build**
+
+  ```bash
+  go build ./internal/server/
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(server): gate claim+completion on provenance=AUTHORED
+
+  Non-AUTHORED specs (RETROACTIVE_FROM_PR, DECLARED) are born at done
+  and never visit approved/in_progress/review — claim and
+  report-completion reject with explicit sentinels.
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" internal/server/claim_handler.go internal/server/execution_handler.go
+  ```
+
+---
+
+## Phase 5 — Interfaces (CLI, MCP, render)
+
+### Task 5.1: CLI lifecycle.go output
+
+**Files:**
+- Modify: `cmd/specgraph/lifecycle.go`
+
+The CLI subcommands for amend/supersede/abandon print `lifecycle=...` in their output. Replace with `provenance=...`.
+
+- [ ] **Step 1: Update each print statement**
+
+  Find each occurrence of `.GetLifecycle().String()` (lines 59, 88, 89, 117 per the earlier grep) and replace with `.GetProvenanceType().String()`. Update the field label too:
+
+  ```go
+  // Before:
+  fmt.Printf("Amended: %s (stage=%s, lifecycle=%s, version=%d)\n", ..., s.GetLifecycle().String(), ...)
+  // After:
+  fmt.Printf("Amended: %s (stage=%s, provenance=%s, version=%d)\n", ..., s.GetProvenanceType().String(), ...)
+  ```
+
+  Do the same for the other three sites in this file.
+
+- [ ] **Step 2: Verify build**
+
+  ```bash
+  go build ./cmd/specgraph/
+  ```
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(cli): replace lifecycle with provenance in lifecycle CLI output
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" cmd/specgraph/lifecycle.go
+  ```
+
+### Task 5.2: CLI spec create flags
+
+**Files:**
+- Modify: `cmd/specgraph/spec.go` (or `cmd/specgraph/create.go` — search first)
+
+- [ ] **Step 1: Locate the create command and any existing --lifecycle flag**
+
+  ```bash
+  grep -n 'create\|lifecycle\|cobra.Command' cmd/specgraph/spec.go | head -20
+  ```
+
+- [ ] **Step 2: Add --provenance and detail flags**
+
+  Add to the create-command flag set:
+
+  ```go
+  cmd.Flags().String("provenance", "authored", "provenance type: authored | retroactive_from_pr | declared")
+  cmd.Flags().String("pr-url", "", "PR URL (required when provenance=retroactive_from_pr)")
+  cmd.Flags().String("pr-sha", "", "merge commit SHA (required when provenance=retroactive_from_pr)")
+  cmd.Flags().String("pr-title", "", "PR title at import time (optional)")
+  cmd.Flags().String("declared-by", "", "human or system identifier (required when provenance=declared)")
+  cmd.Flags().String("declared-note", "", "free-text rationale (optional)")
+  ```
+
+  In the command's `RunE`, parse the flags and build the proto `CreateSpecRequest` with the populated provenance fields. For `authored` (default), no detail is needed. For non-AUTHORED, the caller must also provide stage outputs via JSON files (`--spark-json`, `--shape-json`, etc.) or another mechanism — defer the file-loading helpers to subagent judgment if not already in the codebase.
+
+- [ ] **Step 3: Verify build**
+
+  ```bash
+  go build ./cmd/specgraph/
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(cli): --provenance flag and detail flags on spec create
+
+  Replaces the implicit task-lifecycle default. For non-AUTHORED creates,
+  the caller passes --pr-url/--pr-sha or --declared-by along with the
+  stage-output JSON files.
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" cmd/specgraph/spec.go
+  ```
+
+### Task 5.3: MCP tools_spec.go
+
+**Files:**
+- Modify: `internal/mcp/tools_spec.go`
+
+- [ ] **Step 1: Update the MCP spec tool's create-action schema**
+
+  Find the `create` action handler in `tools_spec.go`. Update the param schema to accept `provenance` (string), `provenance_detail` (JSON object), and the four stage outputs (each a JSON-encoded string, similar to the existing `output` param pattern in `tools_authoring.go`).
+
+- [ ] **Step 2: Parse and forward to the storage layer**
+
+  Convert the friendly provenance string to `storage.SpecProvenanceType`, parse the JSON envelope into `storage.SpecProvenanceDetail`, and call the extended `CreateSpec` storage method.
+
+- [ ] **Step 3: Verify build**
+
+  ```bash
+  go build ./internal/mcp/
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(mcp): provenance + stage-outputs on spec create tool
+
+  The MCP spec tool's create action now accepts provenance and (for
+  non-AUTHORED) all four stage outputs in a single call.
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" internal/mcp/tools_spec.go
+  ```
+
+### Task 5.4: Render layer
+
+**Files:**
+- Modify: `internal/render/spec.go`
+
+The existing `lifecycleString` function (line 57-66) is dead code after this change. Replace with a provenance-aware render.
+
+- [ ] **Step 1: Replace lifecycleString**
+
+  Delete the existing function and add:
+
+  ```go
+  func provenanceString(p specv1.SpecProvenance) string {
+      switch p {
+      case specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED:
+          return "AUTHORED"
+      case specv1.SpecProvenance_SPEC_PROVENANCE_RETROACTIVE_FROM_PR:
+          return "RETROACTIVE_FROM_PR"
+      case specv1.SpecProvenance_SPEC_PROVENANCE_DECLARED:
+          return "DECLARED"
+      default:
+          return "UNSPECIFIED"
+      }
+  }
+
+  // renderProvenanceBlock formats the provenance line(s) for spec render output.
+  // Always renders at least one line (no silent-default).
+  func renderProvenanceBlock(s *specv1.Spec) string {
+      pt := s.GetProvenanceType()
+      switch d := s.GetProvenanceDetail().(type) {
+      case *specv1.Spec_RetroactiveFromPr:
+          r := d.RetroactiveFromPr
+          return fmt.Sprintf(
+              "provenance:   %s\n              %s\n              merged %s (commit %s)",
+              provenanceString(pt), r.GetUrl(),
+              r.GetMergedAt().AsTime().Format("2006-01-02"),
+              r.GetSha(),
+          )
+      case *specv1.Spec_Declared:
+          return fmt.Sprintf(
+              "provenance:   %s\n              declared by %s: %q",
+              provenanceString(pt), d.Declared.GetDeclaredBy(), d.Declared.GetNote(),
+          )
+      default:
+          return fmt.Sprintf("provenance:   %s", provenanceString(pt))
+      }
+  }
+  ```
+
+- [ ] **Step 2: Wire renderProvenanceBlock into the spec-render output**
+
+  Find the main spec-render function (search via `grep -n 'func.*Spec.*string' internal/render/spec.go` — usually `RenderSpec` or similar) and insert a call to `renderProvenanceBlock(s)` after the title/slug and before the stage details.
+
+- [ ] **Step 3: Verify build + render tests**
+
+  ```bash
+  go build ./internal/render/
+  go test ./internal/render/ -run TestSpec
+  ```
+
+  Some existing tests may reference lifecycle and fail. Update them to reference provenance.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(render): provenance-aware spec output
+
+  Replaces lifecycleString switch with provenanceString and a
+  renderProvenanceBlock that handles per-variant detail formatting.
+  Always renders at least one provenance line.
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" internal/render/spec.go
+  ```
+
+---
+
+## Phase 6 — Cross-cutting (linter, export)
+
+### Task 6.1: Linter schema.go
+
+**Files:**
+- Modify: `internal/linter/schema.go`
+
+- [ ] **Step 1: Replace the lifecycle validation block**
+
+  Find lines 71-76 (the current `spec.Lifecycle.IsValid()` check) and replace:
+
+  ```go
+  // Validate provenance type
+  if spec.Provenance != "" && !spec.Provenance.IsValid() {
+      findings = append(findings, ...{
+          Severity: linter.SeverityError,
+          Message:  fmt.Sprintf("invalid provenance %q", spec.Provenance),
+          Location: "provenance",
+      })
+  }
+  ```
+
+  (Match the exact severity/finding-struct shape of the surrounding code.)
+
+- [ ] **Step 2: Add a provenance-vs-stage consistency check**
+
+  After the type validation, add:
+
+  ```go
+  // Provenance and stage consistency: non-AUTHORED specs must be at done.
+  if spec.Provenance != storage.SpecProvenanceAuthored &&
+     spec.Provenance != "" &&
+     spec.Stage != storage.SpecStageDone {
+      findings = append(findings, ...{
+          Severity: linter.SeverityError,
+          Message:  fmt.Sprintf("provenance %q requires stage=done (got %q)", spec.Provenance, spec.Stage),
+          Location: "provenance",
+      })
+  }
+  ```
+
+- [ ] **Step 3: Verify build**
+
+  ```bash
+  go build ./internal/linter/
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(linter): validate provenance + provenance-stage consistency
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" internal/linter/schema.go
+  ```
+
+### Task 6.2: Export engine
+
+**Files:**
+- Modify: `internal/export/engine.go`
+
+- [ ] **Step 1: Replace lifecycle handling in the export path**
+
+  Find lines 439-451 (the `spec.Lifecycle` references). Update to read/write `Provenance` and `ProvenanceDetail` instead:
+
+  ```go
+  // Restore provenance + detail + notes via UpdateSpec / re-export.
+  if spec.Provenance != "" || spec.Notes != "" || spec.SupersededBy != "" || spec.Supersedes != "" {
+      // ... pass spec.Provenance and spec.ProvenanceDetail through the update path ...
+  }
+  ```
+
+  The exact shape depends on how `UpdateSpec` is being used in this file — match the existing pattern.
+
+- [ ] **Step 2: Verify build**
+
+  ```bash
+  go build ./internal/export/
+  ```
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  jj --no-pager commit -m "feat(export): serialize provenance instead of lifecycle
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" internal/export/engine.go
+  ```
+
+---
+
+## Phase 7 — Tests
+
+### Task 7.1: Provenance creation-path integration tests
+
+**Files:**
+- Create: `internal/server/spec_handler_provenance_test.go`
+
+- [ ] **Step 1: Write the AUTHORED-create test**
+
+  ```go
+  // SPDX-License-Identifier: Apache-2.0
+  // Copyright 2026 Sean Brandt
+
+  package server_test
+
+  import (
+      "context"
+      "testing"
+
+      "connectrpc.com/connect"
+      "github.com/stretchr/testify/require"
+      specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+      "github.com/specgraph/specgraph/internal/storage"
+  )
+
+  func TestCreateSpec_AuthoredHappyPath(t *testing.T) {
+      ctx := context.Background()
+      svc, cleanup := newTestSpecService(t)
+      defer cleanup()
+
+      req := &specv1.CreateSpecRequest{
+          Slug:           "test-authored",
+          Intent:         "test the authored happy path",
+          ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED,
+          // No detail set; no stage outputs except spark (optional at create per design).
+      }
+      resp, err := svc.CreateSpec(ctx, connect.NewRequest(req))
+      require.NoError(t, err)
+      require.Equal(t, specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED, resp.Msg.Spec.GetProvenanceType())
+      require.Equal(t, "spark", resp.Msg.Spec.GetStage())
+  }
+  ```
+
+  `newTestSpecService` is a helper to construct the service with a backing test store; reuse the pattern from other `_test.go` files in `internal/server/`. If no such helper exists, write a minimal one using the test backend in `authoring_handler_test.go:175` as a template.
+
+- [ ] **Step 2: Run the test**
+
+  ```bash
+  go test ./internal/server/ -run TestCreateSpec_AuthoredHappyPath -v
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 3: Add the RETROACTIVE happy-path test**
+
+  Append to the same file:
+
+  ```go
+  func TestCreateSpec_RetroactiveBornAtDone(t *testing.T) {
+      ctx := context.Background()
+      svc, cleanup := newTestSpecService(t)
+      defer cleanup()
+
+      req := &specv1.CreateSpecRequest{
+          Slug:           "test-retroactive",
+          Intent:         "test the retroactive create path",
+          ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_RETROACTIVE_FROM_PR,
+          ProvenanceDetail: &specv1.CreateSpecRequest_RetroactiveFromPr{
+              RetroactiveFromPr: &specv1.RetroactiveFromPrProvenance{
+                  Url: "https://github.com/specgraph/specgraph/pull/952",
+                  Sha: "b0684373",
+              },
+          },
+          SparkOutput:     mustParseSparkOutput(t, `{"seed":"s","signal":"s","scopeSniff":"SCOPE_SNIFF_TINY","killTest":"k"}`),
+          ShapeOutput:     mustParseShapeOutput(t, `{"scopeIn":["x"],"scopeOut":["y"],"approaches":[{"name":"a","description":"d","tradeoffs":["t"]}],"chosenApproach":"a","risks":["r"],"successMust":["m"],"successShould":["s"],"successWont":["w"]}`),
+          SpecifyOutput:   mustParseSpecifyOutput(t, `{"interfaces":[{"name":"i","body":"b"}],"verifyCriteria":[{"category":"c","description":"d"}],"invariants":["i"],"touches":[{"path":"p","purpose":"u","changeType":"new"}]}`),
+          DecomposeOutput: mustParseDecomposeOutput(t, `{"strategy":"DECOMPOSITION_STRATEGY_SINGLE_UNIT","slices":[{"id":"s","intent":"i","verify":["v"],"touches":["t"]}]}`),
+      }
+      resp, err := svc.CreateSpec(ctx, connect.NewRequest(req))
+      require.NoError(t, err)
+      require.Equal(t, "done", resp.Msg.Spec.GetStage())
+      require.Equal(t, specv1.SpecProvenance_SPEC_PROVENANCE_RETROACTIVE_FROM_PR, resp.Msg.Spec.GetProvenanceType())
+  }
+  ```
+
+  Define `mustParseSparkOutput` etc. helpers at the top of the file using `protojson.Unmarshal`.
+
+- [ ] **Step 4: Add rejection tests for invariant violations**
+
+  Add tests for each sentinel from Task 1.1:
+
+  ```go
+  func TestCreateSpec_RetroactiveMissingPRRef(t *testing.T) {
+      // ... omit Url ...
+      _, err := svc.CreateSpec(ctx, connect.NewRequest(req))
+      require.Error(t, err)
+      require.ErrorIs(t, err, storage.ErrRetroactiveRequiresPRRef)
+  }
+  ```
+
+  Repeat for: `ErrAuthoredRequiresSparkOnly` (AUTHORED with shape_output set), `ErrRetroactiveRequiresAllOutputs` (omit one stage output), `ErrDeclaredRequiresAllOutputs`, `ErrDeclaredRequiresDeclaredBy`, `ErrProvenanceMismatch` (type/detail mismatch).
+
+- [ ] **Step 5: Add claim/completion rejection tests**
+
+  ```go
+  func TestClaim_RejectsRetroactive(t *testing.T) {
+      // Create a retroactive spec (born at done), then try to claim it.
+      _, err := claimSvc.Claim(ctx, connect.NewRequest(claimReq))
+      require.ErrorIs(t, err, storage.ErrClaimRequiresAuthored)
+  }
+
+  func TestCompletion_RejectsDeclared(t *testing.T) {
+      // ... similar ...
+      require.ErrorIs(t, err, storage.ErrCompletionRequiresAuthored)
+  }
+  ```
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  jj --no-pager commit -m "test(server): provenance creation paths + sentinel rejection
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" internal/server/spec_handler_provenance_test.go
+  ```
+
+### Task 7.2: GetReady mixed-seed integration test
+
+**Files:**
+- Create: `internal/storage/postgres/graph_ready_provenance_test.go`
+
+- [ ] **Step 1: Write the seed-and-assert test**
+
+  ```go
+  //go:build integration
+
+  package postgres_test
+
+  import (
+      "context"
+      "testing"
+
+      "github.com/stretchr/testify/require"
+      "github.com/specgraph/specgraph/internal/storage"
+  )
+
+  func TestGetReady_ProvenanceAndStageFilters(t *testing.T) {
+      ctx := context.Background()
+      store, cleanup := newTestStore(t)
+      defer cleanup()
+
+      // Seed 6 specs spanning the stage + provenance space.
+      mustSeed(t, store, "a-authored-approved",    storage.SpecStageApproved,   storage.SpecProvenanceAuthored)
+      mustSeed(t, store, "b-authored-spark",       storage.SpecStageSpark,      storage.SpecProvenanceAuthored)
+      mustSeed(t, store, "c-authored-done",        storage.SpecStageDone,       storage.SpecProvenanceAuthored)
+      mustSeed(t, store, "d-declared-done",        storage.SpecStageDone,       storage.SpecProvenanceDeclared)
+      mustSeed(t, store, "e-authored-superseded",  storage.SpecStageSuperseded, storage.SpecProvenanceAuthored)
+      mustSeed(t, store, "f-authored-abandoned",   storage.SpecStageAbandoned,  storage.SpecProvenanceAuthored)
+
+      ready, err := store.GetReady(ctx)
+      require.NoError(t, err)
+      require.Len(t, ready, 1)
+      require.Equal(t, "a-authored-approved", ready[0].Slug)
+  }
+  ```
+
+  `newTestStore` and `mustSeed` follow the existing testcontainers pattern in `internal/storage/postgres/`.
+
+- [ ] **Step 2: Run the test**
+
+  ```bash
+  go test -tags integration ./internal/storage/postgres/ -run TestGetReady_ProvenanceAndStageFilters -v
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  jj --no-pager commit -m "test(postgres): GetReady filters by stage and provenance
+
+  Mixed-seed integration test asserting that only AUTHORED specs at
+  stage=approved appear in ready. Covers superseded/abandoned exclusion,
+  DECLARED exclusion, and pre-approved exclusion.
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" internal/storage/postgres/graph_ready_provenance_test.go
+  ```
+
+### Task 7.3: Migration precondition test
+
+**Files:**
+- Create: `internal/storage/postgres/migration_007_test.go`
+
+- [ ] **Step 1: Write the precondition test**
+
+  ```go
+  //go:build integration
+
+  package postgres_test
+
+  import (
+      "context"
+      "testing"
+
+      "github.com/stretchr/testify/require"
+  )
+
+  func TestMigration007_RefusesNonEmptyTable(t *testing.T) {
+      ctx := context.Background()
+      // Roll back to migration 006, manually insert a row into specs, then re-run up to 007.
+      db, cleanup := newTestDB(t)
+      defer cleanup()
+
+      // Migrate to 006 first.
+      require.NoError(t, gooseUp(db, "006"))
+
+      // Insert a row (specs table exists with lifecycle column at this point).
+      _, err := db.Exec(ctx, "INSERT INTO specs (id, slug, project_slug, intent, stage, priority, complexity, lifecycle, notes, content_hash, version, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW(), NOW())",
+          "spec-01TEST", "test-slug", "test-project", "test", "spark", "p2", "medium", "task", "", "deadbeef", 1)
+      require.NoError(t, err)
+
+      // Now try to migrate to 007 — should fail.
+      err = gooseUp(db, "007")
+      require.Error(t, err)
+      require.Contains(t, err.Error(), "migration 007 refuses to run on a non-empty specs table")
+  }
+  ```
+
+  `gooseUp(db, version)` helper applies migrations up to the given version using the `pressly/goose/v3` API. Reuse existing test infrastructure if available.
+
+- [ ] **Step 2: Run the test**
+
+  ```bash
+  go test -tags integration ./internal/storage/postgres/ -run TestMigration007 -v
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  jj --no-pager commit -m "test(postgres): migration 007 refuses non-empty specs table
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" internal/storage/postgres/migration_007_test.go
+  ```
+
+### Task 7.4: Update existing tests that referenced lifecycle
+
+**Files:**
+- Modify: any `*_test.go` file currently referencing `Lifecycle`, `SpecLifecycle`, `LIFECYCLE_TASK`, `LIFECYCLE_LIVING`, etc.
+
+- [ ] **Step 1: Find all stragglers**
+
+  ```bash
+  grep -rln 'Lifecycle\|LIFECYCLE_' --include='*_test.go' . | head -20
+  ```
+
+- [ ] **Step 2: Update each test file**
+
+  For each file: replace lifecycle references with provenance equivalents. The mechanical mapping:
+
+  - `SpecLifecycle_SPEC_LIFECYCLE_TASK` → `SpecProvenance_SPEC_PROVENANCE_AUTHORED`
+  - `SpecLifecycle_SPEC_LIFECYCLE_LIVING` → `SpecProvenance_SPEC_PROVENANCE_DECLARED`
+  - `storage.SpecLifecycleTask` → `storage.SpecProvenanceAuthored`
+  - `storage.SpecLifecycleLiving` → `storage.SpecProvenanceDeclared`
+  - `spec.Lifecycle` → `spec.Provenance`
+  - `Lifecycle: storage.SpecLifecycleTask` → `Provenance: storage.SpecProvenanceAuthored`
+
+  For tests that previously used `LIVING`, decide case-by-case whether the test intent maps to DECLARED (most likely, since LIVING described existing reality) or RETROACTIVE_FROM_PR (less common).
+
+- [ ] **Step 3: Run the full test suite**
+
+  ```bash
+  task test
+  ```
+
+  Expected: all tests pass. If failures remain, address them one at a time.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  jj --no-pager commit -m "test: migrate lifecycle references to provenance
+
+  Mechanical sweep across *_test.go files; mapping per plan Task 7.4.
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" $(grep -rln 'Provenance' --include='*_test.go' . | head -30)
+  ```
+
+---
+
+## Phase 8 — Documentation
+
+### Task 8.1: CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add a breaking-change entry**
+
+  At the top of `CHANGELOG.md` (under the unreleased section if one exists, or a new `## [Unreleased]` header):
+
+  ```markdown
+  ## [Unreleased]
+
+  ### Changed (BREAKING)
+
+  - **Replaced `SpecLifecycle` (task/living) with `SpecProvenance`** (AUTHORED / RETROACTIVE_FROM_PR / DECLARED). Wire-break at proto field 10 plus a new `provenance_detail` oneof. Postgres column `lifecycle` removed; `provenance_type` and `provenance_detail` columns added. See `docs/decisions/ADR-006-spec-provenance-model.md`.
+  - **`specgraph ready` now requires `stage=approved` AND `provenance=authored`**. Previously surfaced any spec at `stage <> done`, including mid-design and superseded/abandoned specs.
+  - **`claim` and `report-completion` reject non-AUTHORED specs** with `ErrClaimRequiresAuthored` / `ErrCompletionRequiresAuthored`.
+  ```
+
+- [ ] **Step 2: Commit**
+
+  ```bash
+  jj --no-pager commit -m "docs(changelog): breaking-change entries for provenance model
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" CHANGELOG.md
+  ```
+
+### Task 8.2: Concept doc
+
+**Files:**
+- Modify: `site/docs/concepts/spec-graph.md`
+
+- [ ] **Step 1: Find and update the lifecycle row**
+
+  ```bash
+  grep -n 'lifecycle\|task.*living' site/docs/concepts/spec-graph.md
+  ```
+
+  Replace the row that says `| **Lifecycle** | lifecycle (task / living), ... |` with a provenance row:
+
+  ```markdown
+  | **Provenance** | `provenance` (AUTHORED / RETROACTIVE_FROM_PR / DECLARED), `superseded_by`, `supersedes` |
+  ```
+
+- [ ] **Step 2: If a longer prose section discusses lifecycle, rewrite it**
+
+  Substantively update any explanation of `living` specs to describe DECLARED specs, and add a short paragraph on RETROACTIVE_FROM_PR for retroactive imports. Reference the design doc for full detail.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  jj --no-pager commit -m "docs(concept): update spec-graph concept doc for provenance model
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" site/docs/concepts/spec-graph.md
+  ```
+
+### Task 8.3: Finalize ADR-006
+
+**Files:**
+- Modify: `docs/decisions/ADR-006-spec-provenance-model.md`
+
+- [ ] **Step 1: Replace the stub with full content**
+
+  ```markdown
+  <!-- SPDX-License-Identifier: Apache-2.0 -->
+
+  # ADR-006: Spec Provenance Model
+
+  - **Status:** Accepted
+  - **Date:** 2026-05-20
+  - **Supersedes:** SpecLifecycle enum (task/living)
+
+  ## Context
+
+  SpecGraph specs previously carried a `lifecycle` field with values
+  `task` and `living`. The intent was to distinguish one-time work
+  (task) from ongoing contracts (living). The actual implementation
+  encoded only the type tag — `GetReady` never consulted it, drift
+  detection ignored it, and the conceptual boundary between
+  task/living/done was vestigial after `done`.
+
+  Adding a `retroactive` lifecycle value (an early proposal) would
+  have created a third value behaviorally identical to LIVING,
+  distinguished only by provenance.
+
+  ## Decision
+
+  Replace `SpecLifecycle` with `SpecProvenance` — an enum capturing
+  **how a spec entered the graph**, not how the funnel should treat
+  it after `done`. Values: AUTHORED, RETROACTIVE_FROM_PR, DECLARED.
+  Per-variant structured payload via a `provenance_detail` oneof.
+
+  Stage drives funnel behavior; provenance drives the
+  forward-vs-imported axis. Done specs of any provenance share
+  drift, dependency, and supersession semantics.
+
+  See `docs/superpowers/specs/2026-05-20-spec-provenance-model-design.md`
+  for full design rationale, alternatives considered, and adversarial
+  review trail.
+
+  ## Consequences
+
+  - Wire-break at proto field 10 (pre-1.0, no production data).
+  - `specgraph ready` semantics tightened: only AUTHORED specs at
+    `stage=approved` with no active claim.
+  - `claim` and `report-completion` reject non-AUTHORED specs.
+  - Drift detection unified on `stage=done`.
+  - Provenance is immutable through amend; supersede creates a fresh
+    spec with fresh provenance.
+  - Adding new provenance values (e.g. `IMPORTED_FROM_BACKUP`) in
+    the future is wire-compatible per proto enum evolution rules.
+  ```
+
+- [ ] **Step 2: Commit**
+
+  ```bash
+  jj --no-pager commit -m "docs(adr): finalize ADR-006 spec provenance model
+
+  Status moves from Proposed to Accepted; full Context/Decision/Consequences.
+
+  Signed-off-by: Sean Brandt <4678+seanb4t@users.noreply.github.com>" docs/decisions/ADR-006-spec-provenance-model.md
+  ```
+
+---
+
+## Phase 9 — Final verification + PR
+
+### Task 9.1: Run task check
+
+- [ ] **Step 1: Verify all unrelated drift restored**
+
+  ```bash
+  jj --no-pager restore .claude/settings.json .cursor/mcp.json .mcp.json opencode.json
+  jj --no-pager status
+  ```
+
+  Expected: working copy clean (or only unrelated files restored to canonical form).
+
+- [ ] **Step 2: Run task check**
+
+  ```bash
+  task check 2>&1 | tail -20
+  ```
+
+  Expected: `Success: No issues found in N files` for markdown lint; all Go tests pass; no FAIL lines. If anything fails, fix it and recommit. Squash the fix into the relevant phase commit using `jj squash --into <change-id>` to keep history clean.
+
+### Task 9.2: Run task pr-prep (optional but recommended)
+
+- [ ] **Step 1: Run pr-prep**
+
+  ```bash
+  task pr-prep 2>&1 | tail -20
+  ```
+
+  Expected: all of `task check` + integration + e2e tests pass. Requires Docker (per CLAUDE.md). If Docker is unavailable, skip and note in PR description.
+
+### Task 9.3: Set bookmark and push
+
+- [ ] **Step 1: Confirm commit stack**
+
+  ```bash
+  jj --no-pager log -r 'ancestors(@-, 30)' --no-graph | head -60
+  ```
+
+  Expected: ordered list of commits from Task 1.1 through Task 8.3, all with proper conventional-commits + DCO sign-off, atop the main branch.
+
+- [ ] **Step 2: Create the bookmark**
+
+  ```bash
+  jj --no-pager bookmark create feat/spec-provenance-model -r @-
+  ```
+
+- [ ] **Step 3: Push**
+
+  ```bash
+  jj --no-pager git push --bookmark feat/spec-provenance-model
+  ```
+
+  Expected: bookmark pushed; GitHub returns a PR-create URL.
+
+### Task 9.4: Open the PR
+
+- [ ] **Step 1: Open the PR from the main colocated checkout**
+
+  ```bash
+  (cd /Users/SeBrandt/Code/github.com/specgraph && gh pr create \
+    --head feat/spec-provenance-model \
+    --base main \
+    --title "feat!: replace SpecLifecycle with SpecProvenance model" \
+    --body "$(cat <<'EOF'
+  ## Summary
+
+  Implements the spec-provenance model design from PR #953.
+
+  - Wire-break at proto field 10 (lifecycle → provenance_type) plus a new provenance_detail oneof at fields 22-24
+  - SpecLifecycle (task/living) replaced with SpecProvenance (AUTHORED / RETROACTIVE_FROM_PR / DECLARED)
+  - Postgres migration 007 drops lifecycle column, adds provenance_type + provenance_detail (with precondition guard)
+  - `specgraph ready` rewritten: stage=approved AND provenance=authored AND no active claim AND deps satisfied
+  - `claim` and `report-completion` gated on provenance=AUTHORED (eight new sentinel errors)
+  - Extended CreateSpec accepts provenance + all four stage outputs for born-at-done flows
+  - Render, CLI, MCP, linter, export all updated
+  - ADR-006 records the model decision
+
+  ## Test plan
+
+  - [x] `task check` passes
+  - [ ] `task pr-prep` (integration + e2e) — see CI
+  - [x] Provenance creation-path tests cover AUTHORED happy-path, RETROACTIVE born-at-done, DECLARED born-at-done, and all eight sentinel rejection paths
+  - [x] GetReady mixed-seed test asserts only AUTHORED-at-approved appears
+  - [x] Migration 007 precondition test asserts refusal on non-empty table
+
+  ## Breaking changes
+
+  See CHANGELOG.md. Wire-break is intentional (pre-1.0, no production data per project status).
+  EOF
+  )")
+  ```
+
+  Expected: gh returns a PR URL.
+
+- [ ] **Step 2: Verify CI on the PR**
+
+  ```bash
+  (cd /Users/SeBrandt/Code/github.com/specgraph && gh pr checks)
+  ```
+
+  Expected: CI workflows queued; address any failures by recommitting on the branch and re-pushing.
+
+---
+
+## Self-Review
+
+Run through this list with fresh eyes after writing the plan.
+
+1. **Spec coverage:** Every section of the design doc is covered by at least one task:
+   - Proto changes (Section "The Model" → Task 1.3, 4.1)
+   - Storage domain types (Section "Storage-side domain type" → Task 2.1)
+   - JSONB envelope (Section "JSONB envelope" → Task 3.2)
+   - Stage progressions per provenance (Section → Tasks 4.1, 4.2)
+   - GetReady semantics (Section → Task 3.3)
+   - Drift behavior (Section → unchanged; verified by existing drift tests + Task 7.2)
+   - Render output (Section → Task 5.4)
+   - Migration footprint (Section → Tasks 3.1, 6.1, 6.2)
+   - Sentinel errors (Section → Task 1.1)
+   - ADR-006, CHANGELOG, concept doc → Tasks 8.1, 8.2, 8.3
+   - Spec.stage proto comment fix → Task 1.3 Step 3
+   - Migration precondition → Task 3.1 + Task 7.3
+
+2. **Placeholder scan:** every code step shows actual code; no "TBD" or "handle appropriately" placeholders. Three steps (Task 4.1 Step 4, Task 5.2 Step 2, Task 6.1 Step 1) reference patterns in existing code and instruct the implementer to match them — this is acceptable given the surface area, but the implementer must read those existing files before coding.
+
+3. **Type consistency:** `SpecProvenance`, `SpecProvenanceType`, `SpecProvenanceDetail`, `RetroactivePRProvenance`, `DeclaredProvenance` are used consistently across all phases. Proto enum values (`SPEC_PROVENANCE_*`) and domain constants (`SpecProvenanceAuthored` etc.) match. Sentinel error names match the design's enumeration.
+
+4. **Commit-by-task tracing:** every task ends with a `jj commit` step naming exactly the files touched, conventional-commits typed, and DCO-signed. Phase 1.3 carries the breaking-change `!` per the convention.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-20-spec-provenance-model.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration. Best for plans of this size (24 tasks) because each task is self-contained and the subagent doesn't accumulate context from earlier ones.
+
+2. **Inline Execution** — execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints. Easier if you want to handle minor issues in real time without subagent round-trips.
+
+**Which approach?**

--- a/e2e/api/graph_test.go
+++ b/e2e/api/graph_test.go
@@ -55,6 +55,14 @@ var _ = Describe("graph queries", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// gq-d is standalone (no dependencies).
+
+		// Transition all four specs to stage=approved so GetReady's
+		// stage=approved filter (added by the provenance model change)
+		// surfaces gq-c and gq-d. gq-a and gq-b stay excluded by the
+		// dependency check, not by the stage filter.
+		for _, slug := range []string{"gq-a", "gq-b", "gq-c", "gq-d"} {
+			Expect(advanceStage(ctx, slug, "approved")).To(Succeed())
+		}
 	})
 
 	It("shows dependencies with GetDependencies", func() {

--- a/gen/specgraph/v1/spec.pb.go
+++ b/gen/specgraph/v1/spec.pb.go
@@ -1089,13 +1089,24 @@ func (x *CompareVersionsResponse) GetDiffs() []*VersionDiff {
 }
 
 type CreateSpecRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Slug          string                 `protobuf:"bytes,1,opt,name=slug,proto3" json:"slug,omitempty"`
-	Intent        string                 `protobuf:"bytes,2,opt,name=intent,proto3" json:"intent,omitempty"`
-	Priority      string                 `protobuf:"bytes,3,opt,name=priority,proto3" json:"priority,omitempty"`     // optional, defaults to "p2"
-	Complexity    string                 `protobuf:"bytes,4,opt,name=complexity,proto3" json:"complexity,omitempty"` // optional, defaults to "medium"
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Slug           string                 `protobuf:"bytes,1,opt,name=slug,proto3" json:"slug,omitempty"`
+	Intent         string                 `protobuf:"bytes,2,opt,name=intent,proto3" json:"intent,omitempty"`
+	Priority       string                 `protobuf:"bytes,3,opt,name=priority,proto3" json:"priority,omitempty"`                                                                     // optional, defaults to "p2"
+	Complexity     string                 `protobuf:"bytes,4,opt,name=complexity,proto3" json:"complexity,omitempty"`                                                                 // optional, defaults to "medium"
+	ProvenanceType SpecProvenance         `protobuf:"varint,5,opt,name=provenance_type,json=provenanceType,proto3,enum=specgraph.v1.SpecProvenance" json:"provenance_type,omitempty"` // optional, defaults to AUTHORED
+	// Types that are valid to be assigned to ProvenanceDetail:
+	//
+	//	*CreateSpecRequest_Authored
+	//	*CreateSpecRequest_RetroactiveFromPr
+	//	*CreateSpecRequest_Declared
+	ProvenanceDetail isCreateSpecRequest_ProvenanceDetail `protobuf_oneof:"provenance_detail"`
+	SparkOutput      *SparkOutput                         `protobuf:"bytes,9,opt,name=spark_output,json=sparkOutput,proto3" json:"spark_output,omitempty"`
+	ShapeOutput      *ShapeOutput                         `protobuf:"bytes,10,opt,name=shape_output,json=shapeOutput,proto3" json:"shape_output,omitempty"`
+	SpecifyOutput    *SpecifyOutput                       `protobuf:"bytes,11,opt,name=specify_output,json=specifyOutput,proto3" json:"specify_output,omitempty"`
+	DecomposeOutput  *DecomposeOutput                     `protobuf:"bytes,12,opt,name=decompose_output,json=decomposeOutput,proto3" json:"decompose_output,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *CreateSpecRequest) Reset() {
@@ -1155,6 +1166,97 @@ func (x *CreateSpecRequest) GetComplexity() string {
 	}
 	return ""
 }
+
+func (x *CreateSpecRequest) GetProvenanceType() SpecProvenance {
+	if x != nil {
+		return x.ProvenanceType
+	}
+	return SpecProvenance_SPEC_PROVENANCE_UNSPECIFIED
+}
+
+func (x *CreateSpecRequest) GetProvenanceDetail() isCreateSpecRequest_ProvenanceDetail {
+	if x != nil {
+		return x.ProvenanceDetail
+	}
+	return nil
+}
+
+func (x *CreateSpecRequest) GetAuthored() *AuthoredProvenance {
+	if x != nil {
+		if x, ok := x.ProvenanceDetail.(*CreateSpecRequest_Authored); ok {
+			return x.Authored
+		}
+	}
+	return nil
+}
+
+func (x *CreateSpecRequest) GetRetroactiveFromPr() *RetroactiveFromPrProvenance {
+	if x != nil {
+		if x, ok := x.ProvenanceDetail.(*CreateSpecRequest_RetroactiveFromPr); ok {
+			return x.RetroactiveFromPr
+		}
+	}
+	return nil
+}
+
+func (x *CreateSpecRequest) GetDeclared() *DeclaredProvenance {
+	if x != nil {
+		if x, ok := x.ProvenanceDetail.(*CreateSpecRequest_Declared); ok {
+			return x.Declared
+		}
+	}
+	return nil
+}
+
+func (x *CreateSpecRequest) GetSparkOutput() *SparkOutput {
+	if x != nil {
+		return x.SparkOutput
+	}
+	return nil
+}
+
+func (x *CreateSpecRequest) GetShapeOutput() *ShapeOutput {
+	if x != nil {
+		return x.ShapeOutput
+	}
+	return nil
+}
+
+func (x *CreateSpecRequest) GetSpecifyOutput() *SpecifyOutput {
+	if x != nil {
+		return x.SpecifyOutput
+	}
+	return nil
+}
+
+func (x *CreateSpecRequest) GetDecomposeOutput() *DecomposeOutput {
+	if x != nil {
+		return x.DecomposeOutput
+	}
+	return nil
+}
+
+type isCreateSpecRequest_ProvenanceDetail interface {
+	isCreateSpecRequest_ProvenanceDetail()
+}
+
+type CreateSpecRequest_Authored struct {
+	Authored *AuthoredProvenance `protobuf:"bytes,6,opt,name=authored,proto3,oneof"`
+}
+
+type CreateSpecRequest_RetroactiveFromPr struct {
+	RetroactiveFromPr *RetroactiveFromPrProvenance `protobuf:"bytes,7,opt,name=retroactive_from_pr,json=retroactiveFromPr,proto3,oneof"`
+}
+
+type CreateSpecRequest_Declared struct {
+	Declared *DeclaredProvenance `protobuf:"bytes,8,opt,name=declared,proto3,oneof"`
+}
+
+func (*CreateSpecRequest_Authored) isCreateSpecRequest_ProvenanceDetail() {}
+
+func (*CreateSpecRequest_RetroactiveFromPr) isCreateSpecRequest_ProvenanceDetail() {}
+
+func (*CreateSpecRequest_Declared) isCreateSpecRequest_ProvenanceDetail() {}
 
 type GetSpecRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1617,14 +1719,24 @@ const file_specgraph_v1_spec_proto_rawDesc = "" +
 	"\n" +
 	"from_stage\x18\x03 \x01(\tR\tfromStage\x12\x19\n" +
 	"\bto_stage\x18\x04 \x01(\tR\atoStage\x12/\n" +
-	"\x05diffs\x18\x05 \x03(\v2\x19.specgraph.v1.VersionDiffR\x05diffs\"{\n" +
+	"\x05diffs\x18\x05 \x03(\v2\x19.specgraph.v1.VersionDiffR\x05diffs\"\xbe\x05\n" +
 	"\x11CreateSpecRequest\x12\x12\n" +
 	"\x04slug\x18\x01 \x01(\tR\x04slug\x12\x16\n" +
 	"\x06intent\x18\x02 \x01(\tR\x06intent\x12\x1a\n" +
 	"\bpriority\x18\x03 \x01(\tR\bpriority\x12\x1e\n" +
 	"\n" +
 	"complexity\x18\x04 \x01(\tR\n" +
-	"complexity\"$\n" +
+	"complexity\x12E\n" +
+	"\x0fprovenance_type\x18\x05 \x01(\x0e2\x1c.specgraph.v1.SpecProvenanceR\x0eprovenanceType\x12>\n" +
+	"\bauthored\x18\x06 \x01(\v2 .specgraph.v1.AuthoredProvenanceH\x00R\bauthored\x12[\n" +
+	"\x13retroactive_from_pr\x18\a \x01(\v2).specgraph.v1.RetroactiveFromPrProvenanceH\x00R\x11retroactiveFromPr\x12>\n" +
+	"\bdeclared\x18\b \x01(\v2 .specgraph.v1.DeclaredProvenanceH\x00R\bdeclared\x12<\n" +
+	"\fspark_output\x18\t \x01(\v2\x19.specgraph.v1.SparkOutputR\vsparkOutput\x12<\n" +
+	"\fshape_output\x18\n" +
+	" \x01(\v2\x19.specgraph.v1.ShapeOutputR\vshapeOutput\x12B\n" +
+	"\x0especify_output\x18\v \x01(\v2\x1b.specgraph.v1.SpecifyOutputR\rspecifyOutput\x12H\n" +
+	"\x10decompose_output\x18\f \x01(\v2\x1d.specgraph.v1.DecomposeOutputR\x0fdecomposeOutputB\x13\n" +
+	"\x11provenance_detail\"$\n" +
 	"\x0eGetSpecRequest\x12\x12\n" +
 	"\x04slug\x18\x01 \x01(\tR\x04slug\"Z\n" +
 	"\x10ListSpecsRequest\x12\x14\n" +
@@ -1731,27 +1843,35 @@ var file_specgraph_v1_spec_proto_depIdxs = []int32{
 	1,  // 15: specgraph.v1.InlineDiff.op:type_name -> specgraph.v1.InlineDiff.Op
 	10, // 16: specgraph.v1.VersionDiff.hunks:type_name -> specgraph.v1.InlineDiff
 	11, // 17: specgraph.v1.CompareVersionsResponse.diffs:type_name -> specgraph.v1.VersionDiff
-	5,  // 18: specgraph.v1.ListSpecsResponse.specs:type_name -> specgraph.v1.Spec
-	5,  // 19: specgraph.v1.CreateSpecResponse.spec:type_name -> specgraph.v1.Spec
-	5,  // 20: specgraph.v1.GetSpecResponse.spec:type_name -> specgraph.v1.Spec
-	5,  // 21: specgraph.v1.UpdateSpecResponse.spec:type_name -> specgraph.v1.Spec
-	14, // 22: specgraph.v1.SpecService.CreateSpec:input_type -> specgraph.v1.CreateSpecRequest
-	15, // 23: specgraph.v1.SpecService.GetSpec:input_type -> specgraph.v1.GetSpecRequest
-	16, // 24: specgraph.v1.SpecService.ListSpecs:input_type -> specgraph.v1.ListSpecsRequest
-	18, // 25: specgraph.v1.SpecService.UpdateSpec:input_type -> specgraph.v1.UpdateSpecRequest
-	8,  // 26: specgraph.v1.SpecService.ListChanges:input_type -> specgraph.v1.ListChangesRequest
-	12, // 27: specgraph.v1.SpecService.CompareVersions:input_type -> specgraph.v1.CompareVersionsRequest
-	19, // 28: specgraph.v1.SpecService.CreateSpec:output_type -> specgraph.v1.CreateSpecResponse
-	20, // 29: specgraph.v1.SpecService.GetSpec:output_type -> specgraph.v1.GetSpecResponse
-	17, // 30: specgraph.v1.SpecService.ListSpecs:output_type -> specgraph.v1.ListSpecsResponse
-	21, // 31: specgraph.v1.SpecService.UpdateSpec:output_type -> specgraph.v1.UpdateSpecResponse
-	9,  // 32: specgraph.v1.SpecService.ListChanges:output_type -> specgraph.v1.ListChangesResponse
-	13, // 33: specgraph.v1.SpecService.CompareVersions:output_type -> specgraph.v1.CompareVersionsResponse
-	28, // [28:34] is the sub-list for method output_type
-	22, // [22:28] is the sub-list for method input_type
-	22, // [22:22] is the sub-list for extension type_name
-	22, // [22:22] is the sub-list for extension extendee
-	0,  // [0:22] is the sub-list for field type_name
+	0,  // 18: specgraph.v1.CreateSpecRequest.provenance_type:type_name -> specgraph.v1.SpecProvenance
+	2,  // 19: specgraph.v1.CreateSpecRequest.authored:type_name -> specgraph.v1.AuthoredProvenance
+	3,  // 20: specgraph.v1.CreateSpecRequest.retroactive_from_pr:type_name -> specgraph.v1.RetroactiveFromPrProvenance
+	4,  // 21: specgraph.v1.CreateSpecRequest.declared:type_name -> specgraph.v1.DeclaredProvenance
+	24, // 22: specgraph.v1.CreateSpecRequest.spark_output:type_name -> specgraph.v1.SparkOutput
+	25, // 23: specgraph.v1.CreateSpecRequest.shape_output:type_name -> specgraph.v1.ShapeOutput
+	26, // 24: specgraph.v1.CreateSpecRequest.specify_output:type_name -> specgraph.v1.SpecifyOutput
+	27, // 25: specgraph.v1.CreateSpecRequest.decompose_output:type_name -> specgraph.v1.DecomposeOutput
+	5,  // 26: specgraph.v1.ListSpecsResponse.specs:type_name -> specgraph.v1.Spec
+	5,  // 27: specgraph.v1.CreateSpecResponse.spec:type_name -> specgraph.v1.Spec
+	5,  // 28: specgraph.v1.GetSpecResponse.spec:type_name -> specgraph.v1.Spec
+	5,  // 29: specgraph.v1.UpdateSpecResponse.spec:type_name -> specgraph.v1.Spec
+	14, // 30: specgraph.v1.SpecService.CreateSpec:input_type -> specgraph.v1.CreateSpecRequest
+	15, // 31: specgraph.v1.SpecService.GetSpec:input_type -> specgraph.v1.GetSpecRequest
+	16, // 32: specgraph.v1.SpecService.ListSpecs:input_type -> specgraph.v1.ListSpecsRequest
+	18, // 33: specgraph.v1.SpecService.UpdateSpec:input_type -> specgraph.v1.UpdateSpecRequest
+	8,  // 34: specgraph.v1.SpecService.ListChanges:input_type -> specgraph.v1.ListChangesRequest
+	12, // 35: specgraph.v1.SpecService.CompareVersions:input_type -> specgraph.v1.CompareVersionsRequest
+	19, // 36: specgraph.v1.SpecService.CreateSpec:output_type -> specgraph.v1.CreateSpecResponse
+	20, // 37: specgraph.v1.SpecService.GetSpec:output_type -> specgraph.v1.GetSpecResponse
+	17, // 38: specgraph.v1.SpecService.ListSpecs:output_type -> specgraph.v1.ListSpecsResponse
+	21, // 39: specgraph.v1.SpecService.UpdateSpec:output_type -> specgraph.v1.UpdateSpecResponse
+	9,  // 40: specgraph.v1.SpecService.ListChanges:output_type -> specgraph.v1.ListChangesResponse
+	13, // 41: specgraph.v1.SpecService.CompareVersions:output_type -> specgraph.v1.CompareVersionsResponse
+	36, // [36:42] is the sub-list for method output_type
+	30, // [30:36] is the sub-list for method input_type
+	30, // [30:30] is the sub-list for extension type_name
+	30, // [30:30] is the sub-list for extension extendee
+	0,  // [0:30] is the sub-list for field type_name
 }
 
 func init() { file_specgraph_v1_spec_proto_init() }
@@ -1764,6 +1884,11 @@ func file_specgraph_v1_spec_proto_init() {
 		(*Spec_Authored)(nil),
 		(*Spec_RetroactiveFromPr)(nil),
 		(*Spec_Declared)(nil),
+	}
+	file_specgraph_v1_spec_proto_msgTypes[12].OneofWrappers = []any{
+		(*CreateSpecRequest_Authored)(nil),
+		(*CreateSpecRequest_RetroactiveFromPr)(nil),
+		(*CreateSpecRequest_Declared)(nil),
 	}
 	file_specgraph_v1_spec_proto_msgTypes[16].OneofWrappers = []any{}
 	type x struct{}

--- a/gen/specgraph/v1/spec.pb.go
+++ b/gen/specgraph/v1/spec.pb.go
@@ -25,52 +25,58 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-type SpecLifecycle int32
+// SpecProvenance records how a spec entered the graph. Replaces the
+// earlier SpecLifecycle field (task/living) at pre-1.0 with a clean
+// wire-break — see docs/superpowers/specs/2026-05-20-spec-provenance-model-design.md.
+type SpecProvenance int32
 
 const (
-	SpecLifecycle_SPEC_LIFECYCLE_UNSPECIFIED SpecLifecycle = 0
-	SpecLifecycle_SPEC_LIFECYCLE_TASK        SpecLifecycle = 1
-	SpecLifecycle_SPEC_LIFECYCLE_LIVING      SpecLifecycle = 2
+	SpecProvenance_SPEC_PROVENANCE_UNSPECIFIED         SpecProvenance = 0
+	SpecProvenance_SPEC_PROVENANCE_AUTHORED            SpecProvenance = 1 // forward-authored via the funnel
+	SpecProvenance_SPEC_PROVENANCE_RETROACTIVE_FROM_PR SpecProvenance = 2 // imported from a merged PR/commit
+	SpecProvenance_SPEC_PROVENANCE_DECLARED            SpecProvenance = 3 // human-declared as describing existing reality
 )
 
-// Enum value maps for SpecLifecycle.
+// Enum value maps for SpecProvenance.
 var (
-	SpecLifecycle_name = map[int32]string{
-		0: "SPEC_LIFECYCLE_UNSPECIFIED",
-		1: "SPEC_LIFECYCLE_TASK",
-		2: "SPEC_LIFECYCLE_LIVING",
+	SpecProvenance_name = map[int32]string{
+		0: "SPEC_PROVENANCE_UNSPECIFIED",
+		1: "SPEC_PROVENANCE_AUTHORED",
+		2: "SPEC_PROVENANCE_RETROACTIVE_FROM_PR",
+		3: "SPEC_PROVENANCE_DECLARED",
 	}
-	SpecLifecycle_value = map[string]int32{
-		"SPEC_LIFECYCLE_UNSPECIFIED": 0,
-		"SPEC_LIFECYCLE_TASK":        1,
-		"SPEC_LIFECYCLE_LIVING":      2,
+	SpecProvenance_value = map[string]int32{
+		"SPEC_PROVENANCE_UNSPECIFIED":         0,
+		"SPEC_PROVENANCE_AUTHORED":            1,
+		"SPEC_PROVENANCE_RETROACTIVE_FROM_PR": 2,
+		"SPEC_PROVENANCE_DECLARED":            3,
 	}
 )
 
-func (x SpecLifecycle) Enum() *SpecLifecycle {
-	p := new(SpecLifecycle)
+func (x SpecProvenance) Enum() *SpecProvenance {
+	p := new(SpecProvenance)
 	*p = x
 	return p
 }
 
-func (x SpecLifecycle) String() string {
+func (x SpecProvenance) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (SpecLifecycle) Descriptor() protoreflect.EnumDescriptor {
+func (SpecProvenance) Descriptor() protoreflect.EnumDescriptor {
 	return file_specgraph_v1_spec_proto_enumTypes[0].Descriptor()
 }
 
-func (SpecLifecycle) Type() protoreflect.EnumType {
+func (SpecProvenance) Type() protoreflect.EnumType {
 	return &file_specgraph_v1_spec_proto_enumTypes[0]
 }
 
-func (x SpecLifecycle) Number() protoreflect.EnumNumber {
+func (x SpecProvenance) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use SpecLifecycle.Descriptor instead.
-func (SpecLifecycle) EnumDescriptor() ([]byte, []int) {
+// Deprecated: Use SpecProvenance.Descriptor instead.
+func (SpecProvenance) EnumDescriptor() ([]byte, []int) {
 	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{0}
 }
 
@@ -120,38 +126,209 @@ func (x InlineDiff_Op) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use InlineDiff_Op.Descriptor instead.
 func (InlineDiff_Op) EnumDescriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{5, 0}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{8, 0}
+}
+
+// AuthoredProvenance is the empty payload variant for AUTHORED specs.
+// The audit trail for AUTHORED specs lives in stage outputs and conversation logs.
+type AuthoredProvenance struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AuthoredProvenance) Reset() {
+	*x = AuthoredProvenance{}
+	mi := &file_specgraph_v1_spec_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AuthoredProvenance) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AuthoredProvenance) ProtoMessage() {}
+
+func (x *AuthoredProvenance) ProtoReflect() protoreflect.Message {
+	mi := &file_specgraph_v1_spec_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AuthoredProvenance.ProtoReflect.Descriptor instead.
+func (*AuthoredProvenance) Descriptor() ([]byte, []int) {
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{0}
+}
+
+type RetroactiveFromPrProvenance struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Url           string                 `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"` // PR URL
+	Sha           string                 `protobuf:"bytes,2,opt,name=sha,proto3" json:"sha,omitempty"` // merge commit SHA
+	MergedAt      *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=merged_at,json=mergedAt,proto3" json:"merged_at,omitempty"`
+	Title         string                 `protobuf:"bytes,4,opt,name=title,proto3" json:"title,omitempty"` // PR title at import time
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RetroactiveFromPrProvenance) Reset() {
+	*x = RetroactiveFromPrProvenance{}
+	mi := &file_specgraph_v1_spec_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RetroactiveFromPrProvenance) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RetroactiveFromPrProvenance) ProtoMessage() {}
+
+func (x *RetroactiveFromPrProvenance) ProtoReflect() protoreflect.Message {
+	mi := &file_specgraph_v1_spec_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RetroactiveFromPrProvenance.ProtoReflect.Descriptor instead.
+func (*RetroactiveFromPrProvenance) Descriptor() ([]byte, []int) {
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *RetroactiveFromPrProvenance) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+func (x *RetroactiveFromPrProvenance) GetSha() string {
+	if x != nil {
+		return x.Sha
+	}
+	return ""
+}
+
+func (x *RetroactiveFromPrProvenance) GetMergedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.MergedAt
+	}
+	return nil
+}
+
+func (x *RetroactiveFromPrProvenance) GetTitle() string {
+	if x != nil {
+		return x.Title
+	}
+	return ""
+}
+
+type DeclaredProvenance struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DeclaredBy    string                 `protobuf:"bytes,1,opt,name=declared_by,json=declaredBy,proto3" json:"declared_by,omitempty"` // human or system identifier
+	Note          string                 `protobuf:"bytes,2,opt,name=note,proto3" json:"note,omitempty"`                               // free-text rationale
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeclaredProvenance) Reset() {
+	*x = DeclaredProvenance{}
+	mi := &file_specgraph_v1_spec_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeclaredProvenance) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeclaredProvenance) ProtoMessage() {}
+
+func (x *DeclaredProvenance) ProtoReflect() protoreflect.Message {
+	mi := &file_specgraph_v1_spec_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeclaredProvenance.ProtoReflect.Descriptor instead.
+func (*DeclaredProvenance) Descriptor() ([]byte, []int) {
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *DeclaredProvenance) GetDeclaredBy() string {
+	if x != nil {
+		return x.DeclaredBy
+	}
+	return ""
+}
+
+func (x *DeclaredProvenance) GetNote() string {
+	if x != nil {
+		return x.Note
+	}
+	return ""
 }
 
 type Spec struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	Id                string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                 // stable ULID, e.g. "spec-01JQXYZ..."
-	Slug              string                 `protobuf:"bytes,2,opt,name=slug,proto3" json:"slug,omitempty"`             // human-readable, e.g. "oauth-refresh-rotation"
-	Intent            string                 `protobuf:"bytes,3,opt,name=intent,proto3" json:"intent,omitempty"`         // what this spec is about
-	Stage             string                 `protobuf:"bytes,4,opt,name=stage,proto3" json:"stage,omitempty"`           // spark | shape | specify | decompose | approved | in_progress | done
-	Priority          string                 `protobuf:"bytes,5,opt,name=priority,proto3" json:"priority,omitempty"`     // p0 | p1 | p2 | p3
-	Complexity        string                 `protobuf:"bytes,6,opt,name=complexity,proto3" json:"complexity,omitempty"` // low | medium | high
-	Version           int32                  `protobuf:"varint,7,opt,name=version,proto3" json:"version,omitempty"`
-	CreatedAt         *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
-	UpdatedAt         *timestamppb.Timestamp `protobuf:"bytes,9,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
-	Lifecycle         SpecLifecycle          `protobuf:"varint,10,opt,name=lifecycle,proto3,enum=specgraph.v1.SpecLifecycle" json:"lifecycle,omitempty"`          // task (default) | living
-	SupersededBy      string                 `protobuf:"bytes,11,opt,name=superseded_by,json=supersededBy,proto3" json:"superseded_by,omitempty"`                 // slug of replacement spec, if superseded
-	Supersedes        string                 `protobuf:"bytes,12,opt,name=supersedes,proto3" json:"supersedes,omitempty"`                                         // slug of spec this replaced
-	Notes             string                 `protobuf:"bytes,14,opt,name=notes,proto3" json:"notes,omitempty"`                                                   // free-text notes (conversation summaries, context)
-	ContentHash       string                 `protobuf:"bytes,15,opt,name=content_hash,json=contentHash,proto3" json:"content_hash,omitempty"`                    // Murmur3-128 hex digest of substantive fields; changes on every mutation
-	ConversationLogs  []*ConversationLog     `protobuf:"bytes,16,rep,name=conversation_logs,json=conversationLogs,proto3" json:"conversation_logs,omitempty"`     // authoring conversation audit trail
-	SparkOutput       *SparkOutput           `protobuf:"bytes,17,opt,name=spark_output,json=sparkOutput,proto3" json:"spark_output,omitempty"`                    // populated when stage >= spark
-	ShapeOutput       *ShapeOutput           `protobuf:"bytes,18,opt,name=shape_output,json=shapeOutput,proto3" json:"shape_output,omitempty"`                    // populated when stage >= shape
-	SpecifyOutput     *SpecifyOutput         `protobuf:"bytes,19,opt,name=specify_output,json=specifyOutput,proto3" json:"specify_output,omitempty"`              // populated when stage >= specify
-	DecomposeOutput   *DecomposeOutput       `protobuf:"bytes,20,opt,name=decompose_output,json=decomposeOutput,proto3" json:"decompose_output,omitempty"`        // populated when stage >= decompose
-	ConversationCount int32                  `protobuf:"varint,21,opt,name=conversation_count,json=conversationCount,proto3" json:"conversation_count,omitempty"` // count of conversation log entries (populated by ListSpecs)
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	Id         string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                 // stable ULID, e.g. "spec-01JQXYZ..."
+	Slug       string                 `protobuf:"bytes,2,opt,name=slug,proto3" json:"slug,omitempty"`             // human-readable, e.g. "oauth-refresh-rotation"
+	Intent     string                 `protobuf:"bytes,3,opt,name=intent,proto3" json:"intent,omitempty"`         // what this spec is about
+	Stage      string                 `protobuf:"bytes,4,opt,name=stage,proto3" json:"stage,omitempty"`           // spark | shape | specify | decompose | approved | in_progress | review | done | superseded | abandoned
+	Priority   string                 `protobuf:"bytes,5,opt,name=priority,proto3" json:"priority,omitempty"`     // p0 | p1 | p2 | p3
+	Complexity string                 `protobuf:"bytes,6,opt,name=complexity,proto3" json:"complexity,omitempty"` // low | medium | high
+	Version    int32                  `protobuf:"varint,7,opt,name=version,proto3" json:"version,omitempty"`
+	CreatedAt  *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	UpdatedAt  *timestamppb.Timestamp `protobuf:"bytes,9,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	// WIRE-BREAK: field 10 was `SpecLifecycle lifecycle`. Repurposed at
+	// pre-1.0 (no production data); semantic intent preserved — it's still
+	// "how should the funnel treat this spec," with cleaner axes.
+	ProvenanceType    SpecProvenance     `protobuf:"varint,10,opt,name=provenance_type,json=provenanceType,proto3,enum=specgraph.v1.SpecProvenance" json:"provenance_type,omitempty"`
+	SupersededBy      string             `protobuf:"bytes,11,opt,name=superseded_by,json=supersededBy,proto3" json:"superseded_by,omitempty"`                 // slug of replacement spec, if superseded
+	Supersedes        string             `protobuf:"bytes,12,opt,name=supersedes,proto3" json:"supersedes,omitempty"`                                         // slug of spec this replaced
+	Notes             string             `protobuf:"bytes,14,opt,name=notes,proto3" json:"notes,omitempty"`                                                   // free-text notes (conversation summaries, context)
+	ContentHash       string             `protobuf:"bytes,15,opt,name=content_hash,json=contentHash,proto3" json:"content_hash,omitempty"`                    // Murmur3-128 hex digest of substantive fields; changes on every mutation
+	ConversationLogs  []*ConversationLog `protobuf:"bytes,16,rep,name=conversation_logs,json=conversationLogs,proto3" json:"conversation_logs,omitempty"`     // authoring conversation audit trail
+	SparkOutput       *SparkOutput       `protobuf:"bytes,17,opt,name=spark_output,json=sparkOutput,proto3" json:"spark_output,omitempty"`                    // populated when stage >= spark
+	ShapeOutput       *ShapeOutput       `protobuf:"bytes,18,opt,name=shape_output,json=shapeOutput,proto3" json:"shape_output,omitempty"`                    // populated when stage >= shape
+	SpecifyOutput     *SpecifyOutput     `protobuf:"bytes,19,opt,name=specify_output,json=specifyOutput,proto3" json:"specify_output,omitempty"`              // populated when stage >= specify
+	DecomposeOutput   *DecomposeOutput   `protobuf:"bytes,20,opt,name=decompose_output,json=decomposeOutput,proto3" json:"decompose_output,omitempty"`        // populated when stage >= decompose
+	ConversationCount int32              `protobuf:"varint,21,opt,name=conversation_count,json=conversationCount,proto3" json:"conversation_count,omitempty"` // count of conversation log entries (populated by ListSpecs)
+	// provenance_detail carries the type-specific payload for non-AUTHORED specs.
+	// The populated variant MUST match provenance_type — enforced server-side
+	// with storage.ErrProvenanceMismatch.
+	//
+	// Types that are valid to be assigned to ProvenanceDetail:
+	//
+	//	*Spec_Authored
+	//	*Spec_RetroactiveFromPr
+	//	*Spec_Declared
+	ProvenanceDetail isSpec_ProvenanceDetail `protobuf_oneof:"provenance_detail"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *Spec) Reset() {
 	*x = Spec{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[0]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -163,7 +340,7 @@ func (x *Spec) String() string {
 func (*Spec) ProtoMessage() {}
 
 func (x *Spec) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[0]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -176,7 +353,7 @@ func (x *Spec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Spec.ProtoReflect.Descriptor instead.
 func (*Spec) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{0}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Spec) GetId() string {
@@ -242,11 +419,11 @@ func (x *Spec) GetUpdatedAt() *timestamppb.Timestamp {
 	return nil
 }
 
-func (x *Spec) GetLifecycle() SpecLifecycle {
+func (x *Spec) GetProvenanceType() SpecProvenance {
 	if x != nil {
-		return x.Lifecycle
+		return x.ProvenanceType
 	}
-	return SpecLifecycle_SPEC_LIFECYCLE_UNSPECIFIED
+	return SpecProvenance_SPEC_PROVENANCE_UNSPECIFIED
 }
 
 func (x *Spec) GetSupersededBy() string {
@@ -319,6 +496,62 @@ func (x *Spec) GetConversationCount() int32 {
 	return 0
 }
 
+func (x *Spec) GetProvenanceDetail() isSpec_ProvenanceDetail {
+	if x != nil {
+		return x.ProvenanceDetail
+	}
+	return nil
+}
+
+func (x *Spec) GetAuthored() *AuthoredProvenance {
+	if x != nil {
+		if x, ok := x.ProvenanceDetail.(*Spec_Authored); ok {
+			return x.Authored
+		}
+	}
+	return nil
+}
+
+func (x *Spec) GetRetroactiveFromPr() *RetroactiveFromPrProvenance {
+	if x != nil {
+		if x, ok := x.ProvenanceDetail.(*Spec_RetroactiveFromPr); ok {
+			return x.RetroactiveFromPr
+		}
+	}
+	return nil
+}
+
+func (x *Spec) GetDeclared() *DeclaredProvenance {
+	if x != nil {
+		if x, ok := x.ProvenanceDetail.(*Spec_Declared); ok {
+			return x.Declared
+		}
+	}
+	return nil
+}
+
+type isSpec_ProvenanceDetail interface {
+	isSpec_ProvenanceDetail()
+}
+
+type Spec_Authored struct {
+	Authored *AuthoredProvenance `protobuf:"bytes,22,opt,name=authored,proto3,oneof"`
+}
+
+type Spec_RetroactiveFromPr struct {
+	RetroactiveFromPr *RetroactiveFromPrProvenance `protobuf:"bytes,23,opt,name=retroactive_from_pr,json=retroactiveFromPr,proto3,oneof"`
+}
+
+type Spec_Declared struct {
+	Declared *DeclaredProvenance `protobuf:"bytes,24,opt,name=declared,proto3,oneof"`
+}
+
+func (*Spec_Authored) isSpec_ProvenanceDetail() {}
+
+func (*Spec_RetroactiveFromPr) isSpec_ProvenanceDetail() {}
+
+func (*Spec_Declared) isSpec_ProvenanceDetail() {}
+
 type FieldChange struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Field         string                 `protobuf:"bytes,1,opt,name=field,proto3" json:"field,omitempty"`
@@ -330,7 +563,7 @@ type FieldChange struct {
 
 func (x *FieldChange) Reset() {
 	*x = FieldChange{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[1]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -342,7 +575,7 @@ func (x *FieldChange) String() string {
 func (*FieldChange) ProtoMessage() {}
 
 func (x *FieldChange) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[1]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -355,7 +588,7 @@ func (x *FieldChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FieldChange.ProtoReflect.Descriptor instead.
 func (*FieldChange) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{1}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *FieldChange) GetField() string {
@@ -396,7 +629,7 @@ type ChangeLogEntry struct {
 
 func (x *ChangeLogEntry) Reset() {
 	*x = ChangeLogEntry{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[2]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -408,7 +641,7 @@ func (x *ChangeLogEntry) String() string {
 func (*ChangeLogEntry) ProtoMessage() {}
 
 func (x *ChangeLogEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[2]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -421,7 +654,7 @@ func (x *ChangeLogEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeLogEntry.ProtoReflect.Descriptor instead.
 func (*ChangeLogEntry) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{2}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ChangeLogEntry) GetId() string {
@@ -499,7 +732,7 @@ type ListChangesRequest struct {
 
 func (x *ListChangesRequest) Reset() {
 	*x = ListChangesRequest{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[3]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -511,7 +744,7 @@ func (x *ListChangesRequest) String() string {
 func (*ListChangesRequest) ProtoMessage() {}
 
 func (x *ListChangesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[3]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -524,7 +757,7 @@ func (x *ListChangesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListChangesRequest.ProtoReflect.Descriptor instead.
 func (*ListChangesRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{3}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ListChangesRequest) GetSlug() string {
@@ -564,7 +797,7 @@ type ListChangesResponse struct {
 
 func (x *ListChangesResponse) Reset() {
 	*x = ListChangesResponse{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[4]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -576,7 +809,7 @@ func (x *ListChangesResponse) String() string {
 func (*ListChangesResponse) ProtoMessage() {}
 
 func (x *ListChangesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[4]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -589,7 +822,7 @@ func (x *ListChangesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListChangesResponse.ProtoReflect.Descriptor instead.
 func (*ListChangesResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{4}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ListChangesResponse) GetEntries() []*ChangeLogEntry {
@@ -609,7 +842,7 @@ type InlineDiff struct {
 
 func (x *InlineDiff) Reset() {
 	*x = InlineDiff{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[5]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -621,7 +854,7 @@ func (x *InlineDiff) String() string {
 func (*InlineDiff) ProtoMessage() {}
 
 func (x *InlineDiff) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[5]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -634,7 +867,7 @@ func (x *InlineDiff) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InlineDiff.ProtoReflect.Descriptor instead.
 func (*InlineDiff) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{5}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *InlineDiff) GetOp() InlineDiff_Op {
@@ -663,7 +896,7 @@ type VersionDiff struct {
 
 func (x *VersionDiff) Reset() {
 	*x = VersionDiff{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[6]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -675,7 +908,7 @@ func (x *VersionDiff) String() string {
 func (*VersionDiff) ProtoMessage() {}
 
 func (x *VersionDiff) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[6]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -688,7 +921,7 @@ func (x *VersionDiff) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VersionDiff.ProtoReflect.Descriptor instead.
 func (*VersionDiff) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{6}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *VersionDiff) GetField() string {
@@ -730,7 +963,7 @@ type CompareVersionsRequest struct {
 
 func (x *CompareVersionsRequest) Reset() {
 	*x = CompareVersionsRequest{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[7]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -742,7 +975,7 @@ func (x *CompareVersionsRequest) String() string {
 func (*CompareVersionsRequest) ProtoMessage() {}
 
 func (x *CompareVersionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[7]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -755,7 +988,7 @@ func (x *CompareVersionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CompareVersionsRequest.ProtoReflect.Descriptor instead.
 func (*CompareVersionsRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{7}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *CompareVersionsRequest) GetSlug() string {
@@ -792,7 +1025,7 @@ type CompareVersionsResponse struct {
 
 func (x *CompareVersionsResponse) Reset() {
 	*x = CompareVersionsResponse{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[8]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -804,7 +1037,7 @@ func (x *CompareVersionsResponse) String() string {
 func (*CompareVersionsResponse) ProtoMessage() {}
 
 func (x *CompareVersionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[8]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -817,7 +1050,7 @@ func (x *CompareVersionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CompareVersionsResponse.ProtoReflect.Descriptor instead.
 func (*CompareVersionsResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{8}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *CompareVersionsResponse) GetFromVersion() int32 {
@@ -867,7 +1100,7 @@ type CreateSpecRequest struct {
 
 func (x *CreateSpecRequest) Reset() {
 	*x = CreateSpecRequest{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[9]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -879,7 +1112,7 @@ func (x *CreateSpecRequest) String() string {
 func (*CreateSpecRequest) ProtoMessage() {}
 
 func (x *CreateSpecRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[9]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -892,7 +1125,7 @@ func (x *CreateSpecRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSpecRequest.ProtoReflect.Descriptor instead.
 func (*CreateSpecRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{9}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *CreateSpecRequest) GetSlug() string {
@@ -932,7 +1165,7 @@ type GetSpecRequest struct {
 
 func (x *GetSpecRequest) Reset() {
 	*x = GetSpecRequest{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[10]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -944,7 +1177,7 @@ func (x *GetSpecRequest) String() string {
 func (*GetSpecRequest) ProtoMessage() {}
 
 func (x *GetSpecRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[10]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -957,7 +1190,7 @@ func (x *GetSpecRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSpecRequest.ProtoReflect.Descriptor instead.
 func (*GetSpecRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{10}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *GetSpecRequest) GetSlug() string {
@@ -978,7 +1211,7 @@ type ListSpecsRequest struct {
 
 func (x *ListSpecsRequest) Reset() {
 	*x = ListSpecsRequest{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[11]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -990,7 +1223,7 @@ func (x *ListSpecsRequest) String() string {
 func (*ListSpecsRequest) ProtoMessage() {}
 
 func (x *ListSpecsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[11]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1003,7 +1236,7 @@ func (x *ListSpecsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSpecsRequest.ProtoReflect.Descriptor instead.
 func (*ListSpecsRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{11}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ListSpecsRequest) GetStage() string {
@@ -1036,7 +1269,7 @@ type ListSpecsResponse struct {
 
 func (x *ListSpecsResponse) Reset() {
 	*x = ListSpecsResponse{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[12]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1048,7 +1281,7 @@ func (x *ListSpecsResponse) String() string {
 func (*ListSpecsResponse) ProtoMessage() {}
 
 func (x *ListSpecsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[12]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1061,7 +1294,7 @@ func (x *ListSpecsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSpecsResponse.ProtoReflect.Descriptor instead.
 func (*ListSpecsResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{12}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ListSpecsResponse) GetSpecs() []*Spec {
@@ -1085,7 +1318,7 @@ type UpdateSpecRequest struct {
 
 func (x *UpdateSpecRequest) Reset() {
 	*x = UpdateSpecRequest{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[13]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1097,7 +1330,7 @@ func (x *UpdateSpecRequest) String() string {
 func (*UpdateSpecRequest) ProtoMessage() {}
 
 func (x *UpdateSpecRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[13]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1110,7 +1343,7 @@ func (x *UpdateSpecRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSpecRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSpecRequest) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{13}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *UpdateSpecRequest) GetSlug() string {
@@ -1164,7 +1397,7 @@ type CreateSpecResponse struct {
 
 func (x *CreateSpecResponse) Reset() {
 	*x = CreateSpecResponse{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[14]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1176,7 +1409,7 @@ func (x *CreateSpecResponse) String() string {
 func (*CreateSpecResponse) ProtoMessage() {}
 
 func (x *CreateSpecResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[14]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1189,7 +1422,7 @@ func (x *CreateSpecResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSpecResponse.ProtoReflect.Descriptor instead.
 func (*CreateSpecResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{14}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *CreateSpecResponse) GetSpec() *Spec {
@@ -1208,7 +1441,7 @@ type GetSpecResponse struct {
 
 func (x *GetSpecResponse) Reset() {
 	*x = GetSpecResponse{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[15]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1220,7 +1453,7 @@ func (x *GetSpecResponse) String() string {
 func (*GetSpecResponse) ProtoMessage() {}
 
 func (x *GetSpecResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[15]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1233,7 +1466,7 @@ func (x *GetSpecResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSpecResponse.ProtoReflect.Descriptor instead.
 func (*GetSpecResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{15}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *GetSpecResponse) GetSpec() *Spec {
@@ -1252,7 +1485,7 @@ type UpdateSpecResponse struct {
 
 func (x *UpdateSpecResponse) Reset() {
 	*x = UpdateSpecResponse{}
-	mi := &file_specgraph_v1_spec_proto_msgTypes[16]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1264,7 +1497,7 @@ func (x *UpdateSpecResponse) String() string {
 func (*UpdateSpecResponse) ProtoMessage() {}
 
 func (x *UpdateSpecResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_specgraph_v1_spec_proto_msgTypes[16]
+	mi := &file_specgraph_v1_spec_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1277,7 +1510,7 @@ func (x *UpdateSpecResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSpecResponse.ProtoReflect.Descriptor instead.
 func (*UpdateSpecResponse) Descriptor() ([]byte, []int) {
-	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{16}
+	return file_specgraph_v1_spec_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *UpdateSpecResponse) GetSpec() *Spec {
@@ -1291,7 +1524,17 @@ var File_specgraph_v1_spec_proto protoreflect.FileDescriptor
 
 const file_specgraph_v1_spec_proto_rawDesc = "" +
 	"\n" +
-	"\x17specgraph/v1/spec.proto\x12\fspecgraph.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cspecgraph/v1/authoring.proto\"\xf1\x06\n" +
+	"\x17specgraph/v1/spec.proto\x12\fspecgraph.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cspecgraph/v1/authoring.proto\"\x14\n" +
+	"\x12AuthoredProvenance\"\x90\x01\n" +
+	"\x1bRetroactiveFromPrProvenance\x12\x10\n" +
+	"\x03url\x18\x01 \x01(\tR\x03url\x12\x10\n" +
+	"\x03sha\x18\x02 \x01(\tR\x03sha\x127\n" +
+	"\tmerged_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\bmergedAt\x12\x14\n" +
+	"\x05title\x18\x04 \x01(\tR\x05title\"I\n" +
+	"\x12DeclaredProvenance\x12\x1f\n" +
+	"\vdeclared_by\x18\x01 \x01(\tR\n" +
+	"declaredBy\x12\x12\n" +
+	"\x04note\x18\x02 \x01(\tR\x04note\"\xef\b\n" +
 	"\x04Spec\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x12\x16\n" +
@@ -1305,9 +1548,9 @@ const file_specgraph_v1_spec_proto_rawDesc = "" +
 	"\n" +
 	"created_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
 	"\n" +
-	"updated_at\x18\t \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\x129\n" +
-	"\tlifecycle\x18\n" +
-	" \x01(\x0e2\x1b.specgraph.v1.SpecLifecycleR\tlifecycle\x12#\n" +
+	"updated_at\x18\t \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\x12E\n" +
+	"\x0fprovenance_type\x18\n" +
+	" \x01(\x0e2\x1c.specgraph.v1.SpecProvenanceR\x0eprovenanceType\x12#\n" +
 	"\rsuperseded_by\x18\v \x01(\tR\fsupersededBy\x12\x1e\n" +
 	"\n" +
 	"supersedes\x18\f \x01(\tR\n" +
@@ -1319,7 +1562,11 @@ const file_specgraph_v1_spec_proto_rawDesc = "" +
 	"\fshape_output\x18\x12 \x01(\v2\x19.specgraph.v1.ShapeOutputR\vshapeOutput\x12B\n" +
 	"\x0especify_output\x18\x13 \x01(\v2\x1b.specgraph.v1.SpecifyOutputR\rspecifyOutput\x12H\n" +
 	"\x10decompose_output\x18\x14 \x01(\v2\x1d.specgraph.v1.DecomposeOutputR\x0fdecomposeOutput\x12-\n" +
-	"\x12conversation_count\x18\x15 \x01(\x05R\x11conversationCountJ\x04\b\r\x10\x0eR\ahistory\"]\n" +
+	"\x12conversation_count\x18\x15 \x01(\x05R\x11conversationCount\x12>\n" +
+	"\bauthored\x18\x16 \x01(\v2 .specgraph.v1.AuthoredProvenanceH\x00R\bauthored\x12[\n" +
+	"\x13retroactive_from_pr\x18\x17 \x01(\v2).specgraph.v1.RetroactiveFromPrProvenanceH\x00R\x11retroactiveFromPr\x12>\n" +
+	"\bdeclared\x18\x18 \x01(\v2 .specgraph.v1.DeclaredProvenanceH\x00R\bdeclaredB\x13\n" +
+	"\x11provenance_detailJ\x04\b\r\x10\x0eR\ahistory\"]\n" +
 	"\vFieldChange\x12\x14\n" +
 	"\x05field\x18\x01 \x01(\tR\x05field\x12\x1b\n" +
 	"\told_value\x18\x02 \x01(\tR\boldValue\x12\x1b\n" +
@@ -1405,11 +1652,12 @@ const file_specgraph_v1_spec_proto_rawDesc = "" +
 	"\x0fGetSpecResponse\x12&\n" +
 	"\x04spec\x18\x01 \x01(\v2\x12.specgraph.v1.SpecR\x04spec\"<\n" +
 	"\x12UpdateSpecResponse\x12&\n" +
-	"\x04spec\x18\x01 \x01(\v2\x12.specgraph.v1.SpecR\x04spec*c\n" +
-	"\rSpecLifecycle\x12\x1e\n" +
-	"\x1aSPEC_LIFECYCLE_UNSPECIFIED\x10\x00\x12\x17\n" +
-	"\x13SPEC_LIFECYCLE_TASK\x10\x01\x12\x19\n" +
-	"\x15SPEC_LIFECYCLE_LIVING\x10\x022\xf9\x03\n" +
+	"\x04spec\x18\x01 \x01(\v2\x12.specgraph.v1.SpecR\x04spec*\x96\x01\n" +
+	"\x0eSpecProvenance\x12\x1f\n" +
+	"\x1bSPEC_PROVENANCE_UNSPECIFIED\x10\x00\x12\x1c\n" +
+	"\x18SPEC_PROVENANCE_AUTHORED\x10\x01\x12'\n" +
+	"#SPEC_PROVENANCE_RETROACTIVE_FROM_PR\x10\x02\x12\x1c\n" +
+	"\x18SPEC_PROVENANCE_DECLARED\x10\x032\xf9\x03\n" +
 	"\vSpecService\x12O\n" +
 	"\n" +
 	"CreateSpec\x12\x1f.specgraph.v1.CreateSpecRequest\x1a .specgraph.v1.CreateSpecResponse\x12F\n" +
@@ -1433,70 +1681,77 @@ func file_specgraph_v1_spec_proto_rawDescGZIP() []byte {
 }
 
 var file_specgraph_v1_spec_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_specgraph_v1_spec_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_specgraph_v1_spec_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_specgraph_v1_spec_proto_goTypes = []any{
-	(SpecLifecycle)(0),              // 0: specgraph.v1.SpecLifecycle
-	(InlineDiff_Op)(0),              // 1: specgraph.v1.InlineDiff.Op
-	(*Spec)(nil),                    // 2: specgraph.v1.Spec
-	(*FieldChange)(nil),             // 3: specgraph.v1.FieldChange
-	(*ChangeLogEntry)(nil),          // 4: specgraph.v1.ChangeLogEntry
-	(*ListChangesRequest)(nil),      // 5: specgraph.v1.ListChangesRequest
-	(*ListChangesResponse)(nil),     // 6: specgraph.v1.ListChangesResponse
-	(*InlineDiff)(nil),              // 7: specgraph.v1.InlineDiff
-	(*VersionDiff)(nil),             // 8: specgraph.v1.VersionDiff
-	(*CompareVersionsRequest)(nil),  // 9: specgraph.v1.CompareVersionsRequest
-	(*CompareVersionsResponse)(nil), // 10: specgraph.v1.CompareVersionsResponse
-	(*CreateSpecRequest)(nil),       // 11: specgraph.v1.CreateSpecRequest
-	(*GetSpecRequest)(nil),          // 12: specgraph.v1.GetSpecRequest
-	(*ListSpecsRequest)(nil),        // 13: specgraph.v1.ListSpecsRequest
-	(*ListSpecsResponse)(nil),       // 14: specgraph.v1.ListSpecsResponse
-	(*UpdateSpecRequest)(nil),       // 15: specgraph.v1.UpdateSpecRequest
-	(*CreateSpecResponse)(nil),      // 16: specgraph.v1.CreateSpecResponse
-	(*GetSpecResponse)(nil),         // 17: specgraph.v1.GetSpecResponse
-	(*UpdateSpecResponse)(nil),      // 18: specgraph.v1.UpdateSpecResponse
-	(*timestamppb.Timestamp)(nil),   // 19: google.protobuf.Timestamp
-	(*ConversationLog)(nil),         // 20: specgraph.v1.ConversationLog
-	(*SparkOutput)(nil),             // 21: specgraph.v1.SparkOutput
-	(*ShapeOutput)(nil),             // 22: specgraph.v1.ShapeOutput
-	(*SpecifyOutput)(nil),           // 23: specgraph.v1.SpecifyOutput
-	(*DecomposeOutput)(nil),         // 24: specgraph.v1.DecomposeOutput
+	(SpecProvenance)(0),                 // 0: specgraph.v1.SpecProvenance
+	(InlineDiff_Op)(0),                  // 1: specgraph.v1.InlineDiff.Op
+	(*AuthoredProvenance)(nil),          // 2: specgraph.v1.AuthoredProvenance
+	(*RetroactiveFromPrProvenance)(nil), // 3: specgraph.v1.RetroactiveFromPrProvenance
+	(*DeclaredProvenance)(nil),          // 4: specgraph.v1.DeclaredProvenance
+	(*Spec)(nil),                        // 5: specgraph.v1.Spec
+	(*FieldChange)(nil),                 // 6: specgraph.v1.FieldChange
+	(*ChangeLogEntry)(nil),              // 7: specgraph.v1.ChangeLogEntry
+	(*ListChangesRequest)(nil),          // 8: specgraph.v1.ListChangesRequest
+	(*ListChangesResponse)(nil),         // 9: specgraph.v1.ListChangesResponse
+	(*InlineDiff)(nil),                  // 10: specgraph.v1.InlineDiff
+	(*VersionDiff)(nil),                 // 11: specgraph.v1.VersionDiff
+	(*CompareVersionsRequest)(nil),      // 12: specgraph.v1.CompareVersionsRequest
+	(*CompareVersionsResponse)(nil),     // 13: specgraph.v1.CompareVersionsResponse
+	(*CreateSpecRequest)(nil),           // 14: specgraph.v1.CreateSpecRequest
+	(*GetSpecRequest)(nil),              // 15: specgraph.v1.GetSpecRequest
+	(*ListSpecsRequest)(nil),            // 16: specgraph.v1.ListSpecsRequest
+	(*ListSpecsResponse)(nil),           // 17: specgraph.v1.ListSpecsResponse
+	(*UpdateSpecRequest)(nil),           // 18: specgraph.v1.UpdateSpecRequest
+	(*CreateSpecResponse)(nil),          // 19: specgraph.v1.CreateSpecResponse
+	(*GetSpecResponse)(nil),             // 20: specgraph.v1.GetSpecResponse
+	(*UpdateSpecResponse)(nil),          // 21: specgraph.v1.UpdateSpecResponse
+	(*timestamppb.Timestamp)(nil),       // 22: google.protobuf.Timestamp
+	(*ConversationLog)(nil),             // 23: specgraph.v1.ConversationLog
+	(*SparkOutput)(nil),                 // 24: specgraph.v1.SparkOutput
+	(*ShapeOutput)(nil),                 // 25: specgraph.v1.ShapeOutput
+	(*SpecifyOutput)(nil),               // 26: specgraph.v1.SpecifyOutput
+	(*DecomposeOutput)(nil),             // 27: specgraph.v1.DecomposeOutput
 }
 var file_specgraph_v1_spec_proto_depIdxs = []int32{
-	19, // 0: specgraph.v1.Spec.created_at:type_name -> google.protobuf.Timestamp
-	19, // 1: specgraph.v1.Spec.updated_at:type_name -> google.protobuf.Timestamp
-	0,  // 2: specgraph.v1.Spec.lifecycle:type_name -> specgraph.v1.SpecLifecycle
-	20, // 3: specgraph.v1.Spec.conversation_logs:type_name -> specgraph.v1.ConversationLog
-	21, // 4: specgraph.v1.Spec.spark_output:type_name -> specgraph.v1.SparkOutput
-	22, // 5: specgraph.v1.Spec.shape_output:type_name -> specgraph.v1.ShapeOutput
-	23, // 6: specgraph.v1.Spec.specify_output:type_name -> specgraph.v1.SpecifyOutput
-	24, // 7: specgraph.v1.Spec.decompose_output:type_name -> specgraph.v1.DecomposeOutput
-	3,  // 8: specgraph.v1.ChangeLogEntry.changes:type_name -> specgraph.v1.FieldChange
-	19, // 9: specgraph.v1.ChangeLogEntry.date:type_name -> google.protobuf.Timestamp
-	4,  // 10: specgraph.v1.ListChangesResponse.entries:type_name -> specgraph.v1.ChangeLogEntry
-	1,  // 11: specgraph.v1.InlineDiff.op:type_name -> specgraph.v1.InlineDiff.Op
-	7,  // 12: specgraph.v1.VersionDiff.hunks:type_name -> specgraph.v1.InlineDiff
-	8,  // 13: specgraph.v1.CompareVersionsResponse.diffs:type_name -> specgraph.v1.VersionDiff
-	2,  // 14: specgraph.v1.ListSpecsResponse.specs:type_name -> specgraph.v1.Spec
-	2,  // 15: specgraph.v1.CreateSpecResponse.spec:type_name -> specgraph.v1.Spec
-	2,  // 16: specgraph.v1.GetSpecResponse.spec:type_name -> specgraph.v1.Spec
-	2,  // 17: specgraph.v1.UpdateSpecResponse.spec:type_name -> specgraph.v1.Spec
-	11, // 18: specgraph.v1.SpecService.CreateSpec:input_type -> specgraph.v1.CreateSpecRequest
-	12, // 19: specgraph.v1.SpecService.GetSpec:input_type -> specgraph.v1.GetSpecRequest
-	13, // 20: specgraph.v1.SpecService.ListSpecs:input_type -> specgraph.v1.ListSpecsRequest
-	15, // 21: specgraph.v1.SpecService.UpdateSpec:input_type -> specgraph.v1.UpdateSpecRequest
-	5,  // 22: specgraph.v1.SpecService.ListChanges:input_type -> specgraph.v1.ListChangesRequest
-	9,  // 23: specgraph.v1.SpecService.CompareVersions:input_type -> specgraph.v1.CompareVersionsRequest
-	16, // 24: specgraph.v1.SpecService.CreateSpec:output_type -> specgraph.v1.CreateSpecResponse
-	17, // 25: specgraph.v1.SpecService.GetSpec:output_type -> specgraph.v1.GetSpecResponse
-	14, // 26: specgraph.v1.SpecService.ListSpecs:output_type -> specgraph.v1.ListSpecsResponse
-	18, // 27: specgraph.v1.SpecService.UpdateSpec:output_type -> specgraph.v1.UpdateSpecResponse
-	6,  // 28: specgraph.v1.SpecService.ListChanges:output_type -> specgraph.v1.ListChangesResponse
-	10, // 29: specgraph.v1.SpecService.CompareVersions:output_type -> specgraph.v1.CompareVersionsResponse
-	24, // [24:30] is the sub-list for method output_type
-	18, // [18:24] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	22, // 0: specgraph.v1.RetroactiveFromPrProvenance.merged_at:type_name -> google.protobuf.Timestamp
+	22, // 1: specgraph.v1.Spec.created_at:type_name -> google.protobuf.Timestamp
+	22, // 2: specgraph.v1.Spec.updated_at:type_name -> google.protobuf.Timestamp
+	0,  // 3: specgraph.v1.Spec.provenance_type:type_name -> specgraph.v1.SpecProvenance
+	23, // 4: specgraph.v1.Spec.conversation_logs:type_name -> specgraph.v1.ConversationLog
+	24, // 5: specgraph.v1.Spec.spark_output:type_name -> specgraph.v1.SparkOutput
+	25, // 6: specgraph.v1.Spec.shape_output:type_name -> specgraph.v1.ShapeOutput
+	26, // 7: specgraph.v1.Spec.specify_output:type_name -> specgraph.v1.SpecifyOutput
+	27, // 8: specgraph.v1.Spec.decompose_output:type_name -> specgraph.v1.DecomposeOutput
+	2,  // 9: specgraph.v1.Spec.authored:type_name -> specgraph.v1.AuthoredProvenance
+	3,  // 10: specgraph.v1.Spec.retroactive_from_pr:type_name -> specgraph.v1.RetroactiveFromPrProvenance
+	4,  // 11: specgraph.v1.Spec.declared:type_name -> specgraph.v1.DeclaredProvenance
+	6,  // 12: specgraph.v1.ChangeLogEntry.changes:type_name -> specgraph.v1.FieldChange
+	22, // 13: specgraph.v1.ChangeLogEntry.date:type_name -> google.protobuf.Timestamp
+	7,  // 14: specgraph.v1.ListChangesResponse.entries:type_name -> specgraph.v1.ChangeLogEntry
+	1,  // 15: specgraph.v1.InlineDiff.op:type_name -> specgraph.v1.InlineDiff.Op
+	10, // 16: specgraph.v1.VersionDiff.hunks:type_name -> specgraph.v1.InlineDiff
+	11, // 17: specgraph.v1.CompareVersionsResponse.diffs:type_name -> specgraph.v1.VersionDiff
+	5,  // 18: specgraph.v1.ListSpecsResponse.specs:type_name -> specgraph.v1.Spec
+	5,  // 19: specgraph.v1.CreateSpecResponse.spec:type_name -> specgraph.v1.Spec
+	5,  // 20: specgraph.v1.GetSpecResponse.spec:type_name -> specgraph.v1.Spec
+	5,  // 21: specgraph.v1.UpdateSpecResponse.spec:type_name -> specgraph.v1.Spec
+	14, // 22: specgraph.v1.SpecService.CreateSpec:input_type -> specgraph.v1.CreateSpecRequest
+	15, // 23: specgraph.v1.SpecService.GetSpec:input_type -> specgraph.v1.GetSpecRequest
+	16, // 24: specgraph.v1.SpecService.ListSpecs:input_type -> specgraph.v1.ListSpecsRequest
+	18, // 25: specgraph.v1.SpecService.UpdateSpec:input_type -> specgraph.v1.UpdateSpecRequest
+	8,  // 26: specgraph.v1.SpecService.ListChanges:input_type -> specgraph.v1.ListChangesRequest
+	12, // 27: specgraph.v1.SpecService.CompareVersions:input_type -> specgraph.v1.CompareVersionsRequest
+	19, // 28: specgraph.v1.SpecService.CreateSpec:output_type -> specgraph.v1.CreateSpecResponse
+	20, // 29: specgraph.v1.SpecService.GetSpec:output_type -> specgraph.v1.GetSpecResponse
+	17, // 30: specgraph.v1.SpecService.ListSpecs:output_type -> specgraph.v1.ListSpecsResponse
+	21, // 31: specgraph.v1.SpecService.UpdateSpec:output_type -> specgraph.v1.UpdateSpecResponse
+	9,  // 32: specgraph.v1.SpecService.ListChanges:output_type -> specgraph.v1.ListChangesResponse
+	13, // 33: specgraph.v1.SpecService.CompareVersions:output_type -> specgraph.v1.CompareVersionsResponse
+	28, // [28:34] is the sub-list for method output_type
+	22, // [22:28] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_specgraph_v1_spec_proto_init() }
@@ -1505,14 +1760,19 @@ func file_specgraph_v1_spec_proto_init() {
 		return
 	}
 	file_specgraph_v1_authoring_proto_init()
-	file_specgraph_v1_spec_proto_msgTypes[13].OneofWrappers = []any{}
+	file_specgraph_v1_spec_proto_msgTypes[3].OneofWrappers = []any{
+		(*Spec_Authored)(nil),
+		(*Spec_RetroactiveFromPr)(nil),
+		(*Spec_Declared)(nil),
+	}
+	file_specgraph_v1_spec_proto_msgTypes[16].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_specgraph_v1_spec_proto_rawDesc), len(file_specgraph_v1_spec_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   17,
+			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/export/engine.go
+++ b/internal/export/engine.go
@@ -386,7 +386,7 @@ func (e *Engine) writeEntities(ctx context.Context, doc *Document) (*ImportResul
 
 	// 3. Specs — create then restore stage via Store*Output + TransitionStage
 	for _, spec := range doc.Data.Specs {
-		if _, err := e.backend.CreateSpec(ctx, spec.Slug, spec.Intent, string(spec.Priority), string(spec.Complexity)); err != nil {
+		if _, err := e.backend.CreateSpec(ctx, spec.Slug, spec.Intent, string(spec.Priority), string(spec.Complexity), storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil); err != nil {
 			return nil, fmt.Errorf("create spec %q: %w", spec.Slug, err)
 		}
 
@@ -445,24 +445,15 @@ func (e *Engine) writeEntities(ctx context.Context, doc *Document) (*ImportResul
 			}
 		}
 
-		// Restore lifecycle and notes via UpdateSpec.
-		if spec.Lifecycle != "" || spec.Notes != "" || spec.SupersededBy != "" || spec.Supersedes != "" {
-			var lifecycle, notes *string
-			if spec.Lifecycle != "" {
-				l := string(spec.Lifecycle)
-				lifecycle = &l
-			}
+		// Restore notes via UpdateSpec. (Lifecycle field removed in migration 007;
+		// provenance is now stored at create time, not replayed here.)
+		if spec.Notes != "" || spec.SupersededBy != "" || spec.Supersedes != "" {
 			if spec.Notes != "" {
-				notes = &spec.Notes
-			}
-			// UpdateSpec only supports intent, stage, priority, complexity, notes.
-			// lifecycle/supersededBy/supersedes are set via other paths.
-			if notes != nil {
-				if _, err := e.backend.UpdateSpec(ctx, spec.Slug, nil, nil, nil, nil, notes); err != nil {
+				notes := spec.Notes
+				if _, err := e.backend.UpdateSpec(ctx, spec.Slug, nil, nil, nil, nil, &notes); err != nil {
 					res.Warnings = append(res.Warnings, fmt.Sprintf("update notes for %q: %v", spec.Slug, err))
 				}
 			}
-			_ = lifecycle // lifecycle is set implicitly by storage layer
 		}
 
 		res.Specs++

--- a/internal/export/engine.go
+++ b/internal/export/engine.go
@@ -384,9 +384,28 @@ func (e *Engine) writeEntities(ctx context.Context, doc *Document) (*ImportResul
 		res.Constitution = 1
 	}
 
-	// 3. Specs — create then restore stage via Store*Output + TransitionStage
+	// 3. Specs — create then restore stage via Store*Output + TransitionStage.
+	// Preserves the original provenance and provenance detail from the imported
+	// document so DECLARED/RETROACTIVE specs don't get rewritten as AUTHORED.
 	for _, spec := range doc.Data.Specs {
-		if _, err := e.backend.CreateSpec(ctx, spec.Slug, spec.Intent, string(spec.Priority), string(spec.Complexity), storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil); err != nil {
+		provenance := spec.Provenance
+		if provenance == "" {
+			provenance = storage.SpecProvenanceAuthored
+		}
+		// For AUTHORED specs, the stage outputs are replayed below to advance the
+		// funnel — pass nil at create. For RETROACTIVE/DECLARED specs, all four
+		// outputs must be present at create (validateProvenance enforces this).
+		var spark *storage.SparkOutput
+		var shape *storage.ShapeOutput
+		var specifyOut *storage.SpecifyOutput
+		var decompose *storage.DecomposeOutput
+		if provenance != storage.SpecProvenanceAuthored {
+			spark = spec.SparkOutput
+			shape = spec.ShapeOutput
+			specifyOut = spec.SpecifyOutput
+			decompose = spec.DecomposeOutput
+		}
+		if _, err := e.backend.CreateSpec(ctx, spec.Slug, spec.Intent, string(spec.Priority), string(spec.Complexity), provenance, spec.ProvenanceDetail, spark, shape, specifyOut, decompose); err != nil {
 			return nil, fmt.Errorf("create spec %q: %w", spec.Slug, err)
 		}
 

--- a/internal/linter/schema.go
+++ b/internal/linter/schema.go
@@ -68,12 +68,22 @@ func ValidateSchema(spec *storage.Spec) []storage.LintViolation {
 		})
 	}
 
-	// Validate lifecycle enum
-	if spec.Lifecycle != "" && !spec.Lifecycle.IsValid() {
+	// Validate provenance type
+	if spec.Provenance != "" && !spec.Provenance.IsValid() {
 		violations = append(violations, storage.LintViolation{
 			Rule: "schema.enum", Severity: storage.LintSeverityError,
-			Message:  fmt.Sprintf("invalid lifecycle %q", spec.Lifecycle),
-			Location: "lifecycle",
+			Message:  fmt.Sprintf("invalid provenance %q", spec.Provenance),
+			Location: "provenance",
+		})
+	}
+
+	// Provenance and stage consistency: non-AUTHORED specs must be at done.
+	if spec.Provenance != storage.SpecProvenanceAuthored && spec.Provenance != "" &&
+		spec.Stage != storage.SpecStageDone {
+		violations = append(violations, storage.LintViolation{
+			Rule: "schema.conditional", Severity: storage.LintSeverityError,
+			Message:  fmt.Sprintf("provenance %q requires stage=done (got %q)", spec.Provenance, spec.Stage),
+			Location: "provenance",
 		})
 	}
 

--- a/internal/linter/schema_test.go
+++ b/internal/linter/schema_test.go
@@ -106,13 +106,13 @@ func TestValidateSchema_InvalidComplexity(t *testing.T) {
 	require.Equal(t, "complexity", violations[0].Location)
 }
 
-func TestValidateSchema_LivingLifecycle(t *testing.T) {
+func TestValidateSchema_DeclaredProvenance(t *testing.T) {
 	spec := &storage.Spec{
-		Slug:      "living-spec",
-		Intent:    "Always evolving",
-		Stage:     storage.SpecStageApproved,
-		Lifecycle: "living",
-		Version:   1,
+		Slug:       "declared-spec",
+		Intent:     "Always evolving",
+		Stage:      storage.SpecStageDone,
+		Provenance: storage.SpecProvenanceDeclared,
+		Version:    1,
 	}
 	violations := linter.ValidateSchema(spec)
 	require.Empty(t, violations)
@@ -142,18 +142,18 @@ func TestValidateSchema_VersionZero(t *testing.T) {
 	require.Contains(t, minViolations[0].Message, "version must be >= 1")
 }
 
-func TestValidateSchema_InvalidLifecycle(t *testing.T) {
+func TestValidateSchema_InvalidProvenance(t *testing.T) {
 	spec := &storage.Spec{
-		Slug:      "bad-lifecycle",
-		Intent:    "Has invalid lifecycle",
-		Stage:     storage.SpecStageSpark,
-		Version:   1,
-		Lifecycle: storage.SpecLifecycle("bogus"),
+		Slug:       "bad-provenance",
+		Intent:     "Has invalid provenance",
+		Stage:      storage.SpecStageSpark,
+		Version:    1,
+		Provenance: storage.SpecProvenanceType("bogus"),
 	}
 	violations := linter.ValidateSchema(spec)
 	enumViolations := filterByRule(violations, "schema.enum")
 	require.Len(t, enumViolations, 1)
-	require.Contains(t, enumViolations[0].Message, "invalid lifecycle")
+	require.Contains(t, enumViolations[0].Message, "invalid provenance")
 }
 
 func TestValidateSchema_NilSpec(t *testing.T) {

--- a/internal/mcp/tools_spec.go
+++ b/internal/mcp/tools_spec.go
@@ -5,10 +5,16 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // RegisterSpecTools registers the spec and decision tools into the registry.
@@ -38,15 +44,21 @@ func (t *specTool) def() ToolDef {
 			props{
 				"action": stringProp("Operation to perform",
 					"get", "list", "create", "update", "changes", "compare"),
-				"slug":         stringProp("Spec slug (required for get/update/changes/compare)"),
-				"intent":       stringProp("What the spec is about (required for create)"),
-				"stage":        stringProp("Authoring stage filter or update value"),
-				"priority":     stringProp("Priority: p0, p1, p2, p3"),
-				"complexity":   stringProp("Complexity: low, medium, high"),
-				"notes":        stringProp("Free-text notes to attach to the spec"),
-				"limit":        intProp("Max results to return for list (default 50)"),
-				"from_version": intProp("From-version for compare"),
-				"to_version":   intProp("To-version for compare"),
+				"slug":               stringProp("Spec slug (required for get/update/changes/compare)"),
+				"intent":             stringProp("What the spec is about (required for create)"),
+				"stage":              stringProp("Authoring stage filter or update value"),
+				"priority":           stringProp("Priority: p0, p1, p2, p3"),
+				"complexity":         stringProp("Complexity: low, medium, high"),
+				"notes":              stringProp("Free-text notes to attach to the spec"),
+				"limit":              intProp("Max results to return for list (default 50)"),
+				"from_version":       intProp("From-version for compare"),
+				"to_version":         intProp("To-version for compare"),
+				"provenance":         stringProp("Provenance type for create: authored | retroactive_from_pr | declared"),
+				"provenance_detail":  stringProp(`JSON-encoded provenance detail object. For retroactive_from_pr: {"url":"...","sha":"...","title":"...","merged_at":"RFC3339"}. For declared: {"declared_by":"...","note":"..."}`),
+				"spark_output":       stringProp("protojson-encoded SparkOutput (optional, non-AUTHORED creates)"),
+				"shape_output":       stringProp("protojson-encoded ShapeOutput (optional, non-AUTHORED creates)"),
+				"specify_output":     stringProp("protojson-encoded SpecifyOutput (optional, non-AUTHORED creates)"),
+				"decompose_output":   stringProp("protojson-encoded DecomposeOutput (optional, non-AUTHORED creates)"),
 			},
 			"action",
 		),
@@ -111,17 +123,117 @@ func (t *specTool) handleCreate(ctx context.Context, params map[string]any) (*To
 	if intent == "" {
 		return errResult("intent is required for create"), nil
 	}
-	resp, err := t.client.Spec.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
-		Slug:       slug,
-		Intent:     intent,
-		Priority:   stringParam(params, "priority"),
-		Complexity: stringParam(params, "complexity"),
-	}))
+
+	provFlag := stringParam(params, "provenance")
+	var provEnum specv1.SpecProvenance
+	switch strings.ToLower(provFlag) {
+	case "", "authored":
+		provEnum = specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED
+	case "retroactive_from_pr", "retroactive-from-pr", "retroactive":
+		provEnum = specv1.SpecProvenance_SPEC_PROVENANCE_RETROACTIVE_FROM_PR
+	case "declared":
+		provEnum = specv1.SpecProvenance_SPEC_PROVENANCE_DECLARED
+	default:
+		return errResult(fmt.Sprintf("invalid provenance %q (valid: authored, retroactive_from_pr, declared)", provFlag)), nil
+	}
+
+	req := &specv1.CreateSpecRequest{
+		Slug:           slug,
+		Intent:         intent,
+		Priority:       stringParam(params, "priority"),
+		Complexity:     stringParam(params, "complexity"),
+		ProvenanceType: provEnum,
+	}
+
+	// Parse provenance_detail JSON envelope when provided.
+	if detailJSON := stringParam(params, "provenance_detail"); detailJSON != "" {
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(detailJSON), &raw); err != nil {
+			return errResult(fmt.Sprintf("invalid provenance_detail JSON: %v", err)), nil
+		}
+		switch provEnum {
+		case specv1.SpecProvenance_SPEC_PROVENANCE_RETROACTIVE_FROM_PR:
+			var pd struct {
+				URL      string `json:"url"`
+				SHA      string `json:"sha"`
+				Title    string `json:"title"`
+				MergedAt string `json:"merged_at"`
+			}
+			if err := json.Unmarshal([]byte(detailJSON), &pd); err != nil {
+				return errResult(fmt.Sprintf("invalid retroactive_from_pr provenance_detail: %v", err)), nil
+			}
+			prov := &specv1.RetroactiveFromPrProvenance{
+				Url:   pd.URL,
+				Sha:   pd.SHA,
+				Title: pd.Title,
+			}
+			if pd.MergedAt != "" {
+				t, err := time.Parse(time.RFC3339, pd.MergedAt)
+				if err != nil {
+					return errResult(fmt.Sprintf("invalid merged_at timestamp: %v", err)), nil
+				}
+				prov.MergedAt = timestamppb.New(t)
+			}
+			req.ProvenanceDetail = &specv1.CreateSpecRequest_RetroactiveFromPr{RetroactiveFromPr: prov}
+		case specv1.SpecProvenance_SPEC_PROVENANCE_DECLARED:
+			var pd struct {
+				DeclaredBy string `json:"declared_by"`
+				Note       string `json:"note"`
+			}
+			if err := json.Unmarshal([]byte(detailJSON), &pd); err != nil {
+				return errResult(fmt.Sprintf("invalid declared provenance_detail: %v", err)), nil
+			}
+			req.ProvenanceDetail = &specv1.CreateSpecRequest_Declared{
+				Declared: &specv1.DeclaredProvenance{DeclaredBy: pd.DeclaredBy, Note: pd.Note},
+			}
+		}
+	}
+
+	// Parse stage output params via protojson.
+	if s := stringParam(params, "spark_output"); s != "" {
+		msg := &specv1.SparkOutput{}
+		if err := unmarshalProtoJSON(s, msg); err != nil {
+			return errResult(fmt.Sprintf("invalid spark_output: %v", err)), nil
+		}
+		req.SparkOutput = msg
+	}
+	if s := stringParam(params, "shape_output"); s != "" {
+		msg := &specv1.ShapeOutput{}
+		if err := unmarshalProtoJSON(s, msg); err != nil {
+			return errResult(fmt.Sprintf("invalid shape_output: %v", err)), nil
+		}
+		req.ShapeOutput = msg
+	}
+	if s := stringParam(params, "specify_output"); s != "" {
+		msg := &specv1.SpecifyOutput{}
+		if err := unmarshalProtoJSON(s, msg); err != nil {
+			return errResult(fmt.Sprintf("invalid specify_output: %v", err)), nil
+		}
+		req.SpecifyOutput = msg
+	}
+	if s := stringParam(params, "decompose_output"); s != "" {
+		msg := &specv1.DecomposeOutput{}
+		if err := unmarshalProtoJSON(s, msg); err != nil {
+			return errResult(fmt.Sprintf("invalid decompose_output: %v", err)), nil
+		}
+		req.DecomposeOutput = msg
+	}
+
+	resp, err := t.client.Spec.CreateSpec(ctx, connect.NewRequest(req))
 	if err != nil {
 		result, rerr := connectErrResult(err)
 		return result, rerr
 	}
 	return jsonResult(resp.Msg), nil
+}
+
+// unmarshalProtoJSON decodes a protojson string into a proto.Message.
+func unmarshalProtoJSON(s string, msg proto.Message) error {
+	opts := protojson.UnmarshalOptions{DiscardUnknown: false}
+	if err := opts.Unmarshal([]byte(s), msg); err != nil {
+		return fmt.Errorf("unmarshal proto JSON: %w", err)
+	}
+	return nil
 }
 
 func (t *specTool) handleUpdate(ctx context.Context, params map[string]any) (*ToolResult, error) {

--- a/internal/render/spec.go
+++ b/internal/render/spec.go
@@ -27,7 +27,7 @@ func Spec(s *specv1.Spec) string {
 		{"Priority", s.Priority},
 		{"Complexity", s.Complexity},
 		{"Version", fmt.Sprintf("%d", s.Version)},
-		{"Lifecycle", lifecycleString(s.Lifecycle)},
+		{"Provenance", provenanceString(s.GetProvenanceType())},
 	}
 	b.WriteString(metadataTable(pairs))
 
@@ -54,13 +54,38 @@ func SpecList(specs []*specv1.Spec) string {
 	return itemTable(headers, rows)
 }
 
-func lifecycleString(lc specv1.SpecLifecycle) string {
-	switch lc {
-	case specv1.SpecLifecycle_SPEC_LIFECYCLE_TASK:
-		return "task"
-	case specv1.SpecLifecycle_SPEC_LIFECYCLE_LIVING:
-		return "living"
+func provenanceString(p specv1.SpecProvenance) string {
+	switch p {
+	case specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED:
+		return "AUTHORED"
+	case specv1.SpecProvenance_SPEC_PROVENANCE_RETROACTIVE_FROM_PR:
+		return "RETROACTIVE_FROM_PR"
+	case specv1.SpecProvenance_SPEC_PROVENANCE_DECLARED:
+		return "DECLARED"
 	default:
-		return "unspecified"
+		return "UNSPECIFIED"
+	}
+}
+
+// renderProvenanceBlock formats the provenance line(s) for spec render output.
+// Always renders at least one line — no silent-default for AUTHORED.
+func renderProvenanceBlock(s *specv1.Spec) string {
+	pt := s.GetProvenanceType()
+	switch d := s.GetProvenanceDetail().(type) {
+	case *specv1.Spec_RetroactiveFromPr:
+		r := d.RetroactiveFromPr
+		return fmt.Sprintf(
+			"provenance:   %s\n              %s\n              merged %s (commit %s)",
+			provenanceString(pt), r.GetUrl(),
+			r.GetMergedAt().AsTime().Format("2006-01-02"),
+			r.GetSha(),
+		)
+	case *specv1.Spec_Declared:
+		return fmt.Sprintf(
+			"provenance:   %s\n              declared by %s: %q",
+			provenanceString(pt), d.Declared.GetDeclaredBy(), d.Declared.GetNote(),
+		)
+	default:
+		return fmt.Sprintf("provenance:   %s", provenanceString(pt))
 	}
 }

--- a/internal/render/spec.go
+++ b/internal/render/spec.go
@@ -67,25 +67,9 @@ func provenanceString(p specv1.SpecProvenance) string {
 	}
 }
 
-// renderProvenanceBlock formats the provenance line(s) for spec render output.
-// Always renders at least one line — no silent-default for AUTHORED.
-func renderProvenanceBlock(s *specv1.Spec) string {
-	pt := s.GetProvenanceType()
-	switch d := s.GetProvenanceDetail().(type) {
-	case *specv1.Spec_RetroactiveFromPr:
-		r := d.RetroactiveFromPr
-		return fmt.Sprintf(
-			"provenance:   %s\n              %s\n              merged %s (commit %s)",
-			provenanceString(pt), r.GetUrl(),
-			r.GetMergedAt().AsTime().Format("2006-01-02"),
-			r.GetSha(),
-		)
-	case *specv1.Spec_Declared:
-		return fmt.Sprintf(
-			"provenance:   %s\n              declared by %s: %q",
-			provenanceString(pt), d.Declared.GetDeclaredBy(), d.Declared.GetNote(),
-		)
-	default:
-		return fmt.Sprintf("provenance:   %s", provenanceString(pt))
-	}
-}
+// Note: a richer renderProvenanceBlock that includes RETROACTIVE/DECLARED
+// detail was prototyped but not wired into the metadata table. The table
+// format displays only the provenance type via provenanceString; the
+// structured detail surfaces in the corresponding stage outputs and via
+// the spec's notes. Re-introduce a block renderer if a future use case
+// needs the detail rendered separately from the table.

--- a/internal/render/spec_test.go
+++ b/internal/render/spec_test.go
@@ -12,13 +12,13 @@ import (
 
 func TestSpec(t *testing.T) {
 	s := &specv1.Spec{
-		Slug:       "login-api",
-		Intent:     "Implement OAuth2 login flow",
-		Stage:      "specify",
-		Priority:   "p1",
-		Complexity: "medium",
-		Version:    3,
-		Lifecycle:  specv1.SpecLifecycle_SPEC_LIFECYCLE_TASK,
+		Slug:           "login-api",
+		Intent:         "Implement OAuth2 login flow",
+		Stage:          "specify",
+		Priority:       "p1",
+		Complexity:     "medium",
+		Version:        3,
+		ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED,
 	}
 	got := Spec(s)
 	if !strings.Contains(got, "# login-api") {
@@ -33,8 +33,8 @@ func TestSpec(t *testing.T) {
 	if !strings.Contains(got, "| Priority | p1 |") {
 		t.Error("missing priority row")
 	}
-	if !strings.Contains(got, "| Lifecycle | task |") {
-		t.Error("missing lifecycle row")
+	if !strings.Contains(got, "| Provenance | AUTHORED |") {
+		t.Error("missing provenance row")
 	}
 }
 

--- a/internal/server/analytical_pass_handler_test.go
+++ b/internal/server/analytical_pass_handler_test.go
@@ -41,7 +41,7 @@ func newAnalyticalPassTestBackend() *analyticalPassTestBackend {
 	}
 }
 
-func (b *analyticalPassTestBackend) CreateSpec(_ context.Context, slug, intent, priority, complexity string) (*storage.Spec, error) {
+func (b *analyticalPassTestBackend) CreateSpec(_ context.Context, slug, intent, priority, complexity string, _ storage.SpecProvenanceType, _ storage.SpecProvenanceDetail, _ *storage.SparkOutput, _ *storage.ShapeOutput, _ *storage.SpecifyOutput, _ *storage.DecomposeOutput) (*storage.Spec, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	spec := &storage.Spec{
@@ -50,6 +50,7 @@ func (b *analyticalPassTestBackend) CreateSpec(_ context.Context, slug, intent, 
 		Stage:       storage.SpecStageSpark,
 		Priority:    storage.SpecPriority(priority),
 		Complexity:  storage.SpecComplexity(complexity),
+		Provenance:  storage.SpecProvenanceAuthored,
 		Version:     1,
 		ContentHash: strings.Repeat("a", 32),
 		CreatedAt:   time.Now(),
@@ -150,7 +151,7 @@ func setupAnalyticalPassServer(t *testing.T, backend storage.ScopedBackend) spec
 
 func TestRunAnalyticalPass_ReturnsPromptAndTools(t *testing.T) {
 	backend := newAnalyticalPassTestBackend()
-	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium")
+	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	client := setupAnalyticalPassServer(t, backend)
@@ -175,7 +176,7 @@ func TestRunAnalyticalPass_ReturnsPromptAndTools(t *testing.T) {
 
 func TestRunAnalyticalPass_UnknownPassType(t *testing.T) {
 	backend := newAnalyticalPassTestBackend()
-	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium")
+	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	client := setupAnalyticalPassServer(t, backend)
@@ -202,7 +203,7 @@ func TestRunAnalyticalPass_SpecNotFound(t *testing.T) {
 
 func TestStoreAndListFindings_RoundTrip(t *testing.T) {
 	backend := newAnalyticalPassTestBackend()
-	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium")
+	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	client := setupAnalyticalPassServer(t, backend)
@@ -243,7 +244,7 @@ func TestStoreAndListFindings_RoundTrip(t *testing.T) {
 
 func TestListFindings_EmptyPassType(t *testing.T) {
 	backend := newAnalyticalPassTestBackend()
-	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium")
+	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	client := setupAnalyticalPassServer(t, backend)
@@ -292,7 +293,7 @@ func TestListProjectFindings_EmptyProject(t *testing.T) {
 
 func TestListProjectFindings_OneSpecNoFindings(t *testing.T) {
 	backend := newAnalyticalPassTestBackend()
-	_, err := backend.CreateSpec(context.Background(), "spec-without-findings", "Test spec", "p1", "medium")
+	_, err := backend.CreateSpec(context.Background(), "spec-without-findings", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	client := setupAnalyticalPassServer(t, backend)
 
@@ -303,9 +304,9 @@ func TestListProjectFindings_OneSpecNoFindings(t *testing.T) {
 
 func TestListProjectFindings_MultipleSpecs(t *testing.T) {
 	backend := newAnalyticalPassTestBackend()
-	_, err := backend.CreateSpec(context.Background(), "spec-a", "A", "p1", "medium")
+	_, err := backend.CreateSpec(context.Background(), "spec-a", "A", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = backend.CreateSpec(context.Background(), "spec-b", "B", "p1", "medium")
+	_, err = backend.CreateSpec(context.Background(), "spec-b", "B", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	client := setupAnalyticalPassServer(t, backend)
 
@@ -344,9 +345,9 @@ func TestListProjectFindings_MultipleSpecs(t *testing.T) {
 
 func TestListProjectFindings_FilterByPassType(t *testing.T) {
 	backend := newAnalyticalPassTestBackend()
-	_, err := backend.CreateSpec(context.Background(), "spec-a", "A", "p1", "medium")
+	_, err := backend.CreateSpec(context.Background(), "spec-a", "A", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = backend.CreateSpec(context.Background(), "spec-b", "B", "p1", "medium")
+	_, err = backend.CreateSpec(context.Background(), "spec-b", "B", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	client := setupAnalyticalPassServer(t, backend)
 
@@ -380,7 +381,7 @@ func TestListProjectFindings_FilterByPassType(t *testing.T) {
 
 func TestStoreFindings_UnknownPassType(t *testing.T) {
 	backend := newAnalyticalPassTestBackend()
-	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium")
+	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	client := setupAnalyticalPassServer(t, backend)
@@ -419,7 +420,7 @@ func TestStoreFindings_SpecNotFound(t *testing.T) {
 
 func TestStoreFindings_NullFindingElement(t *testing.T) {
 	backend := newAnalyticalPassTestBackend()
-	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium")
+	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	client := setupAnalyticalPassServer(t, backend)
@@ -435,7 +436,7 @@ func TestStoreFindings_NullFindingElement(t *testing.T) {
 
 func TestStoreFindings_TooManyFindings(t *testing.T) {
 	backend := newAnalyticalPassTestBackend()
-	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium")
+	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	client := setupAnalyticalPassServer(t, backend)
@@ -483,7 +484,7 @@ func TestListFindings_EmptySlug(t *testing.T) {
 
 func TestListFindings_UnknownPassType(t *testing.T) {
 	backend := newAnalyticalPassTestBackend()
-	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium")
+	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	client := setupAnalyticalPassServer(t, backend)
@@ -524,7 +525,7 @@ func TestRunAnalyticalPass_TemplateOverride(t *testing.T) {
 	require.NoError(t, err)
 
 	backend := newAnalyticalPassTestBackend()
-	_, err = backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium")
+	_, err = backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	client := setupAnalyticalPassServerWithOverrideDir(t, backend, overrideDir)
@@ -542,7 +543,7 @@ func TestRunAnalyticalPass_TemplateOverrideFallback(t *testing.T) {
 	overrideDir := t.TempDir()
 
 	backend := newAnalyticalPassTestBackend()
-	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium")
+	_, err := backend.CreateSpec(context.Background(), "my-spec", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	client := setupAnalyticalPassServerWithOverrideDir(t, backend, overrideDir)

--- a/internal/server/authoring_handler.go
+++ b/internal/server/authoring_handler.go
@@ -77,7 +77,7 @@ func (h *AuthoringHandler) Spark(ctx context.Context, req *connect.Request[specv
 	var safetyFlags []authoring.SafetyFlagResult
 	ops := []func(context.Context) error{
 		func(c context.Context) error {
-			if _, err := store.CreateSpec(c, msg.Slug, msg.Output.GetSeed(), defaultSpecPriority, defaultSpecComplexity); err != nil {
+			if _, err := store.CreateSpec(c, msg.Slug, msg.Output.GetSeed(), defaultSpecPriority, defaultSpecComplexity, storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil); err != nil {
 				return fmt.Errorf("create spec: %w", err)
 			}
 			return nil

--- a/internal/server/authoring_handler_test.go
+++ b/internal/server/authoring_handler_test.go
@@ -93,14 +93,14 @@ func (f *fakeTxBackend) RunInTransaction(_ context.Context, fn func(ctx context.
 	return fn(context.Background())
 }
 
-func (f *fakeBackend) CreateSpec(_ context.Context, slug, _, _, _ string) (*storage.Spec, error) {
+func (f *fakeBackend) CreateSpec(_ context.Context, slug, _, _, _ string, _ storage.SpecProvenanceType, _ storage.SpecProvenanceDetail, _ *storage.SparkOutput, _ *storage.ShapeOutput, _ *storage.SpecifyOutput, _ *storage.DecomposeOutput) (*storage.Spec, error) {
 	if f.createSpecErr != nil {
 		return nil, f.createSpecErr
 	}
 	if f.createSpecResult != nil {
 		return f.createSpecResult, nil
 	}
-	return &storage.Spec{Slug: slug, ContentHash: strings.Repeat("a", 32)}, nil
+	return &storage.Spec{Slug: slug, Provenance: storage.SpecProvenanceAuthored, ContentHash: strings.Repeat("a", 32)}, nil
 }
 
 func (f *fakeBackend) GetSpec(_ context.Context, slug string) (*storage.Spec, error) {
@@ -144,8 +144,8 @@ func (a *txAuthoringTestBackend) RunInTransaction(_ context.Context, fn func(con
 	return fn(context.Background())
 }
 
-func (a *authoringTestBackend) CreateSpec(ctx context.Context, slug, intent, priority, complexity string) (*storage.Spec, error) {
-	return a.backend.CreateSpec(ctx, slug, intent, priority, complexity)
+func (a *authoringTestBackend) CreateSpec(ctx context.Context, slug, intent, priority, complexity string, provenance storage.SpecProvenanceType, detail storage.SpecProvenanceDetail, spark *storage.SparkOutput, shape *storage.ShapeOutput, specify *storage.SpecifyOutput, decompose *storage.DecomposeOutput) (*storage.Spec, error) {
+	return a.backend.CreateSpec(ctx, slug, intent, priority, complexity, provenance, detail, spark, shape, specify, decompose)
 }
 
 func (a *authoringTestBackend) GetSpec(ctx context.Context, slug string) (*storage.Spec, error) {

--- a/internal/server/claim_handler.go
+++ b/internal/server/claim_handler.go
@@ -41,6 +41,14 @@ func (h *ClaimHandler) ClaimSpec(ctx context.Context, req *connect.Request[specv
 		leaseDuration = msg.LeaseDuration.AsDuration()
 	}
 
+	spec, err := store.GetSpec(ctx, msg.SpecSlug)
+	if err != nil {
+		return nil, claimError(err)
+	}
+	if spec.Provenance != storage.SpecProvenanceAuthored {
+		return nil, connect.NewError(connect.CodeInvalidArgument, storage.ErrClaimRequiresAuthored)
+	}
+
 	claim, err := store.ClaimSpec(ctx, msg.SpecSlug, msg.Agent, leaseDuration)
 	if err != nil {
 		return nil, claimError(err)

--- a/internal/server/claim_handler_test.go
+++ b/internal/server/claim_handler_test.go
@@ -31,6 +31,15 @@ func newMockClaimBackend() *mockClaimBackend {
 	return &mockClaimBackend{claims: make(map[string]*storage.Claim)}
 }
 
+// GetSpec returns a minimal AUTHORED spec so the claim handler's provenance
+// gate passes without requiring a full storage backend.
+func (m *mockClaimBackend) GetSpec(_ context.Context, slug string) (*storage.Spec, error) {
+	return &storage.Spec{
+		Slug:       slug,
+		Provenance: storage.SpecProvenanceAuthored,
+	}, nil
+}
+
 func (m *mockClaimBackend) ClaimSpec(_ context.Context, slug, agent string, leaseDuration time.Duration) (*storage.Claim, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/server/convert_spec.go
+++ b/internal/server/convert_spec.go
@@ -13,7 +13,7 @@ import (
 // --- Spec ---
 
 func specToProto(s *storage.Spec) (*specv1.Spec, error) {
-	lc, err := lifecycleToProto(s.Lifecycle)
+	pt, err := specProvenanceToProto(s.Provenance)
 	if err != nil {
 		return nil, fmt.Errorf("spec %q: %w", s.Slug, err)
 	}
@@ -27,13 +27,14 @@ func specToProto(s *storage.Spec) (*specv1.Spec, error) {
 		Version:           s.Version,
 		CreatedAt:         timeToProto(s.CreatedAt),
 		UpdatedAt:         timeToProto(s.UpdatedAt),
-		Lifecycle:         lc,
+		ProvenanceType:    pt,
 		SupersededBy:      s.SupersededBy,
 		Supersedes:        s.Supersedes,
 		Notes:             s.Notes,
 		ContentHash:       s.ContentHash,
 		ConversationCount: safeConvCount(s.ConversationCount),
 	}
+	setSpecProvenanceDetailOnProto(pb, s.ProvenanceDetail)
 	if s.ConversationLogs != nil {
 		logs := make([]*specv1.ConversationLog, len(s.ConversationLogs))
 		for i, entry := range s.ConversationLogs {
@@ -67,20 +68,84 @@ func specsToProto(specs []*storage.Spec) ([]*specv1.Spec, error) {
 	return result, nil
 }
 
-// --- Lifecycle ---
+// --- Provenance ---
 
-// lifecycleToProtoMap maps storage lifecycle values to proto enums.
-// The empty-string entry handles pre-lifecycle specs (created before the field existed)
-// that have no lifecycle set in the graph — these map to UNSPECIFIED on the wire.
-var lifecycleToProtoMap = map[storage.SpecLifecycle]specv1.SpecLifecycle{
-	"":                          specv1.SpecLifecycle_SPEC_LIFECYCLE_UNSPECIFIED,
-	storage.SpecLifecycleTask:   specv1.SpecLifecycle_SPEC_LIFECYCLE_TASK,
-	storage.SpecLifecycleLiving: specv1.SpecLifecycle_SPEC_LIFECYCLE_LIVING,
+// specProvenanceToProtoMap maps storage provenance values to proto enums.
+var specProvenanceToProtoMap = map[storage.SpecProvenanceType]specv1.SpecProvenance{
+	storage.SpecProvenanceAuthored:          specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED,
+	storage.SpecProvenanceRetroactiveFromPR: specv1.SpecProvenance_SPEC_PROVENANCE_RETROACTIVE_FROM_PR,
+	storage.SpecProvenanceDeclared:          specv1.SpecProvenance_SPEC_PROVENANCE_DECLARED,
 }
 
-func lifecycleToProto(l storage.SpecLifecycle) (specv1.SpecLifecycle, error) {
-	if v, ok := lifecycleToProtoMap[l]; ok {
+func specProvenanceToProto(p storage.SpecProvenanceType) (specv1.SpecProvenance, error) {
+	if v, ok := specProvenanceToProtoMap[p]; ok {
 		return v, nil
 	}
-	return specv1.SpecLifecycle_SPEC_LIFECYCLE_UNSPECIFIED, fmt.Errorf("unknown lifecycle: %q", l)
+	return specv1.SpecProvenance_SPEC_PROVENANCE_UNSPECIFIED, fmt.Errorf("unknown provenance: %q", p)
+}
+
+// setSpecProvenanceDetailOnProto sets the oneof field on the proto Spec based on
+// which variant pointer (if any) is populated in the domain detail struct.
+// The oneof interface (isSpec_ProvenanceDetail) is unexported from the gen
+// package, so we assign directly rather than returning an interface value.
+func setSpecProvenanceDetailOnProto(pb *specv1.Spec, d storage.SpecProvenanceDetail) {
+	switch {
+	case d.RetroactiveFromPR != nil:
+		pb.ProvenanceDetail = &specv1.Spec_RetroactiveFromPr{
+			RetroactiveFromPr: &specv1.RetroactiveFromPrProvenance{
+				Url:      d.RetroactiveFromPR.URL,
+				Sha:      d.RetroactiveFromPR.SHA,
+				MergedAt: timeToProto(d.RetroactiveFromPR.MergedAt),
+				Title:    d.RetroactiveFromPR.Title,
+			},
+		}
+	case d.Declared != nil:
+		pb.ProvenanceDetail = &specv1.Spec_Declared{
+			Declared: &specv1.DeclaredProvenance{
+				DeclaredBy: d.Declared.DeclaredBy,
+				Note:       d.Declared.Note,
+			},
+		}
+	default:
+		// AUTHORED — empty payload.
+		pb.ProvenanceDetail = &specv1.Spec_Authored{Authored: &specv1.AuthoredProvenance{}}
+	}
+}
+
+// specProvenanceFromProto converts a proto enum back to the storage discriminator.
+func specProvenanceFromProto(p specv1.SpecProvenance) (storage.SpecProvenanceType, error) {
+	for domainVal, protoVal := range specProvenanceToProtoMap {
+		if protoVal == p {
+			return domainVal, nil
+		}
+	}
+	return "", fmt.Errorf("unknown provenance enum: %q", p.String())
+}
+
+// specProvenanceDetailFromProto reads the oneof on a proto Spec and returns the
+// domain detail struct. The caller passes pb.GetProvenanceDetail() — same
+// unexported-interface caveat as above.
+func specProvenanceDetailFromProto(pb *specv1.Spec) storage.SpecProvenanceDetail {
+	switch v := pb.GetProvenanceDetail().(type) {
+	case *specv1.Spec_RetroactiveFromPr:
+		return storage.SpecProvenanceDetail{
+			RetroactiveFromPR: &storage.RetroactivePRProvenance{
+				URL:      v.RetroactiveFromPr.GetUrl(),
+				SHA:      v.RetroactiveFromPr.GetSha(),
+				MergedAt: v.RetroactiveFromPr.GetMergedAt().AsTime(),
+				Title:    v.RetroactiveFromPr.GetTitle(),
+			},
+		}
+	case *specv1.Spec_Declared:
+		return storage.SpecProvenanceDetail{
+			Declared: &storage.DeclaredProvenance{
+				DeclaredBy: v.Declared.GetDeclaredBy(),
+				Note:       v.Declared.GetNote(),
+			},
+		}
+	case *specv1.Spec_Authored:
+		return storage.SpecProvenanceDetail{}
+	default:
+		return storage.SpecProvenanceDetail{}
+	}
 }

--- a/internal/server/convert_spec.go
+++ b/internal/server/convert_spec.go
@@ -149,3 +149,30 @@ func specProvenanceDetailFromProto(pb *specv1.Spec) storage.SpecProvenanceDetail
 		return storage.SpecProvenanceDetail{}
 	}
 }
+
+// createSpecProvenanceDetailFromProto reads the provenance_detail oneof from a
+// CreateSpecRequest and returns the domain detail struct.
+func createSpecProvenanceDetailFromProto(msg *specv1.CreateSpecRequest) storage.SpecProvenanceDetail {
+	switch v := msg.GetProvenanceDetail().(type) {
+	case *specv1.CreateSpecRequest_RetroactiveFromPr:
+		return storage.SpecProvenanceDetail{
+			RetroactiveFromPR: &storage.RetroactivePRProvenance{
+				URL:      v.RetroactiveFromPr.GetUrl(),
+				SHA:      v.RetroactiveFromPr.GetSha(),
+				MergedAt: v.RetroactiveFromPr.GetMergedAt().AsTime(),
+				Title:    v.RetroactiveFromPr.GetTitle(),
+			},
+		}
+	case *specv1.CreateSpecRequest_Declared:
+		return storage.SpecProvenanceDetail{
+			Declared: &storage.DeclaredProvenance{
+				DeclaredBy: v.Declared.GetDeclaredBy(),
+				Note:       v.Declared.GetNote(),
+			},
+		}
+	case *specv1.CreateSpecRequest_Authored:
+		return storage.SpecProvenanceDetail{}
+	default:
+		return storage.SpecProvenanceDetail{}
+	}
+}

--- a/internal/server/convert_spec.go
+++ b/internal/server/convert_spec.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"fmt"
+	"time"
 
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/specgraph/specgraph/internal/storage"
@@ -127,11 +128,15 @@ func specProvenanceFromProto(p specv1.SpecProvenance) (storage.SpecProvenanceTyp
 func createSpecProvenanceDetailFromProto(msg *specv1.CreateSpecRequest) storage.SpecProvenanceDetail {
 	switch v := msg.GetProvenanceDetail().(type) {
 	case *specv1.CreateSpecRequest_RetroactiveFromPr:
+		var mergedAt time.Time
+		if ts := v.RetroactiveFromPr.GetMergedAt(); ts != nil {
+			mergedAt = ts.AsTime()
+		}
 		return storage.SpecProvenanceDetail{
 			RetroactiveFromPR: &storage.RetroactivePRProvenance{
 				URL:      v.RetroactiveFromPr.GetUrl(),
 				SHA:      v.RetroactiveFromPr.GetSha(),
-				MergedAt: v.RetroactiveFromPr.GetMergedAt().AsTime(),
+				MergedAt: mergedAt,
 				Title:    v.RetroactiveFromPr.GetTitle(),
 			},
 		}

--- a/internal/server/convert_spec.go
+++ b/internal/server/convert_spec.go
@@ -122,34 +122,6 @@ func specProvenanceFromProto(p specv1.SpecProvenance) (storage.SpecProvenanceTyp
 	return "", fmt.Errorf("unknown provenance enum: %q", p.String())
 }
 
-// specProvenanceDetailFromProto reads the oneof on a proto Spec and returns the
-// domain detail struct. The caller passes pb.GetProvenanceDetail() — same
-// unexported-interface caveat as above.
-func specProvenanceDetailFromProto(pb *specv1.Spec) storage.SpecProvenanceDetail {
-	switch v := pb.GetProvenanceDetail().(type) {
-	case *specv1.Spec_RetroactiveFromPr:
-		return storage.SpecProvenanceDetail{
-			RetroactiveFromPR: &storage.RetroactivePRProvenance{
-				URL:      v.RetroactiveFromPr.GetUrl(),
-				SHA:      v.RetroactiveFromPr.GetSha(),
-				MergedAt: v.RetroactiveFromPr.GetMergedAt().AsTime(),
-				Title:    v.RetroactiveFromPr.GetTitle(),
-			},
-		}
-	case *specv1.Spec_Declared:
-		return storage.SpecProvenanceDetail{
-			Declared: &storage.DeclaredProvenance{
-				DeclaredBy: v.Declared.GetDeclaredBy(),
-				Note:       v.Declared.GetNote(),
-			},
-		}
-	case *specv1.Spec_Authored:
-		return storage.SpecProvenanceDetail{}
-	default:
-		return storage.SpecProvenanceDetail{}
-	}
-}
-
 // createSpecProvenanceDetailFromProto reads the provenance_detail oneof from a
 // CreateSpecRequest and returns the domain detail struct.
 func createSpecProvenanceDetailFromProto(msg *specv1.CreateSpecRequest) storage.SpecProvenanceDetail {

--- a/internal/server/convert_test.go
+++ b/internal/server/convert_test.go
@@ -20,6 +20,7 @@ func TestSpecToProto(t *testing.T) {
 	spec := &storage.Spec{
 		ID: "spec-abc", Slug: "login", Intent: "Login API",
 		Stage: "spark", Priority: "p1", Complexity: "medium",
+		Provenance: storage.SpecProvenanceAuthored,
 		Version: 1, CreatedAt: now, UpdatedAt: now,
 	}
 	pb, err := specToProto(spec)
@@ -44,6 +45,7 @@ func TestSpecToProto_LifecycleFields(t *testing.T) {
 		Stage:        "superseded",
 		Priority:     "p1",
 		Complexity:   "medium",
+		Provenance:   storage.SpecProvenanceAuthored,
 		Version:      3,
 		CreatedAt:    now,
 		UpdatedAt:    now,
@@ -58,8 +60,8 @@ func TestSpecToProto_LifecycleFields(t *testing.T) {
 
 func TestSpecsToProto(t *testing.T) {
 	specs := []*storage.Spec{
-		{ID: "a", Slug: "a"},
-		{ID: "b", Slug: "b"},
+		{ID: "a", Slug: "a", Provenance: storage.SpecProvenanceAuthored},
+		{ID: "b", Slug: "b", Provenance: storage.SpecProvenanceAuthored},
 	}
 	pbs, err := specsToProto(specs)
 	require.NoError(t, err)
@@ -76,6 +78,7 @@ func TestSpecToProto_ZeroTimes(t *testing.T) {
 	spec := &storage.Spec{
 		ID: "spec-zero", Slug: "zero-time", Intent: "test",
 		Stage: "spark", Priority: "p2", Complexity: "low",
+		Provenance: storage.SpecProvenanceAuthored,
 	}
 	pb, err := specToProto(spec)
 	require.NoError(t, err)
@@ -205,29 +208,23 @@ func TestEdgeTypeToProto(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestLifecycleToProto(t *testing.T) {
-	t.Run("task lifecycle", func(t *testing.T) {
-		got, err := lifecycleToProto(storage.SpecLifecycleTask)
+func TestSpecProvenanceToProto(t *testing.T) {
+	t.Run("authored provenance", func(t *testing.T) {
+		got, err := specProvenanceToProto(storage.SpecProvenanceAuthored)
 		require.NoError(t, err)
-		assert.Equal(t, specv1.SpecLifecycle_SPEC_LIFECYCLE_TASK, got)
+		assert.Equal(t, specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED, got)
 	})
 
-	t.Run("living lifecycle", func(t *testing.T) {
-		got, err := lifecycleToProto(storage.SpecLifecycleLiving)
+	t.Run("declared provenance", func(t *testing.T) {
+		got, err := specProvenanceToProto(storage.SpecProvenanceDeclared)
 		require.NoError(t, err)
-		assert.Equal(t, specv1.SpecLifecycle_SPEC_LIFECYCLE_LIVING, got)
+		assert.Equal(t, specv1.SpecProvenance_SPEC_PROVENANCE_DECLARED, got)
 	})
 
-	t.Run("empty string maps to unspecified", func(t *testing.T) {
-		got, err := lifecycleToProto("")
-		require.NoError(t, err)
-		assert.Equal(t, specv1.SpecLifecycle_SPEC_LIFECYCLE_UNSPECIFIED, got)
-	})
-
-	t.Run("unknown lifecycle returns error", func(t *testing.T) {
-		_, err := lifecycleToProto("bogus")
+	t.Run("unknown provenance returns error", func(t *testing.T) {
+		_, err := specProvenanceToProto("bogus")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unknown lifecycle")
+		assert.Contains(t, err.Error(), "unknown provenance")
 	})
 }
 
@@ -314,11 +311,11 @@ func TestDriftItemToProto(t *testing.T) {
 	}
 }
 
-func TestSpecToProto_InvalidLifecycle(t *testing.T) {
+func TestSpecToProto_InvalidProvenance(t *testing.T) {
 	spec := &storage.Spec{
-		ID: "spec-bad", Slug: "bad-lifecycle", Intent: "test",
+		ID: "spec-bad", Slug: "bad-provenance", Intent: "test",
 		Stage: "spark", Priority: "p1", Complexity: "low",
-		Lifecycle: storage.SpecLifecycle("bogus"),
+		Provenance: storage.SpecProvenanceType("bogus"),
 	}
 	_, err := specToProto(spec)
 	assert.Error(t, err)
@@ -552,6 +549,7 @@ func TestSpecToProto_ConversationCount(t *testing.T) {
 	spec := &storage.Spec{
 		ID: "spec-conv", Slug: "conv-test", Intent: "test",
 		Stage: "spark", Priority: "p2", Complexity: "low",
+		Provenance:        storage.SpecProvenanceAuthored,
 		ConversationCount: 5,
 	}
 	pb, err := specToProto(spec)

--- a/internal/server/error_sanitize_test.go
+++ b/internal/server/error_sanitize_test.go
@@ -40,7 +40,7 @@ type errorBackend struct {
 	stubBackend
 }
 
-func (errorBackend) CreateSpec(context.Context, string, string, string, string) (*storage.Spec, error) {
+func (errorBackend) CreateSpec(_ context.Context, _, _, _, _ string, _ storage.SpecProvenanceType, _ storage.SpecProvenanceDetail, _ *storage.SparkOutput, _ *storage.ShapeOutput, _ *storage.SpecifyOutput, _ *storage.DecomposeOutput) (*storage.Spec, error) {
 	return nil, errRawDB
 }
 

--- a/internal/server/execution_handler.go
+++ b/internal/server/execution_handler.go
@@ -177,6 +177,14 @@ func (h *ExecutionHandler) ReportCompletion(ctx context.Context, req *connect.Re
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("agent is required"))
 	}
 
+	spec, err := store.GetSpec(ctx, msg.Slug)
+	if err != nil {
+		return nil, executionError(err)
+	}
+	if spec.Provenance != storage.SpecProvenanceAuthored {
+		return nil, connect.NewError(connect.CodeInvalidArgument, storage.ErrCompletionRequiresAuthored)
+	}
+
 	if err := store.RecordCompletion(ctx, msg.Slug, msg.Agent); err != nil {
 		return nil, executionError(err)
 	}

--- a/internal/server/execution_handler_test.go
+++ b/internal/server/execution_handler_test.go
@@ -160,6 +160,7 @@ func TestExecutionHandler_GenerateBundle(t *testing.T) {
 			Slug:        "my-spec",
 			Intent:      "build a widget",
 			Stage:       storage.SpecStageApproved,
+			Provenance:  storage.SpecProvenanceAuthored,
 			ContentHash: strings.Repeat("a", 32),
 		},
 		Decisions: []*storage.Decision{

--- a/internal/server/lifecycle_handler_test.go
+++ b/internal/server/lifecycle_handler_test.go
@@ -114,6 +114,7 @@ func TestLifecycleHandler_Amend(t *testing.T) {
 		return &storage.Spec{
 			Slug:        slug,
 			Stage:       storage.SpecStageShape,
+			Provenance:  storage.SpecProvenanceAuthored,
 			Version:     2,
 			ContentHash: strings.Repeat("a", 32),
 		}, nil
@@ -132,13 +133,13 @@ func TestLifecycleHandler_Amend(t *testing.T) {
 	require.Equal(t, int32(2), s.GetVersion())
 }
 
-func TestLifecycleHandler_Amend_UnknownLifecycleReturnsInternal(t *testing.T) {
+func TestLifecycleHandler_Amend_UnknownProvenanceReturnsInternal(t *testing.T) {
 	deps := defaultTestDeps()
 	deps.store.amendSpec = func(_ context.Context, _, _, _ string) (*storage.Spec, error) {
 		return &storage.Spec{
 			Slug:        "my-spec",
 			Stage:       storage.SpecStageShape,
-			Lifecycle:   storage.SpecLifecycle("bogus"),
+			Provenance:  storage.SpecProvenanceType("bogus"),
 			Version:     2,
 			ContentHash: strings.Repeat("a", 32),
 		}, nil
@@ -213,12 +214,14 @@ func TestLifecycleHandler_Supersede(t *testing.T) {
 		return &storage.Spec{
 				Slug:         oldSlug,
 				Stage:        storage.SpecStageSuperseded,
+				Provenance:   storage.SpecProvenanceAuthored,
 				SupersededBy: newSlug,
 				Version:      3,
 				ContentHash:  strings.Repeat("a", 32),
 			}, &storage.Spec{
 				Slug:        newSlug,
 				Stage:       storage.SpecStageSpark,
+				Provenance:  storage.SpecProvenanceAuthored,
 				Supersedes:  oldSlug,
 				Version:     1,
 				ContentHash: strings.Repeat("a", 32),
@@ -244,6 +247,7 @@ func TestLifecycleHandler_Abandon(t *testing.T) {
 		return &storage.Spec{
 			Slug:        slug,
 			Stage:       storage.SpecStageAbandoned,
+			Provenance:  storage.SpecProvenanceAuthored,
 			Version:     2,
 			ContentHash: strings.Repeat("a", 32),
 		}, nil
@@ -1193,19 +1197,19 @@ func TestLifecycleHandler_Supersede_StorageErrSameSlugs(t *testing.T) {
 	require.Equal(t, connect.CodeInvalidArgument, connErr.Code())
 }
 
-func TestLifecycleHandler_Supersede_InvalidOldSpecLifecycleReturnsInternal(t *testing.T) {
+func TestLifecycleHandler_Supersede_InvalidOldSpecProvenanceReturnsInternal(t *testing.T) {
 	deps := defaultTestDeps()
 	deps.store.supersedeSpec = func(_ context.Context, oldSlug, newSlug string) (*storage.Spec, *storage.Spec, error) {
 		return &storage.Spec{
 				Slug:        oldSlug,
 				Stage:       storage.SpecStageSuperseded,
-				Lifecycle:   storage.SpecLifecycle("bogus"),
+				Provenance:  storage.SpecProvenanceType("bogus"),
 				Version:     2,
 				ContentHash: strings.Repeat("a", 32),
 			}, &storage.Spec{
 				Slug:        newSlug,
 				Stage:       storage.SpecStageSpark,
-				Lifecycle:   storage.SpecLifecycleTask,
+				Provenance:  storage.SpecProvenanceAuthored,
 				Version:     1,
 				ContentHash: strings.Repeat("a", 32),
 			}, nil
@@ -1222,13 +1226,13 @@ func TestLifecycleHandler_Supersede_InvalidOldSpecLifecycleReturnsInternal(t *te
 	require.Equal(t, connect.CodeInternal, connErr.Code())
 }
 
-func TestLifecycleHandler_Abandon_UnknownLifecycleReturnsInternal(t *testing.T) {
+func TestLifecycleHandler_Abandon_UnknownProvenanceReturnsInternal(t *testing.T) {
 	deps := defaultTestDeps()
 	deps.store.abandonSpec = func(_ context.Context, slug, _ string) (*storage.Spec, error) {
 		return &storage.Spec{
 			Slug:        slug,
 			Stage:       storage.SpecStageAbandoned,
-			Lifecycle:   storage.SpecLifecycle("bogus"),
+			Provenance:  storage.SpecProvenanceType("bogus"),
 			Version:     2,
 			ContentHash: strings.Repeat("a", 32),
 		}, nil

--- a/internal/server/provenance_validate.go
+++ b/internal/server/provenance_validate.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"fmt"
+
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// validateProvenance enforces the create-time invariants per the
+// spec-provenance design.
+//
+//   - AUTHORED: no provenance_detail (or only Authored variant), only
+//     spark_output may be set; all later stage outputs must be nil.
+//   - RETROACTIVE_FROM_PR: all 4 stage outputs required; retroactive_from_pr
+//     detail required; url + sha must be non-empty.
+//   - DECLARED: all 4 stage outputs required; declared detail required;
+//     declared_by must be non-empty.
+//
+// Returns the matching sentinel error on violation.
+func validateProvenance(
+	pt storage.SpecProvenanceType,
+	pd storage.SpecProvenanceDetail,
+	spark *storage.SparkOutput,
+	shape *storage.ShapeOutput,
+	specify *storage.SpecifyOutput,
+	decompose *storage.DecomposeOutput,
+) error {
+	switch pt {
+	case storage.SpecProvenanceAuthored, "":
+		// Empty string treated as AUTHORED (default).
+		if shape != nil || specify != nil || decompose != nil {
+			return storage.ErrAuthoredRequiresSparkOnly
+		}
+		if pd.RetroactiveFromPR != nil || pd.Declared != nil {
+			return storage.ErrProvenanceMismatch
+		}
+	case storage.SpecProvenanceRetroactiveFromPR:
+		if spark == nil || shape == nil || specify == nil || decompose == nil {
+			return storage.ErrRetroactiveRequiresAllOutputs
+		}
+		if pd.RetroactiveFromPR == nil {
+			return storage.ErrProvenanceMismatch
+		}
+		if pd.RetroactiveFromPR.URL == "" || pd.RetroactiveFromPR.SHA == "" {
+			return storage.ErrRetroactiveRequiresPRRef
+		}
+		if pd.Declared != nil {
+			return storage.ErrProvenanceMismatch
+		}
+	case storage.SpecProvenanceDeclared:
+		if spark == nil || shape == nil || specify == nil || decompose == nil {
+			return storage.ErrDeclaredRequiresAllOutputs
+		}
+		if pd.Declared == nil {
+			return storage.ErrProvenanceMismatch
+		}
+		if pd.Declared.DeclaredBy == "" {
+			return storage.ErrDeclaredRequiresDeclaredBy
+		}
+		if pd.RetroactiveFromPR != nil {
+			return storage.ErrProvenanceMismatch
+		}
+	default:
+		return fmt.Errorf("unknown provenance type %q", pt)
+	}
+	return nil
+}

--- a/internal/server/spec_handler.go
+++ b/internal/server/spec_handler.go
@@ -68,7 +68,53 @@ func (h *SpecHandler) CreateSpec(ctx context.Context, req *connect.Request[specv
 			fmt.Errorf("invalid complexity %q; valid values: low, medium, high", complexity))
 	}
 
-	spec, err := store.CreateSpec(ctx, msg.Slug, msg.Intent, priority, complexity)
+	// Decode provenance fields from the request.
+	pt := storage.SpecProvenanceAuthored
+	if msg.GetProvenanceType() != specv1.SpecProvenance_SPEC_PROVENANCE_UNSPECIFIED {
+		var ptErr error
+		pt, ptErr = specProvenanceFromProto(msg.GetProvenanceType())
+		if ptErr != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, ptErr)
+		}
+	}
+	pd := createSpecProvenanceDetailFromProto(msg)
+
+	// Convert stage outputs from proto to domain (nil if not set).
+	var spark *storage.SparkOutput
+	if msg.SparkOutput != nil {
+		var sparkErr error
+		spark, sparkErr = sparkOutputToDomain(msg.SparkOutput)
+		if sparkErr != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, sparkErr)
+		}
+	}
+	var shape *storage.ShapeOutput
+	if msg.ShapeOutput != nil {
+		var shapeErr error
+		shape, shapeErr = shapeOutputToDomain(msg.ShapeOutput)
+		if shapeErr != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, shapeErr)
+		}
+	}
+	var specify *storage.SpecifyOutput
+	if msg.SpecifyOutput != nil {
+		specify = specifyOutputToDomain(msg.SpecifyOutput)
+	}
+	var decompose *storage.DecomposeOutput
+	if msg.DecomposeOutput != nil {
+		var decompErr error
+		decompose, decompErr = decomposeOutputToDomain(msg.DecomposeOutput)
+		if decompErr != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, decompErr)
+		}
+	}
+
+	// Validate provenance invariants.
+	if valErr := validateProvenance(pt, pd, spark, shape, specify, decompose); valErr != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, valErr)
+	}
+
+	spec, err := store.CreateSpec(ctx, msg.Slug, msg.Intent, priority, complexity, pt, pd, spark, shape, specify, decompose)
 	if err != nil {
 		return nil, specError(err)
 	}

--- a/internal/server/spec_handler_provenance_test.go
+++ b/internal/server/spec_handler_provenance_test.go
@@ -215,7 +215,6 @@ func TestCreateSpec_AuthoredRequiresSparkOnly(t *testing.T) {
 	}))
 	require.Error(t, err)
 	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
-	require.Contains(t, err.Error(), storage.ErrAuthoredRequiresSparkOnly.Error())
 }
 
 func TestCreateSpec_RetroactiveRequiresAllOutputs(t *testing.T) {
@@ -240,7 +239,6 @@ func TestCreateSpec_RetroactiveRequiresAllOutputs(t *testing.T) {
 	}))
 	require.Error(t, err)
 	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
-	require.Contains(t, err.Error(), storage.ErrRetroactiveRequiresAllOutputs.Error())
 }
 
 func TestCreateSpec_RetroactiveRequiresPRRef(t *testing.T) {
@@ -265,7 +263,6 @@ func TestCreateSpec_RetroactiveRequiresPRRef(t *testing.T) {
 	}))
 	require.Error(t, err)
 	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
-	require.Contains(t, err.Error(), storage.ErrRetroactiveRequiresPRRef.Error())
 }
 
 func TestCreateSpec_DeclaredRequiresAllOutputs(t *testing.T) {
@@ -289,7 +286,6 @@ func TestCreateSpec_DeclaredRequiresAllOutputs(t *testing.T) {
 	}))
 	require.Error(t, err)
 	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
-	require.Contains(t, err.Error(), storage.ErrDeclaredRequiresAllOutputs.Error())
 }
 
 func TestCreateSpec_DeclaredRequiresDeclaredBy(t *testing.T) {
@@ -312,7 +308,6 @@ func TestCreateSpec_DeclaredRequiresDeclaredBy(t *testing.T) {
 	}))
 	require.Error(t, err)
 	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
-	require.Contains(t, err.Error(), storage.ErrDeclaredRequiresDeclaredBy.Error())
 }
 
 func TestCreateSpec_ProvenanceMismatch(t *testing.T) {
@@ -337,7 +332,6 @@ func TestCreateSpec_ProvenanceMismatch(t *testing.T) {
 	}))
 	require.Error(t, err)
 	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
-	require.Contains(t, err.Error(), storage.ErrProvenanceMismatch.Error())
 }
 
 // --- Claim/Completion rejection on non-AUTHORED specs ---
@@ -371,7 +365,6 @@ func TestClaim_RejectsRetroactive(t *testing.T) {
 	}))
 	require.Error(t, err)
 	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
-	require.Contains(t, err.Error(), storage.ErrClaimRequiresAuthored.Error())
 }
 
 func TestCompletion_RejectsDeclared(t *testing.T) {
@@ -402,5 +395,4 @@ func TestCompletion_RejectsDeclared(t *testing.T) {
 	}))
 	require.Error(t, err)
 	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
-	require.Contains(t, err.Error(), storage.ErrCompletionRequiresAuthored.Error())
 }

--- a/internal/server/spec_handler_provenance_test.go
+++ b/internal/server/spec_handler_provenance_test.go
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// provenanceBackend is a mock that respects provenance+stage output combinations
+// to correctly reflect the born-at-done behaviour for RETROACTIVE/DECLARED specs.
+type provenanceBackend struct {
+	stubBackend
+	mu    sync.Mutex
+	specs map[string]*storage.Spec
+	seq   int
+}
+
+func newProvenanceBackend() *provenanceBackend {
+	return &provenanceBackend{specs: make(map[string]*storage.Spec)}
+}
+
+func (m *provenanceBackend) CreateSpec(
+	_ context.Context,
+	slug, intent, priority, complexity string,
+	pt storage.SpecProvenanceType,
+	_ storage.SpecProvenanceDetail,
+	_ *storage.SparkOutput,
+	shape *storage.ShapeOutput,
+	specify *storage.SpecifyOutput,
+	decompose *storage.DecomposeOutput,
+) (*storage.Spec, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.specs[slug]; exists {
+		return nil, fmt.Errorf("spec %q: %w", slug, storage.ErrSpecAlreadyExists)
+	}
+	m.seq++
+	now := time.Now().UTC()
+
+	// Born-at-done when all four stage outputs are provided.
+	stage := storage.SpecStageSpark
+	if shape != nil && specify != nil && decompose != nil {
+		stage = storage.SpecStageDone
+	}
+
+	if priority == "" {
+		priority = "p2"
+	}
+	if complexity == "" {
+		complexity = "medium"
+	}
+
+	spec := &storage.Spec{
+		ID:          fmt.Sprintf("spec-%05d", m.seq),
+		Slug:        slug,
+		Intent:      intent,
+		Stage:       stage,
+		Priority:    storage.SpecPriority(priority),
+		Complexity:  storage.SpecComplexity(complexity),
+		Provenance:  pt,
+		Version:     1,
+		ContentHash: strings.Repeat("a", 32),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	m.specs[slug] = spec
+	return spec, nil
+}
+
+func (m *provenanceBackend) GetSpec(_ context.Context, slug string) (*storage.Spec, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	spec, ok := m.specs[slug]
+	if !ok {
+		return nil, fmt.Errorf("spec %q: %w", slug, storage.ErrSpecNotFound)
+	}
+	return spec, nil
+}
+
+func setupProvenanceServer(t *testing.T) (specgraphv1connect.SpecServiceClient, specgraphv1connect.ClaimServiceClient, specgraphv1connect.ExecutionServiceClient) {
+	t.Helper()
+	mb := newProvenanceBackend()
+	scoper := &testScoper{backend: mb}
+	mux := server.NewMux(scoper)
+	server.RegisterClaimService(mux, scoper)
+	server.RegisterExecutionService(mux, scoper)
+	srv := httptest.NewServer(wrapTestProject(mux))
+	t.Cleanup(srv.Close)
+	specClient := specgraphv1connect.NewSpecServiceClient(http.DefaultClient, srv.URL)
+	claimClient := specgraphv1connect.NewClaimServiceClient(http.DefaultClient, srv.URL)
+	execClient := specgraphv1connect.NewExecutionServiceClient(http.DefaultClient, srv.URL)
+	return specClient, claimClient, execClient
+}
+
+// minSparkOutput returns a minimal valid SparkOutput for use in tests.
+func minSparkOutput() *specv1.SparkOutput {
+	return &specv1.SparkOutput{Seed: "seed text"}
+}
+
+// minShapeOutput returns a minimal valid ShapeOutput for use in tests.
+func minShapeOutput() *specv1.ShapeOutput {
+	return &specv1.ShapeOutput{
+		SuccessMust: []string{"criterion"},
+	}
+}
+
+// minSpecifyOutput returns a minimal valid SpecifyOutput for use in tests.
+func minSpecifyOutput() *specv1.SpecifyOutput {
+	return &specv1.SpecifyOutput{
+		Invariants: []string{"must be idempotent"},
+	}
+}
+
+// minDecomposeOutput returns a minimal valid DecomposeOutput for use in tests.
+func minDecomposeOutput() *specv1.DecomposeOutput {
+	return &specv1.DecomposeOutput{
+		Strategy: specv1.DecompositionStrategy_DECOMPOSITION_STRATEGY_SINGLE_UNIT,
+		Slices: []*specv1.DecompositionSlice{
+			{Id: "slice-1", Intent: "initial slice"},
+		},
+	}
+}
+
+// --- Happy-path creation tests ---
+
+func TestCreateSpec_AuthoredHappyPath(t *testing.T) {
+	specClient, _, _ := setupProvenanceServer(t)
+	ctx := context.Background()
+
+	resp, err := specClient.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+		Slug:          "authored-spec",
+		Intent:        "An authored spec",
+		Priority:      "p1",
+		Complexity:    "low",
+		ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED,
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "spark", resp.Msg.GetSpec().GetStage())
+	require.Equal(t, specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED, resp.Msg.GetSpec().GetProvenanceType())
+}
+
+func TestCreateSpec_RetroactiveBornAtDone(t *testing.T) {
+	specClient, _, _ := setupProvenanceServer(t)
+	ctx := context.Background()
+
+	resp, err := specClient.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+		Slug:           "retro-spec",
+		Intent:         "A retroactive spec born at done",
+		ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_RETROACTIVE_FROM_PR,
+		ProvenanceDetail: &specv1.CreateSpecRequest_RetroactiveFromPr{
+			RetroactiveFromPr: &specv1.RetroactiveFromPrProvenance{
+				Url: "https://github.com/org/repo/pull/42",
+				Sha: "abc123def456",
+			},
+		},
+		SparkOutput:     minSparkOutput(),
+		ShapeOutput:     minShapeOutput(),
+		SpecifyOutput:   minSpecifyOutput(),
+		DecomposeOutput: minDecomposeOutput(),
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "done", resp.Msg.GetSpec().GetStage())
+	require.Equal(t, specv1.SpecProvenance_SPEC_PROVENANCE_RETROACTIVE_FROM_PR, resp.Msg.GetSpec().GetProvenanceType())
+}
+
+func TestCreateSpec_DeclaredBornAtDone(t *testing.T) {
+	specClient, _, _ := setupProvenanceServer(t)
+	ctx := context.Background()
+
+	resp, err := specClient.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+		Slug:           "declared-spec",
+		Intent:         "A declared spec born at done",
+		ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_DECLARED,
+		ProvenanceDetail: &specv1.CreateSpecRequest_Declared{
+			Declared: &specv1.DeclaredProvenance{
+				DeclaredBy: "platform-team",
+			},
+		},
+		SparkOutput:     minSparkOutput(),
+		ShapeOutput:     minShapeOutput(),
+		SpecifyOutput:   minSpecifyOutput(),
+		DecomposeOutput: minDecomposeOutput(),
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "done", resp.Msg.GetSpec().GetStage())
+	require.Equal(t, specv1.SpecProvenance_SPEC_PROVENANCE_DECLARED, resp.Msg.GetSpec().GetProvenanceType())
+}
+
+// --- Sentinel rejection tests ---
+
+func TestCreateSpec_AuthoredRequiresSparkOnly(t *testing.T) {
+	specClient, _, _ := setupProvenanceServer(t)
+	ctx := context.Background()
+
+	_, err := specClient.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+		Slug:           "authored-with-shape",
+		Intent:         "should be rejected",
+		ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_AUTHORED,
+		ShapeOutput:    minShapeOutput(),
+	}))
+	require.Error(t, err)
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	require.Contains(t, err.Error(), storage.ErrAuthoredRequiresSparkOnly.Error())
+}
+
+func TestCreateSpec_RetroactiveRequiresAllOutputs(t *testing.T) {
+	specClient, _, _ := setupProvenanceServer(t)
+	ctx := context.Background()
+
+	// Missing decompose_output.
+	_, err := specClient.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+		Slug:           "retro-missing-decompose",
+		Intent:         "should be rejected",
+		ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_RETROACTIVE_FROM_PR,
+		ProvenanceDetail: &specv1.CreateSpecRequest_RetroactiveFromPr{
+			RetroactiveFromPr: &specv1.RetroactiveFromPrProvenance{
+				Url: "https://github.com/org/repo/pull/1",
+				Sha: "deadbeef",
+			},
+		},
+		SparkOutput:   minSparkOutput(),
+		ShapeOutput:   minShapeOutput(),
+		SpecifyOutput: minSpecifyOutput(),
+		// DecomposeOutput intentionally omitted.
+	}))
+	require.Error(t, err)
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	require.Contains(t, err.Error(), storage.ErrRetroactiveRequiresAllOutputs.Error())
+}
+
+func TestCreateSpec_RetroactiveRequiresPRRef(t *testing.T) {
+	specClient, _, _ := setupProvenanceServer(t)
+	ctx := context.Background()
+
+	// All outputs provided but empty URL.
+	_, err := specClient.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+		Slug:           "retro-no-url",
+		Intent:         "should be rejected",
+		ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_RETROACTIVE_FROM_PR,
+		ProvenanceDetail: &specv1.CreateSpecRequest_RetroactiveFromPr{
+			RetroactiveFromPr: &specv1.RetroactiveFromPrProvenance{
+				Url: "",   // empty — invalid
+				Sha: "abc",
+			},
+		},
+		SparkOutput:     minSparkOutput(),
+		ShapeOutput:     minShapeOutput(),
+		SpecifyOutput:   minSpecifyOutput(),
+		DecomposeOutput: minDecomposeOutput(),
+	}))
+	require.Error(t, err)
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	require.Contains(t, err.Error(), storage.ErrRetroactiveRequiresPRRef.Error())
+}
+
+func TestCreateSpec_DeclaredRequiresAllOutputs(t *testing.T) {
+	specClient, _, _ := setupProvenanceServer(t)
+	ctx := context.Background()
+
+	// Missing decompose_output.
+	_, err := specClient.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+		Slug:           "declared-missing-decompose",
+		Intent:         "should be rejected",
+		ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_DECLARED,
+		ProvenanceDetail: &specv1.CreateSpecRequest_Declared{
+			Declared: &specv1.DeclaredProvenance{
+				DeclaredBy: "platform-team",
+			},
+		},
+		SparkOutput:   minSparkOutput(),
+		ShapeOutput:   minShapeOutput(),
+		SpecifyOutput: minSpecifyOutput(),
+		// DecomposeOutput intentionally omitted.
+	}))
+	require.Error(t, err)
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	require.Contains(t, err.Error(), storage.ErrDeclaredRequiresAllOutputs.Error())
+}
+
+func TestCreateSpec_DeclaredRequiresDeclaredBy(t *testing.T) {
+	specClient, _, _ := setupProvenanceServer(t)
+	ctx := context.Background()
+
+	_, err := specClient.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+		Slug:           "declared-no-by",
+		Intent:         "should be rejected",
+		ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_DECLARED,
+		ProvenanceDetail: &specv1.CreateSpecRequest_Declared{
+			Declared: &specv1.DeclaredProvenance{
+				DeclaredBy: "", // empty — invalid
+			},
+		},
+		SparkOutput:     minSparkOutput(),
+		ShapeOutput:     minShapeOutput(),
+		SpecifyOutput:   minSpecifyOutput(),
+		DecomposeOutput: minDecomposeOutput(),
+	}))
+	require.Error(t, err)
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	require.Contains(t, err.Error(), storage.ErrDeclaredRequiresDeclaredBy.Error())
+}
+
+func TestCreateSpec_ProvenanceMismatch(t *testing.T) {
+	specClient, _, _ := setupProvenanceServer(t)
+	ctx := context.Background()
+
+	// provenance_type=DECLARED but retroactive_from_pr detail.
+	_, err := specClient.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+		Slug:           "mismatch-spec",
+		Intent:         "should be rejected",
+		ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_DECLARED,
+		ProvenanceDetail: &specv1.CreateSpecRequest_RetroactiveFromPr{
+			RetroactiveFromPr: &specv1.RetroactiveFromPrProvenance{
+				Url: "https://github.com/org/repo/pull/99",
+				Sha: "deadbeef",
+			},
+		},
+		SparkOutput:     minSparkOutput(),
+		ShapeOutput:     minShapeOutput(),
+		SpecifyOutput:   minSpecifyOutput(),
+		DecomposeOutput: minDecomposeOutput(),
+	}))
+	require.Error(t, err)
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	require.Contains(t, err.Error(), storage.ErrProvenanceMismatch.Error())
+}
+
+// --- Claim/Completion rejection on non-AUTHORED specs ---
+
+func TestClaim_RejectsRetroactive(t *testing.T) {
+	specClient, claimClient, _ := setupProvenanceServer(t)
+	ctx := context.Background()
+
+	// Create a RETROACTIVE spec.
+	_, err := specClient.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+		Slug:           "retro-claim-test",
+		Intent:         "retroactive spec to test claim rejection",
+		ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_RETROACTIVE_FROM_PR,
+		ProvenanceDetail: &specv1.CreateSpecRequest_RetroactiveFromPr{
+			RetroactiveFromPr: &specv1.RetroactiveFromPrProvenance{
+				Url: "https://github.com/org/repo/pull/7",
+				Sha: "feedface",
+			},
+		},
+		SparkOutput:     minSparkOutput(),
+		ShapeOutput:     minShapeOutput(),
+		SpecifyOutput:   minSpecifyOutput(),
+		DecomposeOutput: minDecomposeOutput(),
+	}))
+	require.NoError(t, err)
+
+	// Attempt to claim — must be rejected.
+	_, err = claimClient.ClaimSpec(ctx, connect.NewRequest(&specv1.ClaimSpecRequest{
+		SpecSlug: "retro-claim-test",
+		Agent:    "agent-1",
+	}))
+	require.Error(t, err)
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	require.Contains(t, err.Error(), storage.ErrClaimRequiresAuthored.Error())
+}
+
+func TestCompletion_RejectsDeclared(t *testing.T) {
+	specClient, _, execClient := setupProvenanceServer(t)
+	ctx := context.Background()
+
+	// Create a DECLARED spec.
+	_, err := specClient.CreateSpec(ctx, connect.NewRequest(&specv1.CreateSpecRequest{
+		Slug:           "declared-completion-test",
+		Intent:         "declared spec to test completion rejection",
+		ProvenanceType: specv1.SpecProvenance_SPEC_PROVENANCE_DECLARED,
+		ProvenanceDetail: &specv1.CreateSpecRequest_Declared{
+			Declared: &specv1.DeclaredProvenance{
+				DeclaredBy: "ops-team",
+			},
+		},
+		SparkOutput:     minSparkOutput(),
+		ShapeOutput:     minShapeOutput(),
+		SpecifyOutput:   minSpecifyOutput(),
+		DecomposeOutput: minDecomposeOutput(),
+	}))
+	require.NoError(t, err)
+
+	// Attempt to report completion — must be rejected.
+	_, err = execClient.ReportCompletion(ctx, connect.NewRequest(&specv1.ReportCompletionRequest{
+		Slug:  "declared-completion-test",
+		Agent: "agent-1",
+	}))
+	require.Error(t, err)
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	require.Contains(t, err.Error(), storage.ErrCompletionRequiresAuthored.Error())
+}

--- a/internal/server/spec_handler_test.go
+++ b/internal/server/spec_handler_test.go
@@ -34,7 +34,7 @@ func newMockBackend() *mockBackend {
 	return &mockBackend{specs: make(map[string]*storage.Spec)}
 }
 
-func (m *mockBackend) CreateSpec(_ context.Context, slug, intent, priority, complexity string) (*storage.Spec, error) {
+func (m *mockBackend) CreateSpec(_ context.Context, slug, intent, priority, complexity string, _ storage.SpecProvenanceType, _ storage.SpecProvenanceDetail, _ *storage.SparkOutput, _ *storage.ShapeOutput, _ *storage.SpecifyOutput, _ *storage.DecomposeOutput) (*storage.Spec, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.seq++
@@ -46,6 +46,7 @@ func (m *mockBackend) CreateSpec(_ context.Context, slug, intent, priority, comp
 		Stage:       storage.SpecStageSpark,
 		Priority:    storage.SpecPriority(priority),
 		Complexity:  storage.SpecComplexity(complexity),
+		Provenance:  storage.SpecProvenanceAuthored,
 		Version:     1,
 		ContentHash: strings.Repeat("a", 32),
 		CreatedAt:   now,
@@ -213,16 +214,16 @@ func TestSpecHandler_UpdateSpec_StageIgnored(t *testing.T) {
 	require.Equal(t, "spark", updateResp.Msg.GetSpec().GetStage(), "UpdateSpec must not mutate stage")
 }
 
-func TestSpecHandler_GetSpec_InvalidLifecycle(t *testing.T) {
+func TestSpecHandler_GetSpec_InvalidProvenance(t *testing.T) {
 	mb := newMockBackend()
-	// Inject a spec with an invalid lifecycle directly.
-	mb.specs["bad-lifecycle"] = &storage.Spec{
+	// Inject a spec with an invalid provenance directly.
+	mb.specs["bad-provenance"] = &storage.Spec{
 		ID:          "spec-bad",
-		Slug:        "bad-lifecycle",
-		Intent:      "test invalid lifecycle",
+		Slug:        "bad-provenance",
+		Intent:      "test invalid provenance",
 		Stage:       storage.SpecStageSpark,
 		Version:     1,
-		Lifecycle:   storage.SpecLifecycle("bogus"),
+		Provenance:  storage.SpecProvenanceType("bogus"),
 		ContentHash: strings.Repeat("a", 32),
 		CreatedAt:   time.Now().UTC(),
 		UpdatedAt:   time.Now().UTC(),
@@ -232,7 +233,7 @@ func TestSpecHandler_GetSpec_InvalidLifecycle(t *testing.T) {
 
 	client := specgraphv1connect.NewSpecServiceClient(http.DefaultClient, srv.URL)
 	_, err := client.GetSpec(context.Background(), connect.NewRequest(&specv1.GetSpecRequest{
-		Slug: "bad-lifecycle",
+		Slug: "bad-provenance",
 	}))
 	require.Error(t, err)
 	require.Equal(t, connect.CodeInternal, connect.CodeOf(err))

--- a/internal/server/test_scoper_test.go
+++ b/internal/server/test_scoper_test.go
@@ -48,7 +48,7 @@ type stubBackend struct{}
 
 // --- Backend ---
 
-func (stubBackend) CreateSpec(context.Context, string, string, string, string) (*storage.Spec, error) {
+func (stubBackend) CreateSpec(_ context.Context, _, _, _, _ string, _ storage.SpecProvenanceType, _ storage.SpecProvenanceDetail, _ *storage.SparkOutput, _ *storage.ShapeOutput, _ *storage.SpecifyOutput, _ *storage.DecomposeOutput) (*storage.Spec, error) {
 	return nil, errNotImplemented
 }
 

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -115,3 +115,29 @@ var (
 	// ErrSyncMappingExists is returned when a sync mapping already exists for the spec+adapter pair.
 	ErrSyncMappingExists = errors.New("sync mapping already exists for this spec and adapter")
 )
+
+// --- Provenance ---
+
+// ErrProvenanceMismatch is returned when provenance_type and provenance_detail are inconsistent.
+var ErrProvenanceMismatch = errors.New("provenance_type does not match populated provenance_detail variant")
+
+// ErrAuthoredRequiresSparkOnly is returned when an AUTHORED spec create includes stage outputs beyond spark.
+var ErrAuthoredRequiresSparkOnly = errors.New("AUTHORED provenance: only spark_output may be set at create")
+
+// ErrRetroactiveRequiresAllOutputs is returned when a RETROACTIVE_FROM_PR create is missing one or more funnel outputs.
+var ErrRetroactiveRequiresAllOutputs = errors.New("RETROACTIVE_FROM_PR provenance: spark/shape/specify/decompose outputs all required")
+
+// ErrRetroactiveRequiresPRRef is returned when a RETROACTIVE_FROM_PR create is missing url or sha.
+var ErrRetroactiveRequiresPRRef = errors.New("RETROACTIVE_FROM_PR provenance: url and sha are required")
+
+// ErrDeclaredRequiresAllOutputs is returned when a DECLARED create is missing one or more funnel outputs.
+var ErrDeclaredRequiresAllOutputs = errors.New("DECLARED provenance: spark/shape/specify/decompose outputs all required")
+
+// ErrDeclaredRequiresDeclaredBy is returned when a DECLARED create is missing declared_by.
+var ErrDeclaredRequiresDeclaredBy = errors.New("DECLARED provenance: declared_by is required")
+
+// ErrClaimRequiresAuthored is returned when claim is invoked on a non-AUTHORED spec.
+var ErrClaimRequiresAuthored = errors.New("claim requires provenance_type = AUTHORED")
+
+// ErrCompletionRequiresAuthored is returned when report-completion is invoked on a non-AUTHORED spec.
+var ErrCompletionRequiresAuthored = errors.New("report-completion requires provenance_type = AUTHORED")

--- a/internal/storage/postgres/authoring_test.go
+++ b/internal/storage/postgres/authoring_test.go
@@ -19,7 +19,7 @@ func TestTransitionStage_Basic(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "funnel-test", "Test the funnel", "p1", "low")
+	_, err := store.CreateSpec(ctx, "funnel-test", "Test the funnel", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// CreateSpec sets stage to "spark", so transition spark → shape.
@@ -43,7 +43,7 @@ func TestTransitionStage_InvalidTransition(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "wrong-stage", "Wrong stage test", "p1", "low")
+	_, err := store.CreateSpec(ctx, "wrong-stage", "Wrong stage test", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Spec is at "spark", but we claim it's at "shape" → should fail.
@@ -65,7 +65,7 @@ func TestTransitionStage_ApprovedGuard(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "approved-guard", "Approved guard test", "p1", "low")
+	_, err := store.CreateSpec(ctx, "approved-guard", "Approved guard test", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, store.TransitionStage(ctx, "approved-guard", storage.SpecStageSpark, storage.SpecStageShape))
@@ -83,7 +83,7 @@ func TestTransitionStage_UpdatesContentHash(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	spec, err := store.CreateSpec(ctx, "stage-hash", "Test", "p1", "medium")
+	spec, err := store.CreateSpec(ctx, "stage-hash", "Test", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	initialHash := spec.ContentHash
 
@@ -101,7 +101,7 @@ func TestStoreSparkOutput(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "spark-out", "Spark output test", "p1", "low")
+	_, err := store.CreateSpec(ctx, "spark-out", "Spark output test", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	err = store.StoreSparkOutput(ctx, "spark-out", &storage.SparkOutput{
@@ -127,7 +127,7 @@ func TestStoreSparkOutput_UpdatesContentHash(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	spec, err := store.CreateSpec(ctx, "authoring-hash", "Test", "p1", "medium")
+	spec, err := store.CreateSpec(ctx, "authoring-hash", "Test", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	initialHash := spec.ContentHash
 	require.NotEmpty(t, initialHash)
@@ -155,7 +155,7 @@ func TestStoreShapeOutput_PromotesDecisions(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "shape-decisions-test", "test spec", "p1", "medium")
+	_, err := store.CreateSpec(ctx, "shape-decisions-test", "test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	shapeOut := &storage.ShapeOutput{
@@ -193,7 +193,7 @@ func TestStoreShapeOutput_IdempotentDecisions(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "idempotent-test", "test spec", "p1", "medium")
+	_, err := store.CreateSpec(ctx, "idempotent-test", "test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	shapeOut := &storage.ShapeOutput{
@@ -223,7 +223,7 @@ func TestStoreSpecifyOutput(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "specify-out", "Specify test", "p1", "low")
+	_, err := store.CreateSpec(ctx, "specify-out", "Specify test", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	err = store.StoreSpecifyOutput(ctx, "specify-out", &storage.SpecifyOutput{
@@ -249,7 +249,7 @@ func TestStoreDecomposeOutput_CreatesSlices(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "decomp-parent", "Parent spec", "p1", "medium")
+	_, err := store.CreateSpec(ctx, "decomp-parent", "Parent spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	children, err := store.StoreDecomposeOutput(ctx, "decomp-parent", &storage.DecomposeOutput{
@@ -309,7 +309,7 @@ func TestStoreDecomposeOutput_Idempotent(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "idem-parent", "Idempotency parent", "p1", "medium")
+	_, err := store.CreateSpec(ctx, "idem-parent", "Idempotency parent", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	output := &storage.DecomposeOutput{
@@ -351,7 +351,7 @@ func TestStoreDecomposeOutput_DuplicateSliceID(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "dup-parent", "Duplicate slice test", "p1", "low")
+	_, err := store.CreateSpec(ctx, "dup-parent", "Duplicate slice test", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.StoreDecomposeOutput(ctx, "dup-parent", &storage.DecomposeOutput{
@@ -370,7 +370,7 @@ func TestStoreDecomposeOutput_UnknownDependency(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "dep-parent", "Unknown dep test", "p1", "low")
+	_, err := store.CreateSpec(ctx, "dep-parent", "Unknown dep test", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.StoreDecomposeOutput(ctx, "dep-parent", &storage.DecomposeOutput{
@@ -389,7 +389,7 @@ func TestStoreSafetyFlags(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "safety-flags-spec", "Safety flags test", "p1", "low")
+	_, err := store.CreateSpec(ctx, "safety-flags-spec", "Safety flags test", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	flags := []storage.SafetyFlag{
@@ -425,9 +425,9 @@ func TestSupersedeSpec_Authoring(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "old-spec", "Original spec", "p1", "low")
+	_, err := store.CreateSpec(ctx, "old-spec", "Original spec", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "new-spec", "Replacement spec", "p1", "low")
+	_, err = store.CreateSpec(ctx, "new-spec", "Replacement spec", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	err = store.SupersedeSpec(ctx, "old-spec", "new-spec", "better approach found")
@@ -444,7 +444,7 @@ func TestSupersedeSpec_NotFound(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "existing-spec", "Exists", "p1", "low")
+	_, err := store.CreateSpec(ctx, "existing-spec", "Exists", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Non-existent old spec.
@@ -461,7 +461,7 @@ func TestAmendSpec(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "amend-test", "Amend test", "p1", "low")
+	_, err := store.CreateSpec(ctx, "amend-test", "Amend test", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, store.TransitionStage(ctx, "amend-test", storage.SpecStageSpark, storage.SpecStageShape))
 	require.NoError(t, store.TransitionStage(ctx, "amend-test", storage.SpecStageShape, storage.SpecStageSpecify))
@@ -478,7 +478,7 @@ func TestAmendSpec_AlreadyApproved(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "approved-spec", "Will be approved", "p1", "low")
+	_, err := store.CreateSpec(ctx, "approved-spec", "Will be approved", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, store.TransitionStage(ctx, "approved-spec", storage.SpecStageSpark, storage.SpecStageShape))
 	require.NoError(t, store.TransitionStage(ctx, "approved-spec", storage.SpecStageShape, storage.SpecStageSpecify))
@@ -494,7 +494,7 @@ func TestAmendSpec_InvalidTransition(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "amend-invalid", "Invalid amend", "p1", "low")
+	_, err := store.CreateSpec(ctx, "amend-invalid", "Invalid amend", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, store.TransitionStage(ctx, "amend-invalid", storage.SpecStageSpark, storage.SpecStageShape))
 
@@ -517,7 +517,7 @@ func TestAmendSpec_UpdatesContentHash(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "amend-hash", "Test", "p1", "medium")
+	_, err := store.CreateSpec(ctx, "amend-hash", "Test", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	err = store.TransitionStage(ctx, "amend-hash", storage.SpecStageSpark, storage.SpecStageShape)
@@ -540,7 +540,7 @@ func TestTransitionStage_BackwardViaAmend(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "backward-test", "Backward transition", "p1", "low")
+	_, err := store.CreateSpec(ctx, "backward-test", "Backward transition", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Advance spark → shape → specify.
@@ -561,9 +561,9 @@ func TestTransitionStage_SupersededGuard(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "superseded-old", "Will be superseded", "p1", "low")
+	_, err := store.CreateSpec(ctx, "superseded-old", "Will be superseded", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "superseded-new", "Replacement", "p1", "low")
+	_, err = store.CreateSpec(ctx, "superseded-new", "Replacement", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	err = store.SupersedeSpec(ctx, "superseded-old", "superseded-new", "better approach")

--- a/internal/storage/postgres/changelog_test.go
+++ b/internal/storage/postgres/changelog_test.go
@@ -19,7 +19,7 @@ func TestListChanges_ReturnsEntries(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "cl-entries", "initial intent", "p1", "medium")
+	_, err := store.CreateSpec(ctx, "cl-entries", "initial intent", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	newIntent := "updated intent"
@@ -48,7 +48,7 @@ func TestListChanges_CheckpointsOnly(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "cl-checkpoints", "intent", "p1", "medium")
+	_, err := store.CreateSpec(ctx, "cl-checkpoints", "intent", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	newIntent := "updated"
@@ -70,7 +70,7 @@ func TestListChanges_SinceVersion(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "cl-since", "intent", "p1", "medium")
+	_, err := store.CreateSpec(ctx, "cl-since", "intent", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	newIntent := "v2"
@@ -88,7 +88,7 @@ func TestListChanges_Limit(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "cl-limit", "intent", "p1", "medium")
+	_, err := store.CreateSpec(ctx, "cl-limit", "intent", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	for i := range 5 {
@@ -118,9 +118,9 @@ func TestListAllChanges(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "all-cl-alpha", "alpha intent", "p1", "low")
+	_, err := store.CreateSpec(ctx, "all-cl-alpha", "alpha intent", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "all-cl-beta", "beta intent", "p2", "high")
+	_, err = store.CreateSpec(ctx, "all-cl-beta", "beta intent", "p2", "high", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	newIntent := "alpha updated"
@@ -163,7 +163,7 @@ func TestListChanges_AfterAmend(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "amend-changelog", "original intent", "p2", "medium")
+	_, err := store.CreateSpec(ctx, "amend-changelog", "original intent", "p2", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	inProgressStage := "in_progress"
@@ -208,12 +208,12 @@ func TestListChanges_AfterSupersede(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "old-spec", "old intent", "p1", "medium")
+	_, err := store.CreateSpec(ctx, "old-spec", "old intent", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	doneStage := "done"
 	_, err = store.UpdateSpec(ctx, "old-spec", nil, &doneStage, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "new-spec", "new intent", "p1", "medium")
+	_, err = store.CreateSpec(ctx, "new-spec", "new intent", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, _, err = store.LifecycleSupersedeSpec(ctx, "old-spec", "new-spec")
@@ -278,7 +278,7 @@ func TestListChanges_AfterAbandon(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "abandon-changelog", "original intent", "p1", "medium")
+	_, err := store.CreateSpec(ctx, "abandon-changelog", "original intent", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.LifecycleAbandonSpec(ctx, "abandon-changelog", "no longer needed")

--- a/internal/storage/postgres/claim_test.go
+++ b/internal/storage/postgres/claim_test.go
@@ -21,7 +21,7 @@ func TestClaimSpec_Basic(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "claim-basic", "intent", "p1", "low")
+	_, err := store.CreateSpec(ctx, "claim-basic", "intent", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	claim, err := store.ClaimSpec(ctx, "claim-basic", "agent-a", 5*time.Minute)
@@ -41,7 +41,7 @@ func TestClaimSpec_ExpiredReleasedFirst(t *testing.T) {
 	fixedPast := time.Now().Add(-30 * time.Minute)
 	pastStore := newStore(t, postgres.WithClock(func() time.Time { return fixedPast }))
 
-	_, err := pastStore.CreateSpec(ctx, "claim-expired", "intent", "", "")
+	_, err := pastStore.CreateSpec(ctx, "claim-expired", "intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Claim with 1-second lease from past clock — already expired by now.
@@ -58,7 +58,7 @@ func TestClaimSpec_DuplicateReturnsError(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "claim-dup", "intent", "", "")
+	_, err := store.CreateSpec(ctx, "claim-dup", "intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.ClaimSpec(ctx, "claim-dup", "agent-a", 5*time.Minute)
@@ -73,7 +73,7 @@ func TestClaimSpec_SameAgentRefreshesLease(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "claim-refresh", "intent", "", "")
+	_, err := store.CreateSpec(ctx, "claim-refresh", "intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	c1, err := store.ClaimSpec(ctx, "claim-refresh", "agent-a", 5*time.Minute)
@@ -89,7 +89,7 @@ func TestUnclaimSpec(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "unclaim-spec", "intent", "", "")
+	_, err := store.CreateSpec(ctx, "unclaim-spec", "intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.ClaimSpec(ctx, "unclaim-spec", "agent-a", 5*time.Minute)
@@ -108,7 +108,7 @@ func TestUnclaimSpec_NotClaimed(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "unclaim-none", "intent", "", "")
+	_, err := store.CreateSpec(ctx, "unclaim-none", "intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	err = store.UnclaimSpec(ctx, "unclaim-none", "agent-a")
@@ -120,7 +120,7 @@ func TestUnclaimSpec_WrongAgent(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "unclaim-wrong", "intent", "", "")
+	_, err := store.CreateSpec(ctx, "unclaim-wrong", "intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.ClaimSpec(ctx, "unclaim-wrong", "agent-a", 5*time.Minute)
@@ -135,7 +135,7 @@ func TestHeartbeat(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "heartbeat-spec", "intent", "", "")
+	_, err := store.CreateSpec(ctx, "heartbeat-spec", "intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	c1, err := store.ClaimSpec(ctx, "heartbeat-spec", "agent-a", 5*time.Minute)
@@ -152,7 +152,7 @@ func TestHeartbeat_NoActiveClaim(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "heartbeat-none", "intent", "", "")
+	_, err := store.CreateSpec(ctx, "heartbeat-none", "intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.Heartbeat(ctx, "heartbeat-none", "agent-a", 5*time.Minute)

--- a/internal/storage/postgres/conversation_test.go
+++ b/internal/storage/postgres/conversation_test.go
@@ -21,7 +21,7 @@ func TestRecordConversation_Basic(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "conv-basic", "test intent", "p2", "medium")
+	_, err := store.CreateSpec(ctx, "conv-basic", "test intent", "p2", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	entry := storage.ConversationLogEntry{
@@ -58,7 +58,7 @@ func TestRecordConversation_ChainEdges(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "conv-chain", "test intent", "p2", "medium")
+	_, err := store.CreateSpec(ctx, "conv-chain", "test intent", "p2", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// First log — should create AUTHORED_VIA edge.
@@ -116,7 +116,7 @@ func TestListConversations_FilterByStage(t *testing.T) {
 	}))
 	clearDatabase(t, clockStore)
 
-	_, err := clockStore.CreateSpec(ctx, "conv-filter", "test", "p2", "medium")
+	_, err := clockStore.CreateSpec(ctx, "conv-filter", "test", "p2", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = clockStore.RecordConversation(ctx, "conv-filter", storage.ConversationLogEntry{
@@ -153,7 +153,7 @@ func TestListConversations_OrderByDate(t *testing.T) {
 	}))
 	clearDatabase(t, clockStore)
 
-	_, err := clockStore.CreateSpec(ctx, "conv-order", "test", "p2", "medium")
+	_, err := clockStore.CreateSpec(ctx, "conv-order", "test", "p2", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	for i := range 3 {
@@ -188,7 +188,7 @@ func TestListConversations_EmptySlice(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "conv-empty", "test", "p2", "medium")
+	_, err := store.CreateSpec(ctx, "conv-empty", "test", "p2", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	entries, err := store.ListConversations(ctx, "conv-empty", "")
@@ -201,9 +201,9 @@ func TestListAllConversations(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "conv-all-a", "intent a", "p1", "low")
+	_, err := store.CreateSpec(ctx, "conv-all-a", "intent a", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "conv-all-b", "intent b", "p2", "medium")
+	_, err = store.CreateSpec(ctx, "conv-all-b", "intent b", "p2", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.RecordConversation(ctx, "conv-all-a", storage.ConversationLogEntry{
@@ -240,7 +240,7 @@ func TestRecordConversation_PersistsPosture(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "spec-posture-1", "intent", "p2", "medium")
+	_, err := store.CreateSpec(ctx, "spec-posture-1", "intent", "p2", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	entry := storage.ConversationLogEntry{
@@ -268,7 +268,7 @@ func TestRecordConversation_PersistsEmptyPosture(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "spec-posture-empty", "intent", "p2", "medium")
+	_, err := store.CreateSpec(ctx, "spec-posture-empty", "intent", "p2", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	entry := storage.ConversationLogEntry{
@@ -296,7 +296,7 @@ func TestGetSpec_IncludesConversationLogs(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "conv-getspec", "test intent", "p2", "medium")
+	_, err := store.CreateSpec(ctx, "conv-getspec", "test intent", "p2", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.RecordConversation(ctx, "conv-getspec", storage.ConversationLogEntry{

--- a/internal/storage/postgres/execution_test.go
+++ b/internal/storage/postgres/execution_test.go
@@ -22,7 +22,7 @@ func approveAndClaim(t *testing.T, store *postgres.Store, slug, agent string) {
 	ctx := context.Background()
 	ptr := func(s string) *string { return &s }
 
-	_, err := store.CreateSpec(ctx, slug, "test intent for "+slug, "p1", "medium")
+	_, err := store.CreateSpec(ctx, slug, "test intent for "+slug, "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.UpdateSpec(ctx, slug, nil, ptr("approved"), nil, nil, nil)
@@ -57,7 +57,7 @@ func TestRecordProgress_NoClaim(t *testing.T) {
 	ctx := context.Background()
 	ptr := func(s string) *string { return &s }
 
-	_, err := store.CreateSpec(ctx, "unclaimed-spec", "unclaimed", "p1", "low")
+	_, err := store.CreateSpec(ctx, "unclaimed-spec", "unclaimed", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	_, err = store.UpdateSpec(ctx, "unclaimed-spec", nil, ptr("approved"), nil, nil, nil)
 	require.NoError(t, err)
@@ -154,10 +154,10 @@ func TestRecordCompletion_HashRefreshed(t *testing.T) {
 	// RefreshDependencyHashes(slug) refreshes the completing spec's outgoing
 	// DEPENDS_ON edges — i.e. the hash recorded on edges FROM the completing spec.
 
-	_, err := store.CreateSpec(ctx, "dep-target", "dep target", "p1", "medium")
+	_, err := store.CreateSpec(ctx, "dep-target", "dep target", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	_, err = store.CreateSpec(ctx, "completing-spec", "completing", "p1", "medium")
+	_, err = store.CreateSpec(ctx, "completing-spec", "completing", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// completing-spec depends on dep-target.
@@ -258,7 +258,7 @@ func TestGenerateBundle_NotApproved(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "spark-spec", "spark stage spec", "p1", "low")
+	_, err := store.CreateSpec(ctx, "spark-spec", "spark stage spec", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.GenerateBundle(ctx, "spark-spec")
@@ -280,9 +280,9 @@ func TestGenerateBundle_IncludesDependencies(t *testing.T) {
 	ctx := context.Background()
 	ptr := func(s string) *string { return &s }
 
-	_, err := store.CreateSpec(ctx, "upstream-dep", "upstream", "p1", "medium")
+	_, err := store.CreateSpec(ctx, "upstream-dep", "upstream", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "downstream-dep", "downstream", "p1", "medium")
+	_, err = store.CreateSpec(ctx, "downstream-dep", "downstream", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.AddEdge(ctx, "downstream-dep", "upstream-dep", storage.EdgeTypeDependsOn)
@@ -302,7 +302,7 @@ func TestGetPrimeData(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "prime-spec", "prime intent", "p1", "medium")
+	_, err := store.CreateSpec(ctx, "prime-spec", "prime intent", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.CreateDecision(ctx, "prime-dec", "Use Redis", "Redis for caching", "Speed",
@@ -332,7 +332,7 @@ func TestGetPrimeData_NoConstitution(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "no-con-spec", "spec without constitution", "p1", "low")
+	_, err := store.CreateSpec(ctx, "no-con-spec", "spec without constitution", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	pd, err := store.GetPrimeData(ctx, "no-con-spec")
@@ -362,7 +362,7 @@ func TestReleaseExpiredClaims(t *testing.T) {
 		return time.Now().Add(-5 * time.Minute)
 	}))
 
-	_, err := pastStore.CreateSpec(ctx, "expiring-spec", "expiring", "p1", "low")
+	_, err := pastStore.CreateSpec(ctx, "expiring-spec", "expiring", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = pastStore.ClaimSpec(ctx, "expiring-spec", "agent-slow", 1*time.Second)
@@ -383,7 +383,7 @@ func TestReleaseExpiredClaims_NoneExpired(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "live-spec", "live claim spec", "p1", "low")
+	_, err := store.CreateSpec(ctx, "live-spec", "live claim spec", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	_, err = store.ClaimSpec(ctx, "live-spec", "agent-live", 15*time.Minute)
 	require.NoError(t, err)

--- a/internal/storage/postgres/findings_test.go
+++ b/internal/storage/postgres/findings_test.go
@@ -18,7 +18,7 @@ func TestStoreFindings_CreatesAndReplacesExisting(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "findings-spec", "Intent", "", "")
+	_, err := store.CreateSpec(ctx, "findings-spec", "Intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Store initial findings.
@@ -62,7 +62,7 @@ func TestListFindings_FilterByPassType(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "filter-spec", "Intent", "", "")
+	_, err := store.CreateSpec(ctx, "filter-spec", "Intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.StoreFindings(ctx, "filter-spec", storage.PassTypeConstitutionCheck, []storage.AnalyticalFindingInput{
@@ -101,9 +101,9 @@ func TestListAllFindings(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "all-spec-a", "A", "", "")
+	_, err := store.CreateSpec(ctx, "all-spec-a", "A", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "all-spec-b", "B", "", "")
+	_, err = store.CreateSpec(ctx, "all-spec-b", "B", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.StoreFindings(ctx, "all-spec-a", storage.PassTypeConstitutionCheck, []storage.AnalyticalFindingInput{

--- a/internal/storage/postgres/graph.go
+++ b/internal/storage/postgres/graph.go
@@ -359,7 +359,15 @@ func (s *Store) GetReady(ctx context.Context) ([]storage.NodeRef, error) {
 	rows, err := s.query(ctx,
 		`SELECT s.slug, 'Spec' AS label, s.stage
 		 FROM specs s
-		 WHERE s.project_slug = $1 AND s.stage <> 'done'
+		 WHERE s.project_slug = $1
+		   AND s.stage = 'approved'
+		   AND s.provenance_type = 'authored'
+		   AND NOT EXISTS (
+		       -- Active claim by any agent
+		       SELECT 1 FROM claims c
+		       WHERE c.project_slug = $1 AND c.spec_slug = s.slug
+		         AND c.lease_expires > NOW()
+		   )
 		   AND NOT EXISTS (
 		       -- Only Spec deps are checked by design; see function comment.
 		       SELECT 1 FROM edges e

--- a/internal/storage/postgres/graph_ready_provenance_test.go
+++ b/internal/storage/postgres/graph_ready_provenance_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetReady_ProvenanceAndStageFilters asserts that GetReady returns only
+// AUTHORED specs at stage=approved with no active claim. Specs in terminal
+// stages (done, superseded, abandoned), non-approved stages (spark), or
+// non-AUTHORED provenance (declared) must all be excluded.
+func TestGetReady_ProvenanceAndStageFilters(t *testing.T) {
+	store := newStore(t)
+	clearDatabase(t, store)
+	ctx := context.Background()
+
+	// 1. AUTHORED + approved — the one that must appear in GetReady.
+	_, err := store.CreateSpec(ctx, "a-authored-approved", "authored approved", "p1", "medium",
+		storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
+	require.NoError(t, err)
+	approvedStage := string(storage.SpecStageApproved)
+	_, err = store.UpdateSpec(ctx, "a-authored-approved", nil, &approvedStage, nil, nil, nil)
+	require.NoError(t, err)
+
+	// 2. AUTHORED + spark — not ready (wrong stage).
+	_, err = store.CreateSpec(ctx, "b-authored-spark", "authored spark", "p1", "medium",
+		storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	// 3. AUTHORED + done — not ready (terminal, wrong stage).
+	_, err = store.CreateSpec(ctx, "c-authored-done", "authored done", "p1", "medium",
+		storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
+	require.NoError(t, err)
+	doneStage := string(storage.SpecStageDone)
+	_, err = store.UpdateSpec(ctx, "c-authored-done", nil, &doneStage, nil, nil, nil)
+	require.NoError(t, err)
+
+	// 4. DECLARED + done — not ready (wrong provenance type).
+	_, err = store.CreateSpec(ctx, "d-declared-done", "declared done", "p1", "medium",
+		storage.SpecProvenanceDeclared,
+		storage.SpecProvenanceDetail{
+			Declared: &storage.DeclaredProvenance{DeclaredBy: "platform-team"},
+		},
+		nil, nil, nil, nil)
+	require.NoError(t, err)
+	_, err = store.UpdateSpec(ctx, "d-declared-done", nil, &doneStage, nil, nil, nil)
+	require.NoError(t, err)
+
+	// 5. AUTHORED + superseded — not ready (fully terminal).
+	_, err = store.CreateSpec(ctx, "e-authored-superseded-old", "to be superseded", "p1", "medium",
+		storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
+	require.NoError(t, err)
+	_, err = store.CreateSpec(ctx, "e-authored-superseded-new", "superseding spec", "p1", "medium",
+		storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
+	require.NoError(t, err)
+	_, _, err = store.LifecycleSupersedeSpec(ctx, "e-authored-superseded-old", "e-authored-superseded-new")
+	require.NoError(t, err)
+
+	// 6. AUTHORED + abandoned — not ready (fully terminal).
+	_, err = store.CreateSpec(ctx, "f-authored-abandoned", "authored abandoned", "p1", "medium",
+		storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
+	require.NoError(t, err)
+	_, err = store.LifecycleAbandonSpec(ctx, "f-authored-abandoned", "no longer needed")
+	require.NoError(t, err)
+
+	// GetReady must return exactly one slug: a-authored-approved.
+	refs, err := store.GetReady(ctx)
+	require.NoError(t, err)
+
+	slugs := make([]string, 0, len(refs))
+	for _, r := range refs {
+		slugs = append(slugs, r.Slug)
+	}
+
+	require.Len(t, slugs, 1, "expected exactly one ready spec, got: %v", slugs)
+	require.Equal(t, "a-authored-approved", slugs[0])
+}

--- a/internal/storage/postgres/graph_ready_provenance_test.go
+++ b/internal/storage/postgres/graph_ready_provenance_test.go
@@ -54,6 +54,21 @@ func TestGetReady_ProvenanceAndStageFilters(t *testing.T) {
 	_, err = store.UpdateSpec(ctx, "d-declared-done", nil, &doneStage, nil, nil, nil)
 	require.NoError(t, err)
 
+	// 4b. DECLARED + approved — not ready (wrong provenance type even at the
+	// correct stage). This fixture isolates the provenance filter: if the
+	// stage=approved predicate were the only gate, this would incorrectly
+	// appear in ready.
+	_, err = store.CreateSpec(ctx, "d2-declared-approved", "declared at approved", "p1", "medium",
+		storage.SpecProvenanceDeclared,
+		storage.SpecProvenanceDetail{
+			Declared: &storage.DeclaredProvenance{DeclaredBy: "platform-team"},
+		},
+		nil, nil, nil, nil)
+	require.NoError(t, err)
+	approvedStage := string(storage.SpecStageApproved)
+	_, err = store.UpdateSpec(ctx, "d2-declared-approved", nil, &approvedStage, nil, nil, nil)
+	require.NoError(t, err)
+
 	// 5. AUTHORED + superseded — not ready (fully terminal).
 	_, err = store.CreateSpec(ctx, "e-authored-superseded-old", "to be superseded", "p1", "medium",
 		storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)

--- a/internal/storage/postgres/graph_ready_provenance_test.go
+++ b/internal/storage/postgres/graph_ready_provenance_test.go
@@ -65,7 +65,6 @@ func TestGetReady_ProvenanceAndStageFilters(t *testing.T) {
 		},
 		nil, nil, nil, nil)
 	require.NoError(t, err)
-	approvedStage := string(storage.SpecStageApproved)
 	_, err = store.UpdateSpec(ctx, "d2-declared-approved", nil, &approvedStage, nil, nil, nil)
 	require.NoError(t, err)
 

--- a/internal/storage/postgres/graph_ready_provenance_test.go
+++ b/internal/storage/postgres/graph_ready_provenance_test.go
@@ -72,6 +72,8 @@ func TestGetReady_ProvenanceAndStageFilters(t *testing.T) {
 	_, err = store.CreateSpec(ctx, "e-authored-superseded-old", "to be superseded", "p1", "medium",
 		storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
+	_, err = store.UpdateSpec(ctx, "e-authored-superseded-old", nil, &doneStage, nil, nil, nil)
+	require.NoError(t, err)
 	_, err = store.CreateSpec(ctx, "e-authored-superseded-new", "superseding spec", "p1", "medium",
 		storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)

--- a/internal/storage/postgres/graph_test.go
+++ b/internal/storage/postgres/graph_test.go
@@ -20,9 +20,9 @@ func TestAddEdge_Basic(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "spec-x", "Spec X", "p1", "low")
+	_, err := store.CreateSpec(ctx, "spec-x", "Spec X", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "spec-y", "Spec Y", "p2", "medium")
+	_, err = store.CreateSpec(ctx, "spec-y", "Spec Y", "p2", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	edge, err := store.AddEdge(ctx, "spec-x", "spec-y", storage.EdgeTypeDependsOn)
@@ -52,11 +52,11 @@ func TestAddEdge_DependsOn_CapturesContentHash(t *testing.T) {
 	ctx := context.Background()
 
 	// Create upstream with a known content hash.
-	upstream, err := store.CreateSpec(ctx, "upstream", "Upstream intent", "p1", "low")
+	upstream, err := store.CreateSpec(ctx, "upstream", "Upstream intent", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, upstream.ContentHash)
 
-	_, err = store.CreateSpec(ctx, "downstream", "Downstream intent", "p2", "low")
+	_, err = store.CreateSpec(ctx, "downstream", "Downstream intent", "p2", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	edge, err := store.AddEdge(ctx, "downstream", "upstream", storage.EdgeTypeDependsOn)
@@ -69,9 +69,9 @@ func TestAddEdge_Idempotent(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "a", "A", "", "")
+	_, err := store.CreateSpec(ctx, "a", "A", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "b", "B", "", "")
+	_, err = store.CreateSpec(ctx, "b", "B", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.AddEdge(ctx, "a", "b", storage.EdgeTypeRelatesTo)
@@ -86,7 +86,7 @@ func TestAddEdge_NodeNotFound(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "exists", "Exists", "", "")
+	_, err := store.CreateSpec(ctx, "exists", "Exists", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.AddEdge(ctx, "exists", "missing", storage.EdgeTypeDependsOn)
@@ -99,9 +99,9 @@ func TestRemoveEdge(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "rm-from", "From", "", "")
+	_, err := store.CreateSpec(ctx, "rm-from", "From", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "rm-to", "To", "", "")
+	_, err = store.CreateSpec(ctx, "rm-to", "To", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.AddEdge(ctx, "rm-from", "rm-to", storage.EdgeTypeDependsOn)
@@ -121,9 +121,9 @@ func TestRemoveEdge_InTransaction_RollsBack(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "tx-from", "From", "", "")
+	_, err := store.CreateSpec(ctx, "tx-from", "From", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "tx-to", "To", "", "")
+	_, err = store.CreateSpec(ctx, "tx-to", "To", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	_, err = store.AddEdge(ctx, "tx-from", "tx-to", storage.EdgeTypeDependsOn)
 	require.NoError(t, err)
@@ -148,7 +148,7 @@ func TestListEdges_ExcludesInternalTypes(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "internal-test", "Test", "", "")
+	_, err := store.CreateSpec(ctx, "internal-test", "Test", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// CreateSpec already creates a BELONGS_TO edge internally.
@@ -166,9 +166,9 @@ func TestListEdges_Bidirectional(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "bidir-a", "A", "", "")
+	_, err := store.CreateSpec(ctx, "bidir-a", "A", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "bidir-b", "B", "", "")
+	_, err = store.CreateSpec(ctx, "bidir-b", "B", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// A -> B
@@ -195,9 +195,9 @@ func TestGetDependencies(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "parent", "Parent", "p1", "medium")
+	_, err := store.CreateSpec(ctx, "parent", "Parent", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "child", "Child", "p2", "low")
+	_, err = store.CreateSpec(ctx, "child", "Child", "p2", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.AddEdge(ctx, "parent", "child", storage.EdgeTypeDependsOn)
@@ -215,9 +215,9 @@ func TestGetDependencies_IncludesBlocksSources(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "blocker", "Blocker", "", "")
+	_, err := store.CreateSpec(ctx, "blocker", "Blocker", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "blocked", "Blocked", "", "")
+	_, err = store.CreateSpec(ctx, "blocked", "Blocked", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// blocker BLOCKS blocked
@@ -235,9 +235,9 @@ func TestGetDependenciesWithEdgeData(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	upstream, err := store.CreateSpec(ctx, "up", "Upstream", "", "")
+	upstream, err := store.CreateSpec(ctx, "up", "Upstream", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "down", "Downstream", "", "")
+	_, err = store.CreateSpec(ctx, "down", "Downstream", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.AddEdge(ctx, "down", "up", storage.EdgeTypeDependsOn)
@@ -256,9 +256,9 @@ func TestRefreshDependencyHashes(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "refresh-up", "Upstream", "", "")
+	_, err := store.CreateSpec(ctx, "refresh-up", "Upstream", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "refresh-down", "Downstream", "", "")
+	_, err = store.CreateSpec(ctx, "refresh-down", "Downstream", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.AddEdge(ctx, "refresh-down", "refresh-up", storage.EdgeTypeDependsOn)
@@ -295,7 +295,7 @@ func TestGetTransitiveDeps(t *testing.T) {
 
 	// Chain: A -> B -> C -> D
 	for _, slug := range []string{"a", "b", "c", "d"} {
-		_, err := store.CreateSpec(ctx, slug, "Spec "+slug, "", "")
+		_, err := store.CreateSpec(ctx, slug, "Spec "+slug, "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 	}
 	_, err := store.AddEdge(ctx, "a", "b", storage.EdgeTypeDependsOn)
@@ -325,7 +325,7 @@ func TestGetTransitiveDeps_Diamond(t *testing.T) {
 
 	// Diamond: A -> B, A -> C, B -> D, C -> D
 	for _, slug := range []string{"a", "b", "c", "d"} {
-		_, err := store.CreateSpec(ctx, slug, "Spec "+slug, "", "")
+		_, err := store.CreateSpec(ctx, slug, "Spec "+slug, "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 	}
 	_, err := store.AddEdge(ctx, "a", "b", storage.EdgeTypeDependsOn)
@@ -354,7 +354,7 @@ func TestGetTransitiveDeps_BoundedChain(t *testing.T) {
 		slugs = append(slugs, fmt.Sprintf("n%02d", i))
 	}
 	for _, slug := range slugs {
-		_, err := store.CreateSpec(ctx, slug, "Spec "+slug, "", "")
+		_, err := store.CreateSpec(ctx, slug, "Spec "+slug, "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 	}
 	// Chain: n54 -> n53 -> ... -> n00
@@ -375,7 +375,7 @@ func TestGetImpact(t *testing.T) {
 
 	// Chain: A -> B -> C -> D
 	for _, slug := range []string{"a", "b", "c", "d"} {
-		_, err := store.CreateSpec(ctx, slug, "Spec "+slug, "", "")
+		_, err := store.CreateSpec(ctx, slug, "Spec "+slug, "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 	}
 	_, err := store.AddEdge(ctx, "a", "b", storage.EdgeTypeDependsOn)
@@ -406,7 +406,7 @@ func TestGetImpact_Diamond(t *testing.T) {
 
 	// Diamond: A -> B, A -> C, B -> D, C -> D
 	for _, slug := range []string{"a", "b", "c", "d"} {
-		_, err := store.CreateSpec(ctx, slug, "Spec "+slug, "", "")
+		_, err := store.CreateSpec(ctx, slug, "Spec "+slug, "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 	}
 	_, err := store.AddEdge(ctx, "a", "b", storage.EdgeTypeDependsOn)
@@ -429,11 +429,11 @@ func TestGetReady(t *testing.T) {
 	ctx := context.Background()
 
 	// Create: blocked depends on blocker, free has no deps.
-	_, err := store.CreateSpec(ctx, "blocked", "Blocked", "", "")
+	_, err := store.CreateSpec(ctx, "blocked", "Blocked", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "blocker", "Blocker", "", "")
+	_, err = store.CreateSpec(ctx, "blocker", "Blocker", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "free", "Free", "", "")
+	_, err = store.CreateSpec(ctx, "free", "Free", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.AddEdge(ctx, "blocked", "blocker", storage.EdgeTypeDependsOn)
@@ -456,9 +456,9 @@ func TestGetReady_BlocksEdgePreventsReady(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "block-target", "Target", "", "")
+	_, err := store.CreateSpec(ctx, "block-target", "Target", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "block-source", "Source", "", "")
+	_, err = store.CreateSpec(ctx, "block-source", "Source", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// block-source BLOCKS block-target
@@ -481,7 +481,7 @@ func TestGetReady_DoneSpecsDontAppear(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "done-spec", "Done", "", "")
+	_, err := store.CreateSpec(ctx, "done-spec", "Done", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	done := "done"
@@ -504,7 +504,7 @@ func TestGetCriticalPath(t *testing.T) {
 	// Diamond: A -> B -> D, A -> C -> D
 	// Both paths have length 3, so critical path from A should be one of them.
 	for _, slug := range []string{"a", "b", "c", "d"} {
-		_, err := store.CreateSpec(ctx, slug, "Spec "+slug, "", "")
+		_, err := store.CreateSpec(ctx, slug, "Spec "+slug, "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 	}
 	_, err := store.AddEdge(ctx, "a", "b", storage.EdgeTypeDependsOn)
@@ -532,7 +532,7 @@ func TestGetCriticalPath_LinearChain(t *testing.T) {
 
 	// A -> B -> C
 	for _, slug := range []string{"a", "b", "c"} {
-		_, err := store.CreateSpec(ctx, slug, "Spec "+slug, "", "")
+		_, err := store.CreateSpec(ctx, slug, "Spec "+slug, "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 	}
 	_, err := store.AddEdge(ctx, "a", "b", storage.EdgeTypeDependsOn)
@@ -553,7 +553,7 @@ func TestGetCriticalPath_NoDeps(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "lonely", "No deps", "", "")
+	_, err := store.CreateSpec(ctx, "lonely", "No deps", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	path, err := store.GetCriticalPath(ctx, "lonely")
@@ -568,9 +568,9 @@ func TestGetFullGraph(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "fg-a", "A", "p1", "")
+	_, err := store.CreateSpec(ctx, "fg-a", "A", "p1", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "fg-b", "B", "p2", "")
+	_, err = store.CreateSpec(ctx, "fg-b", "B", "p2", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.AddEdge(ctx, "fg-a", "fg-b", storage.EdgeTypeDependsOn)
@@ -606,7 +606,7 @@ func TestGetFullGraph_ExcludesInternalEdges(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "fg-internal", "Internal test", "", "")
+	_, err := store.CreateSpec(ctx, "fg-internal", "Internal test", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	graph, err := store.GetFullGraph(ctx)
@@ -637,9 +637,9 @@ func TestBlocksEdgeDirection(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "spec-alpha", "Alpha", "", "")
+	_, err := store.CreateSpec(ctx, "spec-alpha", "Alpha", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "spec-beta", "Beta", "", "")
+	_, err = store.CreateSpec(ctx, "spec-beta", "Beta", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	edge, err := store.AddEdge(ctx, "spec-alpha", "spec-beta", storage.EdgeTypeBlocks)
@@ -667,9 +667,9 @@ func TestRemoveEdge_Idempotent(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "idem-from", "From", "", "")
+	_, err := store.CreateSpec(ctx, "idem-from", "From", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "idem-to", "To", "", "")
+	_, err = store.CreateSpec(ctx, "idem-to", "To", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Remove an edge that does not exist — should not error.

--- a/internal/storage/postgres/graph_test.go
+++ b/internal/storage/postgres/graph_test.go
@@ -439,6 +439,13 @@ func TestGetReady(t *testing.T) {
 	_, err = store.AddEdge(ctx, "blocked", "blocker", storage.EdgeTypeDependsOn)
 	require.NoError(t, err)
 
+	approvedStage := "approved"
+	_, err = store.UpdateSpec(ctx, "free", nil, &approvedStage, nil, nil, nil)
+	require.NoError(t, err)
+	_, err = store.UpdateSpec(ctx, "blocker", nil, &approvedStage, nil, nil, nil)
+	require.NoError(t, err)
+	// blocked stays at spark — should not be ready (dependency check)
+
 	ready, err := store.GetReady(ctx)
 	require.NoError(t, err)
 
@@ -464,6 +471,11 @@ func TestGetReady_BlocksEdgePreventsReady(t *testing.T) {
 	// block-source BLOCKS block-target
 	_, err = store.AddEdge(ctx, "block-source", "block-target", storage.EdgeTypeBlocks)
 	require.NoError(t, err)
+
+	approvedStage := "approved"
+	_, err = store.UpdateSpec(ctx, "block-source", nil, &approvedStage, nil, nil, nil)
+	require.NoError(t, err)
+	// block-target stays at spark — not ready due to BLOCKS edge
 
 	ready, err := store.GetReady(ctx)
 	require.NoError(t, err)

--- a/internal/storage/postgres/lifecycle_test.go
+++ b/internal/storage/postgres/lifecycle_test.go
@@ -20,7 +20,7 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "amend-me", "Test spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "amend-me", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 		inProgressStage := "in_progress"
 		_, err = store.UpdateSpec(ctx, "amend-me", nil, &inProgressStage, nil, nil, nil)
@@ -44,7 +44,7 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "amend-noreentry", "Test spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "amend-noreentry", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 		inProgressStage := "in_progress"
 		_, err = store.UpdateSpec(ctx, "amend-noreentry", nil, &inProgressStage, nil, nil, nil)
@@ -59,7 +59,7 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "not-amendable-spark", "Test spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "not-amendable-spark", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 		// Spec is at "spark" -- not amend-eligible, so amend should fail.
 		_, err = store.LifecycleAmendSpec(ctx, "not-amendable-spark", "reason", "shape")
@@ -71,7 +71,7 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "not-amendable-done", "Test spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "not-amendable-done", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 		doneStage := "done"
 		_, err = store.UpdateSpec(ctx, "not-amendable-done", nil, &doneStage, nil, nil, nil)
@@ -95,7 +95,7 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "amend-terminal", "Test spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "amend-terminal", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		// Abandon the spec to make it terminal.
@@ -114,7 +114,7 @@ func TestLifecycle(t *testing.T) {
 
 		for _, stage := range []string{"approved", "in_progress", "review"} {
 			slug := "amend-eligible-" + stage
-			_, err := store.CreateSpec(ctx, slug, "Test spec", "p1", "medium")
+			_, err := store.CreateSpec(ctx, slug, "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 			require.NoError(t, err)
 			_, err = store.UpdateSpec(ctx, slug, nil, &stage, nil, nil, nil)
 			require.NoError(t, err)
@@ -131,7 +131,7 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "toctou-amend", "Test spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "toctou-amend", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 		inProgressStage := "in_progress"
 		_, err = store.UpdateSpec(ctx, "toctou-amend", nil, &inProgressStage, nil, nil, nil)
@@ -169,7 +169,7 @@ func TestLifecycle(t *testing.T) {
 
 		for _, stage := range []string{"done", "superseded", "abandoned"} {
 			slug := "amend-reentry-" + stage
-			_, err := store.CreateSpec(ctx, slug, "Test spec", "p1", "medium")
+			_, err := store.CreateSpec(ctx, slug, "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 			require.NoError(t, err)
 			inProgressStage := "in_progress"
 			_, err = store.UpdateSpec(ctx, slug, nil, &inProgressStage, nil, nil, nil)
@@ -185,12 +185,12 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "old-lifecycle", "Old spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "old-lifecycle", "Old spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 		doneStage := "done"
 		_, err = store.UpdateSpec(ctx, "old-lifecycle", nil, &doneStage, nil, nil, nil)
 		require.NoError(t, err)
-		_, err = store.CreateSpec(ctx, "new-lifecycle", "New spec", "p1", "medium")
+		_, err = store.CreateSpec(ctx, "new-lifecycle", "New spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		old, newSpec, err := store.LifecycleSupersedeSpec(ctx, "old-lifecycle", "new-lifecycle")
@@ -205,12 +205,12 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "edge-old", "Old spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "edge-old", "Old spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 		doneStage := "done"
 		_, err = store.UpdateSpec(ctx, "edge-old", nil, &doneStage, nil, nil, nil)
 		require.NoError(t, err)
-		_, err = store.CreateSpec(ctx, "edge-new", "New spec", "p1", "medium")
+		_, err = store.CreateSpec(ctx, "edge-new", "New spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		_, _, err = store.LifecycleSupersedeSpec(ctx, "edge-old", "edge-new")
@@ -229,7 +229,7 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "exists-new", "New spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "exists-new", "New spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		_, _, err = store.LifecycleSupersedeSpec(ctx, "nonexistent-old", "exists-new")
@@ -241,7 +241,7 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "exists-old", "Old spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "exists-old", "Old spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 		doneStage := "done"
 		_, err = store.UpdateSpec(ctx, "exists-old", nil, &doneStage, nil, nil, nil)
@@ -256,9 +256,9 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "not-done-old", "Old spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "not-done-old", "Old spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
-		_, err = store.CreateSpec(ctx, "not-done-new", "New spec", "p1", "medium")
+		_, err = store.CreateSpec(ctx, "not-done-new", "New spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		// Old spec is at spark -- not done, supersede should fail.
@@ -271,9 +271,9 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "terminal-old", "Old spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "terminal-old", "Old spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
-		_, err = store.CreateSpec(ctx, "replacement", "New spec", "p1", "medium")
+		_, err = store.CreateSpec(ctx, "replacement", "New spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		// Abandon the old spec first to make it terminal.
@@ -290,12 +290,12 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "old-sup-aband", "Old spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "old-sup-aband", "Old spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 		doneStage := "done"
 		_, err = store.UpdateSpec(ctx, "old-sup-aband", nil, &doneStage, nil, nil, nil)
 		require.NoError(t, err)
-		_, err = store.CreateSpec(ctx, "new-sup-aband", "New spec", "p1", "medium")
+		_, err = store.CreateSpec(ctx, "new-sup-aband", "New spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 		_, err = store.LifecycleAbandonSpec(ctx, "new-sup-aband", "no longer needed")
 		require.NoError(t, err)
@@ -309,7 +309,7 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "same-slug", "Test spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "same-slug", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		_, _, err = store.LifecycleSupersedeSpec(ctx, "same-slug", "same-slug")
@@ -321,7 +321,7 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "abandon-me", "Test spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "abandon-me", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		abandoned, err := store.LifecycleAbandonSpec(ctx, "abandon-me", "no longer needed")
@@ -335,7 +335,7 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "abandon-twice", "Test spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "abandon-twice", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		_, err = store.LifecycleAbandonSpec(ctx, "abandon-twice", "first abandon")
@@ -360,7 +360,7 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "toctou-abandon", "Test spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "toctou-abandon", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		// Two goroutines race to abandon the same spec.
@@ -394,9 +394,9 @@ func TestLifecycle(t *testing.T) {
 		ctx := context.Background()
 
 		// Create upstream and downstream, link with DEPENDS_ON.
-		_, err := store.CreateSpec(ctx, "ack-upstream", "Upstream", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "ack-upstream", "Upstream", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
-		_, err = store.CreateSpec(ctx, "ack-drift", "Test spec", "p1", "medium")
+		_, err = store.CreateSpec(ctx, "ack-drift", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 		_, err = store.AddEdge(ctx, "ack-drift", "ack-upstream", storage.EdgeTypeDependsOn)
 		require.NoError(t, err)
@@ -427,11 +427,11 @@ func TestLifecycle(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "all-up1", "Upstream 1", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "all-up1", "Upstream 1", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
-		_, err = store.CreateSpec(ctx, "all-up2", "Upstream 2", "p1", "medium")
+		_, err = store.CreateSpec(ctx, "all-up2", "Upstream 2", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
-		_, err = store.CreateSpec(ctx, "all-down", "Downstream", "p1", "medium")
+		_, err = store.CreateSpec(ctx, "all-down", "Downstream", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		_, err = store.AddEdge(ctx, "all-down", "all-up1", storage.EdgeTypeDependsOn)
@@ -477,7 +477,7 @@ func TestLifecycle(t *testing.T) {
 		ctx := context.Background()
 
 		// Spec at spark stage is not eligible.
-		_, err := store.CreateSpec(ctx, "ack-ineligible", "Test spec", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "ack-ineligible", "Test spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		err = store.LifecycleAcknowledgeDrift(ctx, "ack-ineligible", "", "should fail")
@@ -502,9 +502,9 @@ func TestLifecycle_AmendRefreshesEdgeHash(t *testing.T) {
 	ctx := context.Background()
 
 	// Create upstream and downstream specs.
-	_, err := store.CreateSpec(ctx, "upstream-hash", "Upstream spec", "p1", "medium")
+	_, err := store.CreateSpec(ctx, "upstream-hash", "Upstream spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "downstream-hash", "Downstream spec", "p1", "medium")
+	_, err = store.CreateSpec(ctx, "downstream-hash", "Downstream spec", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Link downstream -> upstream with a DEPENDS_ON edge.

--- a/internal/storage/postgres/migration_007_test.go
+++ b/internal/storage/postgres/migration_007_test.go
@@ -45,7 +45,7 @@ func TestMigration007_RefusesNonEmptyTable(t *testing.T) {
 			"POSTGRES_PASSWORD": "mig007",
 			"POSTGRES_DB":       "mig007db",
 		},
-		WaitingFor: wait.ForLog("database system is ready to accept connections").
+		WaitingFor: wait.ForLog("database system is ready").
 			WithOccurrence(2).
 			WithStartupTimeout(60 * time.Second),
 	}

--- a/internal/storage/postgres/migration_007_test.go
+++ b/internal/storage/postgres/migration_007_test.go
@@ -92,6 +92,13 @@ func TestMigration007_RefusesNonEmptyTable(t *testing.T) {
 	err = goose.UpTo(db, migrationsDir, 6)
 	require.NoError(t, err, "migrations 001–006 must apply cleanly")
 
+	// Insert a project row to satisfy the project_slug FK constraint on specs.
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO projects (slug) VALUES ($1)`,
+		"test-project",
+	)
+	require.NoError(t, err, "inserting project row must succeed")
+
 	// Insert a spec row using the pre-007 schema (has lifecycle column, no provenance columns).
 	_, err = db.ExecContext(ctx,
 		`INSERT INTO specs (slug, project_slug, intent, stage, priority, complexity, lifecycle, notes, content_hash, version, created_at, updated_at)

--- a/internal/storage/postgres/migration_007_test.go
+++ b/internal/storage/postgres/migration_007_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib" // registers "pgx" driver for database/sql
+	"github.com/pressly/goose/v3"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// TestMigration007_RefusesNonEmptyTable verifies that the precondition guard in
+// migration 007 prevents it from running when the specs table already contains rows.
+//
+// The test:
+//  1. Spins up a fresh postgres container (independent of the TestMain container).
+//  2. Applies migrations 001–006 via goose.UpTo.
+//  3. Inserts a spec row directly using the pre-007 schema shape (has lifecycle column,
+//     no provenance_type/provenance_detail columns).
+//  4. Attempts to apply migration 007 via goose.UpTo.
+//  5. Asserts that migration 007 errors with the precondition message.
+func TestMigration007_RefusesNonEmptyTable(t *testing.T) {
+	ctx := context.Background()
+
+	// Spin up an independent container so this test doesn't conflict with
+	// the shared container from TestMain.
+	req := testcontainers.ContainerRequest{
+		Image:        "pgvector/pgvector:pg18",
+		ExposedPorts: []string{"5432/tcp"},
+		Env: map[string]string{
+			"POSTGRES_USER":     "mig007",
+			"POSTGRES_PASSWORD": "mig007",
+			"POSTGRES_DB":       "mig007db",
+		},
+		WaitingFor: wait.ForLog("database system is ready to accept connections").
+			WithOccurrence(2).
+			WithStartupTimeout(60 * time.Second),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err, "start dedicated postgres container for migration test")
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "5432")
+	require.NoError(t, err)
+
+	cs := fmt.Sprintf("postgres://mig007:mig007@%s:%s/mig007db", host, port.Port())
+
+	db, err := sql.Open("pgx", cs)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Wait for the database to be ready.
+	for range 10 {
+		if pingErr := db.Ping(); pingErr == nil {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	require.NoError(t, db.Ping(), "database must be pingable before running migrations")
+
+	// Resolve the migrations directory on disk relative to this test file.
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller must succeed")
+	migrationsDir := filepath.Join(filepath.Dir(thisFile), "migrations")
+	_, statErr := os.Stat(migrationsDir)
+	require.NoError(t, statErr, "migrations directory must exist at %s", migrationsDir)
+
+	// Apply migrations 001–006 only.
+	goose.SetBaseFS(nil) // use the real filesystem, not embedded FS
+	if err := goose.SetDialect("postgres"); err != nil {
+		t.Fatalf("goose.SetDialect: %v", err)
+	}
+	err = goose.UpTo(db, migrationsDir, 6)
+	require.NoError(t, err, "migrations 001–006 must apply cleanly")
+
+	// Insert a spec row using the pre-007 schema (has lifecycle column, no provenance columns).
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO specs (slug, project_slug, intent, stage, priority, complexity, lifecycle, notes, content_hash, version, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+		"existing-spec",         // slug
+		"test-project",          // project_slug
+		"an existing spec",      // intent
+		"spark",                 // stage
+		"p2",                    // priority
+		"medium",                // complexity
+		"task",                  // lifecycle (pre-007 column)
+		"",                      // notes
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // content_hash (32 chars)
+		int32(1),                // version
+		time.Now().UTC(),        // created_at
+		time.Now().UTC(),        // updated_at
+	)
+	require.NoError(t, err, "inserting pre-007 spec row must succeed")
+
+	// Now attempt migration 007 — must fail with precondition error.
+	err = goose.UpTo(db, migrationsDir, 7)
+	require.Error(t, err, "migration 007 must refuse to run when specs table is non-empty")
+	require.Contains(t, err.Error(), "migration 007 refuses to run on a non-empty specs table",
+		"error must contain the precondition message from the migration guard")
+}

--- a/internal/storage/postgres/migrations/007_spec_provenance.sql
+++ b/internal/storage/postgres/migrations/007_spec_provenance.sql
@@ -16,8 +16,8 @@ END
 $$;
 
 ALTER TABLE specs DROP COLUMN lifecycle;
-ALTER TABLE specs ADD COLUMN provenance_type TEXT NOT NULL;
-ALTER TABLE specs ADD COLUMN provenance_detail JSONB NOT NULL;
+ALTER TABLE specs ADD COLUMN provenance_type TEXT NOT NULL DEFAULT 'authored';
+ALTER TABLE specs ADD COLUMN provenance_detail JSONB NOT NULL DEFAULT '{"type":"authored","data":null}'::jsonb;
 
 -- +goose StatementEnd
 

--- a/internal/storage/postgres/migrations/007_spec_provenance.sql
+++ b/internal/storage/postgres/migrations/007_spec_provenance.sql
@@ -1,0 +1,27 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 Sean Brandt
+
+-- +goose Up
+-- +goose StatementBegin
+
+-- Precondition guard: this migration is a clean-break replacement.
+-- It refuses to run if any rows exist in specs to prevent accidental
+-- data loss in environments where the clean-break assumption is wrong.
+DO $$
+BEGIN
+  IF (SELECT count(*) FROM specs) > 0 THEN
+    RAISE EXCEPTION 'migration 007 refuses to run on a non-empty specs table; clean-break design assumes no data — see docs/superpowers/specs/2026-05-20-spec-provenance-model-design.md';
+  END IF;
+END
+$$;
+
+ALTER TABLE specs DROP COLUMN lifecycle;
+ALTER TABLE specs ADD COLUMN provenance_type TEXT NOT NULL;
+ALTER TABLE specs ADD COLUMN provenance_detail JSONB NOT NULL;
+
+-- +goose StatementEnd
+
+-- +goose Down
+ALTER TABLE specs DROP COLUMN provenance_detail;
+ALTER TABLE specs DROP COLUMN provenance_type;
+ALTER TABLE specs ADD COLUMN lifecycle TEXT NOT NULL DEFAULT 'task';

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -317,7 +317,7 @@ func TestCreateSpec_Basic(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	spec, err := store.CreateSpec(ctx, "test-spec", "Test intent", "p1", "medium")
+	spec, err := store.CreateSpec(ctx, "test-spec", "Test intent", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, "test-spec", spec.Slug)
 	require.Equal(t, storage.SpecStage("spark"), spec.Stage)
@@ -330,9 +330,9 @@ func TestCreateSpec_DuplicateSlug(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "dup-spec", "intent", "", "")
+	_, err := store.CreateSpec(ctx, "dup-spec", "intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "dup-spec", "intent", "", "")
+	_, err = store.CreateSpec(ctx, "dup-spec", "intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.ErrorIs(t, err, storage.ErrSpecAlreadyExists)
 }
 
@@ -341,7 +341,7 @@ func TestGetSpec_Basic(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	created, err := store.CreateSpec(ctx, "get-spec", "Get intent", "p2", "low")
+	created, err := store.CreateSpec(ctx, "get-spec", "Get intent", "p2", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	got, err := store.GetSpec(ctx, "get-spec")
 	require.NoError(t, err)
@@ -363,11 +363,11 @@ func TestListSpecs_WithFilters(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "spec-a", "A intent", "p1", "low")
+	_, err := store.CreateSpec(ctx, "spec-a", "A intent", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "spec-b", "B intent", "p2", "medium")
+	_, err = store.CreateSpec(ctx, "spec-b", "B intent", "p2", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "spec-c", "C intent", "p1", "high")
+	_, err = store.CreateSpec(ctx, "spec-c", "C intent", "p1", "high", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// No filters — all three returned.
@@ -391,9 +391,9 @@ func TestBatchGetSpecs_ReturnsMap(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "batch-a", "Intent A", "", "")
+	_, err := store.CreateSpec(ctx, "batch-a", "Intent A", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "batch-b", "Intent B", "", "")
+	_, err = store.CreateSpec(ctx, "batch-b", "Intent B", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	result, err := store.BatchGetSpecs(ctx, []string{"batch-a", "batch-b", "missing-slug"})
@@ -417,7 +417,7 @@ func TestUpdateSpec_PartialUpdate(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "update-spec", "Original", "p1", "low")
+	_, err := store.CreateSpec(ctx, "update-spec", "Original", "p1", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	newIntent := "Updated"
@@ -432,7 +432,7 @@ func TestUpdateSpec_NoChangeSkipsChangelog(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "noop-spec", "Intent", "", "")
+	_, err := store.CreateSpec(ctx, "noop-spec", "Intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Update with same intent value — content hash unchanged, no changelog entry added.
@@ -460,9 +460,9 @@ func TestClearAll_WipesDataAndPreservesProject(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a spec and an edge so ClearAll has something to remove.
-	_, err := store.CreateSpec(ctx, "ca-spec", "Intent", "", "")
+	_, err := store.CreateSpec(ctx, "ca-spec", "Intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "ca-spec2", "Intent2", "", "")
+	_, err = store.CreateSpec(ctx, "ca-spec2", "Intent2", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	_, err = store.AddEdge(ctx, "ca-spec", "ca-spec2", storage.EdgeTypeDependsOn)
 	require.NoError(t, err)

--- a/internal/storage/postgres/slice_test.go
+++ b/internal/storage/postgres/slice_test.go
@@ -18,7 +18,7 @@ func TestCreateSlice(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "parent-spec", "Parent intent", "", "")
+	_, err := store.CreateSpec(ctx, "parent-spec", "Parent intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	sl := &storage.Slice{
@@ -50,7 +50,7 @@ func TestListSlices(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "list-parent", "Parent", "", "")
+	_, err := store.CreateSpec(ctx, "list-parent", "Parent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	for _, id := range []string{"sl-a", "sl-b", "sl-c"} {
@@ -82,7 +82,7 @@ func TestClaimSlice(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "claim-parent", "Parent", "", "")
+	_, err := store.CreateSpec(ctx, "claim-parent", "Parent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	sl := &storage.Slice{
@@ -108,7 +108,7 @@ func TestCompleteSlice(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "complete-parent", "Parent", "", "")
+	_, err := store.CreateSpec(ctx, "complete-parent", "Parent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	sl := &storage.Slice{
@@ -163,7 +163,7 @@ func TestClaimSlice_AlreadyDone_ReturnsWrongStatus(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "done-parent", "Parent", "", "")
+	_, err := store.CreateSpec(ctx, "done-parent", "Parent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	sl := &storage.Slice{

--- a/internal/storage/postgres/spec.go
+++ b/internal/storage/postgres/spec.go
@@ -119,7 +119,11 @@ func encodeProvenanceDetail(p storage.SpecProvenanceType, d storage.SpecProvenan
 		Type string `json:"type"`
 		Data any    `json:"data"`
 	}{Type: string(p), Data: data}
-	return json.Marshal(env)
+	out, err := json.Marshal(env)
+	if err != nil {
+		return nil, fmt.Errorf("encode provenance_detail envelope: %w", err)
+	}
+	return out, nil
 }
 
 // CreateSpec stores a new spec in Postgres and returns it.

--- a/internal/storage/postgres/spec.go
+++ b/internal/storage/postgres/spec.go
@@ -27,7 +27,11 @@ const (
 // decodeProvenanceDetail parses the JSONB envelope `{"type": "...", "data": {...}}`
 // into a domain detail struct. Empty input returns an empty (AUTHORED-shaped)
 // detail. Returns ErrProvenanceMismatch on envelope mismatch.
-func decodeProvenanceDetail(raw []byte) (storage.SpecProvenanceDetail, error) {
+//
+// If columnType is non-empty, the envelope's "type" field must match the
+// column's provenance_type value — guards against contradictory rows where
+// the column says one thing and the JSONB body says another.
+func decodeProvenanceDetail(raw []byte, columnType storage.SpecProvenanceType) (storage.SpecProvenanceDetail, error) {
 	if len(raw) == 0 {
 		return storage.SpecProvenanceDetail{}, nil
 	}
@@ -37,6 +41,11 @@ func decodeProvenanceDetail(raw []byte) (storage.SpecProvenanceDetail, error) {
 	}
 	if err := json.Unmarshal(raw, &env); err != nil {
 		return storage.SpecProvenanceDetail{}, fmt.Errorf("decode provenance_detail envelope: %w", err)
+	}
+	if columnType != "" && env.Type != "" && storage.SpecProvenanceType(env.Type) != columnType {
+		return storage.SpecProvenanceDetail{}, fmt.Errorf(
+			"decode provenance_detail: envelope type %q != column type %q: %w",
+			env.Type, columnType, storage.ErrProvenanceMismatch)
 	}
 	switch storage.SpecProvenanceType(env.Type) {
 	case storage.SpecProvenanceAuthored, "":
@@ -98,7 +107,7 @@ func encodeProvenanceDetail(p storage.SpecProvenanceType, d storage.SpecProvenan
 		}
 		data = nil
 	case storage.SpecProvenanceRetroactiveFromPR:
-		if d.RetroactiveFromPR == nil {
+		if d.RetroactiveFromPR == nil || d.Declared != nil {
 			return nil, storage.ErrProvenanceMismatch
 		}
 		data = retroactivePayload{
@@ -106,7 +115,7 @@ func encodeProvenanceDetail(p storage.SpecProvenanceType, d storage.SpecProvenan
 			MergedAt: d.RetroactiveFromPR.MergedAt, Title: d.RetroactiveFromPR.Title,
 		}
 	case storage.SpecProvenanceDeclared:
-		if d.Declared == nil {
+		if d.Declared == nil || d.RetroactiveFromPR != nil {
 			return nil, storage.ErrProvenanceMismatch
 		}
 		data = declaredPayload{
@@ -358,7 +367,7 @@ func scanSpec(row pgx.Row) (*storage.Spec, error) {
 	); err != nil {
 		return nil, fmt.Errorf("postgres: scan spec: %w", err)
 	}
-	detail, err := decodeProvenanceDetail(provenanceDetail)
+	detail, err := decodeProvenanceDetail(provenanceDetail, storage.SpecProvenanceType(provenanceType))
 	if err != nil {
 		return nil, fmt.Errorf("scan spec %q: %w", slug, err)
 	}
@@ -404,7 +413,7 @@ func scanSpecWithCount(row pgx.Row) (*storage.Spec, error) {
 	); err != nil {
 		return nil, fmt.Errorf("postgres: scan spec with count: %w", err)
 	}
-	detail, err := decodeProvenanceDetail(provenanceDetail)
+	detail, err := decodeProvenanceDetail(provenanceDetail, storage.SpecProvenanceType(provenanceType))
 	if err != nil {
 		return nil, fmt.Errorf("scan spec %q: %w", slug, err)
 	}
@@ -511,7 +520,7 @@ func (s *Store) ListSpecs(ctx context.Context, stage, priority string, limit int
 		); err != nil {
 			return nil, fmt.Errorf("postgres: list specs: scan: %w", err)
 		}
-		detail, err := decodeProvenanceDetail(provenanceDetail)
+		detail, err := decodeProvenanceDetail(provenanceDetail, storage.SpecProvenanceType(provenanceType))
 		if err != nil {
 			return nil, fmt.Errorf("postgres: list specs: decode provenance %q: %w", slug, err)
 		}
@@ -589,7 +598,7 @@ func (s *Store) BatchGetSpecs(ctx context.Context, slugs []string) (map[string]*
 		); err != nil {
 			return nil, fmt.Errorf("postgres: batch get specs: scan: %w", err)
 		}
-		detail, err := decodeProvenanceDetail(provenanceDetail)
+		detail, err := decodeProvenanceDetail(provenanceDetail, storage.SpecProvenanceType(provenanceType))
 		if err != nil {
 			return nil, fmt.Errorf("postgres: batch get specs: decode provenance %q: %w", slug, err)
 		}

--- a/internal/storage/postgres/spec.go
+++ b/internal/storage/postgres/spec.go
@@ -124,9 +124,44 @@ func encodeProvenanceDetail(p storage.SpecProvenanceType, d storage.SpecProvenan
 
 // CreateSpec stores a new spec in Postgres and returns it.
 // All DB operations run within a single transaction.
-func (s *Store) CreateSpec(ctx context.Context, slug, intent, priority, complexity string) (*storage.Spec, error) {
+//
+// provenance, detail, and stage outputs support all three creation flows:
+//   - AUTHORED (or empty): starts at spark stage; only spark_output may be
+//     supplied (or none). The content_hash is computed from the bare fields.
+//   - RETROACTIVE_FROM_PR / DECLARED: born at done; all four stage outputs
+//     are required. The content_hash is pre-computed from the full outputs
+//     before INSERT.
+//
+// Callers MUST validate these invariants via server.validateProvenance before
+// calling this method.
+func (s *Store) CreateSpec(
+	ctx context.Context,
+	slug, intent, priority, complexity string,
+	provenance storage.SpecProvenanceType,
+	detail storage.SpecProvenanceDetail,
+	spark *storage.SparkOutput,
+	shape *storage.ShapeOutput,
+	specify *storage.SpecifyOutput,
+	decompose *storage.DecomposeOutput,
+) (*storage.Spec, error) {
+	// Normalize empty provenance to AUTHORED.
+	if provenance == "" {
+		provenance = storage.SpecProvenanceAuthored
+	}
+
+	// Determine initial stage and content hash based on provenance.
+	bornAtDone := provenance == storage.SpecProvenanceRetroactiveFromPR ||
+		provenance == storage.SpecProvenanceDeclared
+	initialStage := defaultInitialStage
+	if bornAtDone {
+		initialStage = "done"
+	}
+
+	// Pre-compute content hash including stage outputs.
+	outputs := buildOutputsMap(spark, shape, specify, decompose)
+	ch := contenthash.Spec(intent, initialStage, priority, complexity, outputs)
+
 	now := s.now()
-	ch := contenthash.Spec(intent, defaultInitialStage, priority, complexity, nil)
 
 	var result *storage.Spec
 	err := s.RunInTransaction(ctx, func(txCtx context.Context) error {
@@ -143,8 +178,8 @@ func (s *Store) CreateSpec(ctx context.Context, slug, intent, priority, complexi
 			return fmt.Errorf("postgres: check existing spec: %w", err)
 		}
 
-		// Insert spec row.
-		provDetailJSON, err := encodeProvenanceDetail(storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{})
+		// Encode provenance detail envelope.
+		provDetailJSON, err := encodeProvenanceDetail(provenance, detail)
 		if err != nil {
 			return fmt.Errorf("postgres: create spec: encode provenance: %w", err)
 		}
@@ -154,15 +189,20 @@ func (s *Store) CreateSpec(ctx context.Context, slug, intent, priority, complexi
 			`INSERT INTO specs
 				(id, slug, project_slug, intent, stage, priority, complexity,
 				 provenance_type, provenance_detail, notes,
+				 spark_output, shape_output, specify_output, decompose_output,
 				 content_hash, version, created_at, updated_at)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, '', $10, 1, $11, $11)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, '',
+			         $10, $11, $12, $13,
+			         $14, 1, $15, $15)
 			 RETURNING id, slug, project_slug, intent, stage, priority, complexity,
 			           provenance_type, provenance_detail,
 			           superseded_by, supersedes, notes, content_hash, version,
 			           spark_output, shape_output, specify_output, decompose_output,
 			           created_at, updated_at`,
-			specID, slug, s.project, intent, defaultInitialStage, priority, complexity,
-			string(storage.SpecProvenanceAuthored), provDetailJSON, ch, now,
+			specID, slug, s.project, intent, initialStage, priority, complexity,
+			string(provenance), provDetailJSON,
+			spark, shape, specify, decompose,
+			ch, now,
 		)
 
 		spec, err := scanSpec(row)
@@ -177,17 +217,21 @@ func (s *Store) CreateSpec(ctx context.Context, slug, intent, priority, complexi
 		// Initial changelog entry.
 		allFields := storage.SpecFields{
 			Intent:     intent,
-			Stage:      defaultInitialStage,
+			Stage:      initialStage,
 			Priority:   priority,
 			Complexity: complexity,
 		}
 		deltas := storage.ComputeFieldDeltas(&storage.SpecFields{}, &allFields)
+		summary := "Spec created"
+		if bornAtDone {
+			summary = "Spec created (born at done)"
+		}
 		clEntry := &storage.ChangeLogEntry{
 			Version:     spec.Version,
 			Stage:       string(spec.Stage),
 			ContentHash: spec.ContentHash,
 			Checkpoint:  true,
-			Summary:     "Spec created",
+			Summary:     summary,
 			Date:        spec.CreatedAt,
 		}
 		if clErr := s.createChangeLog(txCtx, slug, clEntry, deltas); clErr != nil {
@@ -208,6 +252,40 @@ func (s *Store) CreateSpec(ctx context.Context, slug, intent, priority, complexi
 		return nil
 	})
 	return result, err
+}
+
+// buildOutputsMap marshals non-nil stage outputs into the map expected by
+// contenthash.Spec. Returns nil if all outputs are nil.
+func buildOutputsMap(
+	spark *storage.SparkOutput,
+	shape *storage.ShapeOutput,
+	specify *storage.SpecifyOutput,
+	decompose *storage.DecomposeOutput,
+) map[string]string {
+	var outputs map[string]string
+	addOutput := func(key string, v any) {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return
+		}
+		if outputs == nil {
+			outputs = make(map[string]string)
+		}
+		outputs[key] = string(b)
+	}
+	if spark != nil {
+		addOutput("spark_output", spark)
+	}
+	if shape != nil {
+		addOutput("shape_output", shape)
+	}
+	if specify != nil {
+		addOutput("specify_output", specify)
+	}
+	if decompose != nil {
+		addOutput("decompose_output", decompose)
+	}
+	return outputs
 }
 
 // GetSpec retrieves a spec by slug within the store's project.

--- a/internal/storage/postgres/spec.go
+++ b/internal/storage/postgres/spec.go
@@ -5,6 +5,7 @@ package postgres
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -19,8 +20,107 @@ import (
 
 const (
 	defaultInitialStage = "spark"
-	defaultLifecycle    = storage.SpecLifecycleTask
 )
+
+// --- Provenance JSONB envelope helpers ---
+
+// decodeProvenanceDetail parses the JSONB envelope `{"type": "...", "data": {...}}`
+// into a domain detail struct. Empty input returns an empty (AUTHORED-shaped)
+// detail. Returns ErrProvenanceMismatch on envelope mismatch.
+func decodeProvenanceDetail(raw []byte) (storage.SpecProvenanceDetail, error) {
+	if len(raw) == 0 {
+		return storage.SpecProvenanceDetail{}, nil
+	}
+	var env struct {
+		Type string          `json:"type"`
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return storage.SpecProvenanceDetail{}, fmt.Errorf("decode provenance_detail envelope: %w", err)
+	}
+	switch storage.SpecProvenanceType(env.Type) {
+	case storage.SpecProvenanceAuthored, "":
+		return storage.SpecProvenanceDetail{}, nil
+	case storage.SpecProvenanceRetroactiveFromPR:
+		var d struct {
+			URL      string    `json:"url"`
+			SHA      string    `json:"sha"`
+			MergedAt time.Time `json:"merged_at"`
+			Title    string    `json:"title"`
+		}
+		if len(env.Data) > 0 && string(env.Data) != "null" {
+			if err := json.Unmarshal(env.Data, &d); err != nil {
+				return storage.SpecProvenanceDetail{}, fmt.Errorf("decode retroactive_from_pr: %w", err)
+			}
+		}
+		return storage.SpecProvenanceDetail{
+			RetroactiveFromPR: &storage.RetroactivePRProvenance{
+				URL: d.URL, SHA: d.SHA, MergedAt: d.MergedAt, Title: d.Title,
+			},
+		}, nil
+	case storage.SpecProvenanceDeclared:
+		var d struct {
+			DeclaredBy string `json:"declared_by"`
+			Note       string `json:"note"`
+		}
+		if len(env.Data) > 0 && string(env.Data) != "null" {
+			if err := json.Unmarshal(env.Data, &d); err != nil {
+				return storage.SpecProvenanceDetail{}, fmt.Errorf("decode declared: %w", err)
+			}
+		}
+		return storage.SpecProvenanceDetail{
+			Declared: &storage.DeclaredProvenance{DeclaredBy: d.DeclaredBy, Note: d.Note},
+		}, nil
+	default:
+		return storage.SpecProvenanceDetail{}, fmt.Errorf("unknown provenance type %q in detail envelope", env.Type)
+	}
+}
+
+// encodeProvenanceDetail produces the JSONB envelope for storage.
+// Returns storage.ErrProvenanceMismatch if the detail's variant pointer is
+// inconsistent with the declared provenance type.
+func encodeProvenanceDetail(p storage.SpecProvenanceType, d storage.SpecProvenanceDetail) ([]byte, error) {
+	type retroactivePayload struct {
+		URL      string    `json:"url"`
+		SHA      string    `json:"sha"`
+		MergedAt time.Time `json:"merged_at"`
+		Title    string    `json:"title"`
+	}
+	type declaredPayload struct {
+		DeclaredBy string `json:"declared_by"`
+		Note       string `json:"note"`
+	}
+	var data any
+	switch p {
+	case storage.SpecProvenanceAuthored:
+		if d.RetroactiveFromPR != nil || d.Declared != nil {
+			return nil, storage.ErrProvenanceMismatch
+		}
+		data = nil
+	case storage.SpecProvenanceRetroactiveFromPR:
+		if d.RetroactiveFromPR == nil {
+			return nil, storage.ErrProvenanceMismatch
+		}
+		data = retroactivePayload{
+			URL: d.RetroactiveFromPR.URL, SHA: d.RetroactiveFromPR.SHA,
+			MergedAt: d.RetroactiveFromPR.MergedAt, Title: d.RetroactiveFromPR.Title,
+		}
+	case storage.SpecProvenanceDeclared:
+		if d.Declared == nil {
+			return nil, storage.ErrProvenanceMismatch
+		}
+		data = declaredPayload{
+			DeclaredBy: d.Declared.DeclaredBy, Note: d.Declared.Note,
+		}
+	default:
+		return nil, fmt.Errorf("unknown provenance type %q", p)
+	}
+	env := struct {
+		Type string `json:"type"`
+		Data any    `json:"data"`
+	}{Type: string(p), Data: data}
+	return json.Marshal(env)
+}
 
 // CreateSpec stores a new spec in Postgres and returns it.
 // All DB operations run within a single transaction.
@@ -44,18 +144,25 @@ func (s *Store) CreateSpec(ctx context.Context, slug, intent, priority, complexi
 		}
 
 		// Insert spec row.
+		provDetailJSON, err := encodeProvenanceDetail(storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{})
+		if err != nil {
+			return fmt.Errorf("postgres: create spec: encode provenance: %w", err)
+		}
+
 		specID := newID("spec")
 		row := s.queryRow(txCtx,
 			`INSERT INTO specs
-				(id, slug, project_slug, intent, stage, priority, complexity, lifecycle, notes,
+				(id, slug, project_slug, intent, stage, priority, complexity,
+				 provenance_type, provenance_detail, notes,
 				 content_hash, version, created_at, updated_at)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, '', $9, 1, $10, $10)
-			 RETURNING id, slug, project_slug, intent, stage, priority, complexity, lifecycle,
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, '', $10, 1, $11, $11)
+			 RETURNING id, slug, project_slug, intent, stage, priority, complexity,
+			           provenance_type, provenance_detail,
 			           superseded_by, supersedes, notes, content_hash, version,
 			           spark_output, shape_output, specify_output, decompose_output,
 			           created_at, updated_at`,
 			specID, slug, s.project, intent, defaultInitialStage, priority, complexity,
-			string(defaultLifecycle), ch, now,
+			string(storage.SpecProvenanceAuthored), provDetailJSON, ch, now,
 		)
 
 		spec, err := scanSpec(row)
@@ -108,7 +215,8 @@ func (s *Store) CreateSpec(ctx context.Context, slug, intent, priority, complexi
 func (s *Store) GetSpec(ctx context.Context, slug string) (*storage.Spec, error) {
 	row := s.queryRow(ctx,
 		`SELECT s.id, s.slug, s.project_slug, s.intent, s.stage, s.priority, s.complexity,
-		        s.lifecycle, s.superseded_by, s.supersedes, s.notes, s.content_hash, s.version,
+		        s.provenance_type, s.provenance_detail,
+		        s.superseded_by, s.supersedes, s.notes, s.content_hash, s.version,
 		        s.spark_output, s.shape_output, s.specify_output, s.decompose_output,
 		        s.created_at, s.updated_at,
 		        (SELECT count(*) FROM conversation_logs
@@ -145,7 +253,8 @@ func scanSpec(row pgx.Row) (*storage.Spec, error) {
 		stage           string
 		priority        string
 		complexity      string
-		lifecycle       string
+		provenanceType  string
+		provenanceDetail []byte
 		supersededBy    string
 		supersedes      string
 		notes           string
@@ -160,13 +269,19 @@ func scanSpec(row pgx.Row) (*storage.Spec, error) {
 	)
 	if err := row.Scan(
 		&id, &slug, &projectSlug, &intent, &stage, &priority, &complexity,
-		&lifecycle, &supersededBy, &supersedes, &notes, &contentHash, &version,
+		&provenanceType, &provenanceDetail,
+		&supersededBy, &supersedes, &notes, &contentHash, &version,
 		&sparkOutput, &shapeOutput, &specifyOutput, &decomposeOutput,
 		&createdAt, &updatedAt,
 	); err != nil {
 		return nil, fmt.Errorf("postgres: scan spec: %w", err)
 	}
-	return buildSpec(id, slug, intent, stage, priority, complexity, lifecycle,
+	detail, err := decodeProvenanceDetail(provenanceDetail)
+	if err != nil {
+		return nil, fmt.Errorf("scan spec %q: %w", slug, err)
+	}
+	return buildSpec(id, slug, intent, stage, priority, complexity,
+		storage.SpecProvenanceType(provenanceType), detail,
 		supersededBy, supersedes, notes, contentHash, version,
 		sparkOutput, shapeOutput, specifyOutput, decomposeOutput,
 		createdAt, updatedAt, 0), nil
@@ -175,44 +290,53 @@ func scanSpec(row pgx.Row) (*storage.Spec, error) {
 // scanSpecWithCount reads a Spec from a row that includes a trailing conversation_count column.
 func scanSpecWithCount(row pgx.Row) (*storage.Spec, error) {
 	var (
-		id              string
-		slug            string
-		projectSlug     string
-		intent          string
-		stage           string
-		priority        string
-		complexity      string
-		lifecycle       string
-		supersededBy    string
-		supersedes      string
-		notes           string
-		contentHash     string
-		version         int32
-		sparkOutput     *storage.SparkOutput
-		shapeOutput     *storage.ShapeOutput
-		specifyOutput   *storage.SpecifyOutput
-		decomposeOutput *storage.DecomposeOutput
-		createdAt       time.Time
-		updatedAt       time.Time
-		convCount       int
+		id               string
+		slug             string
+		projectSlug      string
+		intent           string
+		stage            string
+		priority         string
+		complexity       string
+		provenanceType   string
+		provenanceDetail []byte
+		supersededBy     string
+		supersedes       string
+		notes            string
+		contentHash      string
+		version          int32
+		sparkOutput      *storage.SparkOutput
+		shapeOutput      *storage.ShapeOutput
+		specifyOutput    *storage.SpecifyOutput
+		decomposeOutput  *storage.DecomposeOutput
+		createdAt        time.Time
+		updatedAt        time.Time
+		convCount        int
 	)
 	if err := row.Scan(
 		&id, &slug, &projectSlug, &intent, &stage, &priority, &complexity,
-		&lifecycle, &supersededBy, &supersedes, &notes, &contentHash, &version,
+		&provenanceType, &provenanceDetail,
+		&supersededBy, &supersedes, &notes, &contentHash, &version,
 		&sparkOutput, &shapeOutput, &specifyOutput, &decomposeOutput,
 		&createdAt, &updatedAt,
 		&convCount,
 	); err != nil {
 		return nil, fmt.Errorf("postgres: scan spec with count: %w", err)
 	}
-	return buildSpec(id, slug, intent, stage, priority, complexity, lifecycle,
+	detail, err := decodeProvenanceDetail(provenanceDetail)
+	if err != nil {
+		return nil, fmt.Errorf("scan spec %q: %w", slug, err)
+	}
+	return buildSpec(id, slug, intent, stage, priority, complexity,
+		storage.SpecProvenanceType(provenanceType), detail,
 		supersededBy, supersedes, notes, contentHash, version,
 		sparkOutput, shapeOutput, specifyOutput, decomposeOutput,
 		createdAt, updatedAt, convCount), nil
 }
 
 func buildSpec(
-	id, slug, intent, stage, priority, complexity, lifecycle,
+	id, slug, intent, stage, priority, complexity string,
+	provenance storage.SpecProvenanceType,
+	provenanceDetail storage.SpecProvenanceDetail,
 	supersededBy, supersedes, notes, contentHash string,
 	version int32,
 	sparkOutput *storage.SparkOutput,
@@ -230,7 +354,8 @@ func buildSpec(
 		Priority:          storage.SpecPriority(priority),
 		Complexity:        storage.SpecComplexity(complexity),
 		Version:           version,
-		Lifecycle:         storage.SpecLifecycle(lifecycle),
+		Provenance:        provenance,
+		ProvenanceDetail:  provenanceDetail,
 		SupersededBy:      supersededBy,
 		Supersedes:        supersedes,
 		Notes:             notes,
@@ -250,7 +375,8 @@ func buildSpec(
 func (s *Store) ListSpecs(ctx context.Context, stage, priority string, limit int) ([]*storage.Spec, error) {
 	rows, err := s.query(ctx,
 		`SELECT s.id, s.slug, s.project_slug, s.intent, s.stage, s.priority, s.complexity,
-		        s.lifecycle, s.superseded_by, s.supersedes, s.notes, s.content_hash, s.version,
+		        s.provenance_type, s.provenance_detail,
+		        s.superseded_by, s.supersedes, s.notes, s.content_hash, s.version,
 		        s.spark_output, s.shape_output, s.specify_output, s.decompose_output,
 		        s.created_at, s.updated_at,
 		        (SELECT count(*) FROM conversation_logs cl
@@ -271,37 +397,44 @@ func (s *Store) ListSpecs(ctx context.Context, stage, priority string, limit int
 	var specs []*storage.Spec
 	for rows.Next() {
 		var (
-			id              string
-			slug            string
-			projectSlug     string
-			intent          string
-			stageVal        string
-			priorityVal     string
-			complexity      string
-			lifecycle       string
-			supersededBy    string
-			supersedes      string
-			notes           string
-			contentHash     string
-			version         int32
-			sparkOutput     *storage.SparkOutput
-			shapeOutput     *storage.ShapeOutput
-			specifyOutput   *storage.SpecifyOutput
-			decomposeOutput *storage.DecomposeOutput
-			createdAt       time.Time
-			updatedAt       time.Time
-			convCount       int
+			id               string
+			slug             string
+			projectSlug      string
+			intent           string
+			stageVal         string
+			priorityVal      string
+			complexity       string
+			provenanceType   string
+			provenanceDetail []byte
+			supersededBy     string
+			supersedes       string
+			notes            string
+			contentHash      string
+			version          int32
+			sparkOutput      *storage.SparkOutput
+			shapeOutput      *storage.ShapeOutput
+			specifyOutput    *storage.SpecifyOutput
+			decomposeOutput  *storage.DecomposeOutput
+			createdAt        time.Time
+			updatedAt        time.Time
+			convCount        int
 		)
 		if err := rows.Scan(
 			&id, &slug, &projectSlug, &intent, &stageVal, &priorityVal, &complexity,
-			&lifecycle, &supersededBy, &supersedes, &notes, &contentHash, &version,
+			&provenanceType, &provenanceDetail,
+			&supersededBy, &supersedes, &notes, &contentHash, &version,
 			&sparkOutput, &shapeOutput, &specifyOutput, &decomposeOutput,
 			&createdAt, &updatedAt,
 			&convCount,
 		); err != nil {
 			return nil, fmt.Errorf("postgres: list specs: scan: %w", err)
 		}
-		specs = append(specs, buildSpec(id, slug, intent, stageVal, priorityVal, complexity, lifecycle,
+		detail, err := decodeProvenanceDetail(provenanceDetail)
+		if err != nil {
+			return nil, fmt.Errorf("postgres: list specs: decode provenance %q: %w", slug, err)
+		}
+		specs = append(specs, buildSpec(id, slug, intent, stageVal, priorityVal, complexity,
+			storage.SpecProvenanceType(provenanceType), detail,
 			supersededBy, supersedes, notes, contentHash, version,
 			sparkOutput, shapeOutput, specifyOutput, decomposeOutput,
 			createdAt, updatedAt, convCount))
@@ -325,7 +458,8 @@ func (s *Store) BatchGetSpecs(ctx context.Context, slugs []string) (map[string]*
 
 	rows, err := s.query(ctx,
 		`SELECT s.id, s.slug, s.project_slug, s.intent, s.stage, s.priority, s.complexity,
-		        s.lifecycle, s.superseded_by, s.supersedes, s.notes, s.content_hash, s.version,
+		        s.provenance_type, s.provenance_detail,
+		        s.superseded_by, s.supersedes, s.notes, s.content_hash, s.version,
 		        s.spark_output, s.shape_output, s.specify_output, s.decompose_output,
 		        s.created_at, s.updated_at,
 		        0 AS conversation_count
@@ -341,37 +475,44 @@ func (s *Store) BatchGetSpecs(ctx context.Context, slugs []string) (map[string]*
 	result := make(map[string]*storage.Spec, len(slugs))
 	for rows.Next() {
 		var (
-			id              string
-			slug            string
-			projectSlug     string
-			intent          string
-			stage           string
-			priority        string
-			complexity      string
-			lifecycle       string
-			supersededBy    string
-			supersedes      string
-			notes           string
-			contentHash     string
-			version         int32
-			sparkOutput     *storage.SparkOutput
-			shapeOutput     *storage.ShapeOutput
-			specifyOutput   *storage.SpecifyOutput
-			decomposeOutput *storage.DecomposeOutput
-			createdAt       time.Time
-			updatedAt       time.Time
-			convCount       int
+			id               string
+			slug             string
+			projectSlug      string
+			intent           string
+			stage            string
+			priority         string
+			complexity       string
+			provenanceType   string
+			provenanceDetail []byte
+			supersededBy     string
+			supersedes       string
+			notes            string
+			contentHash      string
+			version          int32
+			sparkOutput      *storage.SparkOutput
+			shapeOutput      *storage.ShapeOutput
+			specifyOutput    *storage.SpecifyOutput
+			decomposeOutput  *storage.DecomposeOutput
+			createdAt        time.Time
+			updatedAt        time.Time
+			convCount        int
 		)
 		if err := rows.Scan(
 			&id, &slug, &projectSlug, &intent, &stage, &priority, &complexity,
-			&lifecycle, &supersededBy, &supersedes, &notes, &contentHash, &version,
+			&provenanceType, &provenanceDetail,
+			&supersededBy, &supersedes, &notes, &contentHash, &version,
 			&sparkOutput, &shapeOutput, &specifyOutput, &decomposeOutput,
 			&createdAt, &updatedAt,
 			&convCount,
 		); err != nil {
 			return nil, fmt.Errorf("postgres: batch get specs: scan: %w", err)
 		}
-		result[slug] = buildSpec(id, slug, intent, stage, priority, complexity, lifecycle,
+		detail, err := decodeProvenanceDetail(provenanceDetail)
+		if err != nil {
+			return nil, fmt.Errorf("postgres: batch get specs: decode provenance %q: %w", slug, err)
+		}
+		result[slug] = buildSpec(id, slug, intent, stage, priority, complexity,
+			storage.SpecProvenanceType(provenanceType), detail,
 			supersededBy, supersedes, notes, contentHash, version,
 			sparkOutput, shapeOutput, specifyOutput, decomposeOutput,
 			createdAt, updatedAt, convCount)

--- a/internal/storage/postgres/spec_version_test.go
+++ b/internal/storage/postgres/spec_version_test.go
@@ -22,7 +22,7 @@ func TestGetSpecAtVersion(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		created, err := store.CreateSpec(ctx, "sv-current", "initial intent", "p1", "medium")
+		created, err := store.CreateSpec(ctx, "sv-current", "initial intent", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		result, err := store.GetSpecAtVersion(ctx, "sv-current", created.Version)
@@ -36,7 +36,7 @@ func TestGetSpecAtVersion(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "sv-history", "original intent", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "sv-history", "original intent", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		_, err = store.UpdateSpec(ctx, "sv-history", strPtr("updated intent"), nil, nil, nil, nil)
@@ -60,7 +60,7 @@ func TestGetSpecAtVersion(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "sv-zero", "some intent", "p2", "low")
+		_, err := store.CreateSpec(ctx, "sv-zero", "some intent", "p2", "low", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		_, err = store.UpdateSpec(ctx, "sv-zero", strPtr("newer intent"), nil, nil, nil, nil)
@@ -87,7 +87,7 @@ func TestGetSpecAtVersion(t *testing.T) {
 		clearDatabase(t, store)
 		ctx := context.Background()
 
-		_, err := store.CreateSpec(ctx, "sv-toohigh", "intent", "p1", "medium")
+		_, err := store.CreateSpec(ctx, "sv-toohigh", "intent", "p1", "medium", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		_, err = store.GetSpecAtVersion(ctx, "sv-toohigh", 999)

--- a/internal/storage/postgres/sync_test.go
+++ b/internal/storage/postgres/sync_test.go
@@ -18,7 +18,7 @@ func TestCreateSyncMapping(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "sync-spec", "Sync intent", "", "")
+	_, err := store.CreateSpec(ctx, "sync-spec", "Sync intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	m, err := store.CreateSyncMapping(ctx, "sync-spec", storage.SyncAdapterBeads, "bead-42")
@@ -35,7 +35,7 @@ func TestCreateSyncMapping_Duplicate(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "sync-dup", "Dup", "", "")
+	_, err := store.CreateSpec(ctx, "sync-dup", "Dup", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.CreateSyncMapping(ctx, "sync-dup", storage.SyncAdapterBeads, "ext-1")
@@ -50,7 +50,7 @@ func TestUpdateSyncState(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "sync-update", "Update", "", "")
+	_, err := store.CreateSpec(ctx, "sync-update", "Update", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.CreateSyncMapping(ctx, "sync-update", storage.SyncAdapterGitHub, "gh-99")
@@ -76,9 +76,9 @@ func TestListSyncMappings_Filter(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "list-sync-a", "A", "", "")
+	_, err := store.CreateSpec(ctx, "list-sync-a", "A", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = store.CreateSpec(ctx, "list-sync-b", "B", "", "")
+	_, err = store.CreateSpec(ctx, "list-sync-b", "B", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.CreateSyncMapping(ctx, "list-sync-a", storage.SyncAdapterBeads, "bead-a")
@@ -115,7 +115,7 @@ func TestDeleteSyncMapping_Idempotent(t *testing.T) {
 	clearDatabase(t, store)
 	ctx := context.Background()
 
-	_, err := store.CreateSpec(ctx, "del-sync", "Del", "", "")
+	_, err := store.CreateSpec(ctx, "del-sync", "Del", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = store.CreateSyncMapping(ctx, "del-sync", storage.SyncAdapterBeads, "bead-del")

--- a/internal/storage/spec_domain.go
+++ b/internal/storage/spec_domain.go
@@ -131,23 +131,48 @@ func (p SpecPriority) IsValid() bool {
 	}
 }
 
-// SpecLifecycle represents the lifecycle model of a spec.
-type SpecLifecycle string
+// SpecProvenanceType is the string-typed discriminator for how a spec
+// entered the graph. Mirrors the SpecProvenance proto enum.
+type SpecProvenanceType string
 
-// Spec lifecycle model values.
+// Spec provenance discriminator values.
 const (
-	SpecLifecycleTask   SpecLifecycle = "task"
-	SpecLifecycleLiving SpecLifecycle = "living"
+	SpecProvenanceAuthored          SpecProvenanceType = "authored"
+	SpecProvenanceRetroactiveFromPR SpecProvenanceType = "retroactive_from_pr"
+	SpecProvenanceDeclared          SpecProvenanceType = "declared"
 )
 
-// IsValid reports whether l is a known spec lifecycle.
-func (l SpecLifecycle) IsValid() bool {
-	switch l {
-	case SpecLifecycleTask, SpecLifecycleLiving:
+// IsValid reports whether p is a known spec provenance type.
+func (p SpecProvenanceType) IsValid() bool {
+	switch p {
+	case SpecProvenanceAuthored, SpecProvenanceRetroactiveFromPR, SpecProvenanceDeclared:
 		return true
 	default:
 		return false
 	}
+}
+
+// SpecProvenanceDetail is the structured payload for non-AUTHORED specs.
+// Exactly one of the embedded pointers is non-nil; both nil is valid (AUTHORED).
+// The populated variant must match the Spec.Provenance discriminator —
+// enforced at the server boundary with storage.ErrProvenanceMismatch.
+type SpecProvenanceDetail struct {
+	RetroactiveFromPR *RetroactivePRProvenance // populated when type == retroactive_from_pr
+	Declared          *DeclaredProvenance      // populated when type == declared
+}
+
+// RetroactivePRProvenance carries PR metadata for retroactive-import specs.
+type RetroactivePRProvenance struct {
+	URL      string
+	SHA      string
+	MergedAt time.Time
+	Title    string
+}
+
+// DeclaredProvenance carries declaration metadata for human-declared specs.
+type DeclaredProvenance struct {
+	DeclaredBy string
+	Note       string
 }
 
 // SpecComplexity represents the complexity level of a spec.
@@ -182,7 +207,8 @@ type Spec struct {
 	Version           int32
 	CreatedAt         time.Time
 	UpdatedAt         time.Time
-	Lifecycle         SpecLifecycle           // "task" (default) or "living"
+	Provenance        SpecProvenanceType
+	ProvenanceDetail  SpecProvenanceDetail
 	SupersededBy      string                  // slug of replacement spec
 	Supersedes        string                  // slug of spec this replaced
 	Notes             string                  // free-text notes (conversation summaries, context)

--- a/internal/storage/spec_domain_test.go
+++ b/internal/storage/spec_domain_test.go
@@ -139,19 +139,20 @@ func TestSpecStage_PrecedingAuthStage(t *testing.T) {
 	}
 }
 
-func TestSpecLifecycle_IsValid(t *testing.T) {
+func TestSpecProvenanceType_IsValid(t *testing.T) {
 	tests := []struct {
-		lifecycle storage.SpecLifecycle
-		expected  bool
+		provenance storage.SpecProvenanceType
+		expected   bool
 	}{
-		{storage.SpecLifecycleTask, true},
-		{storage.SpecLifecycleLiving, true},
-		{storage.SpecLifecycle("bogus"), false},
-		{storage.SpecLifecycle(""), false},
+		{storage.SpecProvenanceAuthored, true},
+		{storage.SpecProvenanceDeclared, true},
+		{storage.SpecProvenanceRetroactiveFromPR, true},
+		{storage.SpecProvenanceType("bogus"), false},
+		{storage.SpecProvenanceType(""), false},
 	}
 	for _, tc := range tests {
-		t.Run(string(tc.lifecycle), func(t *testing.T) {
-			assert.Equal(t, tc.expected, tc.lifecycle.IsValid())
+		t.Run(string(tc.provenance), func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.provenance.IsValid())
 		})
 	}
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -23,7 +23,18 @@ type SpecReader interface {
 // Backend is the interface that all storage backends must implement.
 type Backend interface {
 	// CreateSpec stores a new spec and returns it with generated ID and timestamps.
-	CreateSpec(ctx context.Context, slug, intent, priority, complexity string) (*Spec, error)
+	// provenance, detail, and stage outputs support all three creation flows:
+	// AUTHORED (spark only), RETROACTIVE_FROM_PR, and DECLARED (born at done).
+	CreateSpec(
+		ctx context.Context,
+		slug, intent, priority, complexity string,
+		provenance SpecProvenanceType,
+		detail SpecProvenanceDetail,
+		spark *SparkOutput,
+		shape *ShapeOutput,
+		specify *SpecifyOutput,
+		decompose *DecomposeOutput,
+	) (*Spec, error)
 
 	// GetSpec retrieves a spec by slug.
 	GetSpec(ctx context.Context, slug string) (*Spec, error)

--- a/proto/specgraph/v1/spec.proto
+++ b/proto/specgraph/v1/spec.proto
@@ -141,6 +141,16 @@ message CreateSpecRequest {
   string intent = 2;
   string priority = 3;     // optional, defaults to "p2"
   string complexity = 4;   // optional, defaults to "medium"
+  SpecProvenance provenance_type = 5;  // optional, defaults to AUTHORED
+  oneof provenance_detail {
+    AuthoredProvenance          authored             = 6;
+    RetroactiveFromPrProvenance retroactive_from_pr  = 7;
+    DeclaredProvenance          declared             = 8;
+  }
+  SparkOutput     spark_output     = 9;
+  ShapeOutput     shape_output     = 10;
+  SpecifyOutput   specify_output   = 11;
+  DecomposeOutput decompose_output = 12;
 }
 
 message GetSpecRequest {

--- a/proto/specgraph/v1/spec.proto
+++ b/proto/specgraph/v1/spec.proto
@@ -12,10 +12,30 @@ import "specgraph/v1/authoring.proto";
 
 // --- Enums ---
 
-enum SpecLifecycle {
-  SPEC_LIFECYCLE_UNSPECIFIED = 0;
-  SPEC_LIFECYCLE_TASK = 1;
-  SPEC_LIFECYCLE_LIVING = 2;
+// SpecProvenance records how a spec entered the graph. Replaces the
+// earlier SpecLifecycle field (task/living) at pre-1.0 with a clean
+// wire-break — see docs/superpowers/specs/2026-05-20-spec-provenance-model-design.md.
+enum SpecProvenance {
+  SPEC_PROVENANCE_UNSPECIFIED         = 0;
+  SPEC_PROVENANCE_AUTHORED            = 1; // forward-authored via the funnel
+  SPEC_PROVENANCE_RETROACTIVE_FROM_PR = 2; // imported from a merged PR/commit
+  SPEC_PROVENANCE_DECLARED            = 3; // human-declared as describing existing reality
+}
+
+// AuthoredProvenance is the empty payload variant for AUTHORED specs.
+// The audit trail for AUTHORED specs lives in stage outputs and conversation logs.
+message AuthoredProvenance {}
+
+message RetroactiveFromPrProvenance {
+  string url       = 1; // PR URL
+  string sha       = 2; // merge commit SHA
+  google.protobuf.Timestamp merged_at = 3;
+  string title     = 4; // PR title at import time
+}
+
+message DeclaredProvenance {
+  string declared_by = 1; // human or system identifier
+  string note        = 2; // free-text rationale
 }
 
 // --- Messages ---
@@ -24,13 +44,16 @@ message Spec {
   string id = 1;           // stable ULID, e.g. "spec-01JQXYZ..."
   string slug = 2;         // human-readable, e.g. "oauth-refresh-rotation"
   string intent = 3;       // what this spec is about
-  string stage = 4;        // spark | shape | specify | decompose | approved | in_progress | done
+  string stage = 4;        // spark | shape | specify | decompose | approved | in_progress | review | done | superseded | abandoned
   string priority = 5;     // p0 | p1 | p2 | p3
   string complexity = 6;   // low | medium | high
   int32 version = 7;
   google.protobuf.Timestamp created_at = 8;
   google.protobuf.Timestamp updated_at = 9;
-  SpecLifecycle lifecycle = 10; // task (default) | living
+  // WIRE-BREAK: field 10 was `SpecLifecycle lifecycle`. Repurposed at
+  // pre-1.0 (no production data); semantic intent preserved — it's still
+  // "how should the funnel treat this spec," with cleaner axes.
+  SpecProvenance provenance_type = 10;
   string superseded_by = 11;   // slug of replacement spec, if superseded
   string supersedes = 12;      // slug of spec this replaced
   reserved 13;
@@ -43,6 +66,14 @@ message Spec {
   specgraph.v1.SpecifyOutput specify_output = 19;     // populated when stage >= specify
   specgraph.v1.DecomposeOutput decompose_output = 20; // populated when stage >= decompose
   int32 conversation_count = 21; // count of conversation log entries (populated by ListSpecs)
+  // provenance_detail carries the type-specific payload for non-AUTHORED specs.
+  // The populated variant MUST match provenance_type — enforced server-side
+  // with storage.ErrProvenanceMismatch.
+  oneof provenance_detail {
+    AuthoredProvenance          authored             = 22;
+    RetroactiveFromPrProvenance retroactive_from_pr  = 23;
+    DeclaredProvenance          declared             = 24;
+  }
 }
 
 message FieldChange {

--- a/site/docs/concepts/spec-graph.md
+++ b/site/docs/concepts/spec-graph.md
@@ -119,7 +119,7 @@ The full spec schema is organized into five categories:
 |---|---|
 | **Identity** | `id`, `slug`, `version`, `content_hash`, `created_at`, `updated_at` |
 | **Intent** | `intent`, `stage` (spark / shape / specify / decompose / approved / in_progress / review / done / superseded / abandoned), `priority` (p0-p3), `complexity`, `notes` — see [Lifecycle Transitions](lifecycle.md) for lifecycle transitions |
-| **Lifecycle** | `lifecycle` (task / living), `superseded_by`, `supersedes` |
+| **Provenance** | `provenance` (AUTHORED / RETROACTIVE_FROM_PR / DECLARED), `superseded_by`, `supersedes` |
 | **Edges** | `depends_on`, `blocks`, `composes`, `relates_to`, `supersedes` |
 | **Authoring Outputs** | `spark_output`, `shape_output`, `specify_output`, `decompose_output`, `conversation_logs` |
 | **Verification** | `verify` (acceptance criteria), `invariants` (conditions that must hold before and after execution) |
@@ -127,6 +127,28 @@ The full spec schema is organized into five categories:
 Not every field is required. The minimal spec uses only `slug` (as the `spec`
 key), `intent`, and `verify`. Additional fields appear as the spec moves through
 the authoring funnel and as team needs grow.
+
+### Provenance
+
+`provenance` records **how a spec entered the graph**, not how it behaves after
+`done`. Three values:
+
+- **`AUTHORED`** — the spec walked the full authoring funnel (Spark → Shape →
+  Specify → Decompose → Approved). This is the normal path for new work.
+- **`RETROACTIVE_FROM_PR`** — a pull-request sync adapter created the spec from
+  an already-merged PR. The spec is born at `done` with full content populated
+  atomically.
+- **`DECLARED`** — a spec was injected directly (e.g. from a design doc or
+  import) and also born at `done`. No funnel history.
+
+Only AUTHORED specs are surfaced by `specgraph ready` and are eligible for
+`claim` / `report-completion`. RETROACTIVE_FROM_PR and DECLARED specs are
+`done` from birth; drift detection, dependency edges, and supersession semantics
+apply to all three variants equally.
+
+See `docs/decisions/ADR-006-spec-provenance-model.md` and the design doc at
+`docs/superpowers/specs/2026-05-20-spec-provenance-model-design.md` for full
+detail.
 
 ---
 

--- a/web/src/lib/api/gen/specgraph/v1/spec_pb.ts
+++ b/web/src/lib/api/gen/specgraph/v1/spec_pb.ts
@@ -17,7 +17,87 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file specgraph/v1/spec.proto.
  */
 export const file_specgraph_v1_spec: GenFile = /*@__PURE__*/
-  fileDesc("ChdzcGVjZ3JhcGgvdjEvc3BlYy5wcm90bxIMc3BlY2dyYXBoLnYxIosFCgRTcGVjEgoKAmlkGAEgASgJEgwKBHNsdWcYAiABKAkSDgoGaW50ZW50GAMgASgJEg0KBXN0YWdlGAQgASgJEhAKCHByaW9yaXR5GAUgASgJEhIKCmNvbXBsZXhpdHkYBiABKAkSDwoHdmVyc2lvbhgHIAEoBRIuCgpjcmVhdGVkX2F0GAggASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIuCgp1cGRhdGVkX2F0GAkgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIuCglsaWZlY3ljbGUYCiABKA4yGy5zcGVjZ3JhcGgudjEuU3BlY0xpZmVjeWNsZRIVCg1zdXBlcnNlZGVkX2J5GAsgASgJEhIKCnN1cGVyc2VkZXMYDCABKAkSDQoFbm90ZXMYDiABKAkSFAoMY29udGVudF9oYXNoGA8gASgJEjgKEWNvbnZlcnNhdGlvbl9sb2dzGBAgAygLMh0uc3BlY2dyYXBoLnYxLkNvbnZlcnNhdGlvbkxvZxIvCgxzcGFya19vdXRwdXQYESABKAsyGS5zcGVjZ3JhcGgudjEuU3BhcmtPdXRwdXQSLwoMc2hhcGVfb3V0cHV0GBIgASgLMhkuc3BlY2dyYXBoLnYxLlNoYXBlT3V0cHV0EjMKDnNwZWNpZnlfb3V0cHV0GBMgASgLMhsuc3BlY2dyYXBoLnYxLlNwZWNpZnlPdXRwdXQSNwoQZGVjb21wb3NlX291dHB1dBgUIAEoCzIdLnNwZWNncmFwaC52MS5EZWNvbXBvc2VPdXRwdXQSGgoSY29udmVyc2F0aW9uX2NvdW50GBUgASgFSgQIDRAOUgdoaXN0b3J5IkIKC0ZpZWxkQ2hhbmdlEg0KBWZpZWxkGAEgASgJEhEKCW9sZF92YWx1ZRgCIAEoCRIRCgluZXdfdmFsdWUYAyABKAki3QEKDkNoYW5nZUxvZ0VudHJ5EgoKAmlkGAEgASgJEg8KB3ZlcnNpb24YAiABKAUSDQoFc3RhZ2UYAyABKAkSFAoMY29udGVudF9oYXNoGAQgASgJEhIKCmNoZWNrcG9pbnQYBSABKAgSDwoHc3VtbWFyeRgGIAEoCRIOCgZyZWFzb24YByABKAkSKgoHY2hhbmdlcxgIIAMoCzIZLnNwZWNncmFwaC52MS5GaWVsZENoYW5nZRIoCgRkYXRlGAkgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCJiChJMaXN0Q2hhbmdlc1JlcXVlc3QSDAoEc2x1ZxgBIAEoCRIYChBjaGVja3BvaW50c19vbmx5GAIgASgIEhUKDXNpbmNlX3ZlcnNpb24YAyABKAUSDQoFbGltaXQYBCABKAUiRAoTTGlzdENoYW5nZXNSZXNwb25zZRItCgdlbnRyaWVzGAEgAygLMhwuc3BlY2dyYXBoLnYxLkNoYW5nZUxvZ0VudHJ5ImwKCklubGluZURpZmYSJwoCb3AYASABKA4yGy5zcGVjZ3JhcGgudjEuSW5saW5lRGlmZi5PcBIMCgR0ZXh0GAIgASgJIicKAk9wEgkKBUVRVUFMEAASCgoGSU5TRVJUEAESCgoGREVMRVRFEAIiawoLVmVyc2lvbkRpZmYSDQoFZmllbGQYASABKAkSEQoJb2xkX3ZhbHVlGAIgASgJEhEKCW5ld192YWx1ZRgDIAEoCRInCgVodW5rcxgEIAMoCzIYLnNwZWNncmFwaC52MS5JbmxpbmVEaWZmIlAKFkNvbXBhcmVWZXJzaW9uc1JlcXVlc3QSDAoEc2x1ZxgBIAEoCRIUCgxmcm9tX3ZlcnNpb24YAiABKAUSEgoKdG9fdmVyc2lvbhgDIAEoBSKTAQoXQ29tcGFyZVZlcnNpb25zUmVzcG9uc2USFAoMZnJvbV92ZXJzaW9uGAEgASgFEhIKCnRvX3ZlcnNpb24YAiABKAUSEgoKZnJvbV9zdGFnZRgDIAEoCRIQCgh0b19zdGFnZRgEIAEoCRIoCgVkaWZmcxgFIAMoCzIZLnNwZWNncmFwaC52MS5WZXJzaW9uRGlmZiJXChFDcmVhdGVTcGVjUmVxdWVzdBIMCgRzbHVnGAEgASgJEg4KBmludGVudBgCIAEoCRIQCghwcmlvcml0eRgDIAEoCRISCgpjb21wbGV4aXR5GAQgASgJIh4KDkdldFNwZWNSZXF1ZXN0EgwKBHNsdWcYASABKAkiQgoQTGlzdFNwZWNzUmVxdWVzdBINCgVzdGFnZRgBIAEoCRIQCghwcmlvcml0eRgCIAEoCRINCgVsaW1pdBgDIAEoBSI2ChFMaXN0U3BlY3NSZXNwb25zZRIhCgVzcGVjcxgBIAMoCzISLnNwZWNncmFwaC52MS5TcGVjIskBChFVcGRhdGVTcGVjUmVxdWVzdBIMCgRzbHVnGAEgASgJEhMKBmludGVudBgCIAEoCUgAiAEBEhIKBXN0YWdlGAMgASgJSAGIAQESFQoIcHJpb3JpdHkYBCABKAlIAogBARIXCgpjb21wbGV4aXR5GAUgASgJSAOIAQESEgoFbm90ZXMYBiABKAlIBIgBAUIJCgdfaW50ZW50QggKBl9zdGFnZUILCglfcHJpb3JpdHlCDQoLX2NvbXBsZXhpdHlCCAoGX25vdGVzIjYKEkNyZWF0ZVNwZWNSZXNwb25zZRIgCgRzcGVjGAEgASgLMhIuc3BlY2dyYXBoLnYxLlNwZWMiMwoPR2V0U3BlY1Jlc3BvbnNlEiAKBHNwZWMYASABKAsyEi5zcGVjZ3JhcGgudjEuU3BlYyI2ChJVcGRhdGVTcGVjUmVzcG9uc2USIAoEc3BlYxgBIAEoCzISLnNwZWNncmFwaC52MS5TcGVjKmMKDVNwZWNMaWZlY3ljbGUSHgoaU1BFQ19MSUZFQ1lDTEVfVU5TUEVDSUZJRUQQABIXChNTUEVDX0xJRkVDWUNMRV9UQVNLEAESGQoVU1BFQ19MSUZFQ1lDTEVfTElWSU5HEAIy+QMKC1NwZWNTZXJ2aWNlEk8KCkNyZWF0ZVNwZWMSHy5zcGVjZ3JhcGgudjEuQ3JlYXRlU3BlY1JlcXVlc3QaIC5zcGVjZ3JhcGgudjEuQ3JlYXRlU3BlY1Jlc3BvbnNlEkYKB0dldFNwZWMSHC5zcGVjZ3JhcGgudjEuR2V0U3BlY1JlcXVlc3QaHS5zcGVjZ3JhcGgudjEuR2V0U3BlY1Jlc3BvbnNlEkwKCUxpc3RTcGVjcxIeLnNwZWNncmFwaC52MS5MaXN0U3BlY3NSZXF1ZXN0Gh8uc3BlY2dyYXBoLnYxLkxpc3RTcGVjc1Jlc3BvbnNlEk8KClVwZGF0ZVNwZWMSHy5zcGVjZ3JhcGgudjEuVXBkYXRlU3BlY1JlcXVlc3QaIC5zcGVjZ3JhcGgudjEuVXBkYXRlU3BlY1Jlc3BvbnNlElIKC0xpc3RDaGFuZ2VzEiAuc3BlY2dyYXBoLnYxLkxpc3RDaGFuZ2VzUmVxdWVzdBohLnNwZWNncmFwaC52MS5MaXN0Q2hhbmdlc1Jlc3BvbnNlEl4KD0NvbXBhcmVWZXJzaW9ucxIkLnNwZWNncmFwaC52MS5Db21wYXJlVmVyc2lvbnNSZXF1ZXN0GiUuc3BlY2dyYXBoLnYxLkNvbXBhcmVWZXJzaW9uc1Jlc3BvbnNlQj1aO2dpdGh1Yi5jb20vc3BlY2dyYXBoL3NwZWNncmFwaC9nZW4vc3BlY2dyYXBoL3YxO3NwZWNncmFwaHYxYgZwcm90bzM", [file_google_protobuf_timestamp, file_specgraph_v1_authoring]);
+  fileDesc("ChdzcGVjZ3JhcGgvdjEvc3BlYy5wcm90bxIMc3BlY2dyYXBoLnYxIhQKEkF1dGhvcmVkUHJvdmVuYW5jZSJ1ChtSZXRyb2FjdGl2ZUZyb21QclByb3ZlbmFuY2USCwoDdXJsGAEgASgJEgsKA3NoYRgCIAEoCRItCgltZXJnZWRfYXQYAyABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEg0KBXRpdGxlGAQgASgJIjcKEkRlY2xhcmVkUHJvdmVuYW5jZRITCgtkZWNsYXJlZF9ieRgBIAEoCRIMCgRub3RlGAIgASgJIt0GCgRTcGVjEgoKAmlkGAEgASgJEgwKBHNsdWcYAiABKAkSDgoGaW50ZW50GAMgASgJEg0KBXN0YWdlGAQgASgJEhAKCHByaW9yaXR5GAUgASgJEhIKCmNvbXBsZXhpdHkYBiABKAkSDwoHdmVyc2lvbhgHIAEoBRIuCgpjcmVhdGVkX2F0GAggASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIuCgp1cGRhdGVkX2F0GAkgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBI1Cg9wcm92ZW5hbmNlX3R5cGUYCiABKA4yHC5zcGVjZ3JhcGgudjEuU3BlY1Byb3ZlbmFuY2USFQoNc3VwZXJzZWRlZF9ieRgLIAEoCRISCgpzdXBlcnNlZGVzGAwgASgJEg0KBW5vdGVzGA4gASgJEhQKDGNvbnRlbnRfaGFzaBgPIAEoCRI4ChFjb252ZXJzYXRpb25fbG9ncxgQIAMoCzIdLnNwZWNncmFwaC52MS5Db252ZXJzYXRpb25Mb2cSLwoMc3Bhcmtfb3V0cHV0GBEgASgLMhkuc3BlY2dyYXBoLnYxLlNwYXJrT3V0cHV0Ei8KDHNoYXBlX291dHB1dBgSIAEoCzIZLnNwZWNncmFwaC52MS5TaGFwZU91dHB1dBIzCg5zcGVjaWZ5X291dHB1dBgTIAEoCzIbLnNwZWNncmFwaC52MS5TcGVjaWZ5T3V0cHV0EjcKEGRlY29tcG9zZV9vdXRwdXQYFCABKAsyHS5zcGVjZ3JhcGgudjEuRGVjb21wb3NlT3V0cHV0EhoKEmNvbnZlcnNhdGlvbl9jb3VudBgVIAEoBRI0CghhdXRob3JlZBgWIAEoCzIgLnNwZWNncmFwaC52MS5BdXRob3JlZFByb3ZlbmFuY2VIABJIChNyZXRyb2FjdGl2ZV9mcm9tX3ByGBcgASgLMikuc3BlY2dyYXBoLnYxLlJldHJvYWN0aXZlRnJvbVByUHJvdmVuYW5jZUgAEjQKCGRlY2xhcmVkGBggASgLMiAuc3BlY2dyYXBoLnYxLkRlY2xhcmVkUHJvdmVuYW5jZUgAQhMKEXByb3ZlbmFuY2VfZGV0YWlsSgQIDRAOUgdoaXN0b3J5IkIKC0ZpZWxkQ2hhbmdlEg0KBWZpZWxkGAEgASgJEhEKCW9sZF92YWx1ZRgCIAEoCRIRCgluZXdfdmFsdWUYAyABKAki3QEKDkNoYW5nZUxvZ0VudHJ5EgoKAmlkGAEgASgJEg8KB3ZlcnNpb24YAiABKAUSDQoFc3RhZ2UYAyABKAkSFAoMY29udGVudF9oYXNoGAQgASgJEhIKCmNoZWNrcG9pbnQYBSABKAgSDwoHc3VtbWFyeRgGIAEoCRIOCgZyZWFzb24YByABKAkSKgoHY2hhbmdlcxgIIAMoCzIZLnNwZWNncmFwaC52MS5GaWVsZENoYW5nZRIoCgRkYXRlGAkgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCJiChJMaXN0Q2hhbmdlc1JlcXVlc3QSDAoEc2x1ZxgBIAEoCRIYChBjaGVja3BvaW50c19vbmx5GAIgASgIEhUKDXNpbmNlX3ZlcnNpb24YAyABKAUSDQoFbGltaXQYBCABKAUiRAoTTGlzdENoYW5nZXNSZXNwb25zZRItCgdlbnRyaWVzGAEgAygLMhwuc3BlY2dyYXBoLnYxLkNoYW5nZUxvZ0VudHJ5ImwKCklubGluZURpZmYSJwoCb3AYASABKA4yGy5zcGVjZ3JhcGgudjEuSW5saW5lRGlmZi5PcBIMCgR0ZXh0GAIgASgJIicKAk9wEgkKBUVRVUFMEAASCgoGSU5TRVJUEAESCgoGREVMRVRFEAIiawoLVmVyc2lvbkRpZmYSDQoFZmllbGQYASABKAkSEQoJb2xkX3ZhbHVlGAIgASgJEhEKCW5ld192YWx1ZRgDIAEoCRInCgVodW5rcxgEIAMoCzIYLnNwZWNncmFwaC52MS5JbmxpbmVEaWZmIlAKFkNvbXBhcmVWZXJzaW9uc1JlcXVlc3QSDAoEc2x1ZxgBIAEoCRIUCgxmcm9tX3ZlcnNpb24YAiABKAUSEgoKdG9fdmVyc2lvbhgDIAEoBSKTAQoXQ29tcGFyZVZlcnNpb25zUmVzcG9uc2USFAoMZnJvbV92ZXJzaW9uGAEgASgFEhIKCnRvX3ZlcnNpb24YAiABKAUSEgoKZnJvbV9zdGFnZRgDIAEoCRIQCgh0b19zdGFnZRgEIAEoCRIoCgVkaWZmcxgFIAMoCzIZLnNwZWNncmFwaC52MS5WZXJzaW9uRGlmZiKpBAoRQ3JlYXRlU3BlY1JlcXVlc3QSDAoEc2x1ZxgBIAEoCRIOCgZpbnRlbnQYAiABKAkSEAoIcHJpb3JpdHkYAyABKAkSEgoKY29tcGxleGl0eRgEIAEoCRI1Cg9wcm92ZW5hbmNlX3R5cGUYBSABKA4yHC5zcGVjZ3JhcGgudjEuU3BlY1Byb3ZlbmFuY2USNAoIYXV0aG9yZWQYBiABKAsyIC5zcGVjZ3JhcGgudjEuQXV0aG9yZWRQcm92ZW5hbmNlSAASSAoTcmV0cm9hY3RpdmVfZnJvbV9wchgHIAEoCzIpLnNwZWNncmFwaC52MS5SZXRyb2FjdGl2ZUZyb21QclByb3ZlbmFuY2VIABI0CghkZWNsYXJlZBgIIAEoCzIgLnNwZWNncmFwaC52MS5EZWNsYXJlZFByb3ZlbmFuY2VIABIvCgxzcGFya19vdXRwdXQYCSABKAsyGS5zcGVjZ3JhcGgudjEuU3BhcmtPdXRwdXQSLwoMc2hhcGVfb3V0cHV0GAogASgLMhkuc3BlY2dyYXBoLnYxLlNoYXBlT3V0cHV0EjMKDnNwZWNpZnlfb3V0cHV0GAsgASgLMhsuc3BlY2dyYXBoLnYxLlNwZWNpZnlPdXRwdXQSNwoQZGVjb21wb3NlX291dHB1dBgMIAEoCzIdLnNwZWNncmFwaC52MS5EZWNvbXBvc2VPdXRwdXRCEwoRcHJvdmVuYW5jZV9kZXRhaWwiHgoOR2V0U3BlY1JlcXVlc3QSDAoEc2x1ZxgBIAEoCSJCChBMaXN0U3BlY3NSZXF1ZXN0Eg0KBXN0YWdlGAEgASgJEhAKCHByaW9yaXR5GAIgASgJEg0KBWxpbWl0GAMgASgFIjYKEUxpc3RTcGVjc1Jlc3BvbnNlEiEKBXNwZWNzGAEgAygLMhIuc3BlY2dyYXBoLnYxLlNwZWMiyQEKEVVwZGF0ZVNwZWNSZXF1ZXN0EgwKBHNsdWcYASABKAkSEwoGaW50ZW50GAIgASgJSACIAQESEgoFc3RhZ2UYAyABKAlIAYgBARIVCghwcmlvcml0eRgEIAEoCUgCiAEBEhcKCmNvbXBsZXhpdHkYBSABKAlIA4gBARISCgVub3RlcxgGIAEoCUgEiAEBQgkKB19pbnRlbnRCCAoGX3N0YWdlQgsKCV9wcmlvcml0eUINCgtfY29tcGxleGl0eUIICgZfbm90ZXMiNgoSQ3JlYXRlU3BlY1Jlc3BvbnNlEiAKBHNwZWMYASABKAsyEi5zcGVjZ3JhcGgudjEuU3BlYyIzCg9HZXRTcGVjUmVzcG9uc2USIAoEc3BlYxgBIAEoCzISLnNwZWNncmFwaC52MS5TcGVjIjYKElVwZGF0ZVNwZWNSZXNwb25zZRIgCgRzcGVjGAEgASgLMhIuc3BlY2dyYXBoLnYxLlNwZWMqlgEKDlNwZWNQcm92ZW5hbmNlEh8KG1NQRUNfUFJPVkVOQU5DRV9VTlNQRUNJRklFRBAAEhwKGFNQRUNfUFJPVkVOQU5DRV9BVVRIT1JFRBABEicKI1NQRUNfUFJPVkVOQU5DRV9SRVRST0FDVElWRV9GUk9NX1BSEAISHAoYU1BFQ19QUk9WRU5BTkNFX0RFQ0xBUkVEEAMy+QMKC1NwZWNTZXJ2aWNlEk8KCkNyZWF0ZVNwZWMSHy5zcGVjZ3JhcGgudjEuQ3JlYXRlU3BlY1JlcXVlc3QaIC5zcGVjZ3JhcGgudjEuQ3JlYXRlU3BlY1Jlc3BvbnNlEkYKB0dldFNwZWMSHC5zcGVjZ3JhcGgudjEuR2V0U3BlY1JlcXVlc3QaHS5zcGVjZ3JhcGgudjEuR2V0U3BlY1Jlc3BvbnNlEkwKCUxpc3RTcGVjcxIeLnNwZWNncmFwaC52MS5MaXN0U3BlY3NSZXF1ZXN0Gh8uc3BlY2dyYXBoLnYxLkxpc3RTcGVjc1Jlc3BvbnNlEk8KClVwZGF0ZVNwZWMSHy5zcGVjZ3JhcGgudjEuVXBkYXRlU3BlY1JlcXVlc3QaIC5zcGVjZ3JhcGgudjEuVXBkYXRlU3BlY1Jlc3BvbnNlElIKC0xpc3RDaGFuZ2VzEiAuc3BlY2dyYXBoLnYxLkxpc3RDaGFuZ2VzUmVxdWVzdBohLnNwZWNncmFwaC52MS5MaXN0Q2hhbmdlc1Jlc3BvbnNlEl4KD0NvbXBhcmVWZXJzaW9ucxIkLnNwZWNncmFwaC52MS5Db21wYXJlVmVyc2lvbnNSZXF1ZXN0GiUuc3BlY2dyYXBoLnYxLkNvbXBhcmVWZXJzaW9uc1Jlc3BvbnNlQj1aO2dpdGh1Yi5jb20vc3BlY2dyYXBoL3NwZWNncmFwaC9nZW4vc3BlY2dyYXBoL3YxO3NwZWNncmFwaHYxYgZwcm90bzM", [file_google_protobuf_timestamp, file_specgraph_v1_authoring]);
+
+/**
+ * AuthoredProvenance is the empty payload variant for AUTHORED specs.
+ * The audit trail for AUTHORED specs lives in stage outputs and conversation logs.
+ *
+ * @generated from message specgraph.v1.AuthoredProvenance
+ */
+export type AuthoredProvenance = Message<"specgraph.v1.AuthoredProvenance"> & {
+};
+
+/**
+ * Describes the message specgraph.v1.AuthoredProvenance.
+ * Use `create(AuthoredProvenanceSchema)` to create a new message.
+ */
+export const AuthoredProvenanceSchema: GenMessage<AuthoredProvenance> = /*@__PURE__*/
+  messageDesc(file_specgraph_v1_spec, 0);
+
+/**
+ * @generated from message specgraph.v1.RetroactiveFromPrProvenance
+ */
+export type RetroactiveFromPrProvenance = Message<"specgraph.v1.RetroactiveFromPrProvenance"> & {
+  /**
+   * PR URL
+   *
+   * @generated from field: string url = 1;
+   */
+  url: string;
+
+  /**
+   * merge commit SHA
+   *
+   * @generated from field: string sha = 2;
+   */
+  sha: string;
+
+  /**
+   * @generated from field: google.protobuf.Timestamp merged_at = 3;
+   */
+  mergedAt?: Timestamp | undefined;
+
+  /**
+   * PR title at import time
+   *
+   * @generated from field: string title = 4;
+   */
+  title: string;
+};
+
+/**
+ * Describes the message specgraph.v1.RetroactiveFromPrProvenance.
+ * Use `create(RetroactiveFromPrProvenanceSchema)` to create a new message.
+ */
+export const RetroactiveFromPrProvenanceSchema: GenMessage<RetroactiveFromPrProvenance> = /*@__PURE__*/
+  messageDesc(file_specgraph_v1_spec, 1);
+
+/**
+ * @generated from message specgraph.v1.DeclaredProvenance
+ */
+export type DeclaredProvenance = Message<"specgraph.v1.DeclaredProvenance"> & {
+  /**
+   * human or system identifier
+   *
+   * @generated from field: string declared_by = 1;
+   */
+  declaredBy: string;
+
+  /**
+   * free-text rationale
+   *
+   * @generated from field: string note = 2;
+   */
+  note: string;
+};
+
+/**
+ * Describes the message specgraph.v1.DeclaredProvenance.
+ * Use `create(DeclaredProvenanceSchema)` to create a new message.
+ */
+export const DeclaredProvenanceSchema: GenMessage<DeclaredProvenance> = /*@__PURE__*/
+  messageDesc(file_specgraph_v1_spec, 2);
 
 /**
  * @generated from message specgraph.v1.Spec
@@ -45,7 +125,7 @@ export type Spec = Message<"specgraph.v1.Spec"> & {
   intent: string;
 
   /**
-   * spark | shape | specify | decompose | approved | in_progress | done
+   * spark | shape | specify | decompose | approved | in_progress | review | done | superseded | abandoned
    *
    * @generated from field: string stage = 4;
    */
@@ -81,11 +161,13 @@ export type Spec = Message<"specgraph.v1.Spec"> & {
   updatedAt?: Timestamp | undefined;
 
   /**
-   * task (default) | living
+   * WIRE-BREAK: field 10 was `SpecLifecycle lifecycle`. Repurposed at
+   * pre-1.0 (no production data); semantic intent preserved — it's still
+   * "how should the funnel treat this spec," with cleaner axes.
    *
-   * @generated from field: specgraph.v1.SpecLifecycle lifecycle = 10;
+   * @generated from field: specgraph.v1.SpecProvenance provenance_type = 10;
    */
-  lifecycle: SpecLifecycle;
+  provenanceType: SpecProvenance;
 
   /**
    * slug of replacement spec, if superseded
@@ -156,6 +238,33 @@ export type Spec = Message<"specgraph.v1.Spec"> & {
    * @generated from field: int32 conversation_count = 21;
    */
   conversationCount: number;
+
+  /**
+   * provenance_detail carries the type-specific payload for non-AUTHORED specs.
+   * The populated variant MUST match provenance_type — enforced server-side
+   * with storage.ErrProvenanceMismatch.
+   *
+   * @generated from oneof specgraph.v1.Spec.provenance_detail
+   */
+  provenanceDetail: {
+    /**
+     * @generated from field: specgraph.v1.AuthoredProvenance authored = 22;
+     */
+    value: AuthoredProvenance;
+    case: "authored";
+  } | {
+    /**
+     * @generated from field: specgraph.v1.RetroactiveFromPrProvenance retroactive_from_pr = 23;
+     */
+    value: RetroactiveFromPrProvenance;
+    case: "retroactiveFromPr";
+  } | {
+    /**
+     * @generated from field: specgraph.v1.DeclaredProvenance declared = 24;
+     */
+    value: DeclaredProvenance;
+    case: "declared";
+  } | { case: undefined; value?: undefined };
 };
 
 /**
@@ -163,7 +272,7 @@ export type Spec = Message<"specgraph.v1.Spec"> & {
  * Use `create(SpecSchema)` to create a new message.
  */
 export const SpecSchema: GenMessage<Spec> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 0);
+  messageDesc(file_specgraph_v1_spec, 3);
 
 /**
  * @generated from message specgraph.v1.FieldChange
@@ -190,7 +299,7 @@ export type FieldChange = Message<"specgraph.v1.FieldChange"> & {
  * Use `create(FieldChangeSchema)` to create a new message.
  */
 export const FieldChangeSchema: GenMessage<FieldChange> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 1);
+  messageDesc(file_specgraph_v1_spec, 4);
 
 /**
  * @generated from message specgraph.v1.ChangeLogEntry
@@ -247,7 +356,7 @@ export type ChangeLogEntry = Message<"specgraph.v1.ChangeLogEntry"> & {
  * Use `create(ChangeLogEntrySchema)` to create a new message.
  */
 export const ChangeLogEntrySchema: GenMessage<ChangeLogEntry> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 2);
+  messageDesc(file_specgraph_v1_spec, 5);
 
 /**
  * @generated from message specgraph.v1.ListChangesRequest
@@ -279,7 +388,7 @@ export type ListChangesRequest = Message<"specgraph.v1.ListChangesRequest"> & {
  * Use `create(ListChangesRequestSchema)` to create a new message.
  */
 export const ListChangesRequestSchema: GenMessage<ListChangesRequest> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 3);
+  messageDesc(file_specgraph_v1_spec, 6);
 
 /**
  * @generated from message specgraph.v1.ListChangesResponse
@@ -296,7 +405,7 @@ export type ListChangesResponse = Message<"specgraph.v1.ListChangesResponse"> & 
  * Use `create(ListChangesResponseSchema)` to create a new message.
  */
 export const ListChangesResponseSchema: GenMessage<ListChangesResponse> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 4);
+  messageDesc(file_specgraph_v1_spec, 7);
 
 /**
  * @generated from message specgraph.v1.InlineDiff
@@ -318,7 +427,7 @@ export type InlineDiff = Message<"specgraph.v1.InlineDiff"> & {
  * Use `create(InlineDiffSchema)` to create a new message.
  */
 export const InlineDiffSchema: GenMessage<InlineDiff> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 5);
+  messageDesc(file_specgraph_v1_spec, 8);
 
 /**
  * @generated from enum specgraph.v1.InlineDiff.Op
@@ -344,7 +453,7 @@ export enum InlineDiff_Op {
  * Describes the enum specgraph.v1.InlineDiff.Op.
  */
 export const InlineDiff_OpSchema: GenEnum<InlineDiff_Op> = /*@__PURE__*/
-  enumDesc(file_specgraph_v1_spec, 5, 0);
+  enumDesc(file_specgraph_v1_spec, 8, 0);
 
 /**
  * @generated from message specgraph.v1.VersionDiff
@@ -376,7 +485,7 @@ export type VersionDiff = Message<"specgraph.v1.VersionDiff"> & {
  * Use `create(VersionDiffSchema)` to create a new message.
  */
 export const VersionDiffSchema: GenMessage<VersionDiff> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 6);
+  messageDesc(file_specgraph_v1_spec, 9);
 
 /**
  * @generated from message specgraph.v1.CompareVersionsRequest
@@ -403,7 +512,7 @@ export type CompareVersionsRequest = Message<"specgraph.v1.CompareVersionsReques
  * Use `create(CompareVersionsRequestSchema)` to create a new message.
  */
 export const CompareVersionsRequestSchema: GenMessage<CompareVersionsRequest> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 7);
+  messageDesc(file_specgraph_v1_spec, 10);
 
 /**
  * @generated from message specgraph.v1.CompareVersionsResponse
@@ -440,7 +549,7 @@ export type CompareVersionsResponse = Message<"specgraph.v1.CompareVersionsRespo
  * Use `create(CompareVersionsResponseSchema)` to create a new message.
  */
 export const CompareVersionsResponseSchema: GenMessage<CompareVersionsResponse> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 8);
+  messageDesc(file_specgraph_v1_spec, 11);
 
 /**
  * @generated from message specgraph.v1.CreateSpecRequest
@@ -469,6 +578,56 @@ export type CreateSpecRequest = Message<"specgraph.v1.CreateSpecRequest"> & {
    * @generated from field: string complexity = 4;
    */
   complexity: string;
+
+  /**
+   * optional, defaults to AUTHORED
+   *
+   * @generated from field: specgraph.v1.SpecProvenance provenance_type = 5;
+   */
+  provenanceType: SpecProvenance;
+
+  /**
+   * @generated from oneof specgraph.v1.CreateSpecRequest.provenance_detail
+   */
+  provenanceDetail: {
+    /**
+     * @generated from field: specgraph.v1.AuthoredProvenance authored = 6;
+     */
+    value: AuthoredProvenance;
+    case: "authored";
+  } | {
+    /**
+     * @generated from field: specgraph.v1.RetroactiveFromPrProvenance retroactive_from_pr = 7;
+     */
+    value: RetroactiveFromPrProvenance;
+    case: "retroactiveFromPr";
+  } | {
+    /**
+     * @generated from field: specgraph.v1.DeclaredProvenance declared = 8;
+     */
+    value: DeclaredProvenance;
+    case: "declared";
+  } | { case: undefined; value?: undefined };
+
+  /**
+   * @generated from field: specgraph.v1.SparkOutput spark_output = 9;
+   */
+  sparkOutput?: SparkOutput | undefined;
+
+  /**
+   * @generated from field: specgraph.v1.ShapeOutput shape_output = 10;
+   */
+  shapeOutput?: ShapeOutput | undefined;
+
+  /**
+   * @generated from field: specgraph.v1.SpecifyOutput specify_output = 11;
+   */
+  specifyOutput?: SpecifyOutput | undefined;
+
+  /**
+   * @generated from field: specgraph.v1.DecomposeOutput decompose_output = 12;
+   */
+  decomposeOutput?: DecomposeOutput | undefined;
 };
 
 /**
@@ -476,7 +635,7 @@ export type CreateSpecRequest = Message<"specgraph.v1.CreateSpecRequest"> & {
  * Use `create(CreateSpecRequestSchema)` to create a new message.
  */
 export const CreateSpecRequestSchema: GenMessage<CreateSpecRequest> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 9);
+  messageDesc(file_specgraph_v1_spec, 12);
 
 /**
  * @generated from message specgraph.v1.GetSpecRequest
@@ -493,7 +652,7 @@ export type GetSpecRequest = Message<"specgraph.v1.GetSpecRequest"> & {
  * Use `create(GetSpecRequestSchema)` to create a new message.
  */
 export const GetSpecRequestSchema: GenMessage<GetSpecRequest> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 10);
+  messageDesc(file_specgraph_v1_spec, 13);
 
 /**
  * @generated from message specgraph.v1.ListSpecsRequest
@@ -526,7 +685,7 @@ export type ListSpecsRequest = Message<"specgraph.v1.ListSpecsRequest"> & {
  * Use `create(ListSpecsRequestSchema)` to create a new message.
  */
 export const ListSpecsRequestSchema: GenMessage<ListSpecsRequest> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 11);
+  messageDesc(file_specgraph_v1_spec, 14);
 
 /**
  * @generated from message specgraph.v1.ListSpecsResponse
@@ -543,7 +702,7 @@ export type ListSpecsResponse = Message<"specgraph.v1.ListSpecsResponse"> & {
  * Use `create(ListSpecsResponseSchema)` to create a new message.
  */
 export const ListSpecsResponseSchema: GenMessage<ListSpecsResponse> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 12);
+  messageDesc(file_specgraph_v1_spec, 15);
 
 /**
  * @generated from message specgraph.v1.UpdateSpecRequest
@@ -587,7 +746,7 @@ export type UpdateSpecRequest = Message<"specgraph.v1.UpdateSpecRequest"> & {
  * Use `create(UpdateSpecRequestSchema)` to create a new message.
  */
 export const UpdateSpecRequestSchema: GenMessage<UpdateSpecRequest> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 13);
+  messageDesc(file_specgraph_v1_spec, 16);
 
 /**
  * @generated from message specgraph.v1.CreateSpecResponse
@@ -604,7 +763,7 @@ export type CreateSpecResponse = Message<"specgraph.v1.CreateSpecResponse"> & {
  * Use `create(CreateSpecResponseSchema)` to create a new message.
  */
 export const CreateSpecResponseSchema: GenMessage<CreateSpecResponse> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 14);
+  messageDesc(file_specgraph_v1_spec, 17);
 
 /**
  * @generated from message specgraph.v1.GetSpecResponse
@@ -621,7 +780,7 @@ export type GetSpecResponse = Message<"specgraph.v1.GetSpecResponse"> & {
  * Use `create(GetSpecResponseSchema)` to create a new message.
  */
 export const GetSpecResponseSchema: GenMessage<GetSpecResponse> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 15);
+  messageDesc(file_specgraph_v1_spec, 18);
 
 /**
  * @generated from message specgraph.v1.UpdateSpecResponse
@@ -638,32 +797,47 @@ export type UpdateSpecResponse = Message<"specgraph.v1.UpdateSpecResponse"> & {
  * Use `create(UpdateSpecResponseSchema)` to create a new message.
  */
 export const UpdateSpecResponseSchema: GenMessage<UpdateSpecResponse> = /*@__PURE__*/
-  messageDesc(file_specgraph_v1_spec, 16);
+  messageDesc(file_specgraph_v1_spec, 19);
 
 /**
- * @generated from enum specgraph.v1.SpecLifecycle
+ * SpecProvenance records how a spec entered the graph. Replaces the
+ * earlier SpecLifecycle field (task/living) at pre-1.0 with a clean
+ * wire-break — see docs/superpowers/specs/2026-05-20-spec-provenance-model-design.md.
+ *
+ * @generated from enum specgraph.v1.SpecProvenance
  */
-export enum SpecLifecycle {
+export enum SpecProvenance {
   /**
-   * @generated from enum value: SPEC_LIFECYCLE_UNSPECIFIED = 0;
+   * @generated from enum value: SPEC_PROVENANCE_UNSPECIFIED = 0;
    */
   UNSPECIFIED = 0,
 
   /**
-   * @generated from enum value: SPEC_LIFECYCLE_TASK = 1;
+   * forward-authored via the funnel
+   *
+   * @generated from enum value: SPEC_PROVENANCE_AUTHORED = 1;
    */
-  TASK = 1,
+  AUTHORED = 1,
 
   /**
-   * @generated from enum value: SPEC_LIFECYCLE_LIVING = 2;
+   * imported from a merged PR/commit
+   *
+   * @generated from enum value: SPEC_PROVENANCE_RETROACTIVE_FROM_PR = 2;
    */
-  LIVING = 2,
+  RETROACTIVE_FROM_PR = 2,
+
+  /**
+   * human-declared as describing existing reality
+   *
+   * @generated from enum value: SPEC_PROVENANCE_DECLARED = 3;
+   */
+  DECLARED = 3,
 }
 
 /**
- * Describes the enum specgraph.v1.SpecLifecycle.
+ * Describes the enum specgraph.v1.SpecProvenance.
  */
-export const SpecLifecycleSchema: GenEnum<SpecLifecycle> = /*@__PURE__*/
+export const SpecProvenanceSchema: GenEnum<SpecProvenance> = /*@__PURE__*/
   enumDesc(file_specgraph_v1_spec, 0);
 
 /**

--- a/web/src/lib/components/MetadataBar.svelte
+++ b/web/src/lib/components/MetadataBar.svelte
@@ -1,24 +1,25 @@
 <script lang="ts">
-  import { SpecLifecycle } from '$lib/api/gen/specgraph/v1/spec_pb';
+  import { SpecProvenance } from '$lib/api/gen/specgraph/v1/spec_pb';
 
   interface Props {
     createdAt?: { seconds: bigint };
     updatedAt?: { seconds: bigint };
-    lifecycle?: SpecLifecycle;
+    provenanceType?: SpecProvenance;
     contentHash?: string;
   }
-  let { createdAt, updatedAt, lifecycle, contentHash }: Props = $props();
+  let { createdAt, updatedAt, provenanceType, contentHash }: Props = $props();
 
-  function lifecycleLabel(lc: SpecLifecycle | undefined): string | undefined {
-    if (lc === undefined || lc === SpecLifecycle.UNSPECIFIED) return undefined;
+  function provenanceLabel(p: SpecProvenance | undefined): string | undefined {
+    if (p === undefined || p === SpecProvenance.UNSPECIFIED) return undefined;
     const labels: Record<number, string> = {
-      [SpecLifecycle.TASK]: 'task',
-      [SpecLifecycle.LIVING]: 'living',
+      [SpecProvenance.AUTHORED]: 'AUTHORED',
+      [SpecProvenance.RETROACTIVE_FROM_PR]: 'RETROACTIVE_FROM_PR',
+      [SpecProvenance.DECLARED]: 'DECLARED',
     };
-    return labels[lc];
+    return labels[p];
   }
 
-  let displayLifecycle = $derived(lifecycleLabel(lifecycle));
+  let displayProvenance = $derived(provenanceLabel(provenanceType));
 
   function formatDate(ts: { seconds: bigint } | undefined): string {
     if (!ts) return '—';
@@ -43,9 +44,9 @@
   <span>Created: <strong>{formatDate(createdAt)}</strong></span>
   <span class="sep">·</span>
   <span>Updated: <strong>{relativeTime(updatedAt)}</strong></span>
-  {#if displayLifecycle}
+  {#if displayProvenance}
     <span class="sep">·</span>
-    <span>Lifecycle: <span class="lifecycle-badge">{displayLifecycle}</span></span>
+    <span>Provenance: <span class="provenance-badge">{displayProvenance}</span></span>
   {/if}
   {#if contentHash}
     <span class="sep">·</span>
@@ -73,7 +74,7 @@
     font-weight: 500;
   }
 
-  .lifecycle-badge {
+  .provenance-badge {
     background: #dbeafe;
     color: #2563eb;
     padding: 0.05rem 0.3rem;

--- a/web/src/routes/spec/[...slug]/+page.svelte
+++ b/web/src/routes/spec/[...slug]/+page.svelte
@@ -182,7 +182,7 @@
   <MetadataBar
     createdAt={spec.createdAt}
     updatedAt={spec.updatedAt}
-    lifecycle={spec.lifecycle}
+    provenanceType={spec.provenanceType}
     contentHash={spec.contentHash}
   />
 


### PR DESCRIPTION
## Summary

Implements the spec-provenance model design from PR #953 — replaces \`SpecLifecycle\` (task/living) with \`SpecProvenance\` (AUTHORED / RETROACTIVE_FROM_PR / DECLARED) end-to-end.

- **Wire-break at proto field 10**: \`lifecycle\` → \`provenance_type\`, plus new \`provenance_detail\` oneof at fields 22-24 (per ADR-006)
- **Postgres migration 007**: drops \`lifecycle\` column, adds \`provenance_type\` + \`provenance_detail\` JSONB, with a precondition guard refusing to run on a non-empty \`specs\` table (no production data exists; clean break is licensed)
- **\`specgraph ready\` query rewritten**: \`stage = 'approved' AND provenance_type = 'authored' AND no active claim AND no incomplete deps/blockers\`. Previously surfaced any spec at \`stage <> done\`, including mid-design and superseded/abandoned specs — a documented implementation gap closed by this change
- **\`claim\` and \`report-completion\` gated on provenance=AUTHORED** with eight new sentinel errors (ErrProvenanceMismatch, ErrAuthoredRequiresSparkOnly, ErrRetroactiveRequiresAllOutputs, ErrRetroactiveRequiresPRRef, ErrDeclaredRequiresAllOutputs, ErrDeclaredRequiresDeclaredBy, ErrClaimRequiresAuthored, ErrCompletionRequiresAuthored)
- **CreateSpec extended** to accept provenance + all four stage outputs in a single call for born-at-done flows (RETROACTIVE_FROM_PR + DECLARED)
- **CLI and MCP** both expose the new flows: \`spec create --provenance retroactive_from_pr --pr-url ... --spark-json ...\` etc.
- **Render, linter, export, web frontend** all updated to use provenance
- **ADR-006** records the model decision; CHANGELOG flags the breaking change; concept doc updated

## Implementation order

28 atomic commits ordered per \`docs/superpowers/plans/2026-05-20-spec-provenance-model.md\`. The proto change in commit 3 (\`feat(proto)!\`) intentionally breaks the build; subsequent commits use the type-checker as a find-every-caller tool. The build is green again from commit 15 onward (Task 7.4 test sweep).

## Test plan

- [x] \`task check\` passes (fmt, license, lint go+markdown+yaml, skills validate, build, unit tests)
- [x] All test files migrated from lifecycle → provenance via the mechanical sweep (Task 7.4)
- [x] New unit tests cover all three creation paths (AUTHORED happy / RETROACTIVE born-at-done / DECLARED born-at-done) plus all 6 sentinel rejection cases plus claim/completion rejection on non-AUTHORED specs (Task 7.1)
- [x] New integration tests cover \`GetReady\` mixed-seed scenarios (Task 7.2) and migration 007 precondition (Task 7.3) — build-tag gated, run in CI
- [ ] \`task pr-prep\` (integration + e2e under Docker) — not run locally; CI exercises it

## Breaking changes

See CHANGELOG.md. Wire-break is intentional and licensed (pre-1.0, no production data per project status). ADR-006 documents the rationale.