### PR TITLE
spgr-8ar PR A: storage gap close + export round-trip fix

### DIFF
--- a/docs/superpowers/plans/2026-05-21-spgr-8ar-piece-a-implementation-plan.md
+++ b/docs/superpowers/plans/2026-05-21-spgr-8ar-piece-a-implementation-plan.md
@@ -1,0 +1,1360 @@
+# spgr-8ar Piece A — Storage Gap + Export Round-Trip Fix
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the storage-direct constitution-read gaps (PrimeData + export.engine) by routing both through a new `GetMergedConstitution` method, thread constitution provenance through `PrimeData`, and fix the export round-trip bug by bumping export schema to v2 with a list of layers.
+
+**Architecture:** One new storage interface method (`GetMergedConstitution`) implemented as `GetAllLayers` + `merge.Layers`. `PrimeData` gains a `ConstitutionProvenance` field (domain only — no proto change in Piece A). Export bumps `CurrentSchemaVersion` from 1 to 2 with a `Constitutions []` field replacing the single `Constitution` field; import handles both schema versions with cross-field validation that rejects mismatched documents.
+
+**Tech Stack:** Go, pgx v5, ConnectRPC, existing `internal/constitution/merge` package, existing `spaolacci/murmur3`. No new external dependencies in Piece A.
+
+**Reference spec:** [docs/superpowers/specs/2026-05-21-multi-layer-constitution-completion-design.md](../specs/2026-05-21-multi-layer-constitution-completion-design.md) — Sections 1, 2, 3, 11 (Piece D's CI guard is set up but Piece D itself ships later); Section 14 invariants 1, 2, 7, 9.
+
+---
+
+## File Structure
+
+### Files created
+
+| Path | Responsibility |
+|---|---|
+| `internal/storage/postgres/get_merged_constitution_test.go` | Postgres-level tests for new method (empty, single-layer, multi-layer) |
+
+### Files modified
+
+| Path | Change |
+|---|---|
+| `internal/storage/constitution.go` | Add `GetMergedConstitution` to `ConstitutionBackend`; mark `GetConstitution` `// Deprecated` |
+| `internal/storage/postgres/constitution.go` | Add `GetMergedConstitution` implementation |
+| `internal/storage/execution_domain.go` | Add `ProvenanceEntry` type; add `ConstitutionProvenance []ProvenanceEntry` to `PrimeData` |
+| `internal/storage/postgres/execution.go` | `GetPrimeData` switches from `GetConstitution` to `GetMergedConstitution`; populate provenance |
+| `internal/storage/postgres/execution_test.go` | Update existing prime tests; add multi-layer provenance test |
+| `internal/server/test_scoper_test.go` | Add `GetMergedConstitution` stub to `stubBackend` |
+| `internal/server/constitution_handler_test.go` | Add stub to `mockConstitutionBackend` |
+| `internal/server/sync_handler_test.go` | Add stub to `syncTestBackend` |
+| `internal/server/error_sanitize_test.go` | Add stub to `errorBackend` (returns sentinel error) |
+| `internal/server/execution_handler_test.go` | Update `mockExecutionBackend.seedPrime` to accept provenance |
+| `internal/export/schema.go` | Bump `CurrentSchemaVersion` to 2; add `Constitutions` field to `Data` |
+| `internal/export/engine.go` | `collect` uses `GetAllLayers`; `writeEntities` schema-version-aware with cross-field validation |
+| `internal/export/engine_test.go` | New tests for v1→v2 migration, cross-field validation, multi-layer export |
+
+---
+
+## Prerequisites
+
+- Working tree on `main` with no uncommitted changes (the design doc commit `ulvupoow` is the parent).
+- Postgres available for integration tests (`task test:integration`).
+- `task tools` has been run; `golangci-lint` and friends installed.
+
+---
+
+## Task 0: Set up isolated workspace
+
+**Files:** none (workspace setup)
+
+- [ ] **Step 1: Create the workspace**
+
+Run:
+
+```bash
+jj --no-pager workspace add ../specgraph-8ar-piece-a
+```
+
+Expected output: confirmation that the workspace is created and a new working copy is initialized.
+
+- [ ] **Step 2: Switch to the workspace and base on the design commit**
+
+Run:
+
+```bash
+cd ../specgraph-8ar-piece-a
+jj --no-pager new ulvupoow -m "(working) piece A"
+```
+
+Expected: `@` is a new empty change with the design commit as parent.
+
+- [ ] **Step 3: Verify clean state**
+
+Run:
+
+```bash
+jj --no-pager status
+```
+
+Expected output: "Working copy: (empty)" with parent the design commit.
+
+---
+
+## Task 1: Add `GetMergedConstitution` to interface + Postgres impl + tests
+
+**Files:**
+
+- Modify: `internal/storage/constitution.go`
+- Modify: `internal/storage/postgres/constitution.go`
+- Create: `internal/storage/postgres/get_merged_constitution_test.go`
+
+- [ ] **Step 1: Write failing tests for `GetMergedConstitution`**
+
+Create `internal/storage/postgres/get_merged_constitution_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+func TestGetMergedConstitution_Empty(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.GetMergedConstitution(ctx)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, storage.ErrConstitutionNotFound),
+		"empty project must return ErrConstitutionNotFound, got %v", err)
+}
+
+func TestGetMergedConstitution_SingleLayer(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.UpdateConstitution(ctx, &storage.Constitution{
+		Name:  "test",
+		Layer: storage.ConstitutionLayerProject,
+		Principles: []storage.Principle{
+			{ID: "p1", Statement: "Prefer explicit over implicit"},
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := store.GetMergedConstitution(ctx)
+
+	require.NoError(t, err)
+	require.NotNil(t, result.Constitution)
+	assert.Len(t, result.Constitution.Principles, 1)
+	assert.Equal(t, "p1", result.Constitution.Principles[0].ID)
+	assert.Equal(t, storage.ConstitutionLayerProject,
+		result.Provenance["principles[p1]"],
+		"provenance must attribute p1 to project layer")
+}
+
+func TestGetMergedConstitution_MultiLayer(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.UpdateConstitution(ctx, &storage.Constitution{
+		Name:  "org",
+		Layer: storage.ConstitutionLayerOrg,
+		Principles: []storage.Principle{
+			{ID: "p-org", Statement: "Org rule"},
+			{ID: "p-shared", Statement: "Org's version"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = store.UpdateConstitution(ctx, &storage.Constitution{
+		Name:  "project",
+		Layer: storage.ConstitutionLayerProject,
+		Principles: []storage.Principle{
+			{ID: "p-proj", Statement: "Project rule"},
+			{ID: "p-shared", Statement: "Project's version"},
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := store.GetMergedConstitution(ctx)
+
+	require.NoError(t, err)
+	require.NotNil(t, result.Constitution)
+	assert.Len(t, result.Constitution.Principles, 3, "merge must yield org+proj unique + shared key")
+
+	// Provenance attributes shared key to highest-precedence layer (project)
+	assert.Equal(t, storage.ConstitutionLayerProject,
+		result.Provenance["principles[p-shared]"],
+		"shared key must be attributed to project (highest precedence)")
+	assert.Equal(t, storage.ConstitutionLayerOrg,
+		result.Provenance["principles[p-org]"])
+	assert.Equal(t, storage.ConstitutionLayerProject,
+		result.Provenance["principles[p-proj]"])
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail with a compile error**
+
+Run:
+
+```bash
+go test -tags integration ./internal/storage/postgres/ -run TestGetMergedConstitution -v
+```
+
+Expected: compile error — `s.GetMergedConstitution undefined`.
+
+- [ ] **Step 3: Add `GetMergedConstitution` to the storage interface**
+
+Edit `internal/storage/constitution.go` — replace the entire `ConstitutionBackend` interface block with:
+
+```go
+// ConstitutionBackend defines storage operations for the project constitution.
+type ConstitutionBackend interface {
+	// GetConstitution returns the active constitution.
+	//
+	// Deprecated: returns only the single highest-precedence layer with no
+	// provenance. Use GetMergedConstitution for the effective constitution
+	// across all layers. This method is removed in spgr-8ar Piece D once all
+	// callers migrate.
+	GetConstitution(ctx context.Context) (*Constitution, error)
+
+	// GetConstitutionLayer returns a single layer's raw constitution data.
+	// Returns ErrConstitutionNotFound if the layer does not exist.
+	GetConstitutionLayer(ctx context.Context, layer ConstitutionLayer) (*Constitution, error)
+
+	// GetAllLayers returns all constitution layers for the project,
+	// ordered by precedence (user, org, project, domain).
+	// Returns an empty slice (not error) if no layers exist.
+	GetAllLayers(ctx context.Context) ([]*Constitution, error)
+
+	// GetMergedConstitution returns all layers composed into a single
+	// constitution plus per-field provenance. The single source of truth
+	// for "the effective constitution."
+	//
+	// Returns ErrConstitutionNotFound if no layers exist.
+	GetMergedConstitution(ctx context.Context) (*merge.Result, error)
+
+	// UpdateConstitution stores or replaces a constitution layer,
+	// bumping its version. The layer is determined by constitution.Layer.
+	UpdateConstitution(ctx context.Context, constitution *Constitution) (*Constitution, error)
+}
+```
+
+Add the merge import at the top:
+
+```go
+import (
+	"context"
+
+	"github.com/specgraph/specgraph/internal/constitution/merge"
+)
+```
+
+- [ ] **Step 4: Implement `GetMergedConstitution` on the Postgres store**
+
+Append to `internal/storage/postgres/constitution.go` (after the existing `UpdateConstitution`):
+
+```go
+// GetMergedConstitution returns all layers composed into a single
+// constitution plus per-field provenance.
+// Returns ErrConstitutionNotFound if no layers exist.
+func (s *Store) GetMergedConstitution(ctx context.Context) (*merge.Result, error) {
+	layers, err := s.GetAllLayers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: get merged constitution: %w", err)
+	}
+	if len(layers) == 0 {
+		return nil, fmt.Errorf("postgres: %w", storage.ErrConstitutionNotFound)
+	}
+	result, mergeErr := merge.Layers(layers)
+	if mergeErr != nil {
+		return nil, fmt.Errorf("postgres: merge layers: %w", mergeErr)
+	}
+	return result, nil
+}
+```
+
+Add the merge import at the top of the file:
+
+```go
+import (
+	// ... existing imports ...
+	"github.com/specgraph/specgraph/internal/constitution/merge"
+)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+
+```bash
+go test -tags integration ./internal/storage/postgres/ -run TestGetMergedConstitution -v
+```
+
+Expected: all three tests PASS.
+
+- [ ] **Step 6: Run full storage test suite to check for regressions**
+
+Run:
+
+```bash
+go test -tags integration ./internal/storage/...
+```
+
+Expected: all tests PASS. If any mock backends in `internal/storage/...` fail to compile because they need to implement the new method, address them now — but the mocks under `internal/server/` are handled in Task 5.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/storage/constitution.go internal/storage/postgres/constitution.go internal/storage/postgres/get_merged_constitution_test.go
+git commit -s -m "feat(storage): add GetMergedConstitution method (spgr-8ar piece A)
+
+Adds a convenience method on ConstitutionBackend that returns the
+merged constitution plus per-field provenance. Implementation calls
+GetAllLayers followed by merge.Layers, matching the pattern already
+used by ConstitutionService.GetConstitution RPC handler.
+
+Marks single-layer GetConstitution as Deprecated. Removal happens in
+Piece D once PrimeData and export.engine migrate (Piece A subsequent
+tasks).
+
+Part of spgr-8ar Piece A."
+```
+
+---
+
+## Task 2: Add `ProvenanceEntry` domain type + extend `PrimeData`
+
+**Files:**
+
+- Modify: `internal/storage/execution_domain.go`
+
+- [ ] **Step 1: Add `ProvenanceEntry` and extend `PrimeData`**
+
+Replace the `PrimeData` struct in `internal/storage/execution_domain.go` (currently lines 87-92) with:
+
+```go
+// ProvenanceEntry maps a constitution field path to the layer that set its value.
+type ProvenanceEntry struct {
+	Path  string
+	Layer ConstitutionLayer
+}
+
+// PrimeData holds the raw data needed to compose a prime response.
+type PrimeData struct {
+	Spec         *Spec
+	Decisions    []*Decision
+	Constitution *Constitution
+	// ConstitutionProvenance maps constitution field paths to the layer
+	// that set each value. Empty iff Constitution is nil.
+	ConstitutionProvenance []ProvenanceEntry
+}
+```
+
+- [ ] **Step 2: Verify the package compiles**
+
+Run:
+
+```bash
+go build ./internal/storage/...
+```
+
+Expected: clean build (no callers yet read the new field).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/storage/execution_domain.go
+git commit -s -m "feat(storage): add ProvenanceEntry + PrimeData.ConstitutionProvenance
+
+Threads constitution provenance through the prime path so polecats and
+Gastown see which layer set each constitution value. Domain-only change;
+proto changes are deferred to Piece E (single source of truth in the
+view oneof, not duplicated on PrimeResponse).
+
+Part of spgr-8ar Piece A."
+```
+
+---
+
+## Task 3: Route `GetPrimeData` through merged constitution + thread provenance
+
+**Files:**
+
+- Modify: `internal/storage/postgres/execution.go`
+- Modify: `internal/storage/postgres/execution_test.go`
+
+- [ ] **Step 1: Write a failing test for multi-layer prime provenance**
+
+Append to `internal/storage/postgres/execution_test.go`:
+
+```go
+func TestGetPrimeData_MultiLayerProvenance(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Org layer with one principle.
+	_, err := store.UpdateConstitution(ctx, &storage.Constitution{
+		Name:  "org",
+		Layer: storage.ConstitutionLayerOrg,
+		Principles: []storage.Principle{
+			{ID: "p-org", Statement: "Org rule"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Project layer with another principle.
+	_, err = store.UpdateConstitution(ctx, &storage.Constitution{
+		Name:  "project",
+		Layer: storage.ConstitutionLayerProject,
+		Principles: []storage.Principle{
+			{ID: "p-proj", Statement: "Project rule"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Seed a spec so GetPrimeData has something to find.
+	_, err = store.CreateSpec(ctx, "prime-spec", "intent", "P2", "M",
+		storage.SpecProvenanceAuthored, "", nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	pd, err := store.GetPrimeData(ctx, "prime-spec")
+
+	require.NoError(t, err)
+	require.NotNil(t, pd.Constitution)
+	assert.Len(t, pd.Constitution.Principles, 2,
+		"PrimeData must carry merged constitution from both layers")
+
+	// Build a provenance lookup for assertion clarity.
+	provByPath := map[string]storage.ConstitutionLayer{}
+	for _, e := range pd.ConstitutionProvenance {
+		provByPath[e.Path] = e.Layer
+	}
+	assert.Equal(t, storage.ConstitutionLayerOrg, provByPath["principles[p-org]"])
+	assert.Equal(t, storage.ConstitutionLayerProject, provByPath["principles[p-proj]"])
+}
+
+func TestGetPrimeData_NoConstitution_EmptyProvenance(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.CreateSpec(ctx, "no-con-spec", "intent", "P2", "M",
+		storage.SpecProvenanceAuthored, "", nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	pd, err := store.GetPrimeData(ctx, "no-con-spec")
+
+	require.NoError(t, err)
+	assert.Nil(t, pd.Constitution,
+		"invariant: Constitution nil when no layers exist")
+	assert.Empty(t, pd.ConstitutionProvenance,
+		"invariant: provenance empty iff Constitution nil")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+go test -tags integration ./internal/storage/postgres/ -run TestGetPrimeData_MultiLayerProvenance -v
+go test -tags integration ./internal/storage/postgres/ -run TestGetPrimeData_NoConstitution_EmptyProvenance -v
+```
+
+Expected: `TestGetPrimeData_MultiLayerProvenance` fails (only one principle returned because current code calls single-layer `GetConstitution`); the empty-provenance test fails because the field doesn't get populated.
+
+- [ ] **Step 3: Update `GetPrimeData` to use merged constitution**
+
+Replace the `GetPrimeData` function in `internal/storage/postgres/execution.go` (lines 235-260) with:
+
+```go
+// GetPrimeData returns the data needed to compose a prime response.
+func (s *Store) GetPrimeData(ctx context.Context, slug string) (*storage.PrimeData, error) {
+	spec, err := s.GetSpec(ctx, slug)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: get prime data: %w", err)
+	}
+
+	decisions, err := s.fetchLinkedDecisions(ctx, slug)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: get prime data decisions: %w", err)
+	}
+
+	pd := &storage.PrimeData{
+		Spec:      spec,
+		Decisions: decisions,
+	}
+
+	merged, err := s.GetMergedConstitution(ctx)
+	switch {
+	case err == nil:
+		pd.Constitution = merged.Constitution
+		pd.ConstitutionProvenance = make([]storage.ProvenanceEntry, 0, len(merged.Provenance))
+		for path, layer := range merged.Provenance {
+			pd.ConstitutionProvenance = append(pd.ConstitutionProvenance, storage.ProvenanceEntry{
+				Path:  path,
+				Layer: layer,
+			})
+		}
+		// Sort for deterministic output across runs.
+		sort.Slice(pd.ConstitutionProvenance, func(i, j int) bool {
+			return pd.ConstitutionProvenance[i].Path < pd.ConstitutionProvenance[j].Path
+		})
+	case errors.Is(err, storage.ErrConstitutionNotFound):
+		// No layers exist — leave Constitution nil and Provenance empty.
+		// Matches existing no-constitution behavior.
+	default:
+		return nil, fmt.Errorf("postgres: get prime data constitution: %w", err)
+	}
+
+	return pd, nil
+}
+```
+
+Add `"sort"` to the imports if not already present.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+go test -tags integration ./internal/storage/postgres/ -run TestGetPrimeData -v
+```
+
+Expected: all `TestGetPrimeData*` tests PASS, including the two new ones.
+
+- [ ] **Step 5: Run the full server test suite (compile check for callers)**
+
+Run:
+
+```bash
+go build ./...
+go test ./internal/server/... -count=1
+```
+
+Expected: build succeeds; server tests pass (the existing `*BackendsStub` types in `internal/server/test_scoper_test.go` implement `ConstitutionBackend` via embedded stubs which now need `GetMergedConstitution`; addressed in Task 5).
+
+If the server tests fail to compile because of the new interface method, **proceed to Task 5 now**; otherwise commit and continue.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/storage/postgres/execution.go internal/storage/postgres/execution_test.go
+git commit -s -m "feat(storage): GetPrimeData uses merged constitution with provenance
+
+Closes spgr-8ar item (6) — PrimeData carried the highest-precedence
+single layer with no provenance. After this change, PrimeData carries
+the merged constitution and a sorted ProvenanceEntry list. Polecats
+and downstream consumers see the effective constitution.
+
+Invariants enforced (Section 14 of design):
+- Constitution nil iff ConstitutionProvenance empty
+- ProvenanceEntry list is sorted by path for deterministic output
+
+Part of spgr-8ar Piece A."
+```
+
+---
+
+## Task 4: Update mock backends to implement `GetMergedConstitution`
+
+**Files:**
+
+- Modify: `internal/server/test_scoper_test.go`
+- Modify: `internal/server/constitution_handler_test.go`
+- Modify: `internal/server/sync_handler_test.go`
+- Modify: `internal/server/error_sanitize_test.go`
+
+- [ ] **Step 1: Add stub to `stubBackend` in `test_scoper_test.go`**
+
+Find the existing `stubBackend` methods at `internal/server/test_scoper_test.go:146-154`. Add this method right after `GetAllLayers`:
+
+```go
+func (stubBackend) GetMergedConstitution(_ context.Context) (*merge.Result, error) {
+	return nil, storage.ErrConstitutionNotFound
+}
+```
+
+Add the import if not present:
+
+```go
+"github.com/specgraph/specgraph/internal/constitution/merge"
+```
+
+- [ ] **Step 2: Add stub to `mockConstitutionBackend` in `constitution_handler_test.go`**
+
+After the existing `GetAllLayers` method at `internal/server/constitution_handler_test.go:65`, add:
+
+```go
+func (m *mockConstitutionBackend) GetMergedConstitution(ctx context.Context) (*merge.Result, error) {
+	layers, err := m.GetAllLayers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(layers) == 0 {
+		return nil, storage.ErrConstitutionNotFound
+	}
+	return merge.Layers(layers)
+}
+```
+
+Add the import if not present.
+
+- [ ] **Step 3: Add stub to `syncTestBackend` in `sync_handler_test.go`**
+
+After the existing `GetAllLayers` delegation at `internal/server/sync_handler_test.go:197-199`, add:
+
+```go
+func (s *syncTestBackend) GetMergedConstitution(ctx context.Context) (*merge.Result, error) {
+	if s.con != nil {
+		return s.con.GetMergedConstitution(ctx)
+	}
+	return nil, storage.ErrConstitutionNotFound
+}
+```
+
+Add the import if not present.
+
+- [ ] **Step 4: Add stub to `errorBackend` in `error_sanitize_test.go`**
+
+After the existing `GetConstitution` method at `internal/server/error_sanitize_test.go:95`, add:
+
+```go
+func (errorBackend) GetMergedConstitution(_ context.Context) (*merge.Result, error) {
+	return nil, errSentinel
+}
+```
+
+If `errSentinel` is not the right name, match whatever sentinel error this file uses for "internal error" testing (check the existing `GetConstitution` return value — that's the right one).
+
+Add the import if not present.
+
+- [ ] **Step 5: Run the server test suite**
+
+Run:
+
+```bash
+go test ./internal/server/... -count=1 -v
+```
+
+Expected: all tests PASS. The new mock methods are unused by existing tests, so behavior is unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/server/test_scoper_test.go internal/server/constitution_handler_test.go internal/server/sync_handler_test.go internal/server/error_sanitize_test.go
+git commit -s -m "test(server): mock backends implement GetMergedConstitution
+
+Adds GetMergedConstitution stubs to stubBackend, mockConstitutionBackend,
+syncTestBackend, and errorBackend so the server test suite compiles
+against the new ConstitutionBackend interface.
+
+Part of spgr-8ar Piece A."
+```
+
+---
+
+## Task 5: Bump export schema to v2 + add `Constitutions` field
+
+**Files:**
+
+- Modify: `internal/export/schema.go`
+
+- [ ] **Step 1: Bump version and add the new field**
+
+Replace `internal/export/schema.go` content with:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+// Package export implements project export, import, and verification.
+package export
+
+import (
+	"time"
+
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// CurrentSchemaVersion is bumped to 2 with the multi-layer constitution
+// migration. v2 documents use the Constitutions list field; v1 documents
+// (still importable) use the singular Constitution field.
+const CurrentSchemaVersion = 2
+
+// Document is the top-level export structure.
+type Document struct {
+	SchemaVersion    int        `json:"schema_version"`
+	ExportedAt       time.Time  `json:"exported_at"`
+	SpecGraphVersion string     `json:"specgraph_version"`
+	ProjectSlug      string     `json:"project_slug"`
+	Data             Data       `json:"data"`
+	Signature        *Signature `json:"signature,omitempty"`
+}
+
+// Signature holds HMAC verification data.
+type Signature struct {
+	Algorithm string `json:"algorithm"`
+	Digest    string `json:"digest"`
+}
+
+// Data contains all exported entities in dependency order.
+type Data struct {
+	Project *storage.Project `json:"project"`
+
+	// Constitution is the v1 single-layer field. Always nil in v2-emitted
+	// documents (omitempty drops it). Populated when importing v1 documents
+	// for the legacy single-layer case.
+	Constitution *storage.Constitution `json:"constitution,omitempty"`
+
+	// Constitutions is the v2 list of constitution layers in precedence
+	// order (user, org, project, domain). Populated by v2 exports; consumed
+	// by v2 imports.
+	Constitutions []*storage.Constitution `json:"constitutions,omitempty"`
+
+	Specs           []*storage.Spec                 `json:"specs"`
+	Decisions       []*storage.Decision             `json:"decisions"`
+	Slices          []*storage.Slice                `json:"slices"`
+	Edges           []Edge                          `json:"edges"`
+	Findings        []*storage.AnalyticalFinding    `json:"findings"`
+	ChangeLogs      []*storage.ChangeLogEntry       `json:"changelogs"`
+	Conversations   []*storage.ConversationLogEntry `json:"conversations"`
+	SyncMappings    []*storage.SyncMapping          `json:"sync_mappings"`
+	ExecutionEvents []*storage.ExecutionEvent       `json:"execution_events"`
+}
+
+// Edge is the export representation of a graph edge.
+type Edge struct {
+	FromSlug          string `json:"from_slug"`
+	ToSlug            string `json:"to_slug"`
+	Type              string `json:"type"`
+	ContentHashAtLink string `json:"content_hash_at_link,omitempty"`
+}
+```
+
+- [ ] **Step 2: Run existing export tests — expect failures, file the symptoms**
+
+Run:
+
+```bash
+go test ./internal/export/... -count=1
+```
+
+Expected: `TestImport_RejectsUnsupportedSchemaVersion` and other tests using `CurrentSchemaVersion` should still pass (no v999 / v2 conflict). Existing tests using `doc.Data.Constitution` will compile but may exercise different behavior — note any unexpected failures; they will be addressed in Task 7.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/export/schema.go
+git commit -s -m "feat(export): bump schema to v2 with multi-layer constitutions
+
+Adds Data.Constitutions []*Constitution alongside the legacy singular
+Constitution field. v2 exports populate Constitutions; v1 imports
+continue to use Constitution. Cross-field validation is added in the
+import path next.
+
+Part of spgr-8ar Piece A."
+```
+
+---
+
+## Task 6: Update `Engine.collect` to use `GetAllLayers`
+
+**Files:**
+
+- Modify: `internal/export/engine.go`
+- Modify: `internal/export/engine_test.go`
+
+- [ ] **Step 1: Write a failing test for multi-layer export**
+
+Append to `internal/export/engine_test.go`:
+
+```go
+func TestExport_MultiLayerConstitution(t *testing.T) {
+	backend := newTestBackend(t)
+	ctx := context.Background()
+
+	// Seed two layers.
+	_, err := backend.UpdateConstitution(ctx, &storage.Constitution{
+		Name:  "org",
+		Layer: storage.ConstitutionLayerOrg,
+		Principles: []storage.Principle{{ID: "p-org", Statement: "Org"}},
+	})
+	require.NoError(t, err)
+
+	_, err = backend.UpdateConstitution(ctx, &storage.Constitution{
+		Name:  "project",
+		Layer: storage.ConstitutionLayerProject,
+		Principles: []storage.Principle{{ID: "p-proj", Statement: "Proj"}},
+	})
+	require.NoError(t, err)
+
+	engine := NewEngine(backend, "", "test-version")
+	out, err := engine.Export(ctx, "test-project")
+	require.NoError(t, err)
+
+	var doc Document
+	require.NoError(t, json.Unmarshal(out, &doc))
+
+	assert.Equal(t, 2, doc.SchemaVersion)
+	assert.Nil(t, doc.Data.Constitution, "v2 exports never populate the v1 field")
+	require.Len(t, doc.Data.Constitutions, 2, "v2 export must contain both layers")
+	assert.Equal(t, storage.ConstitutionLayerOrg, doc.Data.Constitutions[0].Layer,
+		"layers in precedence order: org before project")
+	assert.Equal(t, storage.ConstitutionLayerProject, doc.Data.Constitutions[1].Layer)
+}
+```
+
+(If `newTestBackend` is not the right helper name, use the existing test backend constructor in the file.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+go test ./internal/export/ -run TestExport_MultiLayerConstitution -v
+```
+
+Expected: fail — current `collect` calls `GetConstitution` (single layer) and writes to `doc.Data.Constitution`; the test asserts both `Constitutions` populated and `Constitution` nil, which the current code can't do.
+
+- [ ] **Step 3: Update `Engine.collect`**
+
+In `internal/export/engine.go`, find the constitution block at lines 93-97:
+
+```go
+// Constitution (optional — may not exist)
+constitution, err := e.backend.GetConstitution(ctx)
+if err == nil {
+	doc.Data.Constitution = constitution
+}
+```
+
+Replace with:
+
+```go
+// Constitutions (optional — may not exist; v2 emits the list field).
+layers, err := e.backend.GetAllLayers(ctx)
+if err != nil {
+	return nil, fmt.Errorf("get constitution layers: %w", err)
+}
+if len(layers) > 0 {
+	doc.Data.Constitutions = layers
+}
+```
+
+`GetAllLayers` returns an empty slice (not error) when no layers exist, so the `len > 0` guard prevents emitting an empty list.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+
+```bash
+go test ./internal/export/ -run TestExport_MultiLayerConstitution -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run all export tests to verify no regressions**
+
+Run:
+
+```bash
+go test ./internal/export/... -count=1 -v
+```
+
+Expected: all tests PASS. If any pre-existing test asserts on `doc.Data.Constitution` from an export (single-layer case), it should be updated to assert on `doc.Data.Constitutions[0]` instead. Update such tests as part of this commit.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/export/engine.go internal/export/engine_test.go
+git commit -s -m "feat(export): collect uses GetAllLayers for v2 schema
+
+Engine.collect now reads all constitution layers via GetAllLayers and
+emits them as the v2 Constitutions list field. Previously it called
+GetConstitution which returns only the highest-precedence layer,
+silently flattening multi-layer projects on export. Bug fix.
+
+Part of spgr-8ar Piece A."
+```
+
+---
+
+## Task 7: Schema-version-aware import with cross-field validation
+
+**Files:**
+
+- Modify: `internal/export/engine.go`
+- Modify: `internal/export/engine_test.go`
+
+- [ ] **Step 1: Write failing tests for v1/v2 import paths and cross-field validation**
+
+Append to `internal/export/engine_test.go`:
+
+```go
+func TestImport_V1Document_SingleLayer(t *testing.T) {
+	backend := newTestBackend(t)
+	ctx := context.Background()
+
+	// Hand-crafted v1 document with the legacy singular field.
+	v1Doc := Document{
+		SchemaVersion:    1,
+		ProjectSlug:      "test-project",
+		SpecGraphVersion: "test-version",
+		Data: Data{
+			Project: &storage.Project{Slug: "test-project"},
+			Constitution: &storage.Constitution{
+				Name:  "v1-only",
+				Layer: storage.ConstitutionLayerProject,
+				Principles: []storage.Principle{{ID: "p1", Statement: "P1"}},
+			},
+		},
+	}
+	data, err := json.Marshal(v1Doc)
+	require.NoError(t, err)
+
+	engine := NewEngine(backend, "", "test-version")
+	result, err := engine.Import(ctx, data, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Constitution, "exactly one layer imported")
+
+	layers, err := backend.GetAllLayers(ctx)
+	require.NoError(t, err)
+	require.Len(t, layers, 1)
+	assert.Equal(t, "v1-only", layers[0].Name)
+	assert.Equal(t, storage.ConstitutionLayerProject, layers[0].Layer)
+}
+
+func TestImport_V2Document_MultipleLayers(t *testing.T) {
+	backend := newTestBackend(t)
+	ctx := context.Background()
+
+	v2Doc := Document{
+		SchemaVersion:    2,
+		ProjectSlug:      "test-project",
+		SpecGraphVersion: "test-version",
+		Data: Data{
+			Project: &storage.Project{Slug: "test-project"},
+			Constitutions: []*storage.Constitution{
+				{Name: "org", Layer: storage.ConstitutionLayerOrg, Principles: []storage.Principle{{ID: "po"}}},
+				{Name: "proj", Layer: storage.ConstitutionLayerProject, Principles: []storage.Principle{{ID: "pp"}}},
+			},
+		},
+	}
+	data, err := json.Marshal(v2Doc)
+	require.NoError(t, err)
+
+	engine := NewEngine(backend, "", "test-version")
+	result, err := engine.Import(ctx, data, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Constitution, "both layers imported")
+
+	layers, err := backend.GetAllLayers(ctx)
+	require.NoError(t, err)
+	assert.Len(t, layers, 2)
+}
+
+func TestImport_V1Document_WithV2Field_Rejected(t *testing.T) {
+	backend := newTestBackend(t)
+
+	mismatched := Document{
+		SchemaVersion: 1,
+		ProjectSlug:   "test-project",
+		Data: Data{
+			Project: &storage.Project{Slug: "test-project"},
+			Constitutions: []*storage.Constitution{
+				{Layer: storage.ConstitutionLayerProject},
+			},
+		},
+	}
+	data, err := json.Marshal(mismatched)
+	require.NoError(t, err)
+
+	engine := NewEngine(backend, "", "test-version")
+	_, err = engine.Import(context.Background(), data, false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "v1 documents must use 'constitution' field, not 'constitutions'")
+}
+
+func TestImport_V2Document_WithV1Field_Rejected(t *testing.T) {
+	backend := newTestBackend(t)
+
+	mismatched := Document{
+		SchemaVersion: 2,
+		ProjectSlug:   "test-project",
+		Data: Data{
+			Project: &storage.Project{Slug: "test-project"},
+			Constitution: &storage.Constitution{
+				Layer: storage.ConstitutionLayerProject,
+			},
+		},
+	}
+	data, err := json.Marshal(mismatched)
+	require.NoError(t, err)
+
+	engine := NewEngine(backend, "", "test-version")
+	_, err = engine.Import(context.Background(), data, false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "v2 documents must use 'constitutions' field, not 'constitution'")
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+go test ./internal/export/ -run "TestImport_V1Document|TestImport_V2Document" -v
+```
+
+Expected: all four fail. The current `writeEntities` calls `UpdateConstitution` with `doc.Data.Constitution` regardless of schema version, so the v2 path doesn't import layers, the v1 path works incidentally, and the cross-field validation is absent.
+
+- [ ] **Step 3: Update `Engine.writeEntities` constitution block**
+
+In `internal/export/engine.go`, find the constitution block in `writeEntities` (currently lines 379-385):
+
+```go
+// 2. Constitution
+if doc.Data.Constitution != nil {
+	if _, err := e.backend.UpdateConstitution(ctx, doc.Data.Constitution); err != nil {
+		return nil, fmt.Errorf("update constitution: %w", err)
+	}
+	res.Constitution = 1
+}
+```
+
+Replace with:
+
+```go
+// 2. Constitutions — handle schema v1 (single) and v2 (list) with strict
+// cross-field validation to prevent silent data loss from mismatched docs.
+var layers []*storage.Constitution
+switch doc.SchemaVersion {
+case 1:
+	if doc.Data.Constitutions != nil {
+		return nil, fmt.Errorf("v1 documents must use 'constitution' field, not 'constitutions'")
+	}
+	if doc.Data.Constitution != nil {
+		layers = []*storage.Constitution{doc.Data.Constitution}
+	}
+case 2:
+	if doc.Data.Constitution != nil {
+		return nil, fmt.Errorf("v2 documents must use 'constitutions' field, not 'constitution'")
+	}
+	layers = doc.Data.Constitutions
+}
+for _, layer := range layers {
+	if _, err := e.backend.UpdateConstitution(ctx, layer); err != nil {
+		return nil, fmt.Errorf("update constitution layer %s: %w", layer.Layer, err)
+	}
+	res.Constitution++
+}
+```
+
+- [ ] **Step 4: Run the new tests**
+
+Run:
+
+```bash
+go test ./internal/export/ -run "TestImport_V1Document|TestImport_V2Document" -v
+```
+
+Expected: all four PASS.
+
+- [ ] **Step 5: Run the full export test suite**
+
+Run:
+
+```bash
+go test ./internal/export/... -count=1 -v
+```
+
+Expected: all tests PASS, including pre-existing import tests that use `CurrentSchemaVersion` (now 2 with `Constitutions` field). If any pre-existing test populated `doc.Data.Constitution` on a `SchemaVersion: CurrentSchemaVersion` document, it now hits the v2 cross-field error and must be updated to use `Constitutions: []*storage.Constitution{...}` instead. Update such tests as part of this commit.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/export/engine.go internal/export/engine_test.go
+git commit -s -m "feat(export): schema-aware import with cross-field validation
+
+Engine.writeEntities now handles both schema v1 (singular Constitution
+field) and v2 (Constitutions list). Cross-field validation rejects
+documents with schema_version + field mismatch (e.g., v1 doc with
+'constitutions' populated) to prevent silent data loss.
+
+Closes export round-trip bug surfaced in adversarial review: v1 docs
+imported under v2 code preserve their single layer; v2 docs import all
+layers; mismatched docs error explicitly.
+
+Part of spgr-8ar Piece A."
+```
+
+---
+
+## Task 8: v1↔v2 round-trip integration test
+
+**Files:**
+
+- Modify: `internal/export/engine_test.go`
+
+- [ ] **Step 1: Write the round-trip test**
+
+Append to `internal/export/engine_test.go`:
+
+```go
+func TestExportImport_V1ToV2_RoundTrip(t *testing.T) {
+	// Hand-craft a v1 document, import it via the new code, re-export,
+	// verify the resulting v2 document preserves the single layer.
+
+	v1Source := Document{
+		SchemaVersion:    1,
+		ProjectSlug:      "rt-project",
+		SpecGraphVersion: "test-version",
+		Data: Data{
+			Project: &storage.Project{Slug: "rt-project"},
+			Constitution: &storage.Constitution{
+				Name:  "legacy",
+				Layer: storage.ConstitutionLayerProject,
+				Principles: []storage.Principle{
+					{ID: "legacy-p1", Statement: "Legacy principle"},
+				},
+				Constraints: []string{"legacy-constraint"},
+			},
+		},
+	}
+	v1Bytes, err := json.Marshal(v1Source)
+	require.NoError(t, err)
+
+	backend := newTestBackend(t)
+	ctx := context.Background()
+	engine := NewEngine(backend, "", "test-version")
+
+	// Import v1.
+	_, err = engine.Import(ctx, v1Bytes, false, false)
+	require.NoError(t, err)
+
+	// Re-export as v2.
+	v2Bytes, err := engine.Export(ctx, "rt-project")
+	require.NoError(t, err)
+
+	var v2 Document
+	require.NoError(t, json.Unmarshal(v2Bytes, &v2))
+
+	assert.Equal(t, 2, v2.SchemaVersion, "re-export uses CurrentSchemaVersion=2")
+	assert.Nil(t, v2.Data.Constitution, "v2 export never populates v1 field")
+	require.Len(t, v2.Data.Constitutions, 1, "exactly one layer preserved")
+
+	got := v2.Data.Constitutions[0]
+	assert.Equal(t, "legacy", got.Name)
+	assert.Equal(t, storage.ConstitutionLayerProject, got.Layer)
+	require.Len(t, got.Principles, 1)
+	assert.Equal(t, "legacy-p1", got.Principles[0].ID)
+	require.Len(t, got.Constraints, 1)
+	assert.Equal(t, "legacy-constraint", got.Constraints[0])
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run:
+
+```bash
+go test ./internal/export/ -run TestExportImport_V1ToV2_RoundTrip -v
+```
+
+Expected: PASS. Implementation from Tasks 5-7 already supports this; the test is the explicit invariant verification.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/export/engine_test.go
+git commit -s -m "test(export): v1 to v2 round-trip migration
+
+Asserts the invariant: a v1 export document imports under v2 code and
+re-exports as a v2 document with the single layer preserved (under the
+Constitutions list field). Covers the 'forward-compatible for the data
+v1 could hold' contract from the design.
+
+Part of spgr-8ar Piece A."
+```
+
+---
+
+## Task 9: Quality gate run
+
+**Files:** none
+
+- [ ] **Step 1: Run `task check`**
+
+Run:
+
+```bash
+task check
+```
+
+Expected: all checks PASS — fmt, license, lint, build, unit tests.
+
+If `revive` complains about a missing package comment, fix it inline. If `wrapcheck` complains, wrap the offending error. If `govet -shadow` complains, rename the shadowed variable. These are usually 1-line fixes.
+
+- [ ] **Step 2: Run `task pr-prep`**
+
+Run:
+
+```bash
+task pr-prep
+```
+
+Expected: all checks PASS — `task check` + `test:integration` + `test:e2e`. Docker must be available (per project rule: always is).
+
+If integration or e2e tests fail in areas unrelated to Piece A (flaky tests, environmental issues), document the symptom and investigate before pushing.
+
+- [ ] **Step 3: Update bd issue with progress note**
+
+Run:
+
+```bash
+bd update spgr-8ar --notes "Piece A complete: GetMergedConstitution + PrimeData provenance + export schema v2 with v1->v2 migration. Pieces B/C/D/E remaining."
+```
+
+- [ ] **Step 4: Sync beads**
+
+Run:
+
+```bash
+bd dolt push
+```
+
+Expected: "Push complete."
+
+---
+
+## Task 10: Push and open PR
+
+**Files:** none
+
+- [ ] **Step 1: Verify the commit graph**
+
+Run:
+
+```bash
+jj --no-pager log -r 'main..@-' --limit 20
+```
+
+Expected: 8 commits (one per Tasks 1-8), each with a `Signed-off-by: Sean Brandt <SeBrandt@geico.com>` trailer, conventional commit type prefixes, and `spgr-8ar piece A` mentioned in the message.
+
+- [ ] **Step 2: Verify auth account for push**
+
+Run:
+
+```bash
+gh auth switch -u seanb4t -h github.com
+gh auth status
+```
+
+Expected: `Active account: true` on the `seanb4t` row (per the `gh-auth-gotcha-specgraph-seanb4t-is-the-personal` memory).
+
+- [ ] **Step 3: Set the bookmark for the PR branch**
+
+Run:
+
+```bash
+jj --no-pager bookmark set spgr-8ar-piece-a -r @-
+```
+
+Expected: bookmark created/moved to point at the top commit of the Piece A stack.
+
+- [ ] **Step 4: Push the bookmark**
+
+Run:
+
+```bash
+jj --no-pager git push --bookmark spgr-8ar-piece-a
+```
+
+Expected: branch pushed successfully to `origin`.
+
+- [ ] **Step 5: Open the PR**
+
+Run:
+
+```bash
+gh pr create --title "spgr-8ar PR A: storage gap close + export round-trip fix" --body "$(cat <<'EOF'
+## Summary
+
+- Adds `GetMergedConstitution` to `ConstitutionBackend`; routes `PrimeData` and (future) `export.engine` through it
+- Threads `ConstitutionProvenance` through `PrimeData` (domain only — no proto change in this PR; deferred to Piece E)
+- Bumps export `CurrentSchemaVersion` from 1 to 2; replaces single `Constitution` field with `Constitutions []` list; schema-version-aware import with cross-field validation
+- Marks single-layer `Store.GetConstitution` as `// Deprecated` (removal in Piece D)
+
+Implements Piece A of [spgr-8ar design](docs/superpowers/specs/2026-05-21-multi-layer-constitution-completion-design.md). Closes the genuine bead acceptance criterion (item 6: PrimeData uses merged constitution) and fixes the unstated export-flattens-layers bug surfaced in adversarial review.
+
+## Test plan
+
+- [ ] `task check` passes (fmt, lint, build, unit)
+- [ ] `task pr-prep` passes (check + integration + e2e)
+- [ ] `TestGetMergedConstitution_{Empty,SingleLayer,MultiLayer}` exercise the new method
+- [ ] `TestGetPrimeData_MultiLayerProvenance` confirms prime path carries merged constitution + sorted provenance
+- [ ] `TestGetPrimeData_NoConstitution_EmptyProvenance` confirms invariant (Constitution nil iff Provenance empty)
+- [ ] `TestExport_MultiLayerConstitution` confirms v2 exports populate `Constitutions` list in precedence order
+- [ ] `TestImport_V1Document_SingleLayer` confirms v1 documents still import correctly
+- [ ] `TestImport_V2Document_MultipleLayers` confirms v2 import populates all layers
+- [ ] `TestImport_{V1,V2}Document_With{V2,V1}Field_Rejected` confirms cross-field validation
+- [ ] `TestExportImport_V1ToV2_RoundTrip` confirms forward migration is lossless for v1-expressible data
+
+Pieces B/C/D/E remain — separate PRs per the design's piece breakdown.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed to stdout.
+
+- [ ] **Step 6: Drop the local working-copy commit**
+
+Back in the workspace, the working copy `@` is empty after the push. Leave it for the next session, or:
+
+```bash
+jj --no-pager abandon @
+```
+
+to clean up. The pushed commits remain on the bookmark.
+
+---
+
+## Self-review
+
+### Spec coverage check
+
+- **Section 1 (Storage interface)**: Task 1 adds `GetMergedConstitution`; Task 4 propagates to mocks ✓
+- **Section 2 (PrimeData provenance)**: Task 2 adds domain types; Task 3 routes through it ✓
+- **Section 3 (Export round-trip fix)**: Tasks 5-8 cover schema v2, GetAllLayers in collect, cross-field validation, v1→v2 round-trip ✓
+- **Section 14 invariant: Merge consistency** — both PrimeData and (this PR's) export read paths converge on merged; the storage interface deprecation comment plus the eventual Piece D CI guard structurally enforces it ✓
+- **Section 14 invariant: Provenance ↔ Constitution coupling** — Task 3 Step 1 explicitly tests both branches ✓
+- **Section 14 invariant: v1 ↔ v2 export** — Tasks 7-8 cover both directions, plus cross-field rejection ✓
+
+### Placeholder scan
+
+- No `TBD`, `TODO`, "fill in details", or "similar to Task N" references.
+- Every step that changes code shows the actual code.
+- Every test step has runnable assertions.
+
+### Type consistency
+
+- `ProvenanceEntry` defined once in Task 2; referenced consistently in Tasks 3, 4 ✓
+- `GetMergedConstitution` signature `func(ctx) (*merge.Result, error)` consistent across interface, impl, mocks ✓
+- `merge.Result` from `internal/constitution/merge` — existing type, no redefinition needed ✓
+
+### Out-of-scope deferrals
+
+Pieces B (remote fetch), C (provenance display), D (delete `GetConstitution`), E (prime unification) are explicitly out of scope for this plan. Each gets its own plan document.
+
+Note: the `// Deprecated` comment on `Store.GetConstitution` lands in Task 1 of this plan; the actual deletion is in Piece D's plan after this merges and we verify no remaining callers.
+
+---
+
+## Plan complete
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-21-spgr-8ar-piece-a-implementation-plan.md`.** Two execution options:
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration
+2. **Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-21-multi-layer-constitution-completion-design.md
+++ b/docs/superpowers/specs/2026-05-21-multi-layer-constitution-completion-design.md
@@ -1,0 +1,929 @@
+# Multi-Layer Constitution Completion + Prime Unification — Design Spec
+
+**Date:** 2026-05-21
+**Status:** Draft v5 (after three rounds of adversarial review + invariants/security audit)
+**Bead:** spgr-8ar
+**Predecessor:** [2026-04-07-layered-constitution-design.md](2026-04-07-layered-constitution-design.md)
+**Goal:** Close the genuine multi-layer constitution gap (PrimeData and export do not use the merged constitution), add the affordances that make multi-layer support practically usable (remote-source import, drift sync, provenance display), retire the single-layer compatibility method, and unify the three "prime" surfaces (RPC, MCP resource, CLI) onto one composer so they stay consistent going forward.
+
+## Context
+
+The 2026-04-07 design landed the foundation: schema migration to `(project_slug, layer)`, layer-aware storage methods, the `internal/constitution/merge` package with provenance tracking, and `$delete` directives. Subsequent PRs wired the `ConstitutionService.GetConstitution` RPC handler to call `merge.Layers` by default, added `repeated ProvenanceEntry` to the proto response, and extended the CLI with `constitution import --layer` and `constitution show --layer`.
+
+### Honest scope statement
+
+The bead's six acceptance criteria are largely already met. Only item (6) — PrimeData uses merged constitution — is a genuine remaining gap. Adversarial review also revealed an unstated bug: `export.engine` silently flattens multi-layer constitutions on round-trip. A second review pass surfaced a structural problem: the three "prime" surfaces (the `ExecutionService.GetPrime` RPC, the `specgraph://prime` MCP resource, and the `specgraph prime` CLI) have drifted from each other in what content they expose and how — the CLI shows no constitution at all, the MCP resource shows a summary of the merged constitution, and the RPC returns flattened summary strings.
+
+This spec intentionally expands the bead's scope to cover all of this in one coherent design because:
+
+- **Coherence**: provenance plumbing through PrimeData (Piece A) is wasted unless the surfaces show it.
+- **Avoiding drift**: fixing one surface in isolation creates the next round of "but the other surface still does X." The prime-unification (Piece E) closes that loop.
+- **Single-source-of-truth pattern**: collapsing three independent compositions into one shared `internal/prime` composer matches the architectural commitment of "the merged constitution is the single source of truth."
+
+If a reader feels the scope is too large, the bead can legitimately close after Piece A alone. Pieces B–E are intentional extensions, not requirements.
+
+## Out of scope
+
+- **Server-managed per-tenant credentials** for remote fetch. V1 uses a single optional env var.
+- **Async/scheduled sync** of remote layers. V1 is on-demand only.
+- **Constitution diff UI** in the web dashboard.
+- **Layer-aware `constitution emit`** — continues to emit the merged composition.
+- **SHA pinning resolution** — V1 stores user-supplied URL verbatim; content-hash-only drift.
+- **"Overrides X" annotation** in provenance display — would require merge engine changes.
+- **Token auth for git-protocol URLs** (`github.com/org/repo` shorthand, `git::https://...`) — V1 supports private GitHub only via raw HTTPS URLs.
+
+---
+
+## Pieces
+
+This design ships as five PRs in dependency order. Each adds value on its own and is independently revertible.
+
+| Piece | Title | Required by bead? | Depends on |
+|---|---|---|---|
+| **A** | Storage gap close + export round-trip fix | Yes (bead item 6 + correctness) | — |
+| **B** | Remote-source import + sync (env-var auth) | No (net-new) | — |
+| **C** | Surface provenance in `constitution show` | No (net-new) | A |
+| **D** | Retire the single-layer compat method | No (net-new) | A |
+| **E** | Prime unification (`internal/prime` composer) | No (net-new) | A |
+
+Piece B is independent of A and could ship in either order. C, D, E all depend on A merging first. C, D, E are mutually independent and can ship in any order.
+
+---
+
+## Section 1: Storage interface evolution
+
+Add one method to `ConstitutionBackend`:
+
+```go
+// GetMergedConstitution returns all layers composed into a single
+// constitution plus per-field provenance. The single source of truth
+// for "the effective constitution."
+//
+// Returns ErrConstitutionNotFound if no layers exist.
+GetMergedConstitution(ctx context.Context) (*merge.Result, error)
+```
+
+Postgres implementation: call `GetAllLayers` then `merge.Layers`. If `GetAllLayers` returns empty, return `ErrConstitutionNotFound`.
+
+Mark `Store.GetConstitution` (the single-layer compat method) `// Deprecated: use GetMergedConstitution`. Deletion happens in Piece D. The merge package itself does not change.
+
+---
+
+## Section 2: PrimeData carries provenance
+
+**Piece A is domain-only.** Proto changes wait for Piece E to avoid duplicating the provenance field across multiple proto locations.
+
+Update domain type:
+
+```go
+type PrimeData struct {
+    Spec                   *Spec
+    Decisions              []*Decision
+    Constitution           *Constitution
+    ConstitutionProvenance []ProvenanceEntry  // new
+}
+
+type ProvenanceEntry struct {
+    Path  string
+    Layer ConstitutionLayer
+}
+```
+
+`GetPrimeData` calls `GetMergedConstitution` instead of `GetConstitution`. If no layers exist, `Constitution` is `nil` and `ConstitutionProvenance` is empty.
+
+The proto `PrimeResponse` is **not** touched in Piece A. The existing summary fields (`ConstitutionSummary`, `CodingConventions`) keep populating from the merged constitution as today — they continue to reflect the highest-precedence layer's name in the `(<name> layer)` substring, which is acceptable for backward compat. Provenance is added to the proto only via Piece E's structured `ProjectView`/`SpecView` (Section 10), which is the single location.
+
+This avoids the "three places to store the same data" problem that would result from adding `repeated ProvenanceEntry constitution_provenance` at the top of `PrimeResponse` while Piece E also adds it to the views.
+
+---
+
+## Section 3: Export round-trip fix
+
+`internal/export/engine.go` today reads `*storage.Constitution` via `GetConstitution` and writes it back via `UpdateConstitution`. With multi-layer support, this collapses multi-layer projects to one layer on round-trip. Fix:
+
+### Schema version bump: 1 → 2
+
+```go
+// internal/export/schema.go
+const CurrentSchemaVersion = 2
+```
+
+### Document shape change
+
+```go
+type Data struct {
+    // ... other fields ...
+
+    // Constitution is the v1 single-layer field. Kept for legacy import only.
+    // Always nil in v2-emitted documents (omitempty handles serialization).
+    Constitution *storage.Constitution `json:"constitution,omitempty"`
+
+    // Constitutions is the v2 list of layers in precedence order.
+    Constitutions []*storage.Constitution `json:"constitutions,omitempty"`
+}
+```
+
+Both fields with `omitempty` so v1 docs parse into `Constitution` and v2 docs parse into `Constitutions`; export only emits one (always `Constitutions` from v2 onwards).
+
+### Export path
+
+`Engine.collect` switches from `GetConstitution(ctx)` to `GetAllLayers(ctx)`. Layers are emitted in precedence order (user, org, project, domain) — already guaranteed by `GetAllLayers`'s ORDER BY (verified: `internal/storage/postgres/constitution.go:100-148`).
+
+### Import path
+
+```go
+// 2. Constitutions — handle schema v1 (single) and v2 (list) with strict
+// field/version validation to prevent silent data loss from mismatched docs.
+var layers []*storage.Constitution
+switch doc.SchemaVersion {
+case 1:
+    if doc.Data.Constitutions != nil {
+        return nil, fmt.Errorf("v1 documents must use 'constitution' field, not 'constitutions'")
+    }
+    if doc.Data.Constitution != nil {
+        layers = []*storage.Constitution{doc.Data.Constitution}
+    }
+case 2:
+    if doc.Data.Constitution != nil {
+        return nil, fmt.Errorf("v2 documents must use 'constitutions' field, not 'constitution'")
+    }
+    layers = doc.Data.Constitutions
+}
+for _, layer := range layers {
+    if _, err := e.backend.UpdateConstitution(ctx, layer); err != nil {
+        return nil, fmt.Errorf("update constitution layer %s: %w", layer.Layer, err)
+    }
+    res.Constitution++
+}
+```
+
+The cross-field validation prevents a document that declares one schema version but populates the other version's field from silently importing wrong (or worse, losing data because the populated field is ignored by the branch).
+
+### Forward-compatibility framing
+
+A v1 document holds at most one layer (the schema only supported one). Upgrading v1 → v2 preserves whatever was there; it cannot recover layers that v1 could not express. The spec is "forward-compatible for the data v1 could hold," not "lossless across constitution histories." Test fixtures should make this explicit.
+
+### Migration test
+
+Required: integration test that constructs a v1 document by hand, imports it, re-exports as v2, asserts (a) exactly one element in `Constitutions`, (b) layer/content of that element matches the v1 input. Then a second test: store multiple layers via the API, export as v2, verify all layers present in precedence order.
+
+---
+
+## Section 4: Remote fetch via `hashicorp/go-getter`
+
+### Library version
+
+Pin `github.com/hashicorp/go-getter v1` (latest stable; v2 is alpha). Pin in `go.mod`.
+
+**Verification gate**: before implementing Section 4, confirm the specific go-getter v1 API knobs used below (`Client.Decompressors`, `Client.Getters`, `Client.HttpClient`, `getter.ClientModeFile`). If any API differs from this spec, file a small spec amendment before writing the package.
+
+### Security posture
+
+In `internal/constitution/fetch`:
+
+- `Client.Mode = ClientModeFile` only — no directory mode, no archive extraction.
+- `Client.Getters` set explicitly to a restricted registry: `http`, `https`, `git`, `github` only. `s3`, `gcs`, `hg` are not registered (smaller attack surface; no auth surface to design for them).
+- `Client.Decompressors = nil` — disables auto-extraction of zip/tar archives.
+- `Client.HttpClient` is a custom `*http.Client` with a 10-second total timeout.
+- `file://` getter registered only under `//go:build testfetch`. Production builds reject `file://` URLs at scheme-validation time.
+- Body size cap enforced via `os.Stat` after fetch: reject if > 1 MiB with `CodeInvalidArgument`.
+
+### Auth model — env-var default-public with host allow-list
+
+V1 supports private GitHub **only via raw HTTPS URLs**, with explicit host scoping to prevent token leakage.
+
+- **Default**: anonymous fetch. Public sources work without configuration.
+- **Optional GitHub token**: `SPECGRAPH_FETCH_GITHUB_TOKEN` env var on the server.
+- **Host allow-list**: token is injected **only** when the request host matches one of:
+  - `raw.githubusercontent.com`
+  - `api.github.com`
+  - `*.githubusercontent.com` (covers any future raw subdomains)
+- **Other hosts**: token is **never** injected. Includes `github.com` (shorthand → git protocol), `git::*` URLs, GitLab, Bitbucket, custom domains. Going through go-getter's git path means git's credential helpers handle auth (or fail with anonymous).
+- **Cross-host redirect protection**: the custom `*http.Client.CheckRedirect` strips the `Authorization` header whenever a redirect crosses to a host outside the allow-list. Go's `net/http` does NOT do this automatically for `Authorization` headers (only for some Auth schemes), so this must be done manually.
+- **Per-request host check**: the custom transport's `RoundTrip` re-checks the request host on every call (including post-redirect) and adds the header only when the host is in the allow-list. Defense-in-depth alongside the CheckRedirect.
+- **Logging**: token value is never logged. Logs include URL host only. A test asserts log output excludes the token bytes verbatim.
+- **Future**: server-managed per-tenant credentials and git-protocol auth deferred to follow-up beads.
+
+Sample transport (illustrative — not a literal copy):
+
+```go
+type tokenTransport struct {
+    base    http.RoundTripper
+    token   string
+    hosts   map[string]bool
+}
+
+func (t *tokenTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+    if t.token != "" && t.hostAllowed(r.URL.Host) {
+        r.Header.Set("Authorization", "Bearer "+t.token)
+    }
+    return t.base.RoundTrip(r)
+}
+
+func (t *tokenTransport) hostAllowed(host string) bool {
+    if t.hosts[host] { return true }
+    if strings.HasSuffix(host, ".githubusercontent.com") { return true }
+    return false
+}
+
+// CheckRedirect on the client:
+func stripAuthOnCrossHost(req *http.Request, via []*http.Request) error {
+    if len(via) > 0 && req.URL.Host != via[len(via)-1].URL.Host {
+        req.Header.Del("Authorization")
+    }
+    return nil
+}
+```
+
+### URL syntax (Terraform-compatible subset)
+
+| Source | Example | V1 support | Auth in V1 |
+|---|---|---|---|
+| HTTPS raw | `https://example.com/constitution.yaml` | ✓ | Anonymous + token (if host is github) |
+| GitHub raw | `https://raw.githubusercontent.com/org/repo/ref/path` | ✓ | Anonymous + token via Authorization header |
+| GitHub shorthand | `github.com/org/repo//constitution.yaml?ref=v1.2.3` | ✓ | Anonymous only (public repos) |
+| Explicit git over HTTPS | `git::https://gitlab.example.com/org/repo.git//path?ref=main` | ✓ | Anonymous only (V1) |
+| `git@host:` SSH | — | rejected | n/a |
+| `file://` | — | tests only | n/a |
+| `s3://`, `gcs://`, `hg::...` | — | not registered | n/a |
+
+Unsupported schemes are rejected at parse time with `CodeInvalidArgument`.
+
+### `internal/constitution/fetch` package
+
+```go
+package fetch
+
+type Fetched struct {
+    Body        []byte
+    ResolvedURL string // user-supplied, verbatim
+}
+
+// Fetch retrieves a constitution file from the given URL.
+// Auth (when applicable) is injected internally based on host + env var.
+func Fetch(ctx context.Context, url string) (*Fetched, error) { ... }
+```
+
+The fetcher does **not** compute a hash. Hashing operates on the parsed domain struct (Section 5), so the fetch layer's job ends at returning raw bytes.
+
+### URL credential sanitization
+
+URLs with embedded credentials (userinfo in the authority component per RFC 3986 — e.g., `https://token@raw.githubusercontent.com/...`, `https://user:pass@example.com/...`) are **rejected at parse time** with `CodeInvalidArgument`. Common token-bearing query parameters (`token`, `access_token`, `api_key`, `password`) are also rejected. Rationale:
+
+- Stored `source_url` is opaque text; credentials in it would persist in the database and surface in logs, error messages, and CLI output.
+- The auth model is `SPECGRAPH_FETCH_GITHUB_TOKEN` env var (Section 4 above), not in-URL credentials. Allowing both creates two parallel auth surfaces and confuses the security boundary.
+- The rejection is at parse time in `internal/constitution/fetch`, before any storage write or log line.
+
+Error message names the env var as the supported alternative: `"URL contains embedded credentials; use SPECGRAPH_FETCH_GITHUB_TOKEN env var for authenticated GitHub access"`.
+
+---
+
+## Section 5: Canonical hashing — post-parse, on the domain struct
+
+The first draft of this section proposed canonicalizing the *raw fetched bytes* through a separate YAML library. Adversarial review showed this would introduce a second YAML parser alongside the existing `gopkg.in/yaml.v3` loader, creating a parse/hash divergence risk and an unnecessary dependency. The revised design hashes the **parsed domain struct**, not the raw bytes.
+
+### Flow
+
+```text
+upstream YAML/JSON bytes
+  → parse via existing YAML loader (gopkg.in/yaml.v3, same path as `constitution import <file>`)
+  → convert to *storage.Constitution domain struct
+  → marshal to canonical JSON (encoding/json sorts map keys at every level recursively)
+  → Murmur3-128 hash of the canonical JSON bytes
+```
+
+### Properties
+
+- **Comment-resilient**: YAML comments are dropped by the parser. A comment-only upstream change produces equal hash. Correct for drift detection.
+- **Whitespace-resilient**: same reasoning.
+- **Key-order-resilient**: encoding/json sorts map keys; struct field order is determined by Go declaration order, which is stable across runs.
+- **List-order-sensitive**: list reordering in the source produces a different hash. Intentional: constitution lists are semantically ordered (principle precedence, language allow-lists).
+- **Type-coercion-tolerant**: YAML `1` vs `1.0` both decode to the same Go field type. Hashes match. Matches user intent.
+
+### Algorithm
+
+```go
+// internal/constitution/hash/hash.go
+
+// Hash computes the canonical hash of a Constitution domain struct.
+// Returns hex-encoded Murmur3-128.
+func Hash(c *storage.Constitution) (string, error) {
+    canonical, err := canonicalJSON(c)
+    if err != nil {
+        return "", err
+    }
+    sum := murmur3.Sum128(canonical)
+    return hex.EncodeToString(sum[:]), nil
+}
+
+// canonicalJSON marshals a Constitution with sorted map keys at every level.
+// encoding/json sorts top-level map keys but for embedded interface{} maps we
+// walk the structure manually before marshal.
+func canonicalJSON(c *storage.Constitution) ([]byte, error) { ... }
+```
+
+### Shared dependency
+
+Existing `Spec.ContentHash` uses `spaolacci/murmur3 v1.1.0` (verified in `go.mod`). The constitution hash module imports the same library. No new YAML dependency required.
+
+### Source YAML compatibility note
+
+Both the loader (`internal/config/config.go`) and the hasher operate on the same Go struct types, so any YAML extension supported by the loader (e.g., custom `UnmarshalYAML` for principles) flows through unchanged. There is no risk of "loader and hasher disagree on the meaning of a YAML construct" because they share the same parse step.
+
+### Determinism assumption
+
+`encoding/json.Marshal` sorts keys for `map[string]T` (and types whose keys implement `encoding.TextMarshaler`). All map fields in `*storage.Constitution` today are `map[string]string` (`Frameworks`, `Infrastructure`, `APIStandards`, `Data`, `ForbiddenReasons`), which satisfies this. Struct fields emit in declaration order, which is stable per Go's spec.
+
+**Maintenance invariant**: if a future change adds a `map[K]V` field to `*storage.Constitution` where `K` is not `string` (or a text-marshalable type), the canonicalizer breaks silently. Either reject such fields at code review, or update `canonicalJSON` to walk the structure manually. The Go-version-stability test in CI catches regressions in existing fields but won't catch this proactively.
+
+### Tested invariants
+
+- Hash stable across runs (run-twice test in CI)
+- Hash stable across whitespace and key-order in source YAML
+- Hash stable across YAML comments
+- Hash differs across list-order changes
+- Hash differs when any semantic field differs
+- Hash collision smoke (basic check, not a security claim)
+- **Fixed-expected-hex test**: a sentinel Constitution struct hashes to a hard-coded expected value, asserting Go-version and encoding/json-version stability
+
+---
+
+## Section 6: `RefreshConstitutionLayer` RPC
+
+```protobuf
+service ConstitutionService {
+    rpc RefreshConstitutionLayer(RefreshConstitutionLayerRequest)
+        returns (RefreshConstitutionLayerResponse);
+}
+
+message RefreshConstitutionLayerRequest {
+    ConstitutionLayer layer = 1; // required, non-UNSPECIFIED
+    string source_url = 2;       // required
+    bool dry_run = 3;
+}
+
+message RefreshConstitutionLayerResponse {
+    Constitution before = 1;          // nil if no prior layer
+    Constitution after = 2;           // newly fetched + parsed layer
+    string previous_source_hash = 3;  // "" if no prior layer
+    string new_source_hash = 4;
+    bool changed = 5;                 // false iff hashes match (no write)
+}
+```
+
+### Handler behavior
+
+1. Validate `layer` is one of `user|org|project|domain`. Reject `UNSPECIFIED` and unknown values with `CodeInvalidArgument`.
+2. Validate `source_url` scheme is in the allow-list. Reject with `CodeInvalidArgument` if not.
+3. Call `fetch.Fetch(ctx, source_url)`.
+4. Parse body via the YAML→domain helper (extracted into `internal/constitution/load` from the existing CLI path — see below).
+5. Compute `new_source_hash` via `hash.Hash` on the parsed domain struct.
+6. Load existing layer via `GetConstitutionLayer`. If hashes match: `changed=false`, return existing as `before`/`after`, no write.
+7. If different (or no prior layer): set `changed=true`.
+8. If `dry_run`: return without writing.
+9. Otherwise: set `source_url` and `source_hash` on the parsed struct, call `UpdateConstitution`. (Verified: `UpdateConstitution` UPSERTs both fields at `internal/storage/postgres/constitution.go:198-207`.)
+
+### YAML→domain helper relocation
+
+Today the YAML parse path (`config.LoadConstitutionConfig` → `constitutionConfigToProto` → handler converts proto → domain) is split between `internal/config/` and `cmd/specgraph/`. For Piece B, the server side needs the same parse without round-tripping through proto.
+
+Refactor as part of Piece B opener (1–2 commits before the RPC handler):
+
+- Move `constitutionConfigToProto` and `constitutionFromProto` into a new `internal/constitution/load` package, exposing `LoadFromYAML(bytes []byte) (*storage.Constitution, error)` that returns the domain struct directly.
+- CLI `constitution import` switches to call this same helper.
+- Server-side RPC handler calls the same helper.
+
+Single source of YAML parsing logic across the codebase.
+
+---
+
+## Section 7: CLI surface
+
+```text
+specgraph constitution import <path>                          # local file (existing)
+specgraph constitution import --from-url <url> --layer <X>    # remote (new)
+specgraph constitution sync [--layer X] [--dry-run] [--check]
+specgraph constitution show [--layer X] [--show-provenance]
+specgraph constitution emit ...                               # unchanged
+```
+
+(Prime CLI changes are in Section 10 — Piece E.)
+
+### `constitution import --from-url`
+
+Required: `--from-url <url>`, `--layer <user|org|project|domain>`. Calls `RefreshConstitutionLayer(layer, url, dry_run=false)`.
+
+### `constitution sync`
+
+Iterates the **layers actually present** (via `GetAllLayers`), not all four enum values. Calls `RefreshConstitutionLayer` for those with non-empty `source_url`. Layers without `source_url` are mentioned in the output as "no remote source" so users can see the full picture.
+
+Example output (project has `org` and `project` layers, only `org` has a source):
+
+```text
+$ specgraph constitution sync
+org      unchanged       (sha 3f2a8b...)
+project  no remote source
+
+1 of 1 remote layers checked, 0 updated.
+```
+
+Example where `org` drifted:
+
+```text
+$ specgraph constitution sync
+org      changed         (sha 3f2a8b... → a8b29f...)
+project  no remote source
+
+1 of 1 remote layers checked, 1 updated.
+```
+
+Edge cases (each prints a clarifying line, exits 0):
+
+- No layers exist: `"no constitution found; nothing to sync"`
+- No layers have `source_url`: `"no remote layers configured; nothing to sync"`
+- `--layer X` with no `source_url`: explicit error `CodeFailedPrecondition`
+
+### Exit codes — `--check` flag
+
+- **Default**: exit 0 for "ran successfully," regardless of drift state.
+- **`--check`**: opt-in. Exit 1 if any layer changed or, with `--dry-run`, would change. For CI use.
+- Exit 2 on hard failures (fetch error, parse error, RPC error). One bad layer does not abort the rest; other layers still attempted.
+
+Flag name `--check` chosen over `--exit-code-on-drift` for brevity and familiarity (matches `gofmt -d -e`-style conventions). Documented in `--help` as "exit 1 if drift detected; useful in CI."
+
+---
+
+## Section 8: Drift semantics
+
+V1 detects drift via **content-hash comparison only**:
+
+1. `import --from-url` fetches body, parses, hashes via `hash.Hash` (Section 5), stores `source_hash` and `source_url` (verbatim).
+2. `sync` re-fetches from `source_url`, re-parses, re-hashes, compares.
+3. Hashes differ → drift detected.
+
+### Data preservation on failure
+
+**Fetch failures never modify or delete the existing layer.** If the upstream is unreachable, returns a 5xx, returns a parse-failing body, or fails any pre-flight check, `sync` reports the error for that layer and continues to the next. The previously-stored layer remains intact with its existing `source_hash` and `source_url`. Users explicitly delete a layer via a separate operation (currently: storage-level only; no CLI yet).
+
+This means `sync` can be safely run in a CI cron without risk of "the upstream went down so my project lost its org layer."
+
+### Known limitation: mutable refs
+
+Storing the URL verbatim means `?ref=main` is re-resolved on every `sync`. If the upstream branch moves without content change, we won't detect the ref move (we'd see the new content correctly; we just won't surface "the ref pointer changed"). For most users this is fine — content drift is what matters.
+
+**Git tags are also mutable by default**. `git push --force` can move them. The workaround "pin to a tag for immutability" is only valid if the upstream repo enforces tag protection (branch/tag protection rules, signed-tag enforcement, etc.). For real immutability, pin to a commit SHA: `?ref=abc1234...`. Documented in the CLI help.
+
+SHA pinning resolution (rewriting `?ref=main` → `?ref=<sha>` at fetch time so the stored URL is sha-pinned) is a follow-up bead.
+
+---
+
+## Section 9: Surface provenance in `constitution show` — Piece C
+
+### Renderer signature
+
+The existing `internal/render/constitution.go:Constitution(c *specv1.Constitution) string` stays unchanged. Add a sibling function:
+
+```go
+// ConstitutionWithProvenance renders the same as Constitution but annotates
+// each field with the layer that set it. provenance may be nil/empty, in
+// which case the output is identical to Constitution.
+func ConstitutionWithProvenance(c *specv1.Constitution, provenance []*specv1.ProvenanceEntry) string
+```
+
+No breaking change. Call sites that don't care continue to use `Constitution`. The CLI `--show-provenance` path calls the new function.
+
+### Text mode
+
+```text
+Principles:
+  p1: Prefer explicit over implicit                       (set by: project)
+  p2: Tests are integration tests by default              (set by: org)
+
+Tech > Languages:
+  Primary:   go                                           (set by: project)
+  Allowed:   [go, sql]                                    (set by: org)
+  Forbidden: [javascript]                                 (set by: domain)
+```
+
+### JSON mode
+
+`--json --show-provenance` emits a `provenance` sibling array:
+
+```json
+{
+  "constitution": { ... },
+  "provenance": [
+    {"path": "principles[p1]", "layer": "project"},
+    {"path": "principles[p2]", "layer": "org"}
+  ]
+}
+```
+
+Without `--show-provenance`, output is unchanged from today (no provenance section, no breaking change to scripts).
+
+### Deferred
+
+"Overrides X" annotations (`p3: ... (set by: project, overrides org)`) require expanding `merge.Result.Provenance` to track override chains across input layers. Currently only the winning layer is recorded. Out of scope.
+
+---
+
+## Section 10: Prime unification — Piece E
+
+### Problem
+
+Three "prime" surfaces today:
+
+| Surface | What it does today |
+|---|---|
+| `ExecutionService.GetPrime` RPC (per-spec) | Returns flattened summary strings (`ConstitutionSummary`, `CodingConventions`). Used by polecats. |
+| `specgraph://prime` MCP resource (project-level) | Calls merged `GetConstitution`. Renders markdown with constitution top constraints, graph overview, ready specs, findings, skills pointer. |
+| `specgraph prime` CLI (project-level) | Calls `ListSpecs` and prints active specs as a table. **Does not show constitution.** |
+
+The three are independently implemented and have drifted in what content they expose and how. Adding constitution provenance to one of them creates new drift unless we collapse them onto a shared composer.
+
+### Design
+
+**Two scopes:**
+
+- **Project prime** — orient to a project (no specific spec).
+- **Spec prime** — orient to executing a specific spec.
+
+**One shared composer** in a new `internal/prime` package:
+
+```go
+package prime
+
+type ProjectView struct {
+    Constitution           *storage.Constitution
+    ConstitutionProvenance []storage.ProvenanceEntry
+    GraphOverview          GraphOverview  // counts by stage
+    Ready                  []*storage.Spec  // top 10
+    FindingsBySeverity     map[storage.FindingSeverity]int
+    SkillsCount            int
+}
+
+type SpecView struct {
+    Spec                   *storage.Spec
+    Constitution           *storage.Constitution
+    ConstitutionProvenance []storage.ProvenanceEntry
+    Decisions              []*storage.Decision
+    Slices                 []*storage.Slice
+    Claims                 []*storage.Claim
+    Blockers               []*storage.Blocker
+}
+
+func Project(ctx context.Context, b Backend) (*ProjectView, error)
+func Spec(ctx context.Context, b Backend, slug string) (*SpecView, error)
+```
+
+### Backend interface — explicit aggregate
+
+The composer's `Backend` is a wide aggregate, similar to `internal/export.Backend`:
+
+```go
+type Backend interface {
+    storage.ConstitutionBackend  // GetMergedConstitution
+    storage.Backend              // ListSpecs
+    storage.GraphBackend         // GetReady
+    storage.FindingsBackend      // ListProjectFindings
+    storage.ExecutionBackend     // GetPrimeData
+    storage.SliceBackend         // ListSlices
+
+    // SkillsCount is unusual — skills live in MCP-server-side state, not
+    // storage. The composer takes a `skills.Source` separately as a
+    // constructor dependency, not part of the storage backend.
+}
+
+// Composer wraps a Backend + skills.Source for use by all three surfaces.
+type Composer struct {
+    backend storage.Backend // the wide aggregate above
+    skills  skills.Source
+}
+
+func New(backend Backend, src skills.Source) *Composer { ... }
+func (c *Composer) Project(ctx context.Context) (*ProjectView, error) { ... }
+func (c *Composer) Spec(ctx context.Context, slug string) (*SpecView, error) { ... }
+```
+
+Chosen over the alternative "composer takes pre-built input structs" because that approach pushes orchestration burden back onto every surface, defeating the unification goal. The wide aggregate interface is the same pattern `internal/export` uses today; it's deliberate and ugly but consistent with project conventions.
+
+Tests stub the wide interface. We will likely extract a `testbackend` helper in `internal/prime/internal/testbackend` to reduce boilerplate.
+
+The composer queries each piece via the backend and assembles the view. It does not render — renderers are surface-specific.
+
+### Surface mapping
+
+| Concept | RPC | MCP Resource | CLI |
+|---|---|---|---|
+| Project prime | `GetPrime(slug="")` | `specgraph://prime` | `specgraph prime` |
+| Spec prime | `GetPrime(slug=X)` | `specgraph://prime/spec/{slug}` | `specgraph prime <slug>` |
+
+### Uniform options
+
+| Option | CLI flag | MCP URI param | RPC field |
+|---|---|---|---|
+| Show provenance | `--show-provenance` | `?provenance=true` | `bool show_provenance` |
+| Output format | `--json` | `?format=json` (default markdown) | always structured proto |
+
+### Proto changes
+
+The existing `PrimeResponse` keeps backward-compat summary fields. New typed fields added:
+
+```protobuf
+message PrimeResponse {
+    // Existing summary fields — kept for backward compat with old polecats.
+    string constitution_summary = 1;
+    string project_context = 2;
+    repeated Decision decisions = 3;
+    string coding_conventions = 4;
+    string callback_docs = 5;
+
+    // New structured fields. Exactly one is populated depending on whether
+    // the request specified a slug.
+    oneof view {
+        ProjectView project_view = 10;
+        SpecView spec_view = 11;
+    }
+}
+```
+
+Both `ProjectView` and `SpecView` carry their own `repeated ProvenanceEntry constitution_provenance`. **This is the only place provenance lives in the proto** — the top-level `PrimeResponse` does not duplicate it.
+
+`GetPrimeRequest.slug` becomes optional (today it rejects empty with `CodeInvalidArgument`; new behavior: empty slug returns project view, non-empty returns spec view). This is a backward-compat-friendly relaxation; existing callers either pass a slug (no change) or hit the error today (and would get success going forward — unlikely to be relied upon).
+
+### Legacy summary fields — populated only for spec scope
+
+The summary fields (`ConstitutionSummary`, `ProjectContext`, `CodingConventions`, `CallbackDocs`) only make semantic sense for spec scope (`ProjectContext = spec.Intent`, `CallbackDocs` describes report-progress RPCs for that spec). For project scope, these fields are **left zero**; the new `project_view` oneof carries the project-level data. Old polecats that issue a slug-less call (which they never did, since today's handler rejects empty slug) would get empty summary fields plus the new structured view — they ignore the new view, see empty summaries, and that's fine because no existing polecat code path produces a slug-less call.
+
+### MCP URI parsing
+
+The MCP resource handler dispatches based on path suffix:
+
+- `specgraph://prime` → project view
+- `specgraph://prime/spec/{slug}` → spec view (slug parsed from URI)
+
+Query params (`?provenance=true`, `?format=json`) parsed via `net/url`. Defaults: provenance off, markdown format.
+
+### CLI surface
+
+```text
+specgraph prime [--show-provenance] [--json]              # project view
+specgraph prime <slug> [--show-provenance] [--json]       # spec view
+```
+
+The existing prime behavior (active specs table) becomes part of the project view's terminal renderer, joined by constitution summary and the other sections.
+
+### Implementation order within Piece E
+
+1. Create `internal/prime` package with `ProjectView`, `SpecView`, `Composer.Project`, `Composer.Spec`. Unit tests with stub backend.
+2. Update `ExecutionService.GetPrime` handler to call `Composer.Project` or `Composer.Spec` based on slug. Populate legacy summary fields **only for spec scope**. Populate `view` oneof in both. Existing tests keep passing.
+3. Update `specgraph://prime` MCP resource handler to call `Composer.Project`; add `specgraph://prime/spec/{slug}` templated resource. Render the views to markdown. Parse `?provenance=true` and `?format=json` query params.
+4. Rewrite `cmd/specgraph/prime.go` to: (a) **preserve the existing `runUp` call so SessionStart-hook ergonomics don't regress**, (b) call the `GetPrime` RPC with the slug arg (empty for project scope), (c) render the response. Add `--show-provenance` and `--json` flags. Add the `{slug}` positional argument.
+5. E2E tests verify each surface contains the same known facts seeded by the test (Section 13).
+
+---
+
+## Section 11: Retire the single-layer compat method — Piece D
+
+Two commits, each independently revertible:
+
+1. **Verify no remaining callers.** After Piece A merges, `PrimeData` and `export.engine` no longer call `Store.GetConstitution`. Audit via `grep -rn "GetConstitution\b" --include="*.go"` outside test mocks and the deprecation shim.
+2. **Delete the method.** Remove from `ConstitutionBackend`, Postgres impl, all test mocks. Out-of-tree consumers get a compile error and migrate to `GetMergedConstitution`. No schema change.
+
+The contract change (single-layer → no method) is intentional: silent layer-dropping is the bug Piece A fixed; no path back.
+
+### CI guard against regrowth
+
+Add a CI grep assertion (in `task check` or a dedicated `task lint:constitution-callers`) that fails if `Store.GetConstitution\b` (with word boundary) appears in any non-test, non-deprecation-shim production source file after Piece D ships. The check is one shell pipeline:
+
+```bash
+# Fails CI if the deprecated method reappears in production code.
+if rg -n 'Store\.GetConstitution\b' --type go --type-not test -g '!*_test.go' \
+   --glob '!internal/storage/constitution_deprecated.go' .; then
+    echo "ERROR: Store.GetConstitution is deprecated; use GetMergedConstitution" >&2
+    exit 1
+fi
+```
+
+Prevents accidental reintroduction during future refactors or merge conflicts.
+
+---
+
+## Section 12: Error handling
+
+| Condition | gRPC code |
+|---|---|
+| Unsupported URL scheme | `CodeInvalidArgument` |
+| Layer unspecified or invalid | `CodeInvalidArgument` |
+| Body parse failure (YAML/JSON) | `CodeInvalidArgument` |
+| Body exceeds size cap | `CodeInvalidArgument` |
+| Sync requested for layer with no `source_url` | `CodeFailedPrecondition` |
+| **For HTTPS URLs only**: HEAD pre-flight returns 401/403 | `CodePermissionDenied` (error message names `SPECGRAPH_FETCH_GITHUB_TOKEN` and raw-URL alternative) |
+| **For HTTPS URLs only**: HEAD pre-flight returns 404 | `CodeNotFound` (see GitHub-specific hint below) |
+| Any other fetch failure (network, git-protocol auth, 5xx) | `CodeUnavailable` (with wrapped go-getter error in the message) |
+
+### GitHub 404 — likely-auth hint
+
+GitHub deliberately returns 404 (not 401/403) for missing files in private repos when the request is unauthenticated, to avoid leaking the existence of private resources. This means the most common "I forgot to set the token" path hits the 404 branch, not the 401 branch.
+
+When the URL host is `raw.githubusercontent.com` or `*.githubusercontent.com` AND the HEAD returns 404 AND `SPECGRAPH_FETCH_GITHUB_TOKEN` is not set, the error message is:
+
+```text
+file not found OR private repo (404 from GitHub; if the file exists in a private repo, set SPECGRAPH_FETCH_GITHUB_TOKEN)
+```
+
+The gRPC code stays `CodeNotFound` (the upstream's intentional ambiguity), but the message gives the user the right next step. When the token IS set and 404 still returns, the message is just "file not found" — auth isn't the problem.
+| Hash mismatch on `--dry-run` | *not an error* (`changed=true` in response) |
+
+### HEAD pre-flight scope
+
+HEAD pre-flight applies only to URLs we dispatch to the HTTPS getter (raw HTTPS, `https://raw.githubusercontent.com/...`). For git-protocol URLs (`github.com/org/repo`, `git::https://...`), auth happens during the fetch protocol negotiation; we cannot reliably distinguish 401/403/404/500 without parsing error strings. All such failures map to `CodeUnavailable` with the wrapped error included for diagnostic purposes.
+
+This is a deliberate honest narrowing. Adversarial review noted that promising precise error mapping for go-getter outputs is fragile.
+
+---
+
+## Section 13: Testing
+
+### Unit — `internal/constitution/fetch`
+
+Drive go-getter with `file://` fixtures (under `//go:build testfetch`). Cover: happy path, unsupported scheme, oversized body, token injection for raw GitHub URL, no-token 401 path, log redaction of token bytes.
+
+### Security — `internal/constitution/fetch` (Piece B)
+
+Explicit security checklist; each item is its own test:
+
+- **Token allow-list**: with `SPECGRAPH_FETCH_GITHUB_TOKEN` set, fetch a non-GitHub HTTPS URL (httptest server). Inspect the captured request — assert `Authorization` header is absent.
+- **Cross-host redirect**: configure httptest server to redirect from `raw.githubusercontent.com` (mocked via Host header) to `attacker.example.com`. Assert the second request to the attacker host has no `Authorization` header.
+- **Body size cap**: serve a 2 MiB body. Assert fetch returns `CodeInvalidArgument` before parse, and the body is never read into memory beyond the cap.
+- **Path traversal / `file://` rejection in production**: build the binary without `testfetch` tag; assert `file:///etc/passwd` URL is rejected at scheme validation with `CodeInvalidArgument`.
+- **Decompressor bypass**: serve a body with `Content-Type: application/zip`. Assert no extraction happens; body is treated as raw bytes (which then fails parse as YAML/JSON with `CodeInvalidArgument`).
+- **YAML bomb resistance**: serve a YAML body with a deep alias graph (the classic "billion laughs" construction). Assert parse fails quickly (yaml.v3 has limits — verify they fire rather than hang).
+- **Log redaction**: capture all log output during a successful fetch with token set. Assert the literal token bytes do not appear in any log line.
+- **Decompressors actually disabled**: assert `client.Decompressors` is nil after construction (defensive — guards against future code that re-enables them).
+
+### Unit — `internal/constitution/hash`
+
+Hash stability across runs, whitespace, key-order, comments. Hash sensitivity to list-order, scalar changes, list-element additions/removals. Fixed-expected-hex test for Go-version stability.
+
+### Unit — `internal/constitution/load` (new)
+
+YAML/JSON → domain struct via the relocated helper. Cover existing CLI behaviors so the refactor is no-regression. Both CLI and RPC paths share the same helper.
+
+### Unit — `internal/prime`
+
+Stub backend returning canned data. Cover ProjectView, SpecView; non-existent spec error; empty constitution case; empty findings; provenance flow-through.
+
+### Unit — handlers
+
+`RefreshConstitutionLayer`: inject fake `Fetcher`; cover all error codes from Section 12. `GetPrime`: cover legacy summary fields populated only for spec scope; new `view` oneof populated correctly for both scopes; `view` oneof has exactly one arm populated.
+
+### Renderer — `internal/render/constitution.go` (Piece C)
+
+- **Byte-identical legacy output**: `Constitution(c)` (no provenance) produces output equal byte-for-byte to today's behavior. Test asserts on a golden file fixture.
+- **Provenance annotations**: `ConstitutionWithProvenance(c, prov)` produces text output containing `(set by: <layer>)` annotations for every field present in the provenance map. Field types covered: scalars (process), keyed lists (principles, antipatterns), string lists (constraints), nested maps (tech).
+- **Empty provenance**: `ConstitutionWithProvenance(c, nil)` and `ConstitutionWithProvenance(c, []*ProvenanceEntry{})` both produce output equal to `Constitution(c)`.
+- **Partial provenance**: provenance map missing some keys — annotations appear only for keys present; absent keys render without annotation, no `(set by: unknown)` placeholder.
+- **JSON mode**: `--json --show-provenance` emits a top-level object with `constitution` and `provenance` sibling fields; ordering of `provenance` entries is deterministic (alphabetical by path).
+- **JSON mode without provenance**: `--json` alone produces output identical to today's JSON shape (no `provenance` key, not even empty).
+
+### CLI behavior — `cmd/specgraph/prime.go` and `constitution sync` (Piece E + Piece B)
+
+- **`runUp` preservation**: with no server running, invoke `specgraph prime` and assert (a) `runUp` is called (server starts), (b) the prime RPC succeeds. Regression test against accidental removal during the rewrite.
+- **Slug validation**: `specgraph prime <invalid-slug>` — assert the CLI either pre-validates the slug shape or surfaces the RPC's `CodeNotFound` with a clear "spec not found" message (not a leaked storage error).
+- **Project vs spec scope**: `specgraph prime` (no arg) produces project-view output; `specgraph prime <existing-slug>` produces spec-view output with constitution + decisions + claims sections.
+- **`--check` exit codes**: `constitution sync --check` (unchanged remote) → exit 0; same with modified remote → exit 1; with fetch failure → exit 2.
+- **`--dry-run --check` combination**: dry-run does not write; `--check` reports drift via exit code 1; subsequent `constitution show` confirms no write occurred.
+- **`--json` mode for prime**: `specgraph prime --json` produces well-formed JSON that round-trips through `json.Unmarshal`.
+
+### MCP — resources (Piece E)
+
+- **Templated URI parses**: `specgraph://prime/spec/abc-123` parses to slug `abc-123`; the resource handler is invoked.
+- **Empty slug rejected**: `specgraph://prime/spec/` (trailing slash, no slug) returns a clear error.
+- **Query param parsing**: `?provenance=true`, `?provenance=false`, `?provenance=` (empty), `?provenance=foo` (invalid). First two are honored; empty defaults to false; invalid returns an error or warning.
+- **`?format=json`**: produces JSON content with `mimeType: application/json`; default markdown unchanged.
+
+### Integration (`//go:build integration`)
+
+- Export v1 → import → re-export v2: shape and content correctness (Section 3).
+- Multi-layer export round-trip: all layers in precedence order.
+- `RefreshConstitutionLayer` against a `file://` fixture (testfetch build tag): hash compare, dry-run, write, second sync no-op.
+- `GetPrime` for project + spec scopes: structured fields populated, provenance present when requested.
+
+### E2E (`//go:build e2e`)
+
+- CLI: `constitution import --from-url file://...` → `constitution show --show-provenance` → `constitution sync --check` → modify fixture → `constitution sync --check` (exit 1) → `constitution sync` (writes) → `constitution show` reflects update.
+- CLI: `specgraph prime` (project) and `specgraph prime {slug}` (spec) produce coherent terminal output with constitution + active specs.
+- MCP: `specgraph://prime` and `specgraph://prime/spec/{slug}` resources return matching markdown for same content.
+- Cross-surface fact-presence: seed a known constitution (e.g., `name: "test-org-constitution"`, a unique principle ID like `p-cross-surface-1`), then assert each of the three surfaces' output contains these literal strings. Avoids building three parsers; catches the structural regression "surface X stopped including the constitution name."
+
+---
+
+## Section 14: Invariants
+
+Consolidated list of invariants the system must maintain. Each is testable; references show where coverage lives.
+
+### Merge consistency
+
+- All read paths converge on the merged constitution. PrimeData (Piece A), MCP resources, RPC, CLI `constitution show` no-`--layer`, export (Piece A), prime composer (Piece E) — every read path resolves the constitution via `GetMergedConstitution` or `GetConstitutionLayer`, never via `Store.GetConstitution`. After Piece D this is structurally enforced.
+- **Coverage**: integration tests per read path; Piece D CI grep guard.
+
+### Provenance ↔ Constitution coupling
+
+- `Constitution == nil` iff `ConstitutionProvenance` is empty in any of: `PrimeData`, `ProjectView`, `SpecView`.
+- **Coverage**: unit tests for `GetPrimeData` and `internal/prime`.
+
+### Source URL ↔ source_hash coupling
+
+- If `source_url` is empty, `source_hash` is empty.
+- If `source_url` is non-empty, `source_hash` matches the canonical hash of the constitution last fetched from that URL.
+- **Coverage**: integration test for `RefreshConstitutionLayer` happy path and re-fetch idempotency.
+
+### Hash determinism
+
+- Two semantically equivalent YAML inputs (whitespace, comments, key order) produce equal hash.
+- List reordering produces a different hash (intentional).
+- **Coverage**: unit tests in `internal/constitution/hash` + fixed-expected-hex test.
+
+### Fetch idempotency
+
+- `fetch.Fetch(ctx, url)` called twice on an unchanged upstream returns equal canonical hashes.
+- **Coverage**: integration test issues two consecutive `RefreshConstitutionLayer` calls; second has `changed=false`.
+
+### Token containment
+
+- Token bytes never appear in: log output, error messages, the stored `source_url` value, or HTTP requests to non-allow-list hosts.
+- **Coverage**: Security tests in Section 13 (token allow-list, cross-host redirect, log redaction).
+
+### URL credential containment
+
+- URLs with embedded credentials (userinfo per RFC 3986, or common token query parameters like `token`/`access_token`/`api_key`/`password`) are rejected at parse time in `internal/constitution/fetch` with `CodeInvalidArgument`.
+- No URL containing credentials is ever stored as `source_url` or written to a log line.
+- **Coverage**: Section 13 fetch unit tests must include cases for `https://token@host/path`, `https://user:pass@host/path`, and `https://host/path?token=secret` — all rejected with explicit error referencing `SPECGRAPH_FETCH_GITHUB_TOKEN`.
+
+### Data preservation on failure
+
+- Fetch failure → existing layer unchanged.
+- Parse failure → existing layer unchanged.
+- Hash mismatch on `--dry-run` → existing layer unchanged.
+- **Coverage**: integration test injects fetch error; pre-sync state == post-sync state.
+
+### Concurrency
+
+- Two concurrent `RefreshConstitutionLayer` calls for the same layer: existing version guard on `UpdateConstitution` ensures first-writer-wins; second returns `CodeAborted` (per ADR-004 / transactions PR pattern).
+- Two concurrent calls for different layers: independent rows, no conflict.
+- **Coverage**: integration test for both cases.
+
+### v1 ↔ v2 export
+
+- A v1 export document imports under v2 code; resulting state contains one layer matching the v1 content.
+- A v2 export contains all layers in precedence order (user → org → project → domain).
+- `schema_version: 1` + populated `constitutions` → explicit error.
+- `schema_version: 2` + populated `constitution` → explicit error.
+- **Coverage**: integration tests for forward migration + cross-field validation.
+
+### `view` oneof
+
+- For any `PrimeResponse`, exactly one of `project_view` and `spec_view` is populated.
+- Legacy summary fields populated iff `spec_view` is populated.
+- **Coverage**: unit test on `GetPrime` handler for both scopes.
+
+### CLI byte-stability (backward compat)
+
+- `constitution show` (no `--show-provenance`, no `--layer`) produces byte-identical output to today.
+- `constitution sync` (no `--check`) exits 0 on successful run regardless of drift state.
+- `constitution emit` output unchanged from today.
+- `specgraph prime` output **changes** by addition (constitution section added) but the existing active-specs section is preserved.
+- **Coverage**: golden-file tests for `constitution show`; e2e shell test for sync exit codes; golden-file tests for prime active-specs section.
+
+### Renderer behavior
+
+- `ConstitutionWithProvenance(c, nil)` ≡ `Constitution(c)` for all `c`.
+- JSON mode without `--show-provenance` produces today's JSON shape (no `provenance` key).
+- **Coverage**: Section 13 Renderer subsection.
+
+### Source-URL allow-list
+
+- Only `http`, `https`, `git`, `github` getters are registered in production builds.
+- `file://` registered only under `//go:build testfetch`.
+- `s3`, `gcs`, `hg` never registered.
+- **Coverage**: build-tag tests for production vs testfetch builds.
+
+---
+
+## Open questions
+
+- **Should `specgraph://prime/spec/{slug}` be a templated resource or a static one?** Templated keeps the catalog clean and matches `specgraph://skills/{name}` precedent.
+- **Two layers with the same `source_url`** — V1 allows it; sync runs both. Likely rare; flag as a `bd doctor` future improvement.
+- **What does the existing `GetPrime` `CallbackDocs` field do for project scope?** Spec says "left zero." Reconfirm during implementation that no existing polecat depends on this being non-empty for any path.
+
+---
+
+## References
+
+- Predecessor: [2026-04-07-layered-constitution-design.md](2026-04-07-layered-constitution-design.md)
+- Bead: `spgr-8ar`
+- Related (incoming auth, not outgoing): `spgr-5wb` (Auth & Authorization epic)
+- Library: [hashicorp/go-getter v1](https://github.com/hashicorp/go-getter)
+- Hash library (in use): [spaolacci/murmur3 v1.1.0](https://github.com/spaolacci/murmur3)
+- YAML loader (in use): [gopkg.in/yaml.v3 v3.0.1](https://gopkg.in/yaml.v3) (same parser used by hasher post-parse)

--- a/internal/constitution/merge/merge.go
+++ b/internal/constitution/merge/merge.go
@@ -12,14 +12,12 @@ import (
 	"github.com/specgraph/specgraph/internal/storage"
 )
 
-// Result holds the merged constitution and provenance tracking.
-type Result struct {
-	// Constitution is the merged result of all input layers.
-	Constitution *storage.Constitution
-	// Provenance maps dot/bracket-notation keys to the layer that last set them.
-	// Examples: "process.spec_review", "principles[p1]", "tech_config.frameworks[rpc]"
-	Provenance map[string]storage.ConstitutionLayer
-}
+// Result is a type alias for storage.MergedResult, provided for backward
+// source compatibility. The concrete type lives in the storage package to
+// break the import cycle: internal/storage/postgres imports both
+// internal/constitution/merge and internal/storage, so the return type
+// must be defined in storage, not here.
+type Result = storage.MergedResult
 
 // Layers merges a slice of constitutions ordered lowest-to-highest precedence
 // (user < org < project < domain). It returns the merged Result or an error.

--- a/internal/export/engine.go
+++ b/internal/export/engine.go
@@ -90,10 +90,13 @@ func (e *Engine) collect(ctx context.Context, projectSlug string) (*Document, er
 	}
 	doc.Data.Project = proj
 
-	// Constitution (optional — may not exist)
-	constitution, err := e.backend.GetConstitution(ctx)
-	if err == nil {
-		doc.Data.Constitution = constitution
+	// Constitutions (optional — may not exist; v2 emits the list field).
+	layers, err := e.backend.GetAllLayers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get constitution layers: %w", err)
+	}
+	if len(layers) > 0 {
+		doc.Data.Constitutions = layers
 	}
 
 	// Specs — list summaries, then fetch full data for each

--- a/internal/export/engine.go
+++ b/internal/export/engine.go
@@ -379,12 +379,30 @@ func (e *Engine) writeEntities(ctx context.Context, doc *Document) (*ImportResul
 		res.Project = 1
 	}
 
-	// 2. Constitution
-	if doc.Data.Constitution != nil {
-		if _, err := e.backend.UpdateConstitution(ctx, doc.Data.Constitution); err != nil {
-			return nil, fmt.Errorf("update constitution: %w", err)
+	// 2. Constitutions — handle schema v1 (single) and v2 (list) with strict
+	// cross-field validation to prevent silent data loss from mismatched docs.
+	var layers []*storage.Constitution
+	switch doc.SchemaVersion {
+	case 1:
+		if doc.Data.Constitutions != nil {
+			return nil, fmt.Errorf("v1 documents must use 'constitution' field, not 'constitutions'")
 		}
-		res.Constitution = 1
+		if doc.Data.Constitution != nil {
+			layers = []*storage.Constitution{doc.Data.Constitution}
+		}
+	case 2:
+		if doc.Data.Constitution != nil {
+			return nil, fmt.Errorf("v2 documents must use 'constitutions' field, not 'constitution'")
+		}
+		layers = doc.Data.Constitutions
+	default:
+		return nil, fmt.Errorf("unsupported schema version %d for constitution import", doc.SchemaVersion)
+	}
+	for _, layer := range layers {
+		if _, err := e.backend.UpdateConstitution(ctx, layer); err != nil {
+			return nil, fmt.Errorf("update constitution layer %s: %w", layer.Layer, err)
+		}
+		res.Constitution++
 	}
 
 	// 3. Specs — create then restore stage via Store*Output + TransitionStage.

--- a/internal/export/engine_test.go
+++ b/internal/export/engine_test.go
@@ -575,3 +575,58 @@ func TestImport_DecisionADR003Fields(t *testing.T) {
 	assert.Equal(t, "login-api", got.OriginSpec)
 	assert.Equal(t, "specify", got.OriginStage)
 }
+
+// ---------------------------------------------------------------------------
+// Round-trip migration: v1 import → v2 export
+// ---------------------------------------------------------------------------
+
+func TestExportImport_V1ToV2_RoundTrip(t *testing.T) {
+	// Hand-craft a v1 document, import it via the new code, re-export,
+	// verify the resulting v2 document preserves the single layer.
+
+	v1Source := Document{
+		SchemaVersion:    1,
+		ProjectSlug:      "rt-project",
+		SpecGraphVersion: "test-version",
+		Data: Data{
+			Project: &storage.Project{Slug: "rt-project"},
+			Constitution: &storage.Constitution{
+				Name:  "legacy",
+				Layer: storage.ConstitutionLayerProject,
+				Principles: []storage.Principle{
+					{ID: "legacy-p1", Statement: "Legacy principle"},
+				},
+				Constraints: []string{"legacy-constraint"},
+			},
+		},
+	}
+	v1Bytes, err := json.Marshal(v1Source)
+	require.NoError(t, err)
+
+	backend := newTestBackend(t)
+	ctx := context.Background()
+	engine := NewEngine(backend, "", "test-version")
+
+	// Import v1.
+	_, err = engine.Import(ctx, v1Bytes, false, false)
+	require.NoError(t, err)
+
+	// Re-export as v2.
+	v2Bytes, err := engine.Export(ctx, "rt-project")
+	require.NoError(t, err)
+
+	var v2 Document
+	require.NoError(t, json.Unmarshal(v2Bytes, &v2))
+
+	assert.Equal(t, 2, v2.SchemaVersion, "re-export uses CurrentSchemaVersion=2")
+	assert.Nil(t, v2.Data.Constitution, "v2 export never populates v1 field")
+	require.Len(t, v2.Data.Constitutions, 1, "exactly one layer preserved")
+
+	got := v2.Data.Constitutions[0]
+	assert.Equal(t, "legacy", got.Name)
+	assert.Equal(t, storage.ConstitutionLayerProject, got.Layer)
+	require.Len(t, got.Principles, 1)
+	assert.Equal(t, "legacy-p1", got.Principles[0].ID)
+	require.Len(t, got.Constraints, 1)
+	assert.Equal(t, "legacy-constraint", got.Constraints[0])
+}

--- a/internal/export/engine_test.go
+++ b/internal/export/engine_test.go
@@ -39,6 +39,31 @@ func TestImport_RejectsUnsupportedSchemaVersion(t *testing.T) {
 	}
 }
 
+// TestImport_RejectsSchemaVersionZero guards against silent data-loss on
+// unversioned/hand-crafted documents. SchemaVersion: 0 (e.g. omitted field)
+// passes the high-version check but must be rejected at the constitution
+// switch's default branch so any constitution data isn't silently dropped.
+func TestImport_RejectsSchemaVersionZero(t *testing.T) {
+	backend := newTestBackend(t)
+	doc := Document{
+		SchemaVersion: 0,
+		ProjectSlug:   "test-project",
+		Data: Data{
+			Project: &storage.Project{Slug: "test-project"},
+			Constitution: &storage.Constitution{
+				Layer: storage.ConstitutionLayerProject,
+			},
+		},
+	}
+	data, err := json.Marshal(doc)
+	require.NoError(t, err)
+
+	engine := NewEngine(backend, "", "test-version")
+	_, err = engine.Import(context.Background(), data, false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported schema version 0")
+}
+
 // ---------------------------------------------------------------------------
 // HMAC signature — tested via verifySignature directly to avoid nil backend
 // ---------------------------------------------------------------------------
@@ -345,6 +370,123 @@ func (b *multiLayerExportBackend) ListAllConversations(_ context.Context) ([]*st
 
 func (b *multiLayerExportBackend) ListSyncMappings(_ context.Context, _ storage.SyncAdapterType, _ string) ([]*storage.SyncMapping, error) {
 	return nil, nil
+}
+
+func (b *multiLayerExportBackend) EnsureProject(_ context.Context, slug string) (*storage.Project, error) {
+	if b.project == nil {
+		b.project = &storage.Project{Slug: slug}
+	}
+	return b.project, nil
+}
+
+// ---------------------------------------------------------------------------
+// Import — schema-version-aware constitution import (Task 7)
+// ---------------------------------------------------------------------------
+
+func TestImport_V1Document_SingleLayer(t *testing.T) {
+	backend := newTestBackend(t)
+	ctx := context.Background()
+
+	// Hand-crafted v1 document with the legacy singular field.
+	v1Doc := Document{
+		SchemaVersion:    1,
+		ProjectSlug:      "test-project",
+		SpecGraphVersion: "test-version",
+		Data: Data{
+			Project: &storage.Project{Slug: "test-project"},
+			Constitution: &storage.Constitution{
+				Name:  "v1-only",
+				Layer: storage.ConstitutionLayerProject,
+				Principles: []storage.Principle{{ID: "p1", Statement: "P1"}},
+			},
+		},
+	}
+	data, err := json.Marshal(v1Doc)
+	require.NoError(t, err)
+
+	engine := NewEngine(backend, "", "test-version")
+	result, err := engine.Import(ctx, data, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Constitution, "exactly one layer imported")
+
+	layers, err := backend.GetAllLayers(ctx)
+	require.NoError(t, err)
+	require.Len(t, layers, 1)
+	assert.Equal(t, "v1-only", layers[0].Name)
+	assert.Equal(t, storage.ConstitutionLayerProject, layers[0].Layer)
+}
+
+func TestImport_V2Document_MultipleLayers(t *testing.T) {
+	backend := newTestBackend(t)
+	ctx := context.Background()
+
+	v2Doc := Document{
+		SchemaVersion:    2,
+		ProjectSlug:      "test-project",
+		SpecGraphVersion: "test-version",
+		Data: Data{
+			Project: &storage.Project{Slug: "test-project"},
+			Constitutions: []*storage.Constitution{
+				{Name: "org", Layer: storage.ConstitutionLayerOrg, Principles: []storage.Principle{{ID: "po"}}},
+				{Name: "proj", Layer: storage.ConstitutionLayerProject, Principles: []storage.Principle{{ID: "pp"}}},
+			},
+		},
+	}
+	data, err := json.Marshal(v2Doc)
+	require.NoError(t, err)
+
+	engine := NewEngine(backend, "", "test-version")
+	result, err := engine.Import(ctx, data, false, false)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Constitution, "both layers imported")
+
+	layers, err := backend.GetAllLayers(ctx)
+	require.NoError(t, err)
+	assert.Len(t, layers, 2)
+}
+
+func TestImport_V1Document_WithV2Field_Rejected(t *testing.T) {
+	backend := newTestBackend(t)
+
+	mismatched := Document{
+		SchemaVersion: 1,
+		ProjectSlug:   "test-project",
+		Data: Data{
+			Project: &storage.Project{Slug: "test-project"},
+			Constitutions: []*storage.Constitution{
+				{Layer: storage.ConstitutionLayerProject},
+			},
+		},
+	}
+	data, err := json.Marshal(mismatched)
+	require.NoError(t, err)
+
+	engine := NewEngine(backend, "", "test-version")
+	_, err = engine.Import(context.Background(), data, false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "v1 documents must use 'constitution' field, not 'constitutions'")
+}
+
+func TestImport_V2Document_WithV1Field_Rejected(t *testing.T) {
+	backend := newTestBackend(t)
+
+	mismatched := Document{
+		SchemaVersion: 2,
+		ProjectSlug:   "test-project",
+		Data: Data{
+			Project: &storage.Project{Slug: "test-project"},
+			Constitution: &storage.Constitution{
+				Layer: storage.ConstitutionLayerProject,
+			},
+		},
+	}
+	data, err := json.Marshal(mismatched)
+	require.NoError(t, err)
+
+	engine := NewEngine(backend, "", "test-version")
+	_, err = engine.Import(context.Background(), data, false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "v2 documents must use 'constitutions' field, not 'constitution'")
 }
 
 func TestExport_MultiLayerConstitution(t *testing.T) {

--- a/internal/export/engine_test.go
+++ b/internal/export/engine_test.go
@@ -273,6 +273,114 @@ func (b *decisionCapturingBackend) CreateDecision(_ context.Context, slug, title
 	return dec, nil
 }
 
+// ---------------------------------------------------------------------------
+// Multi-layer constitution export (v2 schema)
+// ---------------------------------------------------------------------------
+
+// multiLayerExportBackend is a minimal in-memory backend for
+// TestExport_MultiLayerConstitution. It stubs every method called by
+// Engine.collect, returning empty data for everything except GetProject and
+// the constitution methods.
+type multiLayerExportBackend struct {
+	Backend
+	project    *storage.Project
+	layers     map[storage.ConstitutionLayer]*storage.Constitution
+	layerOrder []storage.ConstitutionLayer // insertion order for GetAllLayers
+}
+
+func newTestBackend(t *testing.T) *multiLayerExportBackend {
+	t.Helper()
+	return &multiLayerExportBackend{
+		project: &storage.Project{Slug: "test-project"},
+		layers:  make(map[storage.ConstitutionLayer]*storage.Constitution),
+	}
+}
+
+// UpdateConstitution stores a constitution layer in order of first insertion.
+func (b *multiLayerExportBackend) UpdateConstitution(_ context.Context, c *storage.Constitution) (*storage.Constitution, error) {
+	if _, exists := b.layers[c.Layer]; !exists {
+		b.layerOrder = append(b.layerOrder, c.Layer)
+	}
+	clone := *c
+	clone.Version = 1
+	b.layers[c.Layer] = &clone
+	return &clone, nil
+}
+
+func (b *multiLayerExportBackend) GetAllLayers(_ context.Context) ([]*storage.Constitution, error) {
+	out := make([]*storage.Constitution, 0, len(b.layerOrder))
+	for _, l := range b.layerOrder {
+		out = append(out, b.layers[l])
+	}
+	return out, nil
+}
+
+func (b *multiLayerExportBackend) GetProject(_ context.Context, _ string) (*storage.Project, error) {
+	return b.project, nil
+}
+
+func (b *multiLayerExportBackend) ListSpecs(_ context.Context, _, _ string, _ int) ([]*storage.Spec, error) {
+	return nil, nil
+}
+
+func (b *multiLayerExportBackend) ListDecisions(_ context.Context, _ storage.DecisionStatus, _ int) ([]*storage.Decision, error) {
+	return nil, nil
+}
+
+func (b *multiLayerExportBackend) GetFullGraph(_ context.Context) (*storage.FullGraph, error) {
+	return &storage.FullGraph{}, nil
+}
+
+func (b *multiLayerExportBackend) ListAllFindings(_ context.Context) ([]*storage.AnalyticalFinding, error) {
+	return nil, nil
+}
+
+func (b *multiLayerExportBackend) ListAllChanges(_ context.Context) ([]*storage.ChangeLogEntry, error) {
+	return nil, nil
+}
+
+func (b *multiLayerExportBackend) ListAllConversations(_ context.Context) ([]*storage.ConversationLogEntry, error) {
+	return nil, nil
+}
+
+func (b *multiLayerExportBackend) ListSyncMappings(_ context.Context, _ storage.SyncAdapterType, _ string) ([]*storage.SyncMapping, error) {
+	return nil, nil
+}
+
+func TestExport_MultiLayerConstitution(t *testing.T) {
+	backend := newTestBackend(t)
+	ctx := context.Background()
+
+	// Seed two layers.
+	_, err := backend.UpdateConstitution(ctx, &storage.Constitution{
+		Name:  "org",
+		Layer: storage.ConstitutionLayerOrg,
+		Principles: []storage.Principle{{ID: "p-org", Statement: "Org"}},
+	})
+	require.NoError(t, err)
+
+	_, err = backend.UpdateConstitution(ctx, &storage.Constitution{
+		Name:  "project",
+		Layer: storage.ConstitutionLayerProject,
+		Principles: []storage.Principle{{ID: "p-proj", Statement: "Proj"}},
+	})
+	require.NoError(t, err)
+
+	engine := NewEngine(backend, "", "test-version")
+	out, err := engine.Export(ctx, "test-project")
+	require.NoError(t, err)
+
+	var doc Document
+	require.NoError(t, json.Unmarshal(out, &doc))
+
+	assert.Equal(t, 2, doc.SchemaVersion)
+	assert.Nil(t, doc.Data.Constitution, "v2 exports never populate the v1 field")
+	require.Len(t, doc.Data.Constitutions, 2, "v2 export must contain both layers")
+	assert.Equal(t, storage.ConstitutionLayerOrg, doc.Data.Constitutions[0].Layer,
+		"layers in precedence order: org before project")
+	assert.Equal(t, storage.ConstitutionLayerProject, doc.Data.Constitutions[1].Layer)
+}
+
 func TestImport_DecisionADR003Fields(t *testing.T) {
 	back := &decisionCapturingBackend{}
 

--- a/internal/export/schema.go
+++ b/internal/export/schema.go
@@ -10,8 +10,10 @@ import (
 	"github.com/specgraph/specgraph/internal/storage"
 )
 
-// CurrentSchemaVersion is the only supported version.
-const CurrentSchemaVersion = 1
+// CurrentSchemaVersion is bumped to 2 with the multi-layer constitution
+// migration. v2 documents use the Constitutions list field; v1 documents
+// (still importable) use the singular Constitution field.
+const CurrentSchemaVersion = 2
 
 // Document is the top-level export structure.
 type Document struct {
@@ -31,8 +33,18 @@ type Signature struct {
 
 // Data contains all exported entities in dependency order.
 type Data struct {
-	Project         *storage.Project                `json:"project"`
-	Constitution    *storage.Constitution           `json:"constitution,omitempty"`
+	Project *storage.Project `json:"project"`
+
+	// Constitution is the v1 single-layer field. Always nil in v2-emitted
+	// documents (omitempty drops it). Populated when importing v1 documents
+	// for the legacy single-layer case.
+	Constitution *storage.Constitution `json:"constitution,omitempty"`
+
+	// Constitutions is the v2 list of constitution layers in precedence
+	// order (user, org, project, domain). Populated by v2 exports; consumed
+	// by v2 imports.
+	Constitutions []*storage.Constitution `json:"constitutions,omitempty"`
+
 	Specs           []*storage.Spec                 `json:"specs"`
 	Decisions       []*storage.Decision             `json:"decisions"`
 	Slices          []*storage.Slice                `json:"slices"`

--- a/internal/server/constitution_handler_test.go
+++ b/internal/server/constitution_handler_test.go
@@ -13,6 +13,7 @@ import (
 	"connectrpc.com/connect"
 	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
 	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/constitution/merge"
 	"github.com/specgraph/specgraph/internal/server"
 	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/stretchr/testify/assert"
@@ -82,6 +83,17 @@ func (m *mockConstitutionBackend) GetAllLayers(_ context.Context) ([]*storage.Co
 		}
 	}
 	return result, nil
+}
+
+func (m *mockConstitutionBackend) GetMergedConstitution(ctx context.Context) (*storage.MergedResult, error) {
+	layers, err := m.GetAllLayers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(layers) == 0 {
+		return nil, storage.ErrConstitutionNotFound
+	}
+	return merge.Layers(layers)
 }
 
 func (m *mockConstitutionBackend) UpdateConstitution(_ context.Context, c *storage.Constitution) (*storage.Constitution, error) {

--- a/internal/server/error_sanitize_test.go
+++ b/internal/server/error_sanitize_test.go
@@ -96,6 +96,10 @@ func (errorBackend) GetConstitution(context.Context) (*storage.Constitution, err
 	return nil, errRawDB
 }
 
+func (errorBackend) GetMergedConstitution(context.Context) (*storage.MergedResult, error) {
+	return nil, errRawDB
+}
+
 func (errorBackend) UpdateConstitution(context.Context, *storage.Constitution) (*storage.Constitution, error) {
 	return nil, errRawDB
 }

--- a/internal/server/sync_handler_test.go
+++ b/internal/server/sync_handler_test.go
@@ -182,7 +182,7 @@ func (s *syncTestBackend) DeleteSyncMapping(ctx context.Context, specSlug string
 
 func (s *syncTestBackend) GetConstitution(ctx context.Context) (*storage.Constitution, error) {
 	if s.con != nil {
-		return s.con.GetConstitution(ctx)
+		return s.con.GetConstitution(ctx) //nolint:staticcheck // mock must implement the deprecated interface method until Piece D
 	}
 	return nil, storage.ErrConstitutionNotFound
 }
@@ -199,6 +199,13 @@ func (s *syncTestBackend) GetAllLayers(ctx context.Context) ([]*storage.Constitu
 		return s.con.GetAllLayers(ctx)
 	}
 	return []*storage.Constitution{}, nil
+}
+
+func (s *syncTestBackend) GetMergedConstitution(ctx context.Context) (*storage.MergedResult, error) {
+	if s.con != nil {
+		return s.con.GetMergedConstitution(ctx)
+	}
+	return nil, storage.ErrConstitutionNotFound
 }
 
 func (s *syncTestBackend) UpdateConstitution(ctx context.Context, c *storage.Constitution) (*storage.Constitution, error) {

--- a/internal/server/test_scoper_test.go
+++ b/internal/server/test_scoper_test.go
@@ -155,6 +155,10 @@ func (stubBackend) GetAllLayers(_ context.Context) ([]*storage.Constitution, err
 	return nil, errNotImplemented
 }
 
+func (stubBackend) GetMergedConstitution(_ context.Context) (*storage.MergedResult, error) {
+	return nil, errNotImplemented
+}
+
 func (stubBackend) UpdateConstitution(context.Context, *storage.Constitution) (*storage.Constitution, error) {
 	return nil, errNotImplemented
 }

--- a/internal/storage/constitution.go
+++ b/internal/storage/constitution.go
@@ -10,7 +10,11 @@ import (
 // ConstitutionBackend defines storage operations for the project constitution.
 type ConstitutionBackend interface {
 	// GetConstitution returns the active constitution.
-	// For backward compatibility, returns the single highest-precedence layer.
+	//
+	// Deprecated: returns only the single highest-precedence layer with no
+	// provenance. Use GetMergedConstitution for the effective constitution
+	// across all layers. This method is removed in spgr-8ar Piece D once all
+	// callers migrate.
 	GetConstitution(ctx context.Context) (*Constitution, error)
 
 	// GetConstitutionLayer returns a single layer's raw constitution data.
@@ -21,6 +25,13 @@ type ConstitutionBackend interface {
 	// ordered by precedence (user, org, project, domain).
 	// Returns an empty slice (not error) if no layers exist.
 	GetAllLayers(ctx context.Context) ([]*Constitution, error)
+
+	// GetMergedConstitution returns all layers composed into a single
+	// constitution plus per-field provenance. The single source of truth
+	// for "the effective constitution."
+	//
+	// Returns ErrConstitutionNotFound if no layers exist.
+	GetMergedConstitution(ctx context.Context) (*MergedResult, error)
 
 	// UpdateConstitution stores or replaces a constitution layer,
 	// bumping its version. The layer is determined by constitution.Layer.

--- a/internal/storage/constitution_domain.go
+++ b/internal/storage/constitution_domain.go
@@ -102,3 +102,13 @@ type Reference struct {
 	Path   string `json:"path,omitempty"`
 	Delete bool   `json:"$delete,omitempty"`
 }
+
+// MergedResult holds the merged constitution and per-field provenance.
+// It is the return type of GetMergedConstitution.
+type MergedResult struct {
+	// Constitution is the merged result of all input layers.
+	Constitution *Constitution
+	// Provenance maps dot/bracket-notation keys to the layer that last set them.
+	// Examples: "process.spec_review", "principles[p1]", "tech_config.frameworks[rpc]"
+	Provenance map[string]ConstitutionLayer
+}

--- a/internal/storage/execution_domain.go
+++ b/internal/storage/execution_domain.go
@@ -84,9 +84,18 @@ type DependencyInfo struct {
 	Note    string
 }
 
+// ProvenanceEntry maps a constitution field path to the layer that set its value.
+type ProvenanceEntry struct {
+	Path  string
+	Layer ConstitutionLayer
+}
+
 // PrimeData holds the raw data needed to compose a prime response.
 type PrimeData struct {
 	Spec         *Spec
 	Decisions    []*Decision
 	Constitution *Constitution
+	// ConstitutionProvenance maps constitution field paths to the layer
+	// that set each value. Empty iff Constitution is nil.
+	ConstitutionProvenance []ProvenanceEntry
 }

--- a/internal/storage/postgres/constitution.go
+++ b/internal/storage/postgres/constitution.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/specgraph/specgraph/internal/constitution/merge"
 	"github.com/specgraph/specgraph/internal/storage"
 )
 
@@ -212,6 +213,24 @@ func (s *Store) UpdateConstitution(ctx context.Context, constitution *storage.Co
 	}
 
 	return constitutionFromRow(retID, retLayer, retName, retVersion, retDataJSON, retSourceURL, retSourceHash, retCreatedAt, retUpdatedAt)
+}
+
+// GetMergedConstitution returns all layers composed into a single
+// constitution plus per-field provenance.
+// Returns ErrConstitutionNotFound if no layers exist.
+func (s *Store) GetMergedConstitution(ctx context.Context) (*storage.MergedResult, error) {
+	layers, err := s.GetAllLayers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: get merged constitution: %w", err)
+	}
+	if len(layers) == 0 {
+		return nil, fmt.Errorf("postgres: %w", storage.ErrConstitutionNotFound)
+	}
+	result, mergeErr := merge.Layers(layers)
+	if mergeErr != nil {
+		return nil, fmt.Errorf("postgres: merge layers: %w", mergeErr)
+	}
+	return result, nil
 }
 
 // constitutionFromRow assembles a *storage.Constitution from scanned column values.

--- a/internal/storage/postgres/execution.go
+++ b/internal/storage/postgres/execution.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -244,19 +245,33 @@ func (s *Store) GetPrimeData(ctx context.Context, slug string) (*storage.PrimeDa
 		return nil, fmt.Errorf("postgres: get prime data decisions: %w", err)
 	}
 
-	var constitution *storage.Constitution
-	constitution, err = s.GetConstitution(ctx)
-	if err != nil {
-		if !errors.Is(err, storage.ErrConstitutionNotFound) {
-			return nil, fmt.Errorf("postgres: get prime data constitution: %w", err)
-		}
+	pd := &storage.PrimeData{
+		Spec:      spec,
+		Decisions: decisions,
 	}
 
-	return &storage.PrimeData{
-		Spec:         spec,
-		Decisions:    decisions,
-		Constitution: constitution,
-	}, nil
+	merged, err := s.GetMergedConstitution(ctx)
+	switch {
+	case err == nil:
+		pd.Constitution = merged.Constitution
+		pd.ConstitutionProvenance = make([]storage.ProvenanceEntry, 0, len(merged.Provenance))
+		for path, layer := range merged.Provenance {
+			pd.ConstitutionProvenance = append(pd.ConstitutionProvenance, storage.ProvenanceEntry{
+				Path:  path,
+				Layer: layer,
+			})
+		}
+		sort.Slice(pd.ConstitutionProvenance, func(i, j int) bool {
+			return pd.ConstitutionProvenance[i].Path < pd.ConstitutionProvenance[j].Path
+		})
+	case errors.Is(err, storage.ErrConstitutionNotFound):
+		// No layers exist — leave Constitution nil and Provenance empty.
+		// Matches existing no-constitution behavior.
+	default:
+		return nil, fmt.Errorf("postgres: get prime data constitution: %w", err)
+	}
+
+	return pd, nil
 }
 
 // ReleaseExpiredClaims finds and releases all claims past their lease expiry.

--- a/internal/storage/postgres/execution_test.go
+++ b/internal/storage/postgres/execution_test.go
@@ -393,6 +393,88 @@ func TestReleaseExpiredClaims_NoneExpired(t *testing.T) {
 	assert.Equal(t, 0, released)
 }
 
+func TestGetPrimeData_MultiLayerProvenance(t *testing.T) {
+	store := newStore(t)
+	clearDatabase(t, store)
+	ctx := context.Background()
+
+	// Org layer with one principle.
+	_, err := store.UpdateConstitution(ctx, &storage.Constitution{
+		Name:  "org",
+		Layer: storage.ConstitutionLayerOrg,
+		Principles: []storage.Principle{
+			{ID: "p-org", Statement: "Org rule"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Project layer with another principle.
+	_, err = store.UpdateConstitution(ctx, &storage.Constitution{
+		Name:  "project",
+		Layer: storage.ConstitutionLayerProject,
+		Principles: []storage.Principle{
+			{ID: "p-proj", Statement: "Project rule"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Seed a spec so GetPrimeData has something to find.
+	_, err = store.CreateSpec(ctx, "prime-prov-spec", "intent", "P2", "M",
+		storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	pd, err := store.GetPrimeData(ctx, "prime-prov-spec")
+
+	require.NoError(t, err)
+	require.NotNil(t, pd.Constitution)
+
+	// Assert presence of both expected principles by ID — more precise than
+	// a count-only check, and resilient to merge insertion order.
+	var principleIDs []string
+	for _, p := range pd.Constitution.Principles {
+		principleIDs = append(principleIDs, p.ID)
+	}
+	assert.ElementsMatch(t, []string{"p-org", "p-proj"}, principleIDs,
+		"merged constitution must carry principles from both layers")
+
+	// Build a provenance lookup for assertion clarity.
+	provByPath := map[string]storage.ConstitutionLayer{}
+	for _, e := range pd.ConstitutionProvenance {
+		provByPath[e.Path] = e.Layer
+	}
+	assert.Equal(t, storage.ConstitutionLayerOrg, provByPath["principles[p-org]"])
+	assert.Equal(t, storage.ConstitutionLayerProject, provByPath["principles[p-proj]"])
+
+	// Sort invariant: require non-empty first so an empty slice can't
+	// silently pass the loop below.
+	require.NotEmpty(t, pd.ConstitutionProvenance,
+		"provenance must not be empty when constitution is present")
+	for i := 1; i < len(pd.ConstitutionProvenance); i++ {
+		assert.LessOrEqual(t,
+			pd.ConstitutionProvenance[i-1].Path,
+			pd.ConstitutionProvenance[i].Path,
+			"ConstitutionProvenance must be sorted by Path for deterministic output")
+	}
+}
+
+func TestGetPrimeData_NoConstitution_EmptyProvenance(t *testing.T) {
+	store := newStore(t)
+	clearDatabase(t, store)
+	ctx := context.Background()
+
+	_, err := store.CreateSpec(ctx, "no-prov-spec", "intent", "P2", "M",
+		storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	pd, err := store.GetPrimeData(ctx, "no-prov-spec")
+
+	require.NoError(t, err)
+	assert.Nil(t, pd.Constitution,
+		"invariant: Constitution nil when no layers exist")
+	assert.Empty(t, pd.ConstitutionProvenance,
+		"invariant: provenance empty iff Constitution nil")
+}
+
 func TestFullExecutionLifecycle(t *testing.T) {
 	store := newStore(t)
 	clearDatabase(t, store)

--- a/internal/storage/postgres/get_merged_constitution_test.go
+++ b/internal/storage/postgres/get_merged_constitution_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+func TestGetMergedConstitution_Empty(t *testing.T) {
+	store := newStore(t)
+	clearDatabase(t, store)
+	ctx := context.Background()
+
+	_, err := store.GetMergedConstitution(ctx)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, storage.ErrConstitutionNotFound),
+		"empty project must return ErrConstitutionNotFound, got %v", err)
+}
+
+func TestGetMergedConstitution_SingleLayer(t *testing.T) {
+	store := newStore(t)
+	clearDatabase(t, store)
+	ctx := context.Background()
+
+	_, err := store.UpdateConstitution(ctx, &storage.Constitution{
+		Name:  "test",
+		Layer: storage.ConstitutionLayerProject,
+		Principles: []storage.Principle{
+			{ID: "p1", Statement: "Prefer explicit over implicit"},
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := store.GetMergedConstitution(ctx)
+
+	require.NoError(t, err)
+	require.NotNil(t, result.Constitution)
+	assert.Equal(t, "test", result.Constitution.Name,
+		"merge must preserve scalar metadata from the single layer")
+	assert.Equal(t, storage.ConstitutionLayerProject, result.Constitution.Layer,
+		"merged Layer reflects the highest-precedence input layer")
+	assert.Len(t, result.Constitution.Principles, 1)
+	assert.Equal(t, "p1", result.Constitution.Principles[0].ID)
+	assert.Equal(t, storage.ConstitutionLayerProject,
+		result.Provenance["principles[p1]"],
+		"provenance must attribute p1 to project layer")
+}
+
+func TestGetMergedConstitution_MultiLayer(t *testing.T) {
+	store := newStore(t)
+	clearDatabase(t, store)
+	ctx := context.Background()
+
+	_, err := store.UpdateConstitution(ctx, &storage.Constitution{
+		Name:  "org",
+		Layer: storage.ConstitutionLayerOrg,
+		Principles: []storage.Principle{
+			{ID: "p-org", Statement: "Org rule"},
+			{ID: "p-shared", Statement: "Org's version"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = store.UpdateConstitution(ctx, &storage.Constitution{
+		Name:  "project",
+		Layer: storage.ConstitutionLayerProject,
+		Principles: []storage.Principle{
+			{ID: "p-proj", Statement: "Project rule"},
+			{ID: "p-shared", Statement: "Project's version"},
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := store.GetMergedConstitution(ctx)
+
+	require.NoError(t, err)
+	require.NotNil(t, result.Constitution)
+	assert.Len(t, result.Constitution.Principles, 3, "merge must yield org+proj unique + shared key")
+
+	// Provenance attributes shared key to highest-precedence layer (project)
+	assert.Equal(t, storage.ConstitutionLayerProject,
+		result.Provenance["principles[p-shared]"],
+		"shared key must be attributed to project (highest precedence)")
+	assert.Equal(t, storage.ConstitutionLayerOrg,
+		result.Provenance["principles[p-org]"])
+	assert.Equal(t, storage.ConstitutionLayerProject,
+		result.Provenance["principles[p-proj]"])
+}


### PR DESCRIPTION
## Summary

- Adds `GetMergedConstitution` to `ConstitutionBackend`; routes `PrimeData` and `export.engine` through it
- Threads `ConstitutionProvenance []ProvenanceEntry` through `PrimeData` (domain only — proto change deferred to Piece E)
- Bumps export `CurrentSchemaVersion` from 1 to 2; replaces single `Constitution` field with `Constitutions []` list; schema-version-aware import with cross-field validation
- Marks single-layer `Store.GetConstitution` as `// Deprecated` (removal in Piece D)

Implements Piece A of [spgr-8ar design](docs/superpowers/specs/2026-05-21-multi-layer-constitution-completion-design.md). Closes the bead's genuine acceptance criterion (item 6: PrimeData uses merged constitution) and fixes the unstated export-flattens-layers bug surfaced in adversarial review.

Includes the design spec and implementation plan as the first two commits of this stack for reviewer context.

## Notable design choice

To resolve an import cycle (`merge` already imports `storage`), `MergedResult` is defined in package `storage` and `merge.Result` is now a type alias for it. Existing callers of `*merge.Result` continue to work unchanged. Documented in `internal/constitution/merge/merge.go`.

## Test plan

- [x] `task check` passes (fmt, lint, build, unit)
- [x] `task pr-prep` passes (check + integration + e2e including UI)
- [x] `TestGetMergedConstitution_{Empty,SingleLayer,MultiLayer}` exercise the new storage method
- [x] `TestGetPrimeData_MultiLayerProvenance` confirms prime path carries merged constitution + sorted provenance; verifies the sort invariant via loop
- [x] `TestGetPrimeData_NoConstitution_EmptyProvenance` confirms invariant: Constitution nil iff Provenance empty
- [x] `TestExport_MultiLayerConstitution` confirms v2 exports populate `Constitutions` list in precedence order
- [x] `TestImport_V1Document_SingleLayer` confirms v1 documents import correctly under v2 code
- [x] `TestImport_V2Document_MultipleLayers` confirms v2 import populates all layers
- [x] `TestImport_{V1,V2}Document_With{V2,V1}Field_Rejected` confirms cross-field validation rejects mismatched docs
- [x] `TestExportImport_V1ToV2_RoundTrip` confirms forward migration is lossless for v1-expressible data

Pieces B/C/D/E remain — separate PRs (see spgr-15gz, spgr-tf1z, spgr-917q, spgr-nloc).

Closes: spgr-86kn

🤖 Generated with [Claude Code](https://claude.com/claude-code)