### PR TITLE
spgr-8ar PR D: retire single-layer compat method

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -163,6 +163,7 @@ tasks:
       - task: lint:go
       - task: lint:markdown
       - task: lint:yaml
+      - task: lint:constitution-callers
   lint:go:
     desc: Lint Go code
     deps: [generate, 'web:build']
@@ -176,6 +177,31 @@ tasks:
     desc: Lint YAML files
     cmds:
       - yamlfmt -lint .
+  lint:constitution-callers:
+    desc: Guard against reintroducing the deprecated Store.GetConstitution method (spgr-8ar piece D)
+    cmds:
+      - |
+        # Fails the build if anyone reintroduces the storage-layer
+        # GetConstitution method that piece D removed. Detects the
+        # method declaration's unique signature on a *Store or any
+        # ConstitutionBackend implementer:
+        #   func (<recv>) GetConstitution(<ctx>) (*storage.Constitution|*Constitution, error)
+        #
+        # If the method declaration reappears, callers can compile
+        # against it again and the silent-layer-dropping bug
+        # piece A fixed is back. By blocking the declaration, we
+        # transitively block the calls.
+        #
+        # The RPC handler's GetConstitution on *ConstitutionHandler
+        # takes a connect.Request, so it doesn't match this regex. The
+        # composer's GetConstitution returns *authoring.ConstitutionSummary,
+        # so it doesn't match either. Only the deprecated storage form
+        # is caught.
+        if rg -nP 'func\s*\([^)]+\)\s*GetConstitution\s*\(\s*ctx[^)]*\)\s*\(\s*\*(?:storage\.)?Constitution\s*,\s*error\s*\)' --type go . 2>/dev/null; then
+          echo "ERROR: Store.GetConstitution was removed in spgr-8ar piece D." >&2
+          echo "Use GetMergedConstitution (merged + provenance) or GetConstitutionLayer (single layer)." >&2
+          exit 1
+        fi
   # License headers
   license:check:
     desc: Check SPDX license headers

--- a/docs/superpowers/plans/2026-05-21-spgr-8ar-piece-d-implementation-plan.md
+++ b/docs/superpowers/plans/2026-05-21-spgr-8ar-piece-d-implementation-plan.md
@@ -1,0 +1,98 @@
+# spgr-8ar Piece D — Retire Single-Layer Compat Method
+
+> **For agentic workers:** Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove `Store.GetConstitution` (the single-layer "backward compatibility" method marked `// Deprecated` in Piece A) from the storage interface, the Postgres implementation, and all test mocks. Add a CI grep guard against regrowth.
+
+**Architecture:** Pure deletion + a lint-time grep guard. No schema change, no behavior change for callers that already migrated to `GetMergedConstitution`.
+
+## Pre-condition audit
+
+Production callers of `Store.GetConstitution` (the storage interface method, not the RPC) after Piece A merged:
+
+```text
+$ rg 'func.*GetConstitution\(.*context\.Context.*\) \(\*storage\.Constitution' internal/
+internal/server/sync_handler_test.go        # syncTestBackend mock (test-only)
+internal/storage/postgres/constitution.go   # *Store impl
+```
+
+And the matching receiver-less variant for other mocks (`func (stubBackend) GetConstitution(...)`):
+
+```text
+internal/server/test_scoper_test.go         # stubBackend mock
+internal/server/constitution_handler_test.go # mockConstitutionBackend mock
+internal/server/error_sanitize_test.go      # errorBackend mock
+```
+
+Plus tests of the deprecated method itself:
+
+- `internal/storage/postgres/constitution_test.go:62` — `TestGetConstitution_NotFound`
+- `internal/storage/postgres/constitution_test.go:71` — `TestGetConstitution_RoundTrip`
+
+No production code outside test mocks references the method. Safe to delete.
+
+## File Structure
+
+### Files modified
+
+| Path | Change |
+|---|---|
+| `internal/storage/constitution.go` | Remove `GetConstitution` from `ConstitutionBackend` interface |
+| `internal/storage/postgres/constitution.go` | Remove `*Store.GetConstitution` implementation |
+| `internal/storage/postgres/constitution_test.go` | Remove `TestGetConstitution_NotFound`, `TestGetConstitution_RoundTrip` |
+| `internal/server/test_scoper_test.go` | Remove `stubBackend.GetConstitution` stub |
+| `internal/server/constitution_handler_test.go` | Remove `mockConstitutionBackend.GetConstitution` |
+| `internal/server/error_sanitize_test.go` | Remove `errorBackend.GetConstitution` |
+| `internal/server/sync_handler_test.go` | Remove `syncTestBackend.GetConstitution` (including the `//nolint:staticcheck` line) |
+| `Taskfile.yml` or `task lint:*` | Add CI grep guard against `*Store.GetConstitution` reintroduction |
+
+## Tasks
+
+### Task 1: Delete the interface method, impl, and mocks (one commit)
+
+The deletion is mechanical and tightly coupled — interface signature ↔ all implementations must move together or the build breaks. Doing it as a single commit keeps the diff atomic.
+
+- [ ] Remove the deprecated method from `ConstitutionBackend` interface
+- [ ] Remove `*Store.GetConstitution` from Postgres impl
+- [ ] Remove the matching method from each of the four test mocks
+- [ ] Remove the two `TestGetConstitution_*` tests (superseded by `TestGetMergedConstitution_*` + `TestGetConstitutionLayer_*`)
+- [ ] Run `go build ./...` — clean
+- [ ] Run `go test ./internal/...` — all pass
+- [ ] Commit as `refactor(storage): remove deprecated GetConstitution method (spgr-8ar piece D)`
+
+### Task 2: Add CI grep guard
+
+Adds a small shell pipeline that fails the build if `*Store.GetConstitution` or `storage.GetConstitution` reappears in production code. Wire into `task check` so it runs on every PR.
+
+- [ ] Add a new `lint:constitution-callers` task to `Taskfile.yml` that runs:
+
+  ```bash
+  if rg -n 'Store\.GetConstitution\b' --type go -g '!*_test.go' -g '!internal/storage/postgres/constitution_test.go' .; then
+    echo "ERROR: Store.GetConstitution is removed; use GetMergedConstitution" >&2
+    exit 1
+  fi
+  ```
+
+- [ ] Add to the `lint` task's dependencies so `task check` runs it
+- [ ] Manually verify the guard triggers by transiently reintroducing a usage, then revert
+- [ ] Commit as `chore(lint): guard against Store.GetConstitution reintroduction`
+
+### Task 3: Quality gates + PR
+
+- [ ] `task check` green
+- [ ] `task test:integration` green
+- [ ] Direct API e2e green
+- [ ] Push bookmark + open PR
+- [ ] Update bd + push
+
+## Self-Review
+
+- No first-party callers of `Store.GetConstitution` after Piece A merged (verified by audit)
+- All four mocks updated atomically with the interface change (or build breaks)
+- Two deprecated-method tests removed; their behavior is fully covered by sibling tests on `GetMergedConstitution` / `GetConstitutionLayer`
+- CI guard prevents accidental reintroduction
+- DCO trailer uses `4678+seanb4t@users.noreply.github.com`
+
+## Plan complete
+
+2 implementation commits + plan + quality gates = ~3-4 commits total.

--- a/internal/server/constitution_handler_test.go
+++ b/internal/server/constitution_handler_test.go
@@ -35,26 +35,6 @@ func newMockConstitutionBackend() *mockConstitutionBackend {
 	}
 }
 
-func (m *mockConstitutionBackend) GetConstitution(_ context.Context) (*storage.Constitution, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if len(m.layers) == 0 {
-		return nil, storage.ErrConstitutionNotFound
-	}
-	// Return highest-precedence layer (domain > project > org > user).
-	for _, l := range []storage.ConstitutionLayer{
-		storage.ConstitutionLayerDomain,
-		storage.ConstitutionLayerProject,
-		storage.ConstitutionLayerOrg,
-		storage.ConstitutionLayerUser,
-	} {
-		if c, ok := m.layers[l]; ok {
-			return c, nil
-		}
-	}
-	return nil, storage.ErrConstitutionNotFound
-}
-
 func (m *mockConstitutionBackend) GetConstitutionLayer(_ context.Context, layer storage.ConstitutionLayer) (*storage.Constitution, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/server/error_sanitize_test.go
+++ b/internal/server/error_sanitize_test.go
@@ -92,11 +92,21 @@ func (errorBackend) GetFullGraph(context.Context) (*storage.FullGraph, error) {
 	return nil, errRawDB
 }
 
-func (errorBackend) GetConstitution(context.Context) (*storage.Constitution, error) {
+func (errorBackend) GetMergedConstitution(context.Context) (*storage.MergedResult, error) {
 	return nil, errRawDB
 }
 
-func (errorBackend) GetMergedConstitution(context.Context) (*storage.MergedResult, error) {
+// GetConstitutionLayer + GetAllLayers overrides preserve the test intent
+// of TestConstitutionHandler_ErrorSanitization: every storage path that
+// the constitution RPC handler can hit must surface a raw DB error so
+// the test verifies sanitization happens before the client sees it.
+// Without these, the embedded stubBackend returns errNotImplemented and
+// the test exercises a weaker assertion path.
+func (errorBackend) GetConstitutionLayer(context.Context, storage.ConstitutionLayer) (*storage.Constitution, error) {
+	return nil, errRawDB
+}
+
+func (errorBackend) GetAllLayers(context.Context) ([]*storage.Constitution, error) {
 	return nil, errRawDB
 }
 

--- a/internal/server/sync_handler_test.go
+++ b/internal/server/sync_handler_test.go
@@ -180,13 +180,6 @@ func (s *syncTestBackend) DeleteSyncMapping(ctx context.Context, specSlug string
 	return s.syncBackend.DeleteSyncMapping(ctx, specSlug, adapter)
 }
 
-func (s *syncTestBackend) GetConstitution(ctx context.Context) (*storage.Constitution, error) {
-	if s.con != nil {
-		return s.con.GetConstitution(ctx) //nolint:staticcheck // mock must implement the deprecated interface method until Piece D
-	}
-	return nil, storage.ErrConstitutionNotFound
-}
-
 func (s *syncTestBackend) GetConstitutionLayer(ctx context.Context, layer storage.ConstitutionLayer) (*storage.Constitution, error) {
 	if s.con != nil {
 		return s.con.GetConstitutionLayer(ctx, layer)

--- a/internal/server/test_scoper_test.go
+++ b/internal/server/test_scoper_test.go
@@ -143,10 +143,6 @@ func (stubBackend) Heartbeat(context.Context, string, string, time.Duration) (*s
 
 // --- ConstitutionBackend ---
 
-func (stubBackend) GetConstitution(context.Context) (*storage.Constitution, error) {
-	return nil, errNotImplemented
-}
-
 func (stubBackend) GetConstitutionLayer(_ context.Context, _ storage.ConstitutionLayer) (*storage.Constitution, error) {
 	return nil, errNotImplemented
 }

--- a/internal/storage/constitution.go
+++ b/internal/storage/constitution.go
@@ -9,14 +9,6 @@ import (
 
 // ConstitutionBackend defines storage operations for the project constitution.
 type ConstitutionBackend interface {
-	// GetConstitution returns the active constitution.
-	//
-	// Deprecated: returns only the single highest-precedence layer with no
-	// provenance. Use GetMergedConstitution for the effective constitution
-	// across all layers. This method is removed in spgr-8ar Piece D once all
-	// callers migrate.
-	GetConstitution(ctx context.Context) (*Constitution, error)
-
 	// GetConstitutionLayer returns a single layer's raw constitution data.
 	// Returns ErrConstitutionNotFound if the layer does not exist.
 	GetConstitutionLayer(ctx context.Context, layer ConstitutionLayer) (*Constitution, error)

--- a/internal/storage/postgres/constitution.go
+++ b/internal/storage/postgres/constitution.go
@@ -16,6 +16,13 @@ import (
 	"github.com/specgraph/specgraph/internal/storage"
 )
 
+// Compile-time interface assertion. Matches the convention used by every
+// other postgres storage file (authoring.go, graph.go, decision.go, etc.).
+// If a future change adds a method to ConstitutionBackend, this line forces
+// the compiler to verify *Store implements it directly — without it the
+// missing method would only surface at the ScopedBackend composite boundary.
+var _ storage.ConstitutionBackend = (*Store)(nil)
+
 // constitutionData is the intermediate struct marshaled into the JSONB data column.
 // It excludes identity/version fields that are stored as explicit columns.
 type constitutionData struct {
@@ -25,44 +32,6 @@ type constitutionData struct {
 	Constraints  []string               `json:"constraints,omitempty"`
 	Antipatterns []storage.Antipattern  `json:"antipatterns,omitempty"`
 	References   []storage.Reference    `json:"references,omitempty"`
-}
-
-// GetConstitution returns the active constitution for the current project.
-// Returns ErrConstitutionNotFound if none exists.
-func (s *Store) GetConstitution(ctx context.Context) (*storage.Constitution, error) {
-	var (
-		id         string
-		layer      string
-		name       string
-		version    int32
-		dataJSON   []byte
-		sourceURL  string
-		sourceHash string
-		createdAt  time.Time
-		updatedAt  time.Time
-	)
-
-	err := s.queryRow(ctx,
-		`SELECT id, layer, name, version, data, source_url, source_hash, created_at, updated_at
-		 FROM constitutions WHERE project_slug = $1
-		 ORDER BY CASE layer
-		   WHEN 'domain' THEN 1
-		   WHEN 'project' THEN 2
-		   WHEN 'org' THEN 3
-		   WHEN 'user' THEN 4
-		   ELSE 5
-		 END, version DESC
-		 LIMIT 1`,
-		s.project,
-	).Scan(&id, &layer, &name, &version, &dataJSON, &sourceURL, &sourceHash, &createdAt, &updatedAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, fmt.Errorf("postgres: %w", storage.ErrConstitutionNotFound)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("postgres: get constitution: %w", err)
-	}
-
-	return constitutionFromRow(id, layer, name, version, dataJSON, sourceURL, sourceHash, createdAt, updatedAt)
 }
 
 // GetConstitutionLayer returns a single layer's raw constitution data.

--- a/internal/storage/postgres/constitution_test.go
+++ b/internal/storage/postgres/constitution_test.go
@@ -59,16 +59,11 @@ func TestUpdateConstitution_IncrementsVersion(t *testing.T) {
 	require.Equal(t, v1.ID, v2.ID)
 }
 
-func TestGetConstitution_NotFound(t *testing.T) {
-	store := newStore(t)
-	clearDatabase(t, store)
-	ctx := context.Background()
-
-	_, err := store.GetConstitution(ctx)
-	require.ErrorIs(t, err, storage.ErrConstitutionNotFound)
-}
-
-func TestGetConstitution_RoundTrip(t *testing.T) {
+func TestGetConstitutionLayer_RoundTripAllFields(t *testing.T) {
+	// Migrated from the pre-Piece-D TestGetConstitution_RoundTrip: exercises
+	// full field round-trip through UpdateConstitution + GetConstitutionLayer
+	// for the org layer specifically. Field-level assertions are unique to
+	// this test (other layer-aware tests check structure but not every field).
 	store := newStore(t)
 	clearDatabase(t, store)
 	ctx := context.Background()
@@ -101,7 +96,7 @@ func TestGetConstitution_RoundTrip(t *testing.T) {
 	stored, err := store.UpdateConstitution(ctx, input)
 	require.NoError(t, err)
 
-	got, err := store.GetConstitution(ctx)
+	got, err := store.GetConstitutionLayer(ctx, storage.ConstitutionLayerOrg)
 	require.NoError(t, err)
 
 	require.Equal(t, stored.ID, got.ID)


### PR DESCRIPTION
## Summary

Removes the deprecated `Store.GetConstitution` method that Piece A marked `// Deprecated`. After Pieces A–C migrated `PrimeData` and `export.engine` to `GetMergedConstitution`, no first-party caller remained. Pure deletion + a CI guard against regrowth.

## Pre-condition audit

After Piece A merged, the only references to the deprecated method outside the deprecation shim itself were:

- `*Store.GetConstitution` (the Postgres impl, the thing being deleted)
- 4 test mocks (`stubBackend`, `mockConstitutionBackend`, `errorBackend`, `syncTestBackend`) that existed solely to satisfy the interface
- 2 tests (`TestGetConstitution_NotFound`, `TestGetConstitution_RoundTrip`) of the deprecated method

No production caller. The RPC handler `ConstitutionService.GetConstitution` and proto getter `resp.Msg.GetConstitution()` are unaffected — only the **storage interface** method goes away.

## Test migration

- `TestGetConstitution_NotFound` is deleted; coverage moves to `TestGetConstitutionLayer_NotFound` + `TestGetMergedConstitution_Empty`.
- `TestGetConstitution_RoundTrip` becomes `TestGetConstitutionLayer_RoundTripAllFields` — same field-level round-trip assertions, but reads via `GetConstitutionLayer(ConstitutionLayerOrg)` instead of the deprecated method.

## CI guard

New `task lint:constitution-callers` runs as part of `task lint` (and therefore `task check`). It uses `ripgrep` to detect any reappearance of the deprecated method's declaration signature:

```
func (<recv>) GetConstitution(ctx ...) (*storage.Constitution, error)
```

Verified empirically: with the guard in place, transiently re-adding the impl causes `task check` to fail with a clear error message naming `GetMergedConstitution` and `GetConstitutionLayer` as the alternatives. By blocking the **method declaration**, callers can't compile against it, so the guard transitively blocks all call sites.

The guard's regex is tight — it doesn't match the RPC handler's `GetConstitution` (which takes a `connect.Request`) or the composer's `GetConstitution` (which returns `*authoring.ConstitutionSummary`). Only the deprecated storage form is caught.

## Test plan

- [x] `task check` green
- [x] `task test:integration` green (storage + xdg + sync packages)
- [x] Direct API e2e green (`go test -tags e2e ./e2e/api/`)
- [x] Postgres integration tests green (`go test -tags integration ./internal/storage/postgres/`)
- [x] Guard fires on transient regression (verified empirically pre-commit)
- [ ] CI green
- [ ] DCO + CodeRabbit

Closes spgr-917q.

Pieces A, B, C merged. Piece E (prime unification) remains as the last piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)