### PR TITLE
spgr-cxkg: wire active claims through SpecView via ClaimBackend.GetActiveClaim

### DIFF
--- a/internal/prime/backend.go
+++ b/internal/prime/backend.go
@@ -18,4 +18,5 @@ type Backend interface {
 	storage.ExecutionBackend
 	storage.DecisionBackend
 	storage.SliceBackend
+	storage.ClaimBackend
 }

--- a/internal/prime/composer.go
+++ b/internal/prime/composer.go
@@ -163,6 +163,16 @@ func (c *Composer) Spec(ctx context.Context, slug string) (*SpecView, error) {
 	}
 	view.Slices = slices
 
+	// Active claim (lease). 1:1 in the data model; we wrap the zero-or-one
+	// active claim in a slice to match SpecView.Claims' shape.
+	claim, err := c.backend.GetActiveClaim(ctx, slug)
+	if err != nil {
+		return nil, fmt.Errorf("prime: get active claim for %q: %w", slug, err)
+	}
+	if claim != nil {
+		view.Claims = []*storage.Claim{claim}
+	}
+
 	// Blocker events. GetExecutionEvents returns all event types; we
 	// filter to blockers only here so callers do not have to.
 	events, err := c.backend.GetExecutionEvents(ctx, slug, 0)

--- a/internal/prime/composer_test.go
+++ b/internal/prime/composer_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -253,4 +254,53 @@ func TestComposer_Spec_EmptyConstitution(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, view.Constitution)
 	require.Empty(t, view.ConstitutionProvenance)
+}
+
+func TestComposer_Spec_NoActiveClaim(t *testing.T) {
+	be := &prime.StubBackend{
+		GetSpecFn: func(_ context.Context, slug string) (*storage.Spec, error) {
+			return &storage.Spec{Slug: slug}, nil
+		},
+		// GetActiveClaimFn unset → StubBackend default returns (nil, nil)
+		// (unclaimed). Composer should leave Claims empty.
+	}
+	view, err := newComposer(t, be, nil).Spec(context.Background(), "demo")
+	require.NoError(t, err)
+	require.Empty(t, view.Claims, "Claims should be empty when spec is unclaimed")
+}
+
+func TestComposer_Spec_WithActiveClaim(t *testing.T) {
+	want := &storage.Claim{
+		Slug:         "demo",
+		Agent:        "polecat-7",
+		ClaimedAt:    time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC),
+		LeaseExpires: time.Date(2026, 5, 22, 10, 30, 0, 0, time.UTC),
+	}
+	be := &prime.StubBackend{
+		GetSpecFn: func(_ context.Context, slug string) (*storage.Spec, error) {
+			return &storage.Spec{Slug: slug}, nil
+		},
+		GetActiveClaimFn: func(_ context.Context, slug string) (*storage.Claim, error) {
+			require.Equal(t, "demo", slug)
+			return want, nil
+		},
+	}
+	view, err := newComposer(t, be, nil).Spec(context.Background(), "demo")
+	require.NoError(t, err)
+	require.Len(t, view.Claims, 1, "Claims should carry exactly one entry when claimed")
+	require.Same(t, want, view.Claims[0], "Claims should preserve the storage pointer")
+}
+
+func TestComposer_Spec_GetActiveClaimError_BubblesUp(t *testing.T) {
+	be := &prime.StubBackend{
+		GetSpecFn: func(_ context.Context, slug string) (*storage.Spec, error) {
+			return &storage.Spec{Slug: slug}, nil
+		},
+		GetActiveClaimFn: func(context.Context, string) (*storage.Claim, error) {
+			return nil, errors.New("db unavailable")
+		},
+	}
+	_, err := newComposer(t, be, nil).Spec(context.Background(), "demo")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "get active claim")
 }

--- a/internal/prime/prime.go
+++ b/internal/prime/prime.go
@@ -41,16 +41,13 @@ type SpecView struct {
 	ConstitutionProvenance []storage.ProvenanceEntry
 	Decisions              []*storage.Decision
 	Slices                 []*storage.Slice
+	// Claims carries the currently active lease for this spec.
+	// Semantically there is at most one (the lease model is 1:1) and the
+	// composer populates either zero or one entry from
+	// ClaimBackend.GetActiveClaim. Exposed as a slice to match the proto
+	// SpecView.claims repeated field.
+	Claims []*storage.Claim
 	// Blockers contains only execution events with
 	// Type=storage.ExecutionEventTypeBlocker for this spec.
 	Blockers []*storage.ExecutionEvent
 }
-
-// NOTE on Claims: the proto SpecView includes a claims repeated field
-// (forward compat), but the storage layer currently exposes no public
-// read path for the active claim — only the private fetchActiveClaim
-// in internal/storage/postgres. ClaimBackend's public surface is
-// ClaimSpec/UnclaimSpec/Heartbeat only. Adding GetActiveClaim is a
-// schema/storage change, out of scope for this bead per its acceptance
-// criteria. The proto field stays empty; renderers skip the section.
-// A follow-up bead can expose the active claim and populate this view.

--- a/internal/prime/testbackend.go
+++ b/internal/prime/testbackend.go
@@ -5,6 +5,7 @@ package prime
 
 import (
 	"context"
+	"time"
 
 	"github.com/specgraph/specgraph/internal/storage"
 )
@@ -75,6 +76,12 @@ type StubBackend struct {
 	GetSliceFn      func(ctx context.Context, slug string) (*storage.Slice, error)
 	ClaimSliceFn    func(ctx context.Context, slug, assignee string) (*storage.Slice, error)
 	CompleteSliceFn func(ctx context.Context, slug string) (*storage.Slice, error)
+
+	// Claim.
+	ClaimSpecFn      func(ctx context.Context, slug, agent string, leaseDuration time.Duration) (*storage.Claim, error)
+	UnclaimSpecFn    func(ctx context.Context, slug, agent string) error
+	HeartbeatFn      func(ctx context.Context, slug, agent string, extendBy time.Duration) (*storage.Claim, error)
+	GetActiveClaimFn func(ctx context.Context, slug string) (*storage.Claim, error)
 }
 
 // --- ConstitutionBackend ---
@@ -412,6 +419,42 @@ func (s *StubBackend) ClaimSlice(ctx context.Context, slug, assignee string) (*s
 func (s *StubBackend) CompleteSlice(ctx context.Context, slug string) (*storage.Slice, error) {
 	if s.CompleteSliceFn != nil {
 		return s.CompleteSliceFn(ctx, slug)
+	}
+	return nil, nil
+}
+
+// --- ClaimBackend ---
+
+// ClaimSpec dispatches to ClaimSpecFn.
+func (s *StubBackend) ClaimSpec(ctx context.Context, slug, agent string, leaseDuration time.Duration) (*storage.Claim, error) {
+	if s.ClaimSpecFn != nil {
+		return s.ClaimSpecFn(ctx, slug, agent, leaseDuration)
+	}
+	return nil, nil
+}
+
+// UnclaimSpec dispatches to UnclaimSpecFn.
+func (s *StubBackend) UnclaimSpec(ctx context.Context, slug, agent string) error {
+	if s.UnclaimSpecFn != nil {
+		return s.UnclaimSpecFn(ctx, slug, agent)
+	}
+	return nil
+}
+
+// Heartbeat dispatches to HeartbeatFn.
+func (s *StubBackend) Heartbeat(ctx context.Context, slug, agent string, extendBy time.Duration) (*storage.Claim, error) {
+	if s.HeartbeatFn != nil {
+		return s.HeartbeatFn(ctx, slug, agent, extendBy)
+	}
+	return nil, nil
+}
+
+// GetActiveClaim dispatches to GetActiveClaimFn. Unset returns nil
+// (unclaimed) and no error, matching the production semantics on a
+// spec that has no active lease.
+func (s *StubBackend) GetActiveClaim(ctx context.Context, slug string) (*storage.Claim, error) {
+	if s.GetActiveClaimFn != nil {
+		return s.GetActiveClaimFn(ctx, slug)
 	}
 	return nil, nil
 }

--- a/internal/server/convert_execution.go
+++ b/internal/server/convert_execution.go
@@ -216,12 +216,8 @@ func primeProjectViewToProto(v *prime.ProjectView) (*specv1.ProjectView, error) 
 }
 
 // primeSpecViewToProto converts a domain SpecView to its proto
-// representation.
-//
-// Claims is intentionally left nil because the storage layer exposes no
-// public read for the active claim; the renderer in internal/render
-// skips the section when Claims is empty. See internal/prime/prime.go
-// for the rationale and follow-up.
+// representation. The semantically 1:1 Claims slice carries zero or one
+// active claim (populated by Composer.Spec from ClaimBackend.GetActiveClaim).
 func primeSpecViewToProto(v *prime.SpecView) (*specv1.SpecView, error) {
 	if v == nil {
 		return nil, nil
@@ -242,13 +238,20 @@ func primeSpecViewToProto(v *prime.SpecView) (*specv1.SpecView, error) {
 	if err != nil {
 		return nil, fmt.Errorf("primeSpecViewToProto: blockers: %w", err)
 	}
+	claims := make([]*specv1.Claim, 0, len(v.Claims))
+	for _, c := range v.Claims {
+		if c == nil {
+			continue
+		}
+		claims = append(claims, claimToProto(c))
+	}
 	return &specv1.SpecView{
 		Spec:                   spec,
 		Constitution:           constitutionToProto(v.Constitution),
 		ConstitutionProvenance: provenanceEntriesToProto(v.ConstitutionProvenance),
 		Decisions:              decisions,
 		Slices:                 slices,
-		// Claims intentionally left nil — see doc comment above.
-		Blockers: blockers,
+		Claims:                 claims,
+		Blockers:               blockers,
 	}, nil
 }

--- a/internal/server/convert_execution_test.go
+++ b/internal/server/convert_execution_test.go
@@ -161,11 +161,59 @@ func TestPrimeSpecViewToProto_Basic(t *testing.T) {
 	assert.Equal(t, "use-x", pb.Decisions[0].Slug)
 	require.Len(t, pb.Slices, 1)
 	assert.Equal(t, "build-thing/slice-1", pb.Slices[0].Slug)
-	// Claims intentionally not populated by the converter.
+	// Claims left empty in this fixture; TestPrimeSpecViewToProto_WithClaim
+	// covers the populated path.
 	assert.Empty(t, pb.Claims)
 	require.Len(t, pb.Blockers, 1)
 	assert.Equal(t, "evt-1", pb.Blockers[0].Id)
 	assert.Equal(t, specv1.ExecutionEventType_EXECUTION_EVENT_TYPE_BLOCKER, pb.Blockers[0].Type)
+}
+
+func TestPrimeSpecViewToProto_WithClaim(t *testing.T) {
+	claimedAt := time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC)
+	expires := time.Date(2026, 5, 22, 10, 30, 0, 0, time.UTC)
+	v := &prime.SpecView{
+		Spec: &storage.Spec{
+			ID:         "spec-1",
+			Slug:       "claimed-thing",
+			Intent:     "x",
+			Stage:      storage.SpecStageApproved,
+			Provenance: storage.SpecProvenanceAuthored,
+			Version:    1,
+			CreatedAt:  claimedAt,
+			UpdatedAt:  claimedAt,
+		},
+		Claims: []*storage.Claim{
+			{
+				Slug:         "claimed-thing",
+				Agent:        "polecat-7",
+				ClaimedAt:    claimedAt,
+				LeaseExpires: expires,
+			},
+		},
+	}
+	pb, err := primeSpecViewToProto(v)
+	require.NoError(t, err)
+	require.Len(t, pb.Claims, 1)
+	assert.Equal(t, "polecat-7", pb.Claims[0].GetAgent())
+	assert.Equal(t, expires, pb.Claims[0].GetLeaseExpires().AsTime())
+}
+
+func TestPrimeSpecViewToProto_NilClaimSkipped(t *testing.T) {
+	v := &prime.SpecView{
+		Spec: &storage.Spec{
+			ID:         "spec-1",
+			Slug:       "demo",
+			Intent:     "x",
+			Stage:      storage.SpecStageApproved,
+			Provenance: storage.SpecProvenanceAuthored,
+			Version:    1,
+		},
+		Claims: []*storage.Claim{nil},
+	}
+	pb, err := primeSpecViewToProto(v)
+	require.NoError(t, err)
+	assert.Empty(t, pb.Claims, "nil entries must not be carried into the proto slice")
 }
 
 func TestPrimeSpecViewToProto_BlockersOnly(t *testing.T) {

--- a/internal/server/error_sanitize_test.go
+++ b/internal/server/error_sanitize_test.go
@@ -126,6 +126,10 @@ func (errorBackend) Heartbeat(context.Context, string, string, time.Duration) (*
 	return nil, errRawDB
 }
 
+func (errorBackend) GetActiveClaim(context.Context, string) (*storage.Claim, error) {
+	return nil, errRawDB
+}
+
 func (errorBackend) CreateDecision(context.Context, string, string, string, string, string,
 	[]storage.RejectedAlternative, storage.DecisionConfidence,
 	[]string, storage.DecisionScope, string, string,

--- a/internal/server/execution_handler_test.go
+++ b/internal/server/execution_handler_test.go
@@ -209,6 +209,12 @@ func (m *mockExecutionBackend) ReleaseExpiredClaims(_ context.Context) (int, err
 	return 0, nil
 }
 
+// GetActiveClaim returns nil (unclaimed) by default — sufficient for the
+// existing prime-handler tests that don't exercise the claims path.
+func (m *mockExecutionBackend) GetActiveClaim(_ context.Context, _ string) (*storage.Claim, error) {
+	return nil, nil
+}
+
 // seedBundle adds a bundle to the mock for a given slug.
 func (m *mockExecutionBackend) seedBundle(slug string, b *storage.Bundle) { //nolint:unparam // test helper; slug param kept for clarity
 	m.mu.Lock()

--- a/internal/server/test_scoper_test.go
+++ b/internal/server/test_scoper_test.go
@@ -141,6 +141,10 @@ func (stubBackend) Heartbeat(context.Context, string, string, time.Duration) (*s
 	return nil, errNotImplemented
 }
 
+func (stubBackend) GetActiveClaim(context.Context, string) (*storage.Claim, error) {
+	return nil, errNotImplemented
+}
+
 // --- ConstitutionBackend ---
 
 func (stubBackend) GetConstitutionLayer(_ context.Context, _ storage.ConstitutionLayer) (*storage.Constitution, error) {

--- a/internal/storage/claim.go
+++ b/internal/storage/claim.go
@@ -18,4 +18,10 @@ type ClaimBackend interface {
 
 	// Heartbeat extends the lease for a claimed spec.
 	Heartbeat(ctx context.Context, slug, agent string, extendBy time.Duration) (*Claim, error)
+
+	// GetActiveClaim returns the currently active (non-expired) claim for
+	// the given spec, or nil if the spec is unclaimed. Used by the prime
+	// composer to populate SpecView.Claims; expired claims are filtered
+	// out at the storage layer so callers do not have to check lease times.
+	GetActiveClaim(ctx context.Context, slug string) (*Claim, error)
 }

--- a/internal/storage/postgres/claim_test.go
+++ b/internal/storage/postgres/claim_test.go
@@ -159,3 +159,55 @@ func TestHeartbeat_NoActiveClaim(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no active claim")
 }
+
+func TestGetActiveClaim_Unclaimed(t *testing.T) {
+	store := newStore(t)
+	clearDatabase(t, store)
+	ctx := context.Background()
+
+	_, err := store.CreateSpec(ctx, "gac-unclaimed", "intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	claim, err := store.GetActiveClaim(ctx, "gac-unclaimed")
+	require.NoError(t, err)
+	require.Nil(t, claim, "unclaimed spec should return nil + no error")
+}
+
+func TestGetActiveClaim_Active(t *testing.T) {
+	store := newStore(t)
+	clearDatabase(t, store)
+	ctx := context.Background()
+
+	_, err := store.CreateSpec(ctx, "gac-active", "intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	_, err = store.ClaimSpec(ctx, "gac-active", "agent-a", 5*time.Minute)
+	require.NoError(t, err)
+
+	claim, err := store.GetActiveClaim(ctx, "gac-active")
+	require.NoError(t, err)
+	require.NotNil(t, claim)
+	require.Equal(t, "gac-active", claim.Slug)
+	require.Equal(t, "agent-a", claim.Agent)
+	require.True(t, claim.LeaseExpires.After(time.Now()))
+}
+
+func TestGetActiveClaim_ExpiredFilteredOut(t *testing.T) {
+	ctx := context.Background()
+	// Use a fixed past clock so the lease is written with lease_expires in
+	// the past relative to wall-clock "now".
+	fixedPast := time.Now().Add(-30 * time.Minute)
+	pastStore := newStore(t, postgres.WithClock(func() time.Time { return fixedPast }))
+	clearDatabase(t, pastStore)
+
+	_, err := pastStore.CreateSpec(ctx, "gac-expired", "intent", "", "", storage.SpecProvenanceAuthored, storage.SpecProvenanceDetail{}, nil, nil, nil, nil)
+	require.NoError(t, err)
+	_, err = pastStore.ClaimSpec(ctx, "gac-expired", "agent-a", 5*time.Minute)
+	require.NoError(t, err)
+
+	// Real-time store sees lease_expires < now → no active claim.
+	store := newStore(t)
+	claim, err := store.GetActiveClaim(ctx, "gac-expired")
+	require.NoError(t, err)
+	require.Nil(t, claim, "expired lease should be filtered out at the storage layer")
+}

--- a/internal/storage/postgres/execution.go
+++ b/internal/storage/postgres/execution.go
@@ -35,7 +35,7 @@ func (s *Store) GenerateBundle(ctx context.Context, slug string) (*storage.Bundl
 		return nil, fmt.Errorf("postgres: generate bundle decisions: %w", err)
 	}
 
-	claim, err := s.fetchActiveClaim(ctx, slug)
+	claim, err := s.GetActiveClaim(ctx, slug)
 	if err != nil {
 		return nil, fmt.Errorf("postgres: generate bundle claim: %w", err)
 	}
@@ -321,8 +321,9 @@ func (s *Store) ReleaseExpiredClaims(ctx context.Context) (int, error) {
 	return count, err
 }
 
-// fetchActiveClaim returns the active (non-expired) claim for a spec, or nil if unclaimed.
-func (s *Store) fetchActiveClaim(ctx context.Context, slug string) (*storage.Claim, error) {
+// GetActiveClaim returns the active (non-expired) claim for a spec, or nil
+// if the spec is unclaimed. Implements storage.ClaimBackend.GetActiveClaim.
+func (s *Store) GetActiveClaim(ctx context.Context, slug string) (*storage.Claim, error) {
 	now := s.now()
 	var agent string
 	var claimedAt, leaseExpires time.Time


### PR DESCRIPTION
## Summary

Closes the Claims-shaped hole left in PR #960 (spgr-8ar Piece E). The proto \`SpecView.claims\` field existed but was always empty because no public storage method exposed the active lease — \`fetchActiveClaim\` was private to the Postgres impl.

This PR:

- Promotes \`*Store.fetchActiveClaim\` to a public \`ClaimBackend.GetActiveClaim(ctx, slug) (*Claim, error)\` (the receiver name is the only change; same SQL, same expired-lease filter at the storage layer).
- Embeds \`storage.ClaimBackend\` in \`internal/prime.Backend\` so the composer's wide aggregate gains the method.
- Updates \`internal/prime.Composer.Spec\` to call \`GetActiveClaim\` and populate the new \`SpecView.Claims []*Claim\` field with zero or one entry (the lease model is 1:1, but the field stays a slice to match the proto \`repeated claims\` shape).
- Updates \`primeSpecViewToProto\` to carry Claims into the response.
- The renderer Claims section (added in Piece E) already handled the populated case; no renderer change.

No schema or query changes; no behavior change for callers that don't read \`SpecView.Claims\`.

## Test plan

- [x] \`task check\` (fmt, lint, build, unit) — pass
- [x] \`task test:integration\` — pass (includes 3 new postgres claim tests: unclaimed, active, expired-filtered)
- [x] \`go test -tags e2e ./e2e/api/ -count=1\` — pass
- [x] New unit tests: \`TestComposer_Spec_{NoActiveClaim,WithActiveClaim,GetActiveClaimError_BubblesUp}\`, \`TestPrimeSpecViewToProto_{WithClaim,NilClaimSkipped}\`, \`TestGetActiveClaim_{Unclaimed,Active,ExpiredFilteredOut}\`

Closes: spgr-cxkg

🤖 Generated with [Claude Code](https://claude.com/claude-code)