### PR TITLE
docs(plans): identity epic implementation plans (storage, authn, Cedar, bootstrap-UX 4a+4b)

### DIFF
--- a/docs/plans/2026-05-26-identity-authn-implementation-plan.md
+++ b/docs/plans/2026-05-26-identity-authn-implementation-plan.md
@@ -1,0 +1,4220 @@
+# Identity Authn Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the Identity Authn layer specified in `docs/plans/2026-05-22-identity-authn-design.md` — collapse the multi-store routing into one `Resolver.Resolve(ctx, token)` method backed by the new `UsersBackend` (from the Storage plan), split `OIDCStore` into a thin verifier, add JIT user creation with per-issuer rate limiting and email-domain allowlist, and introduce the `Authorizer` interface as the seam between authz mechanisms (static table now, Cedar later).
+
+**Architecture:** Build alongside, then switch, then delete. New `Resolver` interface and `pgIdentityStore` impl live as siblings to the existing `IdentityStore`/`CompositeStore` until everything is wired and tested; the cutover happens in one focused task (#23); old code is removed in #26 once `go build ./...` is green without it. Every task in this plan ends with a compiling, testable package. No half-broken intermediate states.
+
+**Tech Stack:** Go 1.x, ConnectRPC, pgx v5 (via `UsersBackend`), `github.com/coreos/go-oidc/v3` (existing), `github.com/go-jose/go-jose/v4` (existing transitive), `golang.org/x/time/rate` (new dep for per-issuer rate limiting).
+
+**Implements bead:** Implementation of approved design `spgr-n2rw` under epic `spgr-rjrt`. Depends on the Storage plan (`spgr-e82m`) being merged first.
+
+---
+
+## Testing approach
+
+Uses the same four-category framework defined in the Storage plan. Recap:
+
+- **Happy** — normal success per code path.
+- **Invariants** — system-wide rules (soft-deleted user can't authenticate; ClaimsMapping evaluates only at JIT; rate-limit applies per-issuer not globally).
+- **Boundaries** — edges (malformed tokens, NotFound credentials, rate exhaustion, allowlist miss, error categorization).
+- **E2E** — multi-component flows through Resolver → Authorizer → Decision.
+
+Each behavior-introducing task tags categories under `**Covers:**`. Unit tests use a hand-rolled `UsersBackend` stub (Task 8); integration tests reuse the testcontainer harness from Storage via the **exported** `postgrestest.SharedPool(t, ctx)` helper (Storage plan Task 32 — the in-package `sharedTestPool` is not importable cross-package), `//go:build integration`.
+
+---
+
+## File Structure
+
+**Create (Phase A — alongside the old code):**
+
+- `internal/auth/authorizer.go` — `Authorizer` interface + `Decision` type.
+- `internal/auth/static_authorizer.go` — `StaticTableAuthorizer` impl.
+- `internal/auth/static_authorizer_test.go` — unit tests.
+- `internal/auth/oidc_verifier.go` — `OIDCVerifier` type (thin JWT verifier) + `OIDCClaims` struct. Sibling to existing `oidc_store.go`.
+- `internal/auth/oidc_verifier_test.go` — unit tests against an httptest OIDC issuer.
+- `internal/auth/resolver.go` — new `Resolver` interface (single `Resolve` method).
+- `internal/auth/identitystore.go` — `pgIdentityStore` impl of `Resolver`. Sibling to existing `CompositeStore`.
+- `internal/auth/identitystore_test.go` — unit tests (with `UsersBackend` stub).
+- `internal/auth/identitystore_jit_test.go` — JIT-path tests (rate limit, email allowlist).
+- `internal/auth/identitystore_integration_test.go` — integration tests (real `AuthStore`).
+- `internal/auth/usersbackend_stub_test.go` — hand-rolled `UsersBackend` stub for unit tests.
+- `internal/auth/usagetracker/usagetracker.go` — async batched `TouchLastUsed` updater.
+- `internal/auth/usagetracker/usagetracker_test.go` — unit tests.
+
+**Modify (Phase A — additive only):**
+
+- `internal/auth/auth.go` — Add `UserID`, `EffectiveRole`, `Email` to `Identity` struct. **Do not remove `Permissions` yet** — old consumers still use it. The cleanup happens in Phase C after old code is deleted.
+- `internal/auth/store.go` — Add `ErrUnauthenticated` and `ErrTransient` sentinels. Keep old sentinels in place.
+
+**Modify (Phase B — the switch):**
+
+- `internal/auth/interceptor.go` — change signature from `NewAuthInterceptor(store IdentityStore)` to `NewAuthInterceptor(resolver Resolver, authorizer Authorizer)`; call `resolver.Resolve` + `authorizer.Authorize`; map errors per the design's three categories; preserve cookie fallback.
+- `internal/auth/middleware.go` — same shape change for HTTP cookie path.
+- `cmd/specgraph/serve.go` — construct `pgIdentityStore`, `StaticTableAuthorizer`, `usagetracker.Manager`; remove `ConfigStore`/`CompositeStore` instantiation; remove `auth.Bootstrap()` invocation (moves to Bootstrap & UX plan); remove `cfg.Auth.Mode` validation.
+
+**Delete (Phase C — once nothing references them):**
+
+- `internal/auth/config_store.go` + `config_store_test.go`
+- `internal/auth/composite_store.go` + `composite_store_test.go`
+- `internal/auth/token_store.go` + `token_store_test.go`
+- `internal/auth/oidc_store.go` + `oidc_store_test.go`
+- Old sentinels in `store.go` (`ErrUnknownKey`, `ErrNoOIDC`, `ErrUnknownIssuer`, `ErrInvalidToken`).
+- `IdentityStore` interface (replaced by `Resolver`).
+- `Identity.Permissions` field (now unreferenced).
+- `auth.HasPermission` exported helper (moves into `static_authorizer.go` as `hasPermissionInternal`).
+- `auth.Bootstrap()` and friends move to the Bootstrap & UX plan; gone from `internal/auth/bootstrap.go` here.
+
+**Don't touch:** `internal/auth/permissions.go` (`rpcPermissions` table) — survives this plan; consumed by `StaticTableAuthorizer`. The Cedar plan removes it.
+
+---
+
+## Task 1: Add new fields to `Identity` additively
+
+The Identity struct gains `UserID`, `EffectiveRole`, `Email` without losing anything. Existing consumers continue to work because they don't reference the new fields; new code paths read them as they come online.
+
+**Files:**
+
+- Modify: `internal/auth/auth.go`
+
+**Covers:** N/A (type-only change; behavior tests in later tasks).
+
+- [ ] **Step 1: Update the struct**
+
+Replace the existing `Identity` declaration with:
+
+```go
+// Identity represents an authenticated principal. Produced by Resolver.Resolve
+// (or, until the Phase B cutover, by the legacy IdentityStore methods);
+// consumed by the interceptor and by Authorizer implementations.
+//
+// Subject keeps its original namespacing format ("apikey:<id>", "oidc:<sub>",
+// historically "local:<user>") for log-filter and dashboard compatibility.
+// After Phase B the "local:" prefix is no longer produced; the constant is
+// retained as a historical comment only.
+type Identity struct {
+	// New fields (populated by Resolver.Resolve from Task 12 onward).
+	UserID        string // uuid (storage.User.ID); empty for legacy paths
+	EffectiveRole Role   // min(Role, key.RoleDowngrade); equals Role for OIDC
+	Email         string // from User row; populated by new resolver only
+
+	// Existing fields.
+	Subject     string          // "apikey:<id>" | "oidc:<sub>" | (legacy) "local:<user>"
+	DisplayName string          // human-friendly name
+	Role        Role            // role name (built-in or custom)
+	Permissions map[string]bool // raw entries from role definition (legacy; removed in Phase C)
+	Source      string          // "local" | "apikey" | "oidc" ("local" removed in Phase C)
+}
+```
+
+- [ ] **Step 2: Verify compile**
+
+Run: `cd internal/auth && go build ./...`
+
+Expected: PASS. The new fields are zero-valued for existing consumers; nothing breaks.
+
+- [ ] **Step 3: Verify existing tests still pass**
+
+Run: `cd internal/auth && go test ./...`
+
+Expected: PASS (existing auth tests unaffected by additive change).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/auth/auth.go
+git commit -s -m "feat(auth): add UserID, EffectiveRole, Email to Identity (additive)"
+```
+
+---
+
+## Task 2: Add new sentinel errors
+
+The new resolver produces `ErrUnauthenticated` and `ErrTransient` so the interceptor can map them to distinct HTTP codes (401 vs 503). Existing sentinels stay; they'll be removed in Phase C.
+
+**Files:**
+
+- Modify: `internal/auth/store.go`
+
+**Covers:** N/A (definitions only).
+
+- [ ] **Step 1: Append new sentinels**
+
+In `internal/auth/store.go`, before the `IdentityStore` interface declaration, add:
+
+```go
+// ErrUnauthenticated indicates a credential failure: missing, malformed,
+// expired, revoked, soft-deleted user, JIT-rate-limited, allowlist
+// mismatch, or any other "this principal isn't allowed to authenticate"
+// condition. The interceptor maps this to connect.CodeUnauthenticated.
+//
+// Produced by the new Resolver impl (pgIdentityStore). The legacy
+// IdentityStore methods still produce ErrUnknownKey etc. until Phase C.
+var ErrUnauthenticated = errors.New("auth: unauthenticated")
+
+// ErrTransient indicates a backend failure unrelated to the credential:
+// database unavailable, pool exhausted, network timeout. The interceptor
+// maps this to connect.CodeUnavailable so callers know to retry.
+//
+// Errors of this kind wrap the underlying cause; tests use errors.Is to
+// detect ErrTransient.
+var ErrTransient = errors.New("auth: transient backend error")
+```
+
+- [ ] **Step 2: Verify compile and existing tests**
+
+```bash
+cd internal/auth && go build ./... && go test ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/auth/store.go
+git commit -s -m "feat(auth): add ErrUnauthenticated and ErrTransient sentinels"
+```
+
+---
+
+## Task 3: Define the `Authorizer` interface
+
+The seam between today's static-table authz and the future Cedar engine. Defined now; consumed in Phase B's interceptor diff.
+
+**Files:**
+
+- Create: `internal/auth/authorizer.go`
+
+**Covers:** N/A.
+
+- [ ] **Step 1: Write the file**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import "context"
+
+// Authorizer decides whether a resolved Identity may invoke procedure
+// with the given request body. The current StaticTableAuthorizer impl
+// (static_authorizer.go) consults the static rpcPermissions table;
+// the Cedar plan will add a CedarAuthorizer impl that swaps in without
+// any caller changes.
+//
+// req carries the unmarshaled request body so future authorizers
+// (Cedar, ownership rules) can inspect resource attributes. Today's
+// StaticTableAuthorizer ignores req.
+type Authorizer interface {
+	Authorize(ctx context.Context, id *Identity, procedure string, req any) (Decision, error)
+}
+
+// Decision is the outcome of an Authorize call.
+//
+// Allowed=true means the handler should run. Allowed=false means the
+// interceptor returns connect.CodePermissionDenied.
+//
+// Reason carries a short structured tag for audit emission and logging
+// (e.g., "static-table-allow:spec:read", "cedar-deny:no-policy-matched").
+// The interceptor does not parse it.
+type Decision struct {
+	Allowed bool
+	Reason  string
+}
+```
+
+- [ ] **Step 2: Verify compile**
+
+Run: `cd internal/auth && go build ./...`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/auth/authorizer.go
+git commit -s -m "feat(auth): define Authorizer interface (seam for static-table vs Cedar)"
+```
+
+---
+
+## Task 4: Implement `StaticTableAuthorizer`
+
+The current authz mechanism, wrapped in the new interface so the Cedar plan can swap it out with one new file.
+
+**Files:**
+
+- Create: `internal/auth/static_authorizer.go`
+- Create: `internal/auth/static_authorizer_test.go`
+
+**Covers:** Happy (allow on match) + Boundary (deny on role-mismatch, error on unconfigured procedure).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+)
+
+func TestStaticTableAuthorizer_AllowOnMatch(t *testing.T) {
+	a := auth.NewStaticTableAuthorizer(map[auth.Role][]string{
+		auth.RoleReader: {"*:read"},
+	})
+	id := &auth.Identity{Role: auth.RoleReader, EffectiveRole: auth.RoleReader}
+	d, err := a.Authorize(context.Background(), id,
+		specgraphv1connect.SpecServiceGetSpecProcedure, nil)
+	require.NoError(t, err)
+	require.True(t, d.Allowed)
+	require.Contains(t, d.Reason, "static-table-allow")
+}
+
+func TestStaticTableAuthorizer_DenyOnRoleMismatch(t *testing.T) {
+	a := auth.NewStaticTableAuthorizer(map[auth.Role][]string{
+		auth.RoleReader: {"*:read"},
+	})
+	id := &auth.Identity{Role: auth.RoleReader, EffectiveRole: auth.RoleReader}
+	d, err := a.Authorize(context.Background(), id,
+		specgraphv1connect.SpecServiceCreateSpecProcedure, nil)
+	require.NoError(t, err)
+	require.False(t, d.Allowed)
+	require.Contains(t, d.Reason, "static-table-deny")
+}
+
+func TestStaticTableAuthorizer_ErrorOnUnconfigured(t *testing.T) {
+	a := auth.NewStaticTableAuthorizer(nil)
+	id := &auth.Identity{Role: auth.RoleAdmin, EffectiveRole: auth.RoleAdmin}
+	_, err := a.Authorize(context.Background(), id, "/unconfigured/procedure", nil)
+	require.Error(t, err)
+}
+
+func TestStaticTableAuthorizer_AdminWildcard(t *testing.T) {
+	a := auth.NewStaticTableAuthorizer(map[auth.Role][]string{
+		auth.RoleAdmin: {"*:*"},
+	})
+	id := &auth.Identity{Role: auth.RoleAdmin, EffectiveRole: auth.RoleAdmin}
+	d, err := a.Authorize(context.Background(), id,
+		specgraphv1connect.SpecServiceCreateSpecProcedure, nil)
+	require.NoError(t, err)
+	require.True(t, d.Allowed)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestStaticTableAuthorizer' -v`
+
+Expected: FAIL ("undefined: auth.NewStaticTableAuthorizer").
+
+- [ ] **Step 3: Write the impl**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/specgraph/specgraph/internal/config"
+)
+
+// DefaultRolePermissions defines the built-in role permission bundles.
+//
+// RELOCATED here from config_store.go in this task. config_store.go is
+// deleted in Task 30, but LoadRolePerms (below) and the legacy code both
+// reference DefaultRolePermissions, so it must live in a file that
+// survives. static_authorizer.go is the natural home (it owns role→perm
+// policy) and itself survives until the Cedar plan. See Step 3b for the
+// matching removal from config_store.go.
+var DefaultRolePermissions = map[Role][]string{
+	RoleReader: {"*:read"},
+	RoleWriter: {"*:read", "*:write"},
+	RoleAdmin:  {"*:*"},
+}
+
+// StaticTableAuthorizer implements Authorizer by consulting the static
+// rpcPermissions table (permissions.go) and a snapshot of role→permissions
+// loaded at construction time. This impl will be deleted when the Cedar
+// plan introduces CedarAuthorizer.
+type StaticTableAuthorizer struct {
+	rolePerms map[Role]map[string]bool
+}
+
+// NewStaticTableAuthorizer builds a StaticTableAuthorizer from a
+// role→[]permission mapping. The constructor expands the lists into a
+// per-role lookup map for cheap membership checks at Authorize time.
+//
+// rolePerms is typically built by LoadRolePerms(cfg.Auth.Roles) — see
+// `LoadRolePerms` (exported) in this file.
+func NewStaticTableAuthorizer(rolePerms map[Role][]string) *StaticTableAuthorizer {
+	expanded := make(map[Role]map[string]bool, len(rolePerms))
+	for role, perms := range rolePerms {
+		entry := make(map[string]bool, len(perms))
+		for _, p := range perms {
+			entry[p] = true
+		}
+		expanded[role] = entry
+	}
+	return &StaticTableAuthorizer{rolePerms: expanded}
+}
+
+// Authorize implements the Authorizer interface.
+func (a *StaticTableAuthorizer) Authorize(_ context.Context, id *Identity, procedure string, _ any) (Decision, error) {
+	required, ok := rpcPermissions[procedure]
+	if !ok {
+		return Decision{}, fmt.Errorf("static-table: unconfigured procedure %q", procedure)
+	}
+	perms, ok := a.rolePerms[id.EffectiveRole]
+	if !ok {
+		return Decision{
+			Allowed: false,
+			Reason:  fmt.Sprintf("static-table-deny:unknown-role:%s", id.EffectiveRole),
+		}, nil
+	}
+	if hasPermissionInternal(perms, required) {
+		return Decision{
+			Allowed: true,
+			Reason:  fmt.Sprintf("static-table-allow:%s", required),
+		}, nil
+	}
+	return Decision{
+		Allowed: false,
+		Reason:  fmt.Sprintf("static-table-deny:%s not in %s", required, id.EffectiveRole),
+	}, nil
+}
+
+// hasPermissionInternal is the wildcard-matching helper used by
+// StaticTableAuthorizer. The same logic is temporarily duplicated in the
+// exported auth.HasPermission (still consumed by legacy code in Phase A).
+// The duplication is intentional and short-lived: Task 31 removes the
+// exported HasPermission once the legacy stores are gone, leaving this
+// package-private copy as the sole implementation. Package-private here
+// because no caller outside this struct should do raw perm checks — they
+// go through Authorize.
+func hasPermissionInternal(perms map[string]bool, required string) bool {
+	if len(perms) == 0 {
+		return false
+	}
+	if perms["*:*"] {
+		return true
+	}
+	if perms[required] {
+		return true
+	}
+	parts := strings.SplitN(required, ":", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	service, action := parts[0], parts[1]
+	if perms[service+":*"] {
+		return true
+	}
+	if perms["*:"+action] {
+		return true
+	}
+	return false
+}
+
+// LoadRolePerms builds the rolePerms map from the YAML auth.roles section
+// combined with the built-in DefaultRolePermissions. Exported so serve.go
+// (a different package) can construct both the StaticTableAuthorizer and
+// the KnownRoles set for JIT validation from a single source.
+//
+// custom is cfg.Auth.Roles from internal/config — a real named type, not
+// an anonymous struct. The auth package imports internal/config (already
+// imported elsewhere in the package, e.g., OIDCVerifier).
+func LoadRolePerms(custom map[string]config.RoleConfig) map[Role][]string {
+	out := make(map[Role][]string, len(DefaultRolePermissions)+len(custom))
+	for role, perms := range DefaultRolePermissions {
+		out[role] = append([]string(nil), perms...)
+	}
+	for name, rc := range custom {
+		out[Role(name)] = append([]string(nil), rc.Permissions...)
+	}
+	return out
+}
+```
+
+- [ ] **Step 3b: Remove the now-relocated var from `config_store.go`**
+
+`DefaultRolePermissions` now lives in `static_authorizer.go`. Delete the duplicate declaration from `internal/auth/config_store.go` (the `var DefaultRolePermissions = map[Role][]string{...}` block, ~lines 22-27) to avoid a duplicate-package-var compile error. Leave config_store.go's *usage* of it (e.g., `for role, perms := range DefaultRolePermissions`) intact — it still resolves, because the var is now defined elsewhere in the same `auth` package. config_store.go itself is deleted later in Task 30; this step just prevents the duplicate definition in the interim.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/auth && go build ./... && go test -run 'TestStaticTableAuthorizer' -v`
+
+Expected: build PASS (no duplicate `DefaultRolePermissions`), tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/static_authorizer.go internal/auth/static_authorizer_test.go internal/auth/config_store.go
+git commit -s -m "feat(auth): add StaticTableAuthorizer; relocate DefaultRolePermissions to survive Task 30"
+```
+
+---
+
+## Task 5: Create `OIDCVerifier` alongside `OIDCStore`
+
+Sibling to the existing `oidc_store.go` — no rename, no deletion. Both exist; the new resolver uses `OIDCVerifier`, the old `CompositeStore` keeps using `OIDCStore` until the Phase B cutover.
+
+**Files:**
+
+- Create: `internal/auth/oidc_verifier.go`
+
+**Covers:** N/A (behavior tests in Task 6).
+
+- [ ] **Step 1: Write the file**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+
+	"github.com/specgraph/specgraph/internal/config"
+)
+
+// OIDCClaims is the verified claim payload returned by OIDCVerifier.Verify.
+// Subject and Email are unmarshaled for convenience; Raw retains all claims
+// for downstream ClaimsMapping evaluation at JIT time.
+type OIDCClaims struct {
+	Issuer  string
+	Subject string
+	Email   string
+	Raw     map[string]json.RawMessage
+}
+
+// OIDCVerifier verifies JWTs against a single OIDC provider. Successor to
+// OIDCStore: no DB dependency, no role computation, no Identity construction.
+// The resolver materializes the Identity from claims; the verifier just
+// validates signature/audience/expiry.
+type OIDCVerifier struct {
+	providerID string
+	issuer     string
+	verifier   *oidc.IDTokenVerifier
+}
+
+// NewOIDCVerifier discovers the OIDC provider configuration and builds a
+// JWT verifier. ctx should carry a startup deadline (e.g., 10s).
+func NewOIDCVerifier(ctx context.Context, cfg config.OIDCProviderConfig) (*OIDCVerifier, error) {
+	provider, err := oidc.NewProvider(ctx, cfg.Issuer)
+	if err != nil {
+		return nil, fmt.Errorf("discover OIDC provider %s: %w", cfg.ID, err)
+	}
+	audience := cfg.Audience
+	if audience == "" {
+		audience = cfg.ClientID
+	}
+	verifier := provider.Verifier(&oidc.Config{ClientID: audience})
+	return &OIDCVerifier{
+		providerID: cfg.ID,
+		issuer:     cfg.Issuer,
+		verifier:   verifier,
+	}, nil
+}
+
+// Issuer returns the OIDC issuer URL.
+func (v *OIDCVerifier) Issuer() string { return v.issuer }
+
+// ProviderID returns the configured provider ID (used in logs).
+func (v *OIDCVerifier) ProviderID() string { return v.providerID }
+
+// Verify validates the token's signature, audience, and expiry. On success
+// returns the decoded claims; on failure returns a wrapped error.
+//
+// The resolver maps any error from this function to ErrUnauthenticated;
+// callers should not try to distinguish verification failure modes.
+func (v *OIDCVerifier) Verify(ctx context.Context, rawToken string) (*OIDCClaims, error) {
+	idToken, err := v.verifier.Verify(ctx, rawToken)
+	if err != nil {
+		slog.Warn("auth: OIDC token verification failed",
+			"provider", v.providerID, "error", err.Error())
+		return nil, fmt.Errorf("oidc verify: %w", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := idToken.Claims(&raw); err != nil {
+		return nil, fmt.Errorf("extract claims: %w", err)
+	}
+	c := &OIDCClaims{
+		Issuer:  idToken.Issuer,
+		Subject: idToken.Subject,
+		Raw:     raw,
+	}
+	if rawEmail, ok := raw["email"]; ok {
+		var email string
+		if jsonErr := json.Unmarshal(rawEmail, &email); jsonErr == nil {
+			c.Email = email
+		}
+	}
+	return c, nil
+}
+```
+
+- [ ] **Step 2: Verify compile**
+
+Run: `cd internal/auth && go build ./...`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/auth/oidc_verifier.go
+git commit -s -m "feat(auth): add OIDCVerifier alongside OIDCStore"
+```
+
+---
+
+## Task 6: Test `OIDCVerifier`
+
+Pull the test issuer pattern from the existing `oidc_store_test.go` (which is still in place — it'll be deleted in Phase C). Adapt for the new `OIDCVerifier` shape.
+
+**Files:**
+
+- Create: `internal/auth/oidc_verifier_test.go`
+
+**Covers:** Happy (valid token) + Boundary (bad audience, expired, malformed).
+
+- [ ] **Step 1: Write the test harness and failing tests**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/config"
+)
+
+// oidcTestIssuer spins up an httptest server serving OIDC discovery + JWKS.
+// Tests mint JWTs signed with its private key.
+type oidcTestIssuer struct {
+	server *httptest.Server
+	key    *rsa.PrivateKey
+}
+
+func newOIDCTestIssuer(t *testing.T) *oidcTestIssuer {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	mux := http.NewServeMux()
+	var srv *httptest.Server
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":   srv.URL,
+			"jwks_uri": srv.URL + "/jwks",
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
+		jwk := jose.JSONWebKey{Key: &key.PublicKey, KeyID: "k1", Algorithm: string(jose.RS256), Use: "sig"}
+		_ = json.NewEncoder(w).Encode(jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}})
+	})
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return &oidcTestIssuer{server: srv, key: key}
+}
+
+func (p *oidcTestIssuer) mintToken(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: p.key},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", "k1"),
+	)
+	require.NoError(t, err)
+	raw, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+	return raw
+}
+
+func TestOIDCVerifier_VerifyValidToken(t *testing.T) {
+	ctx := context.Background()
+	p := newOIDCTestIssuer(t)
+	v, err := auth.NewOIDCVerifier(ctx, config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "aud-1",
+	})
+	require.NoError(t, err)
+
+	token := p.mintToken(t, map[string]any{
+		"iss":   p.server.URL,
+		"sub":   "user-123",
+		"aud":   "aud-1",
+		"exp":   time.Now().Add(time.Hour).Unix(),
+		"iat":   time.Now().Unix(),
+		"email": "alice@example.com",
+	})
+	claims, err := v.Verify(ctx, token)
+	require.NoError(t, err)
+	require.Equal(t, "user-123", claims.Subject)
+	require.Equal(t, "alice@example.com", claims.Email)
+}
+
+func TestOIDCVerifier_RejectsBadAudience(t *testing.T) {
+	ctx := context.Background()
+	p := newOIDCTestIssuer(t)
+	v, err := auth.NewOIDCVerifier(ctx, config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "expected",
+	})
+	require.NoError(t, err)
+	token := p.mintToken(t, map[string]any{
+		"iss": p.server.URL, "sub": "u", "aud": "wrong",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+	})
+	_, err = v.Verify(ctx, token)
+	require.Error(t, err)
+}
+
+func TestOIDCVerifier_RejectsExpired(t *testing.T) {
+	ctx := context.Background()
+	p := newOIDCTestIssuer(t)
+	v, err := auth.NewOIDCVerifier(ctx, config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "aud-1",
+	})
+	require.NoError(t, err)
+	token := p.mintToken(t, map[string]any{
+		"iss": p.server.URL, "sub": "u", "aud": "aud-1",
+		"exp": time.Now().Add(-time.Hour).Unix(), "iat": time.Now().Add(-2 * time.Hour).Unix(),
+	})
+	_, err = v.Verify(ctx, token)
+	require.Error(t, err)
+}
+
+func TestOIDCVerifier_RejectsMalformed(t *testing.T) {
+	ctx := context.Background()
+	p := newOIDCTestIssuer(t)
+	v, err := auth.NewOIDCVerifier(ctx, config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "aud-1",
+	})
+	require.NoError(t, err)
+	_, err = v.Verify(ctx, "not.a.jwt")
+	require.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd internal/auth && go test -run 'TestOIDCVerifier' -v`
+
+Expected: PASS (the impl from Task 5 is real).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/auth/oidc_verifier_test.go
+git commit -s -m "test(auth): cover OIDCVerifier signature/audience/expiry checks"
+```
+
+---
+
+## Task 7: Define `Resolver` interface
+
+The new interface that `pgIdentityStore` will satisfy. Sibling to the legacy `IdentityStore`. The interceptor will switch from depending on `IdentityStore` to depending on `Resolver` in Phase B.
+
+**Files:**
+
+- Create: `internal/auth/resolver.go`
+
+**Covers:** N/A.
+
+- [ ] **Step 1: Write the file**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import "context"
+
+// Resolver dispatches an authentication token to an Identity. Successor
+// to the legacy IdentityStore interface (which routed across multiple
+// stores). The interceptor depends on Resolver after the Phase B cutover.
+type Resolver interface {
+	// Resolve returns the Identity for the given bearer token.
+	//
+	// Returns ErrUnauthenticated for any credential failure (missing,
+	// malformed, expired, revoked, soft-deleted, JIT-rate-limited,
+	// allowlist mismatch). Returns ErrTransient (wrapping the cause) for
+	// backend failures (DB down, pool exhausted, etc.). Propagates
+	// context.Canceled / context.DeadlineExceeded unwrapped.
+	Resolve(ctx context.Context, token string) (*Identity, error)
+
+	// HasAuth reports whether any non-bootstrap, non-deleted user
+	// exists. Used by warnIfNoAuthOnPublicListen at startup.
+	HasAuth(ctx context.Context) (bool, error)
+}
+```
+
+- [ ] **Step 2: Verify compile**
+
+Run: `cd internal/auth && go build ./...`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/auth/resolver.go
+git commit -s -m "feat(auth): define Resolver interface as successor to IdentityStore"
+```
+
+---
+
+## Task 8: Hand-rolled `UsersBackend` stub for unit tests
+
+Unit tests for the new `pgIdentityStore` mock `UsersBackend` rather than going to Postgres. The project doesn't use testify/mock; the stub is ~150 lines of method-pointer indirection.
+
+**Files:**
+
+- Create: `internal/auth/usersbackend_stub_test.go`
+
+**Covers:** N/A (test fixture).
+
+- [ ] **Step 1: Write the stub**
+
+This file is also the home for the shared PHC test fixtures (`stubPHCSecret`, `stubPHCHash`, `stubAPIKeyToken`) so they exist from Task 8 onward — `activeKey` references `stubPHCHash`, and later tasks (12–15, 33–34) reference all three. Defining them here avoids a forward reference that would break the "every task green" rule.
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"time"
+
+	"golang.org/x/crypto/argon2"
+
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// --- Shared API-key test fixtures ---
+
+// stubPHCSecret is the canonical 32-char test secret. It MUST be exactly
+// 32 characters to match the API-key parser's expected secret length
+// (apiKeySecretLen in identitystore.go). TestStubSecretLength guards this
+// at runtime. Do not change without updating nothing else — all tokens are
+// built from this constant via stubAPIKeyToken.
+const stubPHCSecret = "test-secret-32-chars-padding-aaa"
+
+// stubPHCHash is the argon2id PHC encoding of stubPHCSecret, computed once
+// in init() with the same parameters production uses. A token built by
+// stubAPIKeyToken verifies against this hash.
+var stubPHCHash string
+
+func init() {
+	salt := []byte("teststaltestsalt") // exactly 16 bytes
+	hash := argon2.IDKey([]byte(stubPHCSecret), salt, 2, 19456, 1, 32)
+	stubPHCHash = fmt.Sprintf("$argon2id$v=19$m=19456,t=2,p=1$%s$%s",
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(hash))
+}
+
+// stubAPIKeyToken builds a well-formed API-key token whose secret is
+// stubPHCSecret, so it verifies against stubPHCHash. Callers pass an
+// 8-char prefix.
+func stubAPIKeyToken(prefix string) string {
+	return "spgr_sk_" + prefix + "_" + stubPHCSecret
+}
+
+// usersBackendStub is a hand-rolled stub for storage.UsersBackend used
+// by Resolver unit tests. Each field is a function the test sets to
+// control behavior. Unset functions return a default that flags an
+// unexpected-call test bug.
+type usersBackendStub struct {
+	lookupAPIKey      func(ctx context.Context, prefix string) (*storage.APIKey, error)
+	lookupOIDCBinding func(ctx context.Context, issuer, subject string) (*storage.OIDCBinding, error)
+	getUserByID       func(ctx context.Context, id string) (*storage.User, error)
+	getBootstrap      func(ctx context.Context) (*storage.User, error)
+	jitCreateHuman    func(ctx context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error)
+	touchLastUsed     func(ctx context.Context, keyID string) error
+	listUsers         func(ctx context.Context, f storage.ListUsersFilter) ([]*storage.User, error)
+}
+
+func (s *usersBackendStub) LookupAPIKeyByPrefix(ctx context.Context, prefix string) (*storage.APIKey, error) {
+	if s.lookupAPIKey == nil {
+		return nil, storage.ErrAPIKeyNotFound
+	}
+	return s.lookupAPIKey(ctx, prefix)
+}
+
+func (s *usersBackendStub) LookupOIDCBinding(ctx context.Context, issuer, subject string) (*storage.OIDCBinding, error) {
+	if s.lookupOIDCBinding == nil {
+		return nil, storage.ErrOIDCBindingNotFound
+	}
+	return s.lookupOIDCBinding(ctx, issuer, subject)
+}
+
+func (s *usersBackendStub) GetUserByID(ctx context.Context, id string) (*storage.User, error) {
+	if s.getUserByID == nil {
+		return nil, storage.ErrUserNotFound
+	}
+	return s.getUserByID(ctx, id)
+}
+
+func (s *usersBackendStub) GetBootstrap(ctx context.Context) (*storage.User, error) {
+	if s.getBootstrap == nil {
+		return nil, storage.ErrUserNotFound
+	}
+	return s.getBootstrap(ctx)
+}
+
+func (s *usersBackendStub) JITCreateHuman(ctx context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error) {
+	if s.jitCreateHuman == nil {
+		return nil, nil, errUnexpectedCall("JITCreateHuman")
+	}
+	return s.jitCreateHuman(ctx, u, b)
+}
+
+func (s *usersBackendStub) TouchLastUsed(ctx context.Context, keyID string) error {
+	if s.touchLastUsed == nil {
+		return nil // fire-and-forget; default no-op
+	}
+	return s.touchLastUsed(ctx, keyID)
+}
+
+func (s *usersBackendStub) ListUsers(ctx context.Context, f storage.ListUsersFilter) ([]*storage.User, error) {
+	if s.listUsers == nil {
+		return nil, nil
+	}
+	return s.listUsers(ctx, f)
+}
+
+// Methods unused by Resolver — these are guards that fail loud if the
+// resolver calls them unexpectedly.
+func (s *usersBackendStub) CreateHuman(_ context.Context, _ *storage.User, _ *storage.OIDCBinding) (*storage.User, error) {
+	return nil, errUnexpectedCall("CreateHuman")
+}
+func (s *usersBackendStub) CreateServiceAccount(_ context.Context, _ *storage.User) (*storage.User, error) {
+	return nil, errUnexpectedCall("CreateServiceAccount")
+}
+func (s *usersBackendStub) UpdateUserRole(_ context.Context, _, _ string) error {
+	return errUnexpectedCall("UpdateUserRole")
+}
+func (s *usersBackendStub) SoftDeleteUser(_ context.Context, _ string) error {
+	return errUnexpectedCall("SoftDeleteUser")
+}
+func (s *usersBackendStub) PurgeUser(_ context.Context, _ string) error {
+	return errUnexpectedCall("PurgeUser")
+}
+func (s *usersBackendStub) CreateAPIKey(_ context.Context, _ *storage.APIKey) (*storage.APIKey, error) {
+	return nil, errUnexpectedCall("CreateAPIKey")
+}
+func (s *usersBackendStub) RevokeAPIKey(_ context.Context, _ string) error {
+	return errUnexpectedCall("RevokeAPIKey")
+}
+func (s *usersBackendStub) RotateAPIKey(_ context.Context, _ string, _ *storage.APIKey) (*storage.APIKey, error) {
+	return nil, errUnexpectedCall("RotateAPIKey")
+}
+func (s *usersBackendStub) ListAPIKeys(_ context.Context, _ storage.ListAPIKeysFilter) ([]*storage.APIKey, error) {
+	return nil, errUnexpectedCall("ListAPIKeys")
+}
+func (s *usersBackendStub) ListOIDCBindings(_ context.Context, _ string) ([]*storage.OIDCBinding, error) {
+	return nil, errUnexpectedCall("ListOIDCBindings")
+}
+func (s *usersBackendStub) UnbindOIDC(_ context.Context, _ string) error {
+	return errUnexpectedCall("UnbindOIDC")
+}
+
+func errUnexpectedCall(method string) error {
+	return errors.New("usersBackendStub: unexpected call to " + method + " (test bug)")
+}
+
+// activeUser builds an active user for tests.
+func activeUser(id, role string, kind storage.Kind) *storage.User {
+	return &storage.User{
+		ID: id, Kind: kind, Role: role, DisplayName: "test-" + id,
+		CreatedAt: time.Now(),
+	}
+}
+
+// activeKey builds an active API key for tests. PHCHash is the verifiable
+// stubPHCHash (computed in init() from stubPHCSecret), so a token built via
+// stubAPIKeyToken(prefix) will successfully argon2id-verify against it.
+func activeKey(id, userID, prefix string) *storage.APIKey {
+	return &storage.APIKey{
+		ID: id, UserID: userID, Prefix: prefix,
+		PHCHash:   stubPHCHash,
+		CreatedAt: time.Now(),
+	}
+}
+```
+
+Also add a guard test that pins the secret length. Put it in `identitystore_test.go` (created in Task 9) which already imports `testing` and `testify/require` — keep the fixtures file free of test-framework imports. This is the runtime equivalent of a compile-time assertion — `apiKeySecretLen` is unexported in package `auth`, so `auth_test` can't reference it directly; we assert the literal 32 and rely on the API-key parse tests (Task 11) to catch any drift in the parser's expectation:
+
+```go
+// In identitystore_test.go:
+func TestStubSecretLength(t *testing.T) {
+	require.Len(t, stubPHCSecret, 32,
+		"stubPHCSecret must be 32 chars to match the API-key parser's secret length")
+}
+```
+
+> **Note:** the `PHCHash` value above is a stub; tests that exercise argon2id verification (Task 11) will use a precomputed PHC string for a known-plaintext "test-secret".
+
+- [ ] **Step 2: Verify the stub compiles**
+
+Run: `cd internal/auth && go vet ./...`
+
+Expected: PASS. The stub satisfies `storage.UsersBackend` (every method signature matches).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/auth/usersbackend_stub_test.go
+git commit -s -m "test(auth): add hand-rolled UsersBackend stub for unit tests"
+```
+
+---
+
+## Task 9: Scaffold `pgIdentityStore` + constructor
+
+**Files:**
+
+- Create: `internal/auth/identitystore.go`
+- Create: `internal/auth/identitystore_test.go`
+
+**Covers:** Boundary (constructor rejects nil inputs).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/auth"
+)
+
+func TestNewIdentityStore_RequiresUsers(t *testing.T) {
+	_, err := auth.NewIdentityStore(auth.IdentityStoreConfig{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Users required")
+}
+
+func TestNewIdentityStore_RequiresTracker(t *testing.T) {
+	_, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: &usersBackendStub{},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Tracker required")
+}
+
+func TestNewIdentityStore_BuildsSuccessfully(t *testing.T) {
+	store, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users:   &usersBackendStub{},
+		Tracker: &noopTracker{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, store)
+}
+
+func TestNewIdentityStore_RejectsUnknownJITDefaultRole(t *testing.T) {
+	_, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users:          &usersBackendStub{},
+		Tracker:        &noopTracker{},
+		JITEnabled:     true,
+		JITDefaultRole: "reder", // typo for "reader"
+		KnownRoles:     map[auth.Role]bool{auth.RoleReader: true, auth.RoleWriter: true, auth.RoleAdmin: true},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "JITDefaultRole")
+}
+
+func TestNewIdentityStore_RejectsUnknownClaimsMappingRole(t *testing.T) {
+	_, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users:          &usersBackendStub{},
+		Tracker:        &noopTracker{},
+		JITEnabled:     true,
+		JITDefaultRole: auth.RoleReader,
+		KnownRoles:     map[auth.Role]bool{auth.RoleReader: true},
+		JITClaimsMapping: map[string][]config.ClaimMapping{
+			"https://issuer": {{Claim: "groups", Value: "admins", Role: "superuser"}},
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown role")
+}
+
+// noopTracker implements auth.LastUsedTracker as a no-op stub used until
+// Task 25 wires usagetracker.Manager.
+type noopTracker struct{}
+
+func (noopTracker) Touch(string) {}
+```
+
+These two tests reference `config.ClaimMapping` and `auth.RoleReader`/`RoleWriter`/`RoleAdmin`; add `"github.com/specgraph/specgraph/internal/config"` to the test imports.
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestNewIdentityStore' -v`
+
+Expected: FAIL — `auth.NewIdentityStore`, `auth.IdentityStoreConfig`, and `auth.LastUsedTracker` don't exist yet.
+
+- [ ] **Step 3: Write the scaffold**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// LastUsedTracker is the asynchronous TouchLastUsed surface consumed by
+// pgIdentityStore after a successful API-key resolve. The interface is
+// satisfied by usagetracker.Manager (Task 23) and by test stubs.
+type LastUsedTracker interface {
+	Touch(keyID string)
+}
+
+// pgIdentityStore is the Postgres-backed Resolver impl. Wraps UsersBackend
+// + per-issuer OIDCVerifiers; enforces JIT rate-limit and allowlist.
+type pgIdentityStore struct {
+	users     storage.UsersBackend
+	verifiers map[string]*OIDCVerifier // issuer -> verifier
+	tracker   LastUsedTracker
+
+	jitEnabled         bool
+	jitDefaultRole     Role
+	jitClaimsMapping   map[string][]config.ClaimMapping // issuer -> mappings
+	jitRateLimiters    sync.Map                          // issuer -> *rate.Limiter
+	jitRateBurst       int
+	jitRateRefillPerHr int
+	jitEmailAllowlist  map[string]bool // domain -> true; empty = no allowlist
+
+	now func() time.Time
+}
+
+// IdentityStoreConfig parametrizes pgIdentityStore at construction.
+type IdentityStoreConfig struct {
+	Users     storage.UsersBackend
+	Verifiers []*OIDCVerifier
+	Tracker   LastUsedTracker
+
+	// KnownRoles is the set of role names valid for assignment. Validated
+	// against at construction time: any JITDefaultRole or
+	// JITClaimsMapping role string not in this set causes
+	// NewIdentityStore to return an error. Typically derived from
+	// (built-in roles ∪ cfg.Auth.Roles keys).
+	KnownRoles map[Role]bool
+
+	JITEnabled              bool
+	JITDefaultRole          Role
+	JITClaimsMapping        map[string][]config.ClaimMapping
+	JITRateBurstPerHour     int      // bucket capacity AND refill rate (1:1)
+	JITEmailDomainAllowlist []string // empty = no allowlist
+
+	Now func() time.Time // optional; defaults to time.Now
+}
+
+// NewIdentityStore constructs a pgIdentityStore from the supplied config.
+// Verifiers are indexed by issuer; the allowlist is normalized to
+// lowercase domains.
+func NewIdentityStore(cfg IdentityStoreConfig) (Resolver, error) {
+	if cfg.Users == nil {
+		return nil, errors.New("auth: NewIdentityStore: Users required")
+	}
+	if cfg.Tracker == nil {
+		return nil, errors.New("auth: NewIdentityStore: Tracker required")
+	}
+	verifiers := make(map[string]*OIDCVerifier, len(cfg.Verifiers))
+	for _, v := range cfg.Verifiers {
+		if _, dup := verifiers[v.Issuer()]; dup {
+			return nil, fmt.Errorf("auth: duplicate verifier for issuer %q", v.Issuer())
+		}
+		verifiers[v.Issuer()] = v
+	}
+	// Validate JIT-related role references against KnownRoles. Catches
+	// operator typos (e.g. "reder" instead of "reader") that would create
+	// users whose role can never match any rolePerms entry.
+	if cfg.JITEnabled && len(cfg.KnownRoles) > 0 {
+		if cfg.JITDefaultRole != "" && !cfg.KnownRoles[cfg.JITDefaultRole] {
+			return nil, fmt.Errorf("auth: JITDefaultRole %q not in KnownRoles", cfg.JITDefaultRole)
+		}
+		for issuer, mappings := range cfg.JITClaimsMapping {
+			for _, m := range mappings {
+				if !cfg.KnownRoles[Role(m.Role)] {
+					return nil, fmt.Errorf("auth: ClaimsMapping for issuer %q maps to unknown role %q", issuer, m.Role)
+				}
+			}
+		}
+	}
+
+	allowlist := make(map[string]bool, len(cfg.JITEmailDomainAllowlist))
+	for _, d := range cfg.JITEmailDomainAllowlist {
+		allowlist[strings.ToLower(d)] = true
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	burst := cfg.JITRateBurstPerHour
+	if burst <= 0 {
+		burst = 100 // design default
+	}
+	return &pgIdentityStore{
+		users:              cfg.Users,
+		verifiers:          verifiers,
+		tracker:            cfg.Tracker,
+		jitEnabled:         cfg.JITEnabled,
+		jitDefaultRole:     cfg.JITDefaultRole,
+		jitClaimsMapping:   cfg.JITClaimsMapping,
+		jitRateBurst:       burst,
+		jitRateRefillPerHr: burst,
+		jitEmailAllowlist:  allowlist,
+		now:                now,
+	}, nil
+}
+
+// Resolve is implemented in Tasks 10–21.
+func (s *pgIdentityStore) Resolve(_ context.Context, _ string) (*Identity, error) {
+	return nil, errors.New("Resolve not implemented")
+}
+
+// HasAuth is implemented in Task 22.
+func (s *pgIdentityStore) HasAuth(_ context.Context) (bool, error) {
+	return false, errors.New("HasAuth not implemented")
+}
+
+// rateLimiterFor returns (or lazily creates) the per-issuer limiter.
+func (s *pgIdentityStore) rateLimiterFor(issuer string) *rate.Limiter {
+	if l, ok := s.jitRateLimiters.Load(issuer); ok {
+		return l.(*rate.Limiter)
+	}
+	refill := rate.Every(time.Hour / time.Duration(s.jitRateRefillPerHr))
+	l := rate.NewLimiter(refill, s.jitRateBurst)
+	actual, _ := s.jitRateLimiters.LoadOrStore(issuer, l)
+	return actual.(*rate.Limiter)
+}
+```
+
+- [ ] **Step 4: Run `go mod tidy`**
+
+The plan introduces a direct import of `golang.org/x/time/rate`. Today's `go.mod` lists `golang.org/x/time` as `// indirect`. Promote it to a direct dependency:
+
+Run: `go mod tidy && go build ./...`
+
+Expected: `go.mod` line for `golang.org/x/time` loses the `// indirect` comment; build passes.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cd internal/auth && go test -run 'TestNewIdentityStore' -v`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add go.mod go.sum internal/auth/identitystore.go internal/auth/identitystore_test.go
+git commit -s -m "feat(auth): scaffold pgIdentityStore with constructor validation"
+```
+
+---
+
+## Task 10: Implement token-shape dispatch in `Resolve`
+
+`Resolve` dispatches on whether the token is JWT-shaped (3 dot-separated base64 segments) or an API-key (`spgr_sk_<prefix>_<secret>`). Both branches return "not implemented" stubs; subsequent tasks fill them in.
+
+**Files:**
+
+- Modify: `internal/auth/identitystore.go`
+- Modify: `internal/auth/identitystore_test.go`
+
+**Covers:** Happy (token-shape dispatch picks the right branch) + Boundary (empty/malformed token returns ErrUnauthenticated).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `identitystore_test.go`:
+
+```go
+import (
+	"context"
+	"errors"
+)
+
+func TestResolve_EmptyTokenUnauthenticated(t *testing.T) {
+	store := newTestIdentityStore(t)
+	_, err := store.Resolve(context.Background(), "")
+	require.ErrorIs(t, err, auth.ErrUnauthenticated)
+}
+
+func TestResolve_JWTShapeRoutesToOIDC(t *testing.T) {
+	store := newTestIdentityStore(t)
+	// 3-segment string but garbage payload — dispatches to OIDC, which
+	// will fail because no verifier matches the issuer.
+	_, err := store.Resolve(context.Background(), "abc.def.ghi")
+	require.ErrorIs(t, err, auth.ErrUnauthenticated)
+}
+
+func TestResolve_APIKeyShapeRoutesToKeyPath(t *testing.T) {
+	store := newTestIdentityStore(t)
+	_, err := store.Resolve(context.Background(), "spgr_sk_abc12345_thirtytwocharsecretthirtytwocha")
+	require.ErrorIs(t, err, auth.ErrUnauthenticated) // no key in stub
+}
+
+// newTestIdentityStore builds an empty pgIdentityStore for dispatch tests.
+func newTestIdentityStore(t *testing.T) auth.Resolver {
+	t.Helper()
+	r, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users:   &usersBackendStub{},
+		Tracker: &noopTracker{},
+	})
+	require.NoError(t, err)
+	return r
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestResolve' -v`
+
+Expected: FAIL — `Resolve` still returns the "not implemented" string error, not `ErrUnauthenticated`.
+
+- [ ] **Step 3: Implement dispatch**
+
+In `identitystore.go`, replace the `Resolve` stub:
+
+```go
+// Resolve dispatches on token shape and produces an Identity (or
+// returns ErrUnauthenticated / ErrTransient).
+func (s *pgIdentityStore) Resolve(ctx context.Context, token string) (*Identity, error) {
+	if token == "" {
+		return nil, ErrUnauthenticated
+	}
+	if isJWTShaped(token) {
+		return s.resolveJWT(ctx, token)
+	}
+	return s.resolveAPIKey(ctx, token)
+}
+
+// isJWTShaped reports whether token looks like a JWS Compact Serialization
+// (three dot-separated base64 segments). Non-strict — a token that LOOKS
+// like a JWT but isn't will fail at the verify step, which also maps to
+// ErrUnauthenticated.
+func isJWTShaped(token string) bool {
+	return strings.Count(token, ".") == 2 && !strings.HasPrefix(token, "spgr_sk_")
+}
+
+// resolveAPIKey is implemented in Tasks 11–15.
+func (s *pgIdentityStore) resolveAPIKey(_ context.Context, _ string) (*Identity, error) {
+	return nil, ErrUnauthenticated
+}
+
+// resolveJWT is implemented in Tasks 16–21.
+func (s *pgIdentityStore) resolveJWT(_ context.Context, _ string) (*Identity, error) {
+	return nil, ErrUnauthenticated
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/auth && go test -run 'TestResolve' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/identitystore.go internal/auth/identitystore_test.go
+git commit -s -m "feat(auth): Resolve dispatches on token shape (JWT vs API-key)"
+```
+
+---
+
+## Task 11: API-key — parse `spgr_sk_<prefix>_<secret>`
+
+Split the token into prefix (8 chars) and secret (32 chars). Malformed tokens return `ErrUnauthenticated` immediately.
+
+**Files:**
+
+- Modify: `internal/auth/identitystore.go`
+- Modify: `internal/auth/identitystore_test.go`
+
+**Covers:** Happy (well-formed splits cleanly) + Boundary (missing prefix, wrong length, no underscores, wrong vendor).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestResolveAPIKey_MalformedTokens(t *testing.T) {
+	store := newTestIdentityStore(t)
+	bad := []string{
+		"not-a-key",
+		"spgr_sk_",                 // missing parts
+		"spgr_sk_short_secret",     // prefix too short
+		"spgr_sk_abc12345_short",   // secret too short
+		"spgr_pk_abc12345_thirtytwocharsecretthirtytwocha", // wrong vendor prefix
+	}
+	for _, tok := range bad {
+		_, err := store.Resolve(context.Background(), tok)
+		require.ErrorIs(t, err, auth.ErrUnauthenticated, "token %q should be Unauthenticated", tok)
+	}
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestResolveAPIKey_Malformed' -v`
+
+Expected: **PASS for the wrong reason** — the current `resolveAPIKey` returns `ErrUnauthenticated` for every token regardless of shape, so malformed-token assertions trivially succeed. The negation isn't covered. To force a real failing test, add the positive case below which DOES fail today (stub returns ErrUnauthenticated even though the token is well-formed):
+
+```go
+func TestResolveAPIKey_WellFormedReachesLookup(t *testing.T) {
+	called := false
+	stub := &usersBackendStub{
+		lookupAPIKey: func(_ context.Context, prefix string) (*storage.APIKey, error) {
+			called = true
+			require.Equal(t, "abc12345", prefix)
+			return nil, storage.ErrAPIKeyNotFound
+		},
+	}
+	store, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Tracker: &noopTracker{},
+	})
+	require.NoError(t, err)
+	_, err = store.Resolve(context.Background(), stubAPIKeyToken("abc12345"))
+	require.ErrorIs(t, err, auth.ErrUnauthenticated)
+	require.True(t, called, "lookupAPIKey should have been invoked once parse logic is wired")
+}
+```
+
+Verify failure: `go test -run 'TestResolveAPIKey_WellFormedReachesLookup' -v` — expected FAIL because `lookupAPIKey` is never invoked (stub `resolveAPIKey` returns before any storage call).
+
+- [ ] **Step 3: Implement parse**
+
+Add helper and rewrite `resolveAPIKey`:
+
+```go
+const (
+	apiKeyPrefix    = "spgr_sk_"
+	apiKeyPrefixLen = 8  // characters
+	apiKeySecretLen = 32 // characters
+)
+
+// parseAPIKey splits a token of the form spgr_sk_<prefix>_<secret> into
+// its components. Returns ("", "", false) for any malformed input.
+func parseAPIKey(token string) (prefix, secret string, ok bool) {
+	if !strings.HasPrefix(token, apiKeyPrefix) {
+		return "", "", false
+	}
+	rest := token[len(apiKeyPrefix):]
+	// Expect <8-char-prefix>_<32-char-secret>
+	sep := strings.IndexByte(rest, '_')
+	if sep != apiKeyPrefixLen {
+		return "", "", false
+	}
+	prefix = rest[:sep]
+	secret = rest[sep+1:]
+	if len(secret) != apiKeySecretLen {
+		return "", "", false
+	}
+	return prefix, secret, true
+}
+
+func (s *pgIdentityStore) resolveAPIKey(ctx context.Context, token string) (*Identity, error) {
+	prefix, _, ok := parseAPIKey(token)
+	if !ok {
+		return nil, ErrUnauthenticated
+	}
+	// Subsequent tasks (12–15) add lookup, verify, owner load, etc.
+	// For now: reach the lookup so the test can prove parse succeeded.
+	_, err := s.users.LookupAPIKeyByPrefix(ctx, prefix)
+	if err != nil {
+		return nil, ErrUnauthenticated
+	}
+	// Will be replaced in Task 12.
+	return nil, ErrUnauthenticated
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/auth && go test -run 'TestResolveAPIKey' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/identitystore.go internal/auth/identitystore_test.go
+git commit -s -m "feat(auth): parse spgr_sk_<prefix>_<secret> API-key tokens"
+```
+
+---
+
+## Task 12: API-key — argon2id verify against `PHCHash`
+
+After the prefix lookup succeeds, verify the presented secret against the stored argon2id PHC hash.
+
+**Files:**
+
+- Modify: `internal/auth/identitystore.go`
+- Modify: `internal/auth/identitystore_test.go`
+
+**Covers:** Happy (matching secret verifies) + Boundary (wrong secret → ErrUnauthenticated; corrupt PHC string → ErrUnauthenticated).
+
+- [ ] **Step 1: Failing test**
+
+The shared fixtures `stubPHCSecret`, `stubPHCHash`, and `stubAPIKeyToken` are already defined in `usersbackend_stub_test.go` (Task 8). This task just consumes them — do NOT redefine. A wrong-secret token is any well-formed token whose secret ≠ `stubPHCSecret`; build one inline since `stubAPIKeyToken` always uses the correct secret.
+
+```go
+func TestResolveAPIKey_WrongSecretUnauthenticated(t *testing.T) {
+	stub := &usersBackendStub{
+		lookupAPIKey: func(_ context.Context, prefix string) (*storage.APIKey, error) {
+			return &storage.APIKey{
+				ID: "k1", UserID: "u1", Prefix: prefix,
+				PHCHash: stubPHCHash,
+			}, nil
+		},
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Tracker: &noopTracker{},
+	})
+	// Well-formed token, correct prefix, but a DIFFERENT secret of the
+	// SAME length — derive it from stubPHCSecret by flipping the first
+	// char so the parse succeeds (length matches) but argon2id verify
+	// fails. Avoids hand-counting a 32-char literal.
+	wrongSecret := "X" + stubPHCSecret[1:]
+	_, err := store.Resolve(context.Background(), "spgr_sk_abc12345_"+wrongSecret)
+	require.ErrorIs(t, err, auth.ErrUnauthenticated)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestResolveAPIKey' -v`
+
+Expected: FAIL — verify isn't wired yet; the call returns `ErrUnauthenticated` for the wrong reason.
+
+- [ ] **Step 3: Implement verify**
+
+Add the argon2id verify helper to `identitystore.go`. We roll our own PHC parse (no extra dependency) since the format is fixed and the parse is ~15 lines. Add these imports to `identitystore.go`'s import block:
+
+```go
+import (
+	// ... existing imports ...
+	"crypto/subtle"
+	"encoding/base64"
+
+	"golang.org/x/crypto/argon2"
+)
+
+// argon2idVerify checks whether secret matches the stored PHC-encoded
+// argon2id hash. Returns false on any parse or mismatch error (callers
+// map all failures to ErrUnauthenticated).
+//
+// PHC format: $argon2id$v=19$m=<m>,t=<t>,p=<p>$<salt-b64>$<hash-b64>
+func argon2idVerify(phc, secret string) bool {
+	parts := strings.Split(phc, "$")
+	// Expected: ["", "argon2id", "v=19", "m=...,t=...,p=...", "<salt>", "<hash>"]
+	if len(parts) != 6 || parts[1] != "argon2id" {
+		return false
+	}
+	var m, t uint32
+	var p uint8
+	if _, err := fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &m, &t, &p); err != nil {
+		return false
+	}
+	salt, err := base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil {
+		return false
+	}
+	storedHash, err := base64.RawStdEncoding.DecodeString(parts[5])
+	if err != nil {
+		return false
+	}
+	computed := argon2.IDKey([]byte(secret), salt, t, m, p, uint32(len(storedHash)))
+	return subtle.ConstantTimeCompare(storedHash, computed) == 1
+}
+
+func (s *pgIdentityStore) resolveAPIKey(ctx context.Context, token string) (*Identity, error) {
+	prefix, secret, ok := parseAPIKey(token)
+	if !ok {
+		return nil, ErrUnauthenticated
+	}
+	key, err := s.users.LookupAPIKeyByPrefix(ctx, prefix)
+	if err != nil {
+		if errors.Is(err, storage.ErrAPIKeyNotFound) {
+			return nil, ErrUnauthenticated
+		}
+		return nil, fmt.Errorf("%w: %v", ErrTransient, err)
+	}
+	if !argon2idVerify(key.PHCHash, secret) {
+		return nil, ErrUnauthenticated
+	}
+	if key.RevokedAt != nil || (key.ExpiresAt != nil && !key.ExpiresAt.After(s.now())) {
+		return nil, ErrUnauthenticated
+	}
+	// Owner load + Identity construction happen in Tasks 13–15.
+	// For now return a partial Identity that tests can assert against.
+	return &Identity{
+		UserID:  key.UserID,
+		Subject: "apikey:" + key.ID,
+		Source:  "apikey",
+	}, nil
+}
+```
+
+The argon2id parameters in `argon2idVerify` (m=19456, t=2, p=1) MUST match the parameters used to generate `stubPHCHash` in the Task 8 fixtures `init()`. They do — both use m=19456, t=2, p=1. The fixtures and the verifier are kept in sync by using the same literals; if production hashing parameters change later, update both sites (a single follow-up bead can centralize them into a shared `argon2Params` struct).
+
+- [ ] **Step 4: Add a happy-path test**
+
+```go
+func TestResolveAPIKey_MatchingSecretSucceeds(t *testing.T) {
+	stub := &usersBackendStub{
+		lookupAPIKey: func(_ context.Context, prefix string) (*storage.APIKey, error) {
+			return &storage.APIKey{
+				ID: "k1", UserID: "u1", Prefix: prefix, PHCHash: stubPHCHash,
+				CreatedAt: time.Now(),
+			}, nil
+		},
+		getUserByID: func(_ context.Context, id string) (*storage.User, error) {
+			// Will be exercised in Task 13; for now this is a forward dep.
+			return activeUser(id, "reader", storage.KindHuman), nil
+		},
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Tracker: &noopTracker{},
+	})
+	id, err := store.Resolve(context.Background(), stubAPIKeyToken("abc12345"))
+	require.NoError(t, err)
+	require.Equal(t, "u1", id.UserID)
+	require.Equal(t, "apikey:k1", id.Subject)
+}
+```
+
+> **Note:** `stubAPIKeyToken(prefix)` (Task 8 fixtures) builds the token from `stubPHCSecret`, so callers can't drift the secret. `TestStubSecretLength` (Task 8) guards that the secret is 32 chars. The verifier and the fixture's hash use identical argon2id parameters, so the token verifies.
+
+- [ ] **Step 5: Run**
+
+Run: `cd internal/auth && go test -run 'TestResolveAPIKey' -v`
+
+Expected: PASS for the happy-path and wrong-secret tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/auth/identitystore.go internal/auth/identitystore_test.go
+git commit -s -m "feat(auth): argon2id verify in API-key Resolve path"
+```
+
+---
+
+## Task 13: API-key — owner load + soft-delete check
+
+After verifying the key, load the user. Reject if soft-deleted.
+
+**Files:**
+
+- Modify: `internal/auth/identitystore.go`
+- Modify: `internal/auth/identitystore_test.go`
+
+**Covers:** Happy (active user resolves) + Invariant (soft-deleted user can't auth via API key).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestResolveAPIKey_SoftDeletedOwnerUnauthenticated(t *testing.T) {
+	deletedAt := time.Now().Add(-time.Hour)
+	stub := &usersBackendStub{
+		lookupAPIKey: func(_ context.Context, prefix string) (*storage.APIKey, error) {
+			return &storage.APIKey{
+				ID: "k1", UserID: "u-del", Prefix: prefix, PHCHash: stubPHCHash,
+			}, nil
+		},
+		getUserByID: func(_ context.Context, id string) (*storage.User, error) {
+			u := activeUser(id, "reader", storage.KindHuman)
+			u.DeletedAt = &deletedAt
+			return u, nil
+		},
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Tracker: &noopTracker{},
+	})
+	_, err := store.Resolve(context.Background(),
+		stubAPIKeyToken("abc12345"))
+	require.ErrorIs(t, err, auth.ErrUnauthenticated)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestResolveAPIKey_SoftDeletedOwner' -v`
+
+Expected: FAIL — the resolveAPIKey impl from Task 12 doesn't yet load the owner or check `deleted_at`.
+
+- [ ] **Step 3: Implement owner load**
+
+In `resolveAPIKey`, replace the partial-Identity return with a full load:
+
+```go
+func (s *pgIdentityStore) resolveAPIKey(ctx context.Context, token string) (*Identity, error) {
+	prefix, secret, ok := parseAPIKey(token)
+	if !ok {
+		return nil, ErrUnauthenticated
+	}
+	key, err := s.users.LookupAPIKeyByPrefix(ctx, prefix)
+	if err != nil {
+		if errors.Is(err, storage.ErrAPIKeyNotFound) {
+			return nil, ErrUnauthenticated
+		}
+		return nil, fmt.Errorf("%w: %v", ErrTransient, err)
+	}
+	if !argon2idVerify(key.PHCHash, secret) {
+		return nil, ErrUnauthenticated
+	}
+	if key.RevokedAt != nil || (key.ExpiresAt != nil && !key.ExpiresAt.After(s.now())) {
+		return nil, ErrUnauthenticated
+	}
+	user, err := s.users.GetUserByID(ctx, key.UserID)
+	if err != nil {
+		if errors.Is(err, storage.ErrUserNotFound) {
+			return nil, ErrUnauthenticated
+		}
+		return nil, fmt.Errorf("%w: %v", ErrTransient, err)
+	}
+	if user.DeletedAt != nil {
+		// Security-observable: a valid credential for a soft-deleted user.
+		// Worth a warn — could indicate a credential that should have been
+		// revoked, or an offboarding gap.
+		slog.Warn("auth: credential resolved to soft-deleted user (api-key)",
+			"user_id", user.ID, "key_id", key.ID)
+		return nil, ErrUnauthenticated
+	}
+	return &Identity{
+		UserID:        user.ID,
+		Subject:       "apikey:" + key.ID,
+		DisplayName:   user.DisplayName,
+		Email:         user.Email,
+		Role:          Role(user.Role),
+		EffectiveRole: Role(user.Role), // Task 14 will clamp by RoleDowngrade
+		Source:        "apikey",
+	}, nil
+}
+```
+
+This task introduces the first `slog` call in `identitystore.go`. Add `"log/slog"` to the file's import block (it stays used from here through Tasks 17, 19, 20). Go will not complain about an unused import because the soft-delete `slog.Warn` above references it.
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/auth && go test -run 'TestResolveAPIKey' -v`
+
+Expected: PASS for all API-key tests so far.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/identitystore.go internal/auth/identitystore_test.go
+git commit -s -m "feat(auth): owner load + soft-delete check in API-key Resolve"
+```
+
+---
+
+## Task 14: API-key — `EffectiveRole = min(user.Role, key.RoleDowngrade)`
+
+Apply the per-key role downgrade clamp at resolve time so demoting a user instantly demotes all their keys.
+
+**Files:**
+
+- Modify: `internal/auth/identitystore.go`
+- Modify: `internal/auth/identitystore_test.go`
+
+**Covers:** Happy (downgrade clamps when set; equals Role when unset) + Boundary (custom role + downgrade is a no-op per Storage design).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestResolveAPIKey_RoleDowngradeClamps(t *testing.T) {
+	stub := &usersBackendStub{
+		lookupAPIKey: func(_ context.Context, prefix string) (*storage.APIKey, error) {
+			return &storage.APIKey{
+				ID: "k1", UserID: "u1", Prefix: prefix, PHCHash: stubPHCHash,
+				RoleDowngrade: "reader",
+			}, nil
+		},
+		getUserByID: func(_ context.Context, id string) (*storage.User, error) {
+			return activeUser(id, "writer", storage.KindHuman), nil
+		},
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Tracker: &noopTracker{},
+	})
+	id, err := store.Resolve(context.Background(),
+		stubAPIKeyToken("abc12345"))
+	require.NoError(t, err)
+	require.Equal(t, auth.Role("writer"), id.Role)
+	require.Equal(t, auth.Role("reader"), id.EffectiveRole)
+}
+
+func TestResolveAPIKey_NoDowngradeEqualsRole(t *testing.T) {
+	stub := &usersBackendStub{
+		lookupAPIKey: func(_ context.Context, prefix string) (*storage.APIKey, error) {
+			return &storage.APIKey{
+				ID: "k1", UserID: "u1", Prefix: prefix, PHCHash: stubPHCHash,
+				// RoleDowngrade: "" (zero value)
+			}, nil
+		},
+		getUserByID: func(_ context.Context, id string) (*storage.User, error) {
+			return activeUser(id, "writer", storage.KindHuman), nil
+		},
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Tracker: &noopTracker{},
+	})
+	id, err := store.Resolve(context.Background(),
+		stubAPIKeyToken("abc12345"))
+	require.NoError(t, err)
+	require.Equal(t, id.Role, id.EffectiveRole)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestResolveAPIKey_Role' -v`
+
+Expected: FAIL — Task 13's impl set `EffectiveRole = Role` unconditionally.
+
+- [ ] **Step 3: Implement clamp**
+
+Add helper and update `resolveAPIKey`:
+
+```go
+// roleLessThan reports whether a is strictly less privileged than b.
+// Built-in roles are linearly ordered: reader < writer < admin. Custom
+// roles return false in either direction (see Storage design's roleLessThan).
+func roleLessThan(a, b Role) bool {
+	rank := map[Role]int{RoleReader: 1, RoleWriter: 2, RoleAdmin: 3}
+	ra, oka := rank[a]
+	rb, okb := rank[b]
+	if !oka || !okb {
+		return false
+	}
+	return ra < rb
+}
+
+// clampedRole returns the lesser of user.Role and key.RoleDowngrade, but
+// only for built-in roles. Custom roles have no defined ordering; the
+// downgrade is a no-op (logged at the call site).
+func clampedRole(userRole, downgrade Role) Role {
+	if downgrade == "" {
+		return userRole
+	}
+	if roleLessThan(downgrade, userRole) {
+		return downgrade
+	}
+	return userRole
+}
+```
+
+Update the Identity construction in `resolveAPIKey`:
+
+```go
+return &Identity{
+	UserID:        user.ID,
+	Subject:       "apikey:" + key.ID,
+	DisplayName:   user.DisplayName,
+	Email:         user.Email,
+	Role:          Role(user.Role),
+	EffectiveRole: clampedRole(Role(user.Role), Role(key.RoleDowngrade)),
+	Source:        "apikey",
+}, nil
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/auth && go test -run 'TestResolveAPIKey' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/identitystore.go internal/auth/identitystore_test.go
+git commit -s -m "feat(auth): clamp EffectiveRole = min(Role, RoleDowngrade) in API-key path"
+```
+
+---
+
+## Task 15: API-key — fire-and-forget `TouchLastUsed`
+
+After a successful resolve, enqueue a `last_used_at` update via the Tracker. The Tracker is async — it returns immediately and batches updates in the background (Task 23 implements the real Manager).
+
+**Files:**
+
+- Modify: `internal/auth/identitystore.go`
+- Modify: `internal/auth/identitystore_test.go`
+
+**Covers:** Happy (successful resolve enqueues a Touch) + Boundary (failed resolve does NOT enqueue).
+
+- [ ] **Step 1: Failing test**
+
+```go
+// countingTracker records every Touch call.
+type countingTracker struct {
+	touched []string
+}
+
+func (c *countingTracker) Touch(keyID string) {
+	c.touched = append(c.touched, keyID)
+}
+
+func TestResolveAPIKey_SuccessTouchesLastUsed(t *testing.T) {
+	tracker := &countingTracker{}
+	stub := &usersBackendStub{
+		lookupAPIKey: func(_ context.Context, prefix string) (*storage.APIKey, error) {
+			return &storage.APIKey{
+				ID: "k1", UserID: "u1", Prefix: prefix, PHCHash: stubPHCHash,
+			}, nil
+		},
+		getUserByID: func(_ context.Context, id string) (*storage.User, error) {
+			return activeUser(id, "reader", storage.KindHuman), nil
+		},
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Tracker: tracker,
+	})
+	_, err := store.Resolve(context.Background(),
+		stubAPIKeyToken("abc12345"))
+	require.NoError(t, err)
+	require.Equal(t, []string{"k1"}, tracker.touched)
+}
+
+func TestResolveAPIKey_FailureDoesNotTouch(t *testing.T) {
+	tracker := &countingTracker{}
+	stub := &usersBackendStub{
+		// No lookupAPIKey set → returns ErrAPIKeyNotFound.
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Tracker: tracker,
+	})
+	_, err := store.Resolve(context.Background(),
+		stubAPIKeyToken("abc12345"))
+	require.ErrorIs(t, err, auth.ErrUnauthenticated)
+	require.Empty(t, tracker.touched)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestResolveAPIKey_Success.*Touch|FailureDoesNotTouch' -v`
+
+Expected: FAIL — Touch isn't called in the current impl.
+
+- [ ] **Step 3: Add the Touch call**
+
+In `resolveAPIKey`, right before the final return, add:
+
+```go
+s.tracker.Touch(key.ID)
+return &Identity{ ... }, nil
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/auth && go test -run 'TestResolveAPIKey' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/identitystore.go internal/auth/identitystore_test.go
+git commit -s -m "feat(auth): fire-and-forget TouchLastUsed on successful API-key resolve"
+```
+
+---
+
+## Task 16: JWT — issuer peek + verifier routing
+
+For JWT-shaped tokens, extract the issuer claim (without verifying yet) and route to the matching `OIDCVerifier`. Unknown issuers return `ErrUnauthenticated`.
+
+**Files:**
+
+- Modify: `internal/auth/identitystore.go`
+- Modify: `internal/auth/identitystore_test.go`
+
+**Covers:** Happy (routes to matching verifier) + Boundary (no matching verifier → ErrUnauthenticated; malformed JWT → ErrUnauthenticated).
+
+- [ ] **Step 1: Failing test**
+
+```go
+import (
+	"github.com/specgraph/specgraph/internal/config"
+)
+
+func TestResolveJWT_UnknownIssuerUnauthenticated(t *testing.T) {
+	store := newTestIdentityStore(t) // no verifiers configured
+	_, err := store.Resolve(context.Background(), "header.payload.signature")
+	require.ErrorIs(t, err, auth.ErrUnauthenticated)
+}
+
+func TestResolveJWT_MalformedJWTUnauthenticated(t *testing.T) {
+	store := newTestIdentityStore(t)
+	_, err := store.Resolve(context.Background(), "not.a.valid.jwt") // 3 dots not 2
+	require.ErrorIs(t, err, auth.ErrUnauthenticated)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestResolveJWT' -v`
+
+Expected: PASS already (resolveJWT is a stub returning ErrUnauthenticated). Add a positive test to force real routing:
+
+```go
+func TestResolveJWT_KnownIssuerRoutes(t *testing.T) {
+	p := newOIDCTestIssuer(t)
+	v, err := auth.NewOIDCVerifier(context.Background(), config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "aud-1",
+	})
+	require.NoError(t, err)
+
+	stub := &usersBackendStub{
+		lookupOIDCBinding: func(_ context.Context, issuer, subject string) (*storage.OIDCBinding, error) {
+			require.Equal(t, p.server.URL, issuer)
+			require.Equal(t, "user-123", subject)
+			return nil, storage.ErrOIDCBindingNotFound // forces JIT path (Task 18)
+		},
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users:     stub,
+		Verifiers: []*auth.OIDCVerifier{v},
+		Tracker:   &noopTracker{},
+		// JITEnabled: false (Task 18 enables and tests JIT)
+	})
+	token := p.mintToken(t, map[string]any{
+		"iss":   p.server.URL,
+		"sub":   "user-123",
+		"aud":   "aud-1",
+		"exp":   time.Now().Add(time.Hour).Unix(),
+		"iat":   time.Now().Unix(),
+		"email": "alice@example.com",
+	})
+	_, err = store.Resolve(context.Background(), token)
+	require.ErrorIs(t, err, auth.ErrUnauthenticated) // JIT disabled → reject on binding miss
+}
+```
+
+This test should FAIL because `resolveJWT` doesn't yet peek the issuer or call the verifier.
+
+- [ ] **Step 3: Implement issuer peek and routing**
+
+```go
+import (
+	"encoding/base64"
+	"encoding/json"
+)
+
+// peekIssuerV2 extracts the iss claim from an unverified JWT payload. Used
+// only to route to the correct OIDCVerifier; the verifier subsequently
+// validates signature+audience+expiry.
+//
+// Named "V2" during Phase A because the legacy composite_store.go already
+// defines an identical `peekIssuer` in this package; two same-name
+// package functions would not compile. Task 30b renames this back to
+// `peekIssuer` after composite_store.go is deleted (Task 30).
+func peekIssuerV2(token string) (string, error) {
+	parts := strings.SplitN(token, ".", 3)
+	if len(parts) != 3 {
+		return "", errors.New("not a JWT")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decode payload: %w", err)
+	}
+	var claims struct {
+		Issuer string `json:"iss"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("unmarshal payload: %w", err)
+	}
+	if claims.Issuer == "" {
+		return "", errors.New("missing iss claim")
+	}
+	return claims.Issuer, nil
+}
+
+func (s *pgIdentityStore) resolveJWT(ctx context.Context, token string) (*Identity, error) {
+	issuer, err := peekIssuerV2(token) // renamed to peekIssuer in Task 30b
+	if err != nil {
+		return nil, ErrUnauthenticated
+	}
+	verifier, ok := s.verifiers[issuer]
+	if !ok {
+		return nil, ErrUnauthenticated
+	}
+	claims, err := verifier.Verify(ctx, token)
+	if err != nil {
+		return nil, ErrUnauthenticated
+	}
+	// Defense-in-depth: the unverified peek issuer (used only for routing)
+	// must equal the verified issuer. go-oidc already binds verification to
+	// the configured issuer, so a mismatch should be impossible — but
+	// asserting it closes the door on a token that claims iss:A in its
+	// (unverified) payload while being validly signed under verifier A's
+	// configured issuer differing from the embedded claim.
+	if claims.Issuer != issuer {
+		slog.Warn("auth: JWT issuer mismatch between peek and verified claim",
+			"peek", issuer, "verified", claims.Issuer)
+		return nil, ErrUnauthenticated
+	}
+	// Binding lookup + user load happen in Task 17.
+	// JIT happens in Task 18.
+	binding, err := s.users.LookupOIDCBinding(ctx, claims.Issuer, claims.Subject)
+	if err != nil {
+		if errors.Is(err, storage.ErrOIDCBindingNotFound) {
+			// Task 18 will replace this with the JIT path.
+			return nil, ErrUnauthenticated
+		}
+		return nil, fmt.Errorf("%w: %v", ErrTransient, err)
+	}
+	_ = binding
+	// Task 17 fills in the rest.
+	return nil, ErrUnauthenticated
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/auth && go test -run 'TestResolveJWT' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/identitystore.go internal/auth/identitystore_test.go
+git commit -s -m "feat(auth): JWT issuer peek and OIDCVerifier routing"
+```
+
+---
+
+## Task 17: JWT — existing binding resolves to owner
+
+For known `(issuer, subject)` pairs, load the bound user and return an Identity. ClaimsMapping does NOT re-evaluate (it's JIT-only per the design).
+
+**Files:**
+
+- Modify: `internal/auth/identitystore.go`
+- Modify: `internal/auth/identitystore_test.go`
+
+**Covers:** Happy (existing binding resolves) + Invariant (DB-persisted role is authoritative; claims-mapping not re-evaluated).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestResolveJWT_ExistingBindingResolves(t *testing.T) {
+	p := newOIDCTestIssuer(t)
+	v, _ := auth.NewOIDCVerifier(context.Background(), config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "aud-1",
+	})
+
+	stub := &usersBackendStub{
+		lookupOIDCBinding: func(_ context.Context, issuer, subject string) (*storage.OIDCBinding, error) {
+			return &storage.OIDCBinding{
+				ID: "b1", UserID: "u1", Issuer: issuer, Subject: subject,
+			}, nil
+		},
+		getUserByID: func(_ context.Context, id string) (*storage.User, error) {
+			u := activeUser(id, "writer", storage.KindHuman)
+			u.Email = "alice@example.com"
+			return u, nil
+		},
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Verifiers: []*auth.OIDCVerifier{v}, Tracker: &noopTracker{},
+	})
+	token := p.mintToken(t, map[string]any{
+		"iss": p.server.URL, "sub": "user-123", "aud": "aud-1",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"email": "alice@example.com",
+		// Claims that would map to "admin" if evaluated — but claims-mapping
+		// is JIT-only, so the DB role (writer) must win.
+		"groups": []string{"specgraph-admins"},
+	})
+	id, err := store.Resolve(context.Background(), token)
+	require.NoError(t, err)
+	require.Equal(t, "u1", id.UserID)
+	require.Equal(t, "oidc:user-123", id.Subject)
+	require.Equal(t, auth.Role("writer"), id.Role) // NOT admin from claims
+	require.Equal(t, auth.Role("writer"), id.EffectiveRole)
+	require.Equal(t, "oidc", id.Source)
+}
+
+func TestResolveJWT_SoftDeletedUserUnauthenticated(t *testing.T) {
+	p := newOIDCTestIssuer(t)
+	v, _ := auth.NewOIDCVerifier(context.Background(), config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "aud-1",
+	})
+	deletedAt := time.Now()
+	stub := &usersBackendStub{
+		lookupOIDCBinding: func(_ context.Context, _, _ string) (*storage.OIDCBinding, error) {
+			return &storage.OIDCBinding{ID: "b1", UserID: "u-del"}, nil
+		},
+		getUserByID: func(_ context.Context, _ string) (*storage.User, error) {
+			u := activeUser("u-del", "writer", storage.KindHuman)
+			u.DeletedAt = &deletedAt
+			return u, nil
+		},
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Verifiers: []*auth.OIDCVerifier{v}, Tracker: &noopTracker{},
+	})
+	token := p.mintToken(t, map[string]any{
+		"iss": p.server.URL, "sub": "u", "aud": "aud-1",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+	})
+	_, err := store.Resolve(context.Background(), token)
+	require.ErrorIs(t, err, auth.ErrUnauthenticated)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestResolveJWT_(Existing|SoftDeleted)' -v`
+
+Expected: FAIL — current `resolveJWT` returns `ErrUnauthenticated` after finding the binding (Task 16's stub).
+
+- [ ] **Step 3: Implement owner load**
+
+Replace the placeholder at the end of `resolveJWT`:
+
+```go
+	user, err := s.users.GetUserByID(ctx, binding.UserID)
+	if err != nil {
+		if errors.Is(err, storage.ErrUserNotFound) {
+			return nil, ErrUnauthenticated
+		}
+		return nil, fmt.Errorf("%w: %v", ErrTransient, err)
+	}
+	if user.DeletedAt != nil {
+		// Security-observable: a valid OIDC binding for a soft-deleted user.
+		// The binding wasn't unbound at offboarding; the deleted_at gate
+		// catches it, but log so operators can notice the gap.
+		slog.Warn("auth: token resolved to soft-deleted user (oidc)",
+			"user_id", user.ID, "subject", claims.Subject)
+		return nil, ErrUnauthenticated
+	}
+	return &Identity{
+		UserID:        user.ID,
+		Subject:       "oidc:" + claims.Subject,
+		DisplayName:   user.DisplayName,
+		Email:         user.Email,
+		Role:          Role(user.Role),
+		EffectiveRole: Role(user.Role), // OIDC has no per-key downgrade
+		Source:        "oidc",
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/auth && go test -run 'TestResolveJWT' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/identitystore.go internal/auth/identitystore_test.go
+git commit -s -m "feat(auth): existing OIDC binding resolves to bound user (JIT-mapping-skipped)"
+```
+
+---
+
+## Task 18: JIT — happy path (no rate-limit / allowlist yet)
+
+When the binding lookup misses AND `JITEnabled`, create a new Human + binding atomically. This task handles the bare happy case; rate-limit (Task 19) and allowlist (Task 20) layer on next.
+
+**Files:**
+
+- Modify: `internal/auth/identitystore.go`
+- Modify: `internal/auth/identitystore_test.go`
+
+**Covers:** Happy (new sub creates user + binding) + Boundary (JIT disabled → reject on miss).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestResolveJWT_JITCreatesNewUser(t *testing.T) {
+	p := newOIDCTestIssuer(t)
+	v, _ := auth.NewOIDCVerifier(context.Background(), config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "aud-1",
+	})
+	var capturedUser *storage.User
+	var capturedBinding *storage.OIDCBinding
+	stub := &usersBackendStub{
+		lookupOIDCBinding: func(_ context.Context, _, _ string) (*storage.OIDCBinding, error) {
+			return nil, storage.ErrOIDCBindingNotFound
+		},
+		jitCreateHuman: func(_ context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error) {
+			u.ID = "new-user"
+			b.ID = "new-binding"
+			b.UserID = u.ID
+			capturedUser, capturedBinding = u, b
+			return u, b, nil
+		},
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Verifiers: []*auth.OIDCVerifier{v}, Tracker: &noopTracker{},
+		JITEnabled:     true,
+		JITDefaultRole: auth.RoleReader,
+	})
+	token := p.mintToken(t, map[string]any{
+		"iss": p.server.URL, "sub": "new-sub", "aud": "aud-1",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"email": "new@example.com",
+	})
+	id, err := store.Resolve(context.Background(), token)
+	require.NoError(t, err)
+	require.Equal(t, "new-user", id.UserID)
+	require.Equal(t, auth.Role("reader"), id.Role)
+	require.NotNil(t, capturedUser)
+	require.Equal(t, "new@example.com", capturedUser.Email)
+	require.NotNil(t, capturedBinding)
+	require.Equal(t, "new-sub", capturedBinding.Subject)
+}
+
+func TestResolveJWT_JITDisabledRejects(t *testing.T) {
+	p := newOIDCTestIssuer(t)
+	v, _ := auth.NewOIDCVerifier(context.Background(), config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "aud-1",
+	})
+	stub := &usersBackendStub{
+		lookupOIDCBinding: func(_ context.Context, _, _ string) (*storage.OIDCBinding, error) {
+			return nil, storage.ErrOIDCBindingNotFound
+		},
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Verifiers: []*auth.OIDCVerifier{v}, Tracker: &noopTracker{},
+		JITEnabled: false,
+	})
+	token := p.mintToken(t, map[string]any{
+		"iss": p.server.URL, "sub": "x", "aud": "aud-1",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+	})
+	_, err := store.Resolve(context.Background(), token)
+	require.ErrorIs(t, err, auth.ErrUnauthenticated)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestResolveJWT_JIT' -v`
+
+Expected: FAIL — Task 16's impl returns ErrUnauthenticated on binding miss; doesn't call JITCreateHuman.
+
+- [ ] **Step 3: Implement JIT happy path**
+
+Replace the `ErrOIDCBindingNotFound` branch in `resolveJWT`:
+
+```go
+	binding, err := s.users.LookupOIDCBinding(ctx, claims.Issuer, claims.Subject)
+	if err != nil {
+		if !errors.Is(err, storage.ErrOIDCBindingNotFound) {
+			return nil, fmt.Errorf("%w: %v", ErrTransient, err)
+		}
+		// Binding miss → JIT path.
+		if !s.jitEnabled {
+			return nil, ErrUnauthenticated
+		}
+		return s.jitResolve(ctx, claims)
+	}
+	// existing binding path continues below ...
+```
+
+Add the JIT method:
+
+```go
+// jitResolve creates a new Human + OIDC binding for an unknown subject.
+// Rate-limit and email-allowlist checks land in Tasks 19–20.
+func (s *pgIdentityStore) jitResolve(ctx context.Context, claims *OIDCClaims) (*Identity, error) {
+	role := s.jitDefaultRole
+	if role == "" {
+		role = RoleReader
+	}
+	u := &storage.User{
+		Kind:        storage.KindHuman,
+		DisplayName: claims.Subject, // operator can rename later via auth user
+		Email:       claims.Email,
+		Role:        string(role),
+	}
+	b := &storage.OIDCBinding{
+		Issuer:      claims.Issuer,
+		Subject:     claims.Subject,
+		EmailAtBind: claims.Email,
+	}
+	user, _, err := s.users.JITCreateHuman(ctx, u, b)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrTransient, err)
+	}
+	return &Identity{
+		UserID:        user.ID,
+		Subject:       "oidc:" + claims.Subject,
+		DisplayName:   user.DisplayName,
+		Email:         user.Email,
+		Role:          Role(user.Role),
+		EffectiveRole: Role(user.Role),
+		Source:        "oidc",
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/auth && go test -run 'TestResolveJWT_JIT' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/identitystore.go internal/auth/identitystore_test.go
+git commit -s -m "feat(auth): JIT-create Human+binding for unknown OIDC subjects (happy path)"
+```
+
+---
+
+## Task 19: JIT — per-issuer rate limit
+
+Bound JIT creation per issuer so a misconfigured trust relationship can't amplify into unbounded user creation.
+
+**Files:**
+
+- Modify: `internal/auth/identitystore.go`
+- Create: `internal/auth/identitystore_jit_test.go`
+
+**Covers:** Happy (allowed within burst) + Invariant (per-issuer cap; exceeded → ErrUnauthenticated).
+
+- [ ] **Step 1: Failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+func TestJIT_RateLimitExhaustion(t *testing.T) {
+	p := newOIDCTestIssuer(t)
+	v, _ := auth.NewOIDCVerifier(context.Background(), config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "aud-1",
+	})
+	stub := &usersBackendStub{
+		lookupOIDCBinding: func(_ context.Context, _, _ string) (*storage.OIDCBinding, error) {
+			return nil, storage.ErrOIDCBindingNotFound
+		},
+		jitCreateHuman: func(_ context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error) {
+			u.ID = "u"
+			b.ID = "b"
+			b.UserID = "u"
+			return u, b, nil
+		},
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Verifiers: []*auth.OIDCVerifier{v}, Tracker: &noopTracker{},
+		JITEnabled:          true,
+		JITDefaultRole:      auth.RoleReader,
+		JITRateBurstPerHour: 5, // small burst so the test runs fast
+	})
+
+	// First 5 JITs succeed.
+	for i := 0; i < 5; i++ {
+		tok := p.mintToken(t, map[string]any{
+			"iss": p.server.URL, "sub": "u" + strconv.Itoa(i),
+			"aud": "aud-1", "exp": time.Now().Add(time.Hour).Unix(),
+			"iat": time.Now().Unix(),
+		})
+		_, err := store.Resolve(context.Background(), tok)
+		require.NoError(t, err, "JIT %d should succeed", i)
+	}
+	// 6th JIT exhausts the bucket.
+	tok := p.mintToken(t, map[string]any{
+		"iss": p.server.URL, "sub": "u-exhaust",
+		"aud": "aud-1", "exp": time.Now().Add(time.Hour).Unix(),
+		"iat": time.Now().Unix(),
+	})
+	_, err := store.Resolve(context.Background(), tok)
+	require.ErrorIs(t, err, auth.ErrUnauthenticated)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestJIT_RateLimit' -v`
+
+Expected: FAIL — `jitResolve` doesn't yet check the rate limiter.
+
+- [ ] **Step 3: Wire the rate limit**
+
+In `jitResolve`, add the rate-limit gate. **Ordering note:** Task 20 will insert the email-allowlist check ABOVE this rate-limit gate, so that allowlist-refused tokens do not consume rate-limit budget. For now (allowlist not yet implemented), the rate limiter is the first gate:
+
+```go
+func (s *pgIdentityStore) jitResolve(ctx context.Context, claims *OIDCClaims) (*Identity, error) {
+	// NOTE (finalized in Task 20): the email-allowlist check is inserted
+	// above this line so tokens that can't create a user never spend a
+	// rate-limit token. The rate limiter therefore bounds *eligible*
+	// creation attempts, which is its design intent.
+	limiter := s.rateLimiterFor(claims.Issuer)
+	if !limiter.Allow() {
+		slog.Warn("auth: JIT rate-limit exceeded",
+			"issuer", claims.Issuer, "subject", claims.Subject)
+		return nil, ErrUnauthenticated
+	}
+	// ... existing JIT body ...
+}
+```
+
+Add `"log/slog"` to imports if not already there.
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/auth && go test -run 'TestJIT_RateLimit' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/identitystore.go internal/auth/identitystore_jit_test.go
+git commit -s -m "feat(auth): per-issuer JIT rate limit via golang.org/x/time/rate"
+```
+
+---
+
+## Task 20: JIT — email-domain allowlist
+
+When the operator configures an email-domain allowlist, JIT refuses tokens whose email claim's domain doesn't match. Missing email + non-empty allowlist also refuses.
+
+**Files:**
+
+- Modify: `internal/auth/identitystore.go`
+- Modify: `internal/auth/identitystore_jit_test.go`
+
+**Covers:** Happy (matching domain succeeds) + Boundary (mismatched domain refuses; missing claim with allowlist refuses; missing claim with empty allowlist allows).
+
+- [ ] **Step 1: Failing tests**
+
+```go
+func TestJIT_EmailAllowlist_Match(t *testing.T) {
+	p := newOIDCTestIssuer(t)
+	v, _ := auth.NewOIDCVerifier(context.Background(), config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "aud-1",
+	})
+	stub := &usersBackendStub{
+		lookupOIDCBinding: func(_ context.Context, _, _ string) (*storage.OIDCBinding, error) {
+			return nil, storage.ErrOIDCBindingNotFound
+		},
+		jitCreateHuman: func(_ context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error) {
+			u.ID = "u"
+			b.ID = "b"
+			b.UserID = "u"
+			return u, b, nil
+		},
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Verifiers: []*auth.OIDCVerifier{v}, Tracker: &noopTracker{},
+		JITEnabled:              true,
+		JITDefaultRole:          auth.RoleReader,
+		JITEmailDomainAllowlist: []string{"example.com"},
+	})
+	tok := p.mintToken(t, map[string]any{
+		"iss": p.server.URL, "sub": "x", "aud": "aud-1",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"email": "alice@example.com",
+	})
+	_, err := store.Resolve(context.Background(), tok)
+	require.NoError(t, err)
+}
+
+func TestJIT_EmailAllowlist_Mismatch(t *testing.T) {
+	// Same setup as above but token email is "bob@other.com".
+	// Expected: ErrUnauthenticated.
+	// (Full setup omitted for brevity in this comment — copy from _Match
+	// and change the email claim. Reuse the stub.)
+}
+
+func TestJIT_EmailAllowlist_MissingClaimRefuses(t *testing.T) {
+	// Allowlist non-empty + token has no "email" claim → ErrUnauthenticated.
+}
+
+func TestJIT_EmptyAllowlistAllowsMissingClaim(t *testing.T) {
+	// Allowlist empty + token has no "email" claim → JIT succeeds; user.Email = "".
+}
+```
+
+> **Note:** the additional three test bodies follow the same pattern as `_Match`. Expanded verbatim in the implementation; the plan shows the first one in full to fix the structure, then the executor copies it for the other three.
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestJIT_EmailAllowlist' -v`
+
+Expected: FAIL — `jitResolve` doesn't check the allowlist.
+
+- [ ] **Step 3: Implement allowlist (placed BEFORE the rate-limit gate)**
+
+In `jitResolve`, insert the allowlist check ABOVE the `limiter := s.rateLimiterFor(...)` line from Task 19. Ordering matters: a token whose email domain isn't allowed can never create a user, so it must not consume a rate-limit token. Putting the allowlist first means the rate limiter bounds only *eligible* creation attempts — its design intent.
+
+```go
+func (s *pgIdentityStore) jitResolve(ctx context.Context, claims *OIDCClaims) (*Identity, error) {
+	// (1) Allowlist gate — cheap, no budget spent. Refused tokens never
+	// reach the rate limiter.
+	if len(s.jitEmailAllowlist) > 0 {
+		domain := emailDomain(claims.Email)
+		if domain == "" {
+			slog.Warn("auth: JIT refused — empty email claim with non-empty allowlist",
+				"issuer", claims.Issuer)
+			return nil, ErrUnauthenticated
+		}
+		if !s.jitEmailAllowlist[domain] {
+			slog.Warn("auth: JIT refused — email domain not in allowlist",
+				"issuer", claims.Issuer, "domain", domain)
+			return nil, ErrUnauthenticated
+		}
+	}
+
+	// (2) Rate-limit gate — bounds eligible creation attempts per issuer.
+	limiter := s.rateLimiterFor(claims.Issuer)
+	if !limiter.Allow() {
+		slog.Warn("auth: JIT rate-limit exceeded",
+			"issuer", claims.Issuer, "subject", claims.Subject)
+		return nil, ErrUnauthenticated
+	}
+
+	// (3) ClaimsMapping + (4) JITCreateHuman follow (Tasks 21, 18).
+	// ... existing JIT body ...
+}
+```
+
+This replaces the rate-limit-first ordering from Task 19's stub. The executor moves the limiter block down and adds the allowlist block above it.
+
+Add the `emailDomain` helper (once):
+
+```go
+func emailDomain(email string) string {
+	i := strings.LastIndexByte(email, '@')
+	if i < 0 || i == len(email)-1 {
+		return ""
+	}
+	return strings.ToLower(email[i+1:])
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/auth && go test -run 'TestJIT_EmailAllowlist' -v`
+
+Expected: PASS for all four sub-tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/identitystore.go internal/auth/identitystore_jit_test.go
+git commit -s -m "feat(auth): JIT email-domain allowlist with missing-claim refusal"
+```
+
+---
+
+## Task 21: JIT — ClaimsMapping evaluation
+
+Map verified claims to a role at JIT-creation time (only). Subsequent sign-ins use the DB-persisted role.
+
+**Files:**
+
+- Modify: `internal/auth/identitystore.go`
+- Modify: `internal/auth/identitystore_jit_test.go`
+
+**Covers:** Happy (matching claim → mapped role) + Invariant (claims-mapping fires ONLY at JIT, never on re-sign-in; verified in Task 17's test).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestJIT_ClaimsMapping_AppliesRole(t *testing.T) {
+	p := newOIDCTestIssuer(t)
+	v, _ := auth.NewOIDCVerifier(context.Background(), config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "aud-1",
+	})
+	var capturedRole string
+	stub := &usersBackendStub{
+		lookupOIDCBinding: func(_ context.Context, _, _ string) (*storage.OIDCBinding, error) {
+			return nil, storage.ErrOIDCBindingNotFound
+		},
+		jitCreateHuman: func(_ context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error) {
+			capturedRole = u.Role
+			u.ID = "u"
+			b.ID = "b"
+			b.UserID = "u"
+			return u, b, nil
+		},
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Verifiers: []*auth.OIDCVerifier{v}, Tracker: &noopTracker{},
+		JITEnabled:     true,
+		JITDefaultRole: auth.RoleReader,
+		JITClaimsMapping: map[string][]config.ClaimMapping{
+			p.server.URL: {
+				{Claim: "groups", Value: "specgraph-admins", Role: "admin"},
+			},
+		},
+	})
+	tok := p.mintToken(t, map[string]any{
+		"iss": p.server.URL, "sub": "x", "aud": "aud-1",
+		"exp":    time.Now().Add(time.Hour).Unix(),
+		"iat":    time.Now().Unix(),
+		"email":  "a@example.com",
+		"groups": []string{"specgraph-admins"},
+	})
+	_, err := store.Resolve(context.Background(), tok)
+	require.NoError(t, err)
+	require.Equal(t, "admin", capturedRole, "claims-mapping should override default-role")
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestJIT_ClaimsMapping' -v`
+
+Expected: FAIL — `jitResolve` uses `jitDefaultRole` unconditionally.
+
+- [ ] **Step 3: Implement claims-mapping**
+
+In `jitResolve`, replace the role assignment:
+
+```go
+	role := s.jitDefaultRole
+	if role == "" {
+		role = RoleReader
+	}
+	if mappings, ok := s.jitClaimsMapping[claims.Issuer]; ok {
+		if mapped := applyClaimsMapping(claims.Raw, mappings); mapped != "" {
+			role = Role(mapped)
+		}
+	}
+```
+
+Add helper:
+
+```go
+// applyClaimsMapping evaluates the mapping rules in order. Returns the
+// first matching role, or "" if no rule matches.
+func applyClaimsMapping(claims map[string]json.RawMessage, rules []config.ClaimMapping) string {
+	for _, m := range rules {
+		raw, ok := claims[m.Claim]
+		if !ok {
+			continue
+		}
+		if matchClaimValueV2(raw, m.Value) {
+			return m.Role
+		}
+	}
+	return ""
+}
+
+// matchClaimValueV2 checks whether a claim value matches the target.
+// Supports string claims and string-array claims.
+//
+// Named "V2" during Phase A because the legacy oidc_store.go already
+// defines an identical `matchClaimValue` in this package. Task 30b
+// renames this back to `matchClaimValue` after oidc_store.go is
+// deleted (Task 30).
+func matchClaimValueV2(raw json.RawMessage, target string) bool {
+	var str string
+	if err := json.Unmarshal(raw, &str); err == nil {
+		return str == target
+	}
+	var arr []string
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		for _, v := range arr {
+			if v == target {
+				return true
+			}
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/auth && go test -run 'TestJIT_ClaimsMapping' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/identitystore.go internal/auth/identitystore_jit_test.go
+git commit -s -m "feat(auth): apply ClaimsMapping at JIT creation only"
+```
+
+---
+
+## Task 22: `HasAuth` impl
+
+Reports whether any non-bootstrap, non-deleted user exists. Used by `warnIfNoAuthOnPublicListen` at startup.
+
+**Files:**
+
+- Modify: `internal/auth/identitystore.go`
+- Modify: `internal/auth/identitystore_test.go`
+
+**Covers:** Happy (one real user → true) + Boundary (only-bootstrap → false).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestHasAuth_OnlyBootstrapReturnsFalse(t *testing.T) {
+	stub := &usersBackendStub{
+		listUsers: func(_ context.Context, f storage.ListUsersFilter) ([]*storage.User, error) {
+			require.Equal(t, storage.KindHuman, f.Kind)
+			require.False(t, f.IncludeDeleted)
+			// Return ONLY the bootstrap user.
+			u := activeUser("u-boot", "admin", storage.KindHuman)
+			u.Bootstrap = true
+			return []*storage.User{u}, nil
+		},
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Tracker: &noopTracker{},
+	})
+	has, err := store.HasAuth(context.Background())
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
+func TestHasAuth_NonBootstrapUserReturnsTrue(t *testing.T) {
+	stub := &usersBackendStub{
+		listUsers: func(_ context.Context, _ storage.ListUsersFilter) ([]*storage.User, error) {
+			return []*storage.User{
+				activeUser("u1", "reader", storage.KindHuman),
+			}, nil
+		},
+	}
+	store, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Tracker: &noopTracker{},
+	})
+	has, err := store.HasAuth(context.Background())
+	require.NoError(t, err)
+	require.True(t, has)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestHasAuth' -v`
+
+Expected: FAIL — `HasAuth` returns "not implemented".
+
+- [ ] **Step 3: Implement**
+
+```go
+func (s *pgIdentityStore) HasAuth(ctx context.Context) (bool, error) {
+	users, err := s.users.ListUsers(ctx, storage.ListUsersFilter{
+		Kind: storage.KindHuman,
+		// Note: ListUsers does not filter by Bootstrap directly; we filter
+		// post-fetch since the bootstrap rows are rare and small in count.
+	})
+	if err != nil {
+		return false, fmt.Errorf("%w: %v", ErrTransient, err)
+	}
+	for _, u := range users {
+		if !u.Bootstrap {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/auth && go test -run 'TestHasAuth' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/identitystore.go internal/auth/identitystore_test.go
+git commit -s -m "feat(auth): HasAuth via ListUsers filter for non-bootstrap presence"
+```
+
+---
+
+## Task 23: `usagetracker` package
+
+Async batched `TouchLastUsed` updater. Channel + drain goroutine + `Close(ctx)` with drain semantics.
+
+**Files:**
+
+- Create: `internal/auth/usagetracker/usagetracker.go`
+- Create: `internal/auth/usagetracker/usagetracker_test.go`
+
+**Covers:** Happy (Touch enqueues; drain calls TouchLastUsed) + Invariant (Close drains in-flight items).
+
+- [ ] **Step 1: Failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package usagetracker_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/auth/usagetracker"
+)
+
+type fakeStorage struct {
+	mu     sync.Mutex
+	touched []string
+}
+
+func (f *fakeStorage) TouchLastUsed(_ context.Context, keyID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.touched = append(f.touched, keyID)
+	return nil
+}
+
+func (f *fakeStorage) snapshot() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.touched))
+	copy(out, f.touched)
+	return out
+}
+
+func TestManager_TouchesAreFlushedOnDrain(t *testing.T) {
+	store := &fakeStorage{}
+	mgr := usagetracker.NewManager(store, usagetracker.Config{
+		BufferSize:    16,
+		FlushInterval: 50 * time.Millisecond,
+	})
+	mgr.Touch("k1")
+	mgr.Touch("k2")
+	mgr.Touch("k3")
+
+	require.NoError(t, mgr.Close(context.Background()))
+	require.ElementsMatch(t, []string{"k1", "k2", "k3"}, store.snapshot())
+}
+
+func TestManager_OverflowDropsButDoesNotBlock(t *testing.T) {
+	store := &fakeStorage{}
+	mgr := usagetracker.NewManager(store, usagetracker.Config{
+		BufferSize:    2,
+		FlushInterval: time.Hour, // drain only on Close
+	})
+	// Enqueue 100 without giving the drain a chance.
+	for i := 0; i < 100; i++ {
+		mgr.Touch("k")
+	}
+	require.NoError(t, mgr.Close(context.Background()))
+	require.LessOrEqual(t, len(store.snapshot()), 100,
+		"Touch should drop on overflow, not block")
+	// With BufferSize=2 and no drain until Close, most of the 100 are
+	// dropped. The dropped counter must be non-zero and account for the
+	// difference between enqueued and persisted.
+	require.Positive(t, mgr.Dropped(), "overflow drops should be counted")
+	require.Equal(t, uint64(100)-uint64(len(store.snapshot())), mgr.Dropped(),
+		"dropped + persisted should equal total enqueued")
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth/usagetracker && go test -v`
+
+Expected: FAIL — package doesn't exist yet.
+
+- [ ] **Step 3: Implement**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+// Package usagetracker provides asynchronous batched last_used_at updates
+// for API keys. The auth Resolver enqueues touches via Manager.Touch; a
+// background goroutine drains them into TouchLastUsedBackend (typically
+// storage.UsersBackend) at a configurable interval.
+package usagetracker
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// TouchLastUsedBackend is the storage surface the Manager uses to persist
+// touches. Satisfied by storage.UsersBackend.
+type TouchLastUsedBackend interface {
+	TouchLastUsed(ctx context.Context, keyID string) error
+}
+
+// Config parametrizes Manager.
+type Config struct {
+	BufferSize    int           // channel capacity; default 256
+	FlushInterval time.Duration // drain interval; default 5s
+}
+
+// Manager batches Touch calls and persists them async.
+type Manager struct {
+	backend TouchLastUsedBackend
+	ch      chan string
+	done    chan struct{}
+	wg      sync.WaitGroup
+	dropped atomic.Uint64 // count of touches dropped on overflow (ops visibility)
+}
+
+// NewManager constructs a Manager and starts its drain goroutine.
+func NewManager(backend TouchLastUsedBackend, cfg Config) *Manager {
+	if cfg.BufferSize <= 0 {
+		cfg.BufferSize = 256
+	}
+	if cfg.FlushInterval <= 0 {
+		cfg.FlushInterval = 5 * time.Second
+	}
+	m := &Manager{
+		backend: backend,
+		ch:      make(chan string, cfg.BufferSize),
+		done:    make(chan struct{}),
+	}
+	m.wg.Add(1)
+	go m.drain(cfg.FlushInterval)
+	return m
+}
+
+// Dropped returns the cumulative count of touches dropped due to channel
+// overflow. Exposed for ops visibility (metrics export, doctor checks, a
+// startup-time warning if non-zero). A chronically non-zero value means
+// BufferSize or FlushInterval needs tuning for the request rate.
+func (m *Manager) Dropped() uint64 {
+	return m.dropped.Load()
+}
+
+// Touch enqueues a key ID for async last_used_at update. Non-blocking:
+// drops on channel overflow, incrementing the dropped counter and logging
+// a warning.
+func (m *Manager) Touch(keyID string) {
+	select {
+	case m.ch <- keyID:
+	default:
+		m.dropped.Add(1)
+		slog.Warn("usagetracker: touch dropped on overflow",
+			"keyID", keyID, "total_dropped", m.dropped.Load())
+	}
+}
+
+func (m *Manager) drain(interval time.Duration) {
+	defer m.wg.Done()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.done:
+			m.flushAll()
+			return
+		case <-ticker.C:
+			m.flushAll()
+		}
+	}
+}
+
+func (m *Manager) flushAll() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	for {
+		select {
+		case id := <-m.ch:
+			if err := m.backend.TouchLastUsed(ctx, id); err != nil {
+				slog.Warn("usagetracker: TouchLastUsed failed", "error", err)
+			}
+		default:
+			return
+		}
+	}
+}
+
+// Close stops the drain goroutine, flushing any in-flight items.
+// Respects ctx cancellation: returns ctx.Err() if cancelled mid-drain.
+func (m *Manager) Close(ctx context.Context) error {
+	close(m.done)
+	doneCh := make(chan struct{})
+	go func() {
+		m.wg.Wait()
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/auth/usagetracker && go test -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/usagetracker/
+git commit -s -m "feat(auth): usagetracker package for async batched TouchLastUsed"
+```
+
+---
+
+## Task 24: `Manager.Close` drain integration test
+
+Beyond the unit tests, verify Close drains correctly under load.
+
+**Files:**
+
+- Modify: `internal/auth/usagetracker/usagetracker_test.go`
+
+**Covers:** Invariant (Close drains in-flight items synchronously).
+
+- [ ] **Step 1: Test**
+
+```go
+func TestManager_CloseDrainsUnderLoad(t *testing.T) {
+	store := &fakeStorage{}
+	mgr := usagetracker.NewManager(store, usagetracker.Config{
+		BufferSize:    1024,
+		FlushInterval: time.Hour, // only Close drains
+	})
+	for i := 0; i < 500; i++ {
+		mgr.Touch("k")
+	}
+	require.NoError(t, mgr.Close(context.Background()))
+	require.Equal(t, 500, len(store.snapshot()))
+}
+
+func TestManager_CloseRespectsCtxCancellation(t *testing.T) {
+	// Backend with intentional slowness.
+	slowStore := &slowFakeStorage{delay: 10 * time.Millisecond}
+	mgr := usagetracker.NewManager(slowStore, usagetracker.Config{
+		BufferSize:    1024,
+		FlushInterval: time.Hour,
+	})
+	for i := 0; i < 100; i++ {
+		mgr.Touch("k")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := mgr.Close(ctx)
+	// Either the close completes (fast enough) OR the ctx wins.
+	// Both are acceptable; the assertion is "Close does not hang".
+	require.True(t, err == nil || err == context.DeadlineExceeded)
+}
+
+type slowFakeStorage struct {
+	delay time.Duration
+}
+
+func (s *slowFakeStorage) TouchLastUsed(_ context.Context, _ string) error {
+	time.Sleep(s.delay)
+	return nil
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cd internal/auth/usagetracker && go test -v`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/auth/usagetracker/usagetracker_test.go
+git commit -s -m "test(auth): Manager.Close drains under load + respects ctx"
+```
+
+---
+
+## Task 25: Wire `usagetracker.Manager` into `pgIdentityStore`
+
+Replace the stub `LastUsedTracker` field with the real `*usagetracker.Manager` (which satisfies the same interface). No behavior changes — the interface is identical.
+
+**Files:**
+
+- Modify: `internal/auth/identitystore.go` (just an import + comment update; Manager already satisfies LastUsedTracker)
+
+**Covers:** N/A (refactor only; tests stay green via the interface).
+
+- [ ] **Step 1: Verify compatibility**
+
+`usagetracker.Manager` exposes `Touch(keyID string)`. `auth.LastUsedTracker` requires `Touch(keyID string)`. Compatible.
+
+- [ ] **Step 2: Add a docstring note**
+
+In `identitystore.go`, update the `LastUsedTracker` comment to point at the canonical implementation:
+
+```go
+// LastUsedTracker is the asynchronous TouchLastUsed surface consumed by
+// pgIdentityStore after a successful API-key resolve.
+//
+// The canonical implementation is *usagetracker.Manager. Tests may use
+// other implementations (stubs, no-ops) that satisfy the interface.
+type LastUsedTracker interface {
+	Touch(keyID string)
+}
+```
+
+No behavior change. The wiring happens in `serve.go` (Task 29) where `usagetracker.NewManager` is constructed and passed via `IdentityStoreConfig.Tracker`.
+
+- [ ] **Step 3: Verify compile + tests**
+
+Run: `cd internal/auth && go build ./... && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/auth/identitystore.go
+git commit -s -m "docs(auth): point LastUsedTracker docstring at usagetracker.Manager"
+```
+
+---
+
+## Task 26: Add `NewAuthInterceptorV2` alongside the legacy `NewAuthInterceptor`
+
+The Phase B cutover starts here. To keep both `internal/auth/` AND `cmd/specgraph/` building green at every task boundary, this task adds the NEW interceptor under a temporary name (`NewAuthInterceptorV2`) while the legacy `NewAuthInterceptor(IdentityStore)` continues to exist. `serve.go` keeps calling the legacy function until Task 29 switches it. Task 30b (after Task 30 deletes the legacy stores) renames `NewAuthInterceptorV2` back to `NewAuthInterceptor` once the legacy version is unreferenced.
+
+**Files:**
+
+- Modify: `internal/auth/interceptor.go`
+- Modify: `internal/auth/interceptor_test.go`
+
+**Covers:** Happy (resolve → authorize → handler) + Boundary (ErrUnauthenticated → 401; ErrTransient → 503; context.Canceled → propagates).
+
+- [ ] **Step 1: Write the failing test**
+
+Existing `interceptor_test.go` tests against the old `IdentityStore` interface. They will need updating in this same task. Start with new tests for the error categorization:
+
+```go
+import (
+	"errors"
+
+	"connectrpc.com/connect"
+)
+
+// fakeResolver is a tiny stub Resolver for interceptor tests.
+type fakeResolver struct {
+	resolve func(ctx context.Context, token string) (*auth.Identity, error)
+}
+
+func (f *fakeResolver) Resolve(ctx context.Context, token string) (*auth.Identity, error) {
+	return f.resolve(ctx, token)
+}
+func (f *fakeResolver) HasAuth(_ context.Context) (bool, error) { return true, nil }
+
+// fakeAuthorizer is a stub Authorizer.
+type fakeAuthorizer struct {
+	authorize func(ctx context.Context, id *auth.Identity, proc string, req any) (auth.Decision, error)
+}
+
+func (f *fakeAuthorizer) Authorize(ctx context.Context, id *auth.Identity, proc string, req any) (auth.Decision, error) {
+	return f.authorize(ctx, id, proc, req)
+}
+
+func TestInterceptor_TransientErrorIs503(t *testing.T) {
+	r := &fakeResolver{
+		resolve: func(_ context.Context, _ string) (*auth.Identity, error) {
+			return nil, fmt.Errorf("%w: pool exhausted", auth.ErrTransient)
+		},
+	}
+	a := &fakeAuthorizer{}
+	// Build a request through a test handler that uses the interceptor.
+	// Assert response code is connect.CodeUnavailable.
+	// (Test harness construction is verbose; full template follows the
+	// existing interceptor_test.go conventions.)
+	_ = r; _ = a
+	t.Skip("expand using existing interceptor_test.go harness conventions")
+}
+```
+
+> **Note:** the full interceptor test harness is involved (httptest server + connect handler + client) and exists in the current `interceptor_test.go`. Adapt those tests to the new interceptor signature; this task's pseudo-test above marks the expected new assertions.
+
+- [ ] **Step 2: Add the V2 interceptor alongside the legacy one**
+
+Add the following functions to `internal/auth/interceptor.go`. **Do NOT** re-paste the `package auth` clause or an import block — the file already has both (`context, errors, log/slog, net/http, strings, connectrpc.com/connect` are all already imported by the existing `NewAuthInterceptor`). Add only the new functions: `NewAuthInterceptorV2`, `authenticateV2`, `sessionCookieValue`, `extractBearerToken`, `mapAuthError`. Leave the existing `NewAuthInterceptor` function in place.
+
+> **Name note:** the helper is `authenticateV2`, NOT `authenticate` — the legacy `middleware.go` already defines `func authenticate(ctx, store IdentityStore, r *http.Request) (*Identity, bool)` in this package, and Go has no overloading. The V2 suffix avoids the redeclaration error during Phase A; Task 30b renames it back to `authenticate` after the legacy middleware/interceptor are deleted.
+
+```go
+// NewAuthInterceptorV2 returns a ConnectRPC unary interceptor that
+// authenticates and authorizes requests using the supplied Resolver and
+// Authorizer. Exempt procedures (Health) bypass both.
+//
+// Named "V2" temporarily during the Phase B cutover. After serve.go
+// switches to this constructor (Task 29) and the legacy NewAuthInterceptor
+// is removed, this function will be renamed back to NewAuthInterceptor
+// in the cleanup task.
+func NewAuthInterceptorV2(resolver Resolver, authorizer Authorizer) connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			procedure := req.Spec().Procedure
+			if IsExempt(procedure) {
+				return next(ctx, req)
+			}
+
+			id, err := authenticateV2(ctx, resolver, req.Header())
+			if err != nil {
+				return nil, mapAuthError(procedure, err)
+			}
+
+			decision, err := authorizer.Authorize(ctx, id, procedure, req.Any())
+			if err != nil {
+				slog.Error("auth: authorizer error",
+					"procedure", procedure, "error", err.Error())
+				return nil, connect.NewError(connect.CodeInternal, nil)
+			}
+			if !decision.Allowed {
+				slog.Warn("auth: permission denied",
+					"subject", id.Subject, "procedure", procedure, "reason", decision.Reason)
+				return nil, connect.NewError(connect.CodePermissionDenied, nil)
+			}
+
+			slog.Info("auth: authenticated",
+				"subject", id.Subject, "procedure", procedure)
+			return next(WithIdentity(ctx, id), req)
+		}
+	}
+}
+
+// authenticateV2 extracts the bearer token (Authorization header or cookie
+// fallback) and resolves it. Returns ErrUnauthenticated on missing token.
+// V2-suffixed during Phase A (legacy middleware.go has a different-signature
+// `authenticate`); renamed to `authenticate` in Task 30b.
+func authenticateV2(ctx context.Context, resolver Resolver, headers http.Header) (*Identity, error) {
+	token := extractBearerToken(headers)
+	if token == "" {
+		token = sessionCookieValue(headers) // dashboard fallback
+	}
+	if token == "" {
+		return nil, ErrUnauthenticated
+	}
+	return resolver.Resolve(ctx, token)
+}
+
+// sessionCookieValue reads the specgraph_session cookie from raw headers.
+// The standard library only exposes cookie parsing via *http.Request, so
+// we wrap the headers in a throwaway request to reuse net/http's RFC-6265
+// parser rather than hand-rolling cookie splitting. Isolated here so the
+// idiom is documented in exactly one place.
+func sessionCookieValue(headers http.Header) string {
+	r := &http.Request{Header: headers}
+	c, err := r.Cookie("specgraph_session")
+	if err != nil || c.Value == "" {
+		return ""
+	}
+	return c.Value
+}
+
+func extractBearerToken(headers http.Header) string {
+	authHeader := headers.Get("Authorization")
+	if authHeader == "" {
+		return ""
+	}
+	scheme, token, ok := strings.Cut(authHeader, " ")
+	if !ok || !strings.EqualFold(scheme, "Bearer") {
+		return ""
+	}
+	return strings.TrimSpace(token)
+}
+
+// mapAuthError maps Resolver / authentication errors to connect codes.
+func mapAuthError(procedure string, err error) error {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return connect.NewError(connect.CodeCanceled, err)
+	case errors.Is(err, context.DeadlineExceeded):
+		return connect.NewError(connect.CodeDeadlineExceeded, err)
+	case errors.Is(err, ErrTransient):
+		slog.Warn("auth: transient backend error", "procedure", procedure, "error", err.Error())
+		return connect.NewError(connect.CodeUnavailable, nil)
+	case errors.Is(err, ErrUnauthenticated):
+		slog.Info("auth: unauthenticated", "procedure", procedure)
+		return connect.NewError(connect.CodeUnauthenticated, nil)
+	default:
+		slog.Error("auth: unexpected error category", "procedure", procedure, "error", err.Error())
+		return connect.NewError(connect.CodeInternal, nil)
+	}
+}
+```
+
+- [ ] **Step 3: Add tests for V2 alongside the existing tests**
+
+The existing `interceptor_test.go` exercises the legacy `NewAuthInterceptor(IdentityStore)` — leave those tests in place; they continue to pass against the legacy function. Add NEW tests for `NewAuthInterceptorV2(Resolver, Authorizer)` using the `fakeResolver` and `fakeAuthorizer` stubs from Step 1. After Task 29 the legacy tests will be removed alongside the legacy function in the cleanup task.
+
+- [ ] **Step 4: Verify compile + tests**
+
+Run: `cd internal/auth && go build ./... && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/interceptor.go internal/auth/interceptor_test.go
+git commit -s -m "feat(auth): interceptor calls Resolver+Authorizer with error categorization"
+```
+
+---
+
+## Task 27: Add `RequireAuthV2` alongside legacy `RequireAuth`
+
+Same V2 transition pattern as Task 26: append the new function under a temporary name; leave the legacy one in place until the cleanup task.
+
+**Files:**
+
+- Modify: `internal/auth/middleware.go`
+- Modify: `internal/auth/middleware_test.go`
+
+**Covers:** Happy (cookie auth → identity in context) + Boundary (missing cookie → 401).
+
+- [ ] **Step 1: Append the V2 helper to middleware.go**
+
+```go
+// RequireAuthV2 returns HTTP middleware that authenticates requests via
+// Bearer header or session cookie using a Resolver. Renamed back to
+// RequireAuth in the Phase C cleanup task once the legacy version is
+// removed.
+func RequireAuthV2(resolver Resolver) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			id, err := authenticateV2(r.Context(), resolver, r.Header) // shared with NewAuthInterceptorV2; renamed in Task 30b
+			if err != nil {
+				switch {
+				case errors.Is(err, ErrTransient):
+					http.Error(w, `{"error":"transient"}`, http.StatusServiceUnavailable)
+				default:
+					http.Error(w, `{"error":"unauthenticated"}`, http.StatusUnauthorized)
+				}
+				return
+			}
+			next.ServeHTTP(w, r.WithContext(WithIdentity(r.Context(), id)))
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Add V2 tests alongside legacy tests**
+
+The existing `middleware_test.go` tests stay; add new tests covering `RequireAuthV2` with a `fakeResolver`. The cleanup task removes the legacy tests with the legacy function.
+
+- [ ] **Step 3: Verify compile + tests**
+
+Run: `cd internal/auth && go build ./... && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/auth/middleware.go internal/auth/middleware_test.go
+git commit -s -m "feat(auth): HTTP middleware uses Resolver (cookie path preserved)"
+```
+
+---
+
+## Task 28: Remove implicit OS-user identity paths
+
+The legacy `os/user.Current()` fallback (when no API keys were configured) is gone from both interceptor and middleware after Tasks 26–27 — but check for any lingering references and remove them.
+
+**Files:**
+
+- Modify: `internal/auth/auth.go` (drop `os` import if unreferenced)
+- Modify: any other files still referencing OS-user identity construction.
+
+- [ ] **Step 1: Grep for residual references**
+
+Run: `cd internal/auth && grep -rn 'os/user\|os.Getenv("USER")\|local:' .`
+
+Inspect the output. The only legitimate matches should be in the legacy stores being deleted in Task 30. Any references in interceptor.go, middleware.go, or other surviving files must be removed.
+
+- [ ] **Step 2: Remove residual references**
+
+If any are found in surviving files, remove them. Update any test that asserted on `"local:"` Subject prefixes.
+
+- [ ] **Step 3: Verify compile + tests**
+
+Run: `cd internal/auth && go build ./... && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/auth/
+git commit -s -m "refactor(auth): remove residual OS-user identity references"
+```
+
+---
+
+## Task 28b: Introduce nested OIDC + JITCreate config
+
+`pgIdentityStore` consumes JIT settings (rate limit, default role, email allowlist) that don't exist in `cfg.AuthConfig` today. Land the config schema change here so Task 29's serve.go references compile.
+
+**Files:**
+
+- Modify: `internal/config/global.go`
+- Modify: `internal/config/global_test.go`
+
+**Covers:** Happy (nested YAML parses) + Boundary (legacy flat `auth.oidc_providers:` returns load-time error pointing at the new path).
+
+- [ ] **Step 1: Add the new struct types**
+
+In `internal/config/global.go`, alongside the existing `AuthConfig`:
+
+```go
+// OIDCConfig wraps the OIDC provider list and JIT settings under a
+// nested auth.oidc key. Replaces the flat AuthConfig.OIDCProviders.
+type OIDCConfig struct {
+	Providers []OIDCProviderConfig `yaml:"providers"`
+	JITCreate JITCreateConfig      `yaml:"jit_create"`
+}
+
+// JITCreateConfig parametrizes just-in-time Human creation on first
+// OIDC sign-in. Consumed by the identity resolver (Authn plan).
+type JITCreateConfig struct {
+	Enabled              bool     `yaml:"enabled"`
+	DefaultRole          string   `yaml:"default_role"`
+	RateLimitPerHour     int      `yaml:"rate_limit_per_hour"`
+	EmailDomainAllowlist []string `yaml:"email_domain_allowlist"`
+}
+```
+
+Add `OIDC OIDCConfig` to `AuthConfig`:
+
+```go
+type AuthConfig struct {
+	Mode          string                `yaml:"mode"`           // deprecated; ignored after Authn plan
+	DefaultRole   string                `yaml:"default_role"`   // deprecated; ignored after Authn plan
+	APIKeys       []APIKeyConfig        `yaml:"api_keys"`       // ignored after Authn plan (storage owns)
+	OIDCProviders []OIDCProviderConfig  `yaml:"oidc_providers"` // deprecated; superseded by OIDC.Providers
+	Roles         map[string]RoleConfig `yaml:"roles"`
+	OIDC          OIDCConfig            `yaml:"oidc"`
+}
+```
+
+Keep `OIDCProviders` for one upgrade cycle so existing YAML files don't break catastrophically — but the loader (`LoadGlobal`) warns when the legacy path is populated.
+
+- [ ] **Step 2: Add migration warning in the loader**
+
+Insert the migration in `loadGlobalAt` (global.go:151), the single function that `LoadGlobal` AND `LoadGlobalExplicit` both delegate to — NOT in `LoadGlobal` directly, or the `--config` path (which uses `LoadGlobalExplicit`) would skip migration. Place it AFTER the YAML unmarshal and before the function returns:
+
+```go
+// Migrate the deprecated flat auth.oidc_providers into auth.oidc.providers.
+// New path wins if both are set (no migration in that case).
+if len(cfg.Auth.OIDCProviders) > 0 && len(cfg.Auth.OIDC.Providers) == 0 {
+	cfg.Auth.OIDC.Providers = cfg.Auth.OIDCProviders
+	slog.Warn("auth.oidc_providers is deprecated; move providers under auth.oidc.providers")
+}
+```
+
+`internal/config/global.go` does not currently import `log/slog` — add it to the import block.
+
+- [ ] **Step 3: Tests**
+
+Add to `global_test.go`:
+
+```go
+func TestLoadGlobal_OIDCJITConfig(t *testing.T) {
+	// Write a tmp YAML with the new nested shape.
+	yamlBody := []byte(`
+auth:
+  oidc:
+    providers:
+      - id: entra
+        issuer: https://login.microsoftonline.com/tenant/v2.0
+        client_id: app-id
+    jit_create:
+      enabled: true
+      default_role: reader
+      rate_limit_per_hour: 200
+      email_domain_allowlist: [example.com, other.com]
+`)
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, yamlBody, 0o600))
+
+	cfg, err := config.LoadGlobal(path)
+	require.NoError(t, err)
+	require.True(t, cfg.Auth.OIDC.JITCreate.Enabled)
+	require.Equal(t, "reader", cfg.Auth.OIDC.JITCreate.DefaultRole)
+	require.Equal(t, 200, cfg.Auth.OIDC.JITCreate.RateLimitPerHour)
+	require.Len(t, cfg.Auth.OIDC.JITCreate.EmailDomainAllowlist, 2)
+	require.Len(t, cfg.Auth.OIDC.Providers, 1)
+}
+
+func TestLoadGlobal_LegacyOIDCProvidersStillWorks(t *testing.T) {
+	yamlBody := []byte(`
+auth:
+  oidc_providers:
+    - id: legacy-entra
+      issuer: https://login.microsoftonline.com/old/v2.0
+      client_id: app-id
+`)
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, yamlBody, 0o600))
+
+	cfg, err := config.LoadGlobal(path)
+	require.NoError(t, err)
+	require.Len(t, cfg.Auth.OIDC.Providers, 1, "legacy path should migrate transparently")
+	require.Equal(t, "legacy-entra", cfg.Auth.OIDC.Providers[0].ID)
+}
+```
+
+- [ ] **Step 4: Verify compile + tests**
+
+Run: `cd internal/config && go build ./... && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/global.go internal/config/global_test.go
+git commit -s -m "feat(config): nest OIDC + JITCreate under auth.oidc with legacy migration"
+```
+
+---
+
+## Task 29: Update `cmd/specgraph/serve.go` wiring
+
+Construct the new components: `usagetracker.Manager`, `OIDCVerifier`s, `pgIdentityStore`, `StaticTableAuthorizer`. Pass to `NewAuthInterceptor`. Remove old store construction. Remove `cfg.Auth.Mode` validation. Remove `auth.Bootstrap()` (moves to Bootstrap & UX plan). Wire `Manager.Close()` into shutdown.
+
+**Files:**
+
+- Modify: `cmd/specgraph/serve.go`
+
+- [ ] **Step 1: Identify the diff**
+
+The existing serve.go (around lines 128–210, per the merged code) has:
+
+- `auth.NewConfigStore(...)` — DELETE
+- `auth.NewCompositeStore(...)` — DELETE
+- `cfg.Auth.Mode` validation block — DELETE
+- `auth.Bootstrap(credPath)` call — DELETE (moves to Bootstrap & UX)
+- `auth.NewOIDCStore(...)` per provider — REPLACE with `auth.NewOIDCVerifier(...)`
+- `auth.NewAuthInterceptor(compositeStore)` — REPLACE with `auth.NewAuthInterceptorV2(resolver, authorizer)` (the V2 name persists until the cleanup task renames it back to `NewAuthInterceptor`)
+
+- [ ] **Step 2: Rewrite the auth wiring section**
+
+```go
+// Build the auth pool via the existing postgres.Store.Pool() accessor.
+authStore, err := postgres.NewAuth(ctx, store.Pool())
+if err != nil {
+	return fmt.Errorf("auth store: %w", err)
+}
+defer func() { _ = authStore.Close(ctx) }()
+
+// Construct OIDC verifiers (one per provider; renamed from OIDCStore).
+// Iterate cfg.Auth.OIDC.Providers — the post-migration canonical field.
+// Task 28b's loader copies legacy cfg.Auth.OIDCProviders into this field,
+// so reading the legacy field here would yield ZERO verifiers for any
+// config that uses the new auth.oidc.providers shape (silently breaking
+// all JWT/JIT auth). Must match the claims-mapping source below.
+verifiers := make([]*auth.OIDCVerifier, 0, len(cfg.Auth.OIDC.Providers))
+for _, pc := range cfg.Auth.OIDC.Providers {
+	issuerCtx, issuerCancel := context.WithTimeout(ctx, 10*time.Second)
+	v, oidcErr := auth.NewOIDCVerifier(issuerCtx, pc)
+	issuerCancel()
+	if oidcErr != nil {
+		return fmt.Errorf("OIDC provider %s: %w", pc.ID, oidcErr)
+	}
+	verifiers = append(verifiers, v)
+}
+
+// usagetracker for async TouchLastUsed.
+tracker := usagetracker.NewManager(authStore, usagetracker.Config{
+	BufferSize:    256,
+	FlushInterval: 5 * time.Second,
+})
+defer func() {
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer shutdownCancel()
+	if err := tracker.Close(shutdownCtx); err != nil {
+		slog.Warn("usagetracker close", "error", err)
+	}
+	if dropped := tracker.Dropped(); dropped > 0 {
+		slog.Warn("usagetracker dropped touches over session lifetime",
+			"count", dropped,
+			"hint", "increase auth usagetracker BufferSize or decrease FlushInterval")
+	}
+}()
+
+// Role→permissions snapshot (built-ins ∪ cfg.Auth.Roles). Shared by the
+// authorizer and used to derive KnownRoles for JIT validation.
+rolePerms := auth.LoadRolePerms(cfg.Auth.Roles)
+knownRoles := make(map[auth.Role]bool, len(rolePerms))
+for r := range rolePerms {
+	knownRoles[r] = true
+}
+
+// IdentityStore.
+resolver, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+	Users:                   authStore,
+	Verifiers:               verifiers,
+	Tracker:                 tracker,
+	KnownRoles:              knownRoles,
+	JITEnabled:              cfg.Auth.OIDC.JITCreate.Enabled,
+	JITDefaultRole:          auth.Role(cfg.Auth.OIDC.JITCreate.DefaultRole),
+	JITClaimsMapping:        buildClaimsMappingByIssuer(cfg.Auth.OIDC.Providers),
+	JITRateBurstPerHour:     cfg.Auth.OIDC.JITCreate.RateLimitPerHour,
+	JITEmailDomainAllowlist: cfg.Auth.OIDC.JITCreate.EmailDomainAllowlist,
+})
+if err != nil {
+	return fmt.Errorf("identity store: %w", err)
+}
+
+// Authorizer (static table for now; Cedar plan swaps).
+authorizer := auth.NewStaticTableAuthorizer(rolePerms)
+
+interceptor := auth.NewAuthInterceptorV2(resolver, authorizer) // renamed in cleanup task
+
+// HasAuth signal for the existing warn path.
+if has, _ := resolver.HasAuth(ctx); !has {
+	warnIfNoAuthOnPublicListen(cfg.Server.Listen, false)
+}
+```
+
+> Note: `buildClaimsMappingByIssuer` is a small helper added to serve.go that converts `[]config.OIDCProviderConfig` into `map[string][]config.ClaimMapping` keyed by issuer URL (each provider contributes its `ClaimsMapping` slice under its issuer). Role→permissions come from the EXPORTED `auth.LoadRolePerms(cfg.Auth.Roles)` (Task 4) — serve.go does not define its own role-perms helper. `cfg.Auth.OIDC.*` references the nested config shape introduced in Task 28b. Add explicit imports for `slog`, `time`, `internal/auth/usagetracker`, and `internal/config` at the top of serve.go.
+
+- [ ] **Step 3: Verify compile + tests**
+
+Run: `cd cmd/specgraph && go build ./... && cd ../.. && go test ./...`
+
+Expected: PASS, with the caveat that integration tests in `e2e/` may need parallel adaptation if they exercise the old auth wiring.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/specgraph/serve.go
+git commit -s -m "feat(serve): wire pgIdentityStore + StaticTableAuthorizer + usagetracker"
+```
+
+---
+
+## Task 30: Delete obsolete files
+
+After Tasks 26–29 land, nothing references `config_store.go`, `composite_store.go`, `token_store.go`, or `oidc_store.go`. Delete them.
+
+**Files:**
+
+- Delete: `internal/auth/config_store.go` + `config_store_test.go`
+- Delete: `internal/auth/composite_store.go` + `composite_store_test.go`
+- Delete: `internal/auth/token_store.go` + `token_store_test.go`
+- Delete: `internal/auth/oidc_store.go` + `oidc_store_test.go`
+
+- [ ] **Step 1: Delete the files**
+
+```bash
+rm internal/auth/config_store.go internal/auth/config_store_test.go
+rm internal/auth/composite_store.go internal/auth/composite_store_test.go
+rm internal/auth/token_store.go internal/auth/token_store_test.go
+rm internal/auth/oidc_store.go internal/auth/oidc_store_test.go
+```
+
+- [ ] **Step 2: Verify the package still compiles**
+
+Run: `cd internal/auth && go build ./... && go test ./...`
+
+Expected: PASS. If FAIL: some Phase B task missed a reference. Re-run grep:
+
+```bash
+grep -rn 'NewConfigStore\|NewCompositeStore\|NewOIDCStore\|TokenStore' .
+```
+
+Resolve any remaining references before committing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A internal/auth/
+git commit -s -m "chore(auth): delete obsolete ConfigStore, CompositeStore, TokenStore, OIDCStore"
+```
+
+---
+
+## Task 30b: Drop the V2 suffixes; delete remaining legacy functions
+
+Phase A used five V2-suffixed names to coexist with identically-named legacy functions: `NewAuthInterceptorV2`, `RequireAuthV2`, `authenticateV2`, `peekIssuerV2`, `matchClaimValueV2`. Task 30 deleted `composite_store.go` (legacy `peekIssuer`) and `oidc_store.go` (legacy `matchClaimValue`), so those two canonical names are now free. The legacy `NewAuthInterceptor`, `RequireAuth`, and `authenticate` still live in `interceptor.go`/`middleware.go` and must be deleted here before their V2 counterparts can take the canonical names.
+
+This task removes all five V2 suffixes and deletes the three remaining legacy functions, leaving the canonical names pointing at the new implementations.
+
+**Files:**
+
+- Modify: `internal/auth/interceptor.go`, `internal/auth/interceptor_test.go`
+- Modify: `internal/auth/middleware.go`, `internal/auth/middleware_test.go`
+- Modify: `internal/auth/identitystore.go` (peekIssuerV2, matchClaimValueV2 + their callers)
+- Modify: `cmd/specgraph/serve.go`
+
+- [ ] **Step 1: Confirm the canonical names are free**
+
+```bash
+# Legacy peekIssuer / matchClaimValue should be GONE (their files were
+# deleted in Task 30). Expect matches ONLY for the V2 names:
+grep -rn 'func peekIssuer\b\|func matchClaimValue\b' --include='*.go' internal/auth/
+# Legacy NewAuthInterceptor / RequireAuth / authenticate still exist here
+# (to be deleted in Step 2); V2 versions also present:
+grep -rn 'func NewAuthInterceptor\|func RequireAuth\|func authenticate' --include='*.go' internal/auth/
+```
+
+If a legacy `peekIssuer`/`matchClaimValue` still appears, Task 30 didn't fully delete its file — fix that first.
+
+- [ ] **Step 2: Delete the three remaining legacy functions**
+
+- Remove legacy `func NewAuthInterceptor(store IdentityStore)` from `interceptor.go`.
+- Remove legacy `func RequireAuth(store IdentityStore)` from `middleware.go`.
+- Remove legacy `func authenticate(ctx, store IdentityStore, r *http.Request) (*Identity, bool)` from `middleware.go`.
+- Remove the legacy tests that exercise them from `interceptor_test.go` and `middleware_test.go`.
+
+- [ ] **Step 3: Drop the V2 suffixes (rename to canonical)**
+
+Search-and-replace across `internal/auth/` and `cmd/specgraph/serve.go`:
+
+- `NewAuthInterceptorV2` → `NewAuthInterceptor`
+- `RequireAuthV2` → `RequireAuth`
+- `authenticateV2` → `authenticate`
+- `peekIssuerV2` → `peekIssuer`
+- `matchClaimValueV2` → `matchClaimValue`
+
+Update the V2 test names to drop the suffix too, and serve.go's `auth.NewAuthInterceptorV2(...)` → `auth.NewAuthInterceptor(...)`.
+
+- [ ] **Step 4: Verify compile + tests**
+
+Run: `cd internal/auth && go build ./... && go test ./... && cd ../../cmd/specgraph && go build ./...`
+
+Then re-run the grep from Step 1 — expect exactly one definition of each canonical name (`peekIssuer`, `matchClaimValue`, `authenticate`, `NewAuthInterceptor`, `RequireAuth`), all pointing at the new implementations.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/interceptor.go internal/auth/interceptor_test.go \
+        internal/auth/middleware.go internal/auth/middleware_test.go \
+        internal/auth/identitystore.go cmd/specgraph/serve.go
+git commit -s -m "chore(auth): drop V2 suffixes, delete remaining legacy auth functions"
+```
+
+---
+
+## Task 31: Remove `Identity.Permissions` and legacy interface
+
+Now that nothing in the package references these, clean them up.
+
+**Files:**
+
+- Modify: `internal/auth/auth.go` (remove `Permissions` field)
+- Modify: `internal/auth/store.go` (remove old sentinels + `IdentityStore` interface)
+- Search-and-fix any remaining references.
+
+- [ ] **Step 1: Grep for residual references**
+
+```bash
+grep -rn 'Permissions\|ErrUnknownKey\|ErrNoOIDC\|ErrUnknownIssuer\|ErrInvalidToken\|IdentityStore' internal/auth/ cmd/specgraph/
+```
+
+Inspect; anything that remains is something to fix in this task before deletion.
+
+- [ ] **Step 2: Remove `Permissions` from `Identity`**
+
+In `auth.go`:
+
+```go
+type Identity struct {
+	UserID        string
+	EffectiveRole Role
+	Email         string
+
+	Subject     string
+	DisplayName string
+	Role        Role
+	Source      string // "apikey" | "oidc"
+}
+```
+
+Drop the `Permissions` line and its comment.
+
+- [ ] **Step 3: Remove `HasPermission` exported helper**
+
+If it survived Task 4 in `auth.go`, delete it. The package-private `hasPermissionInternal` in `static_authorizer.go` is the only remaining permission-check helper.
+
+- [ ] **Step 4: Remove old sentinels and the `IdentityStore` interface from `store.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import "errors"
+
+// ErrUnauthenticated and ErrTransient remain. Old sentinels removed.
+var (
+	ErrUnauthenticated = errors.New("auth: unauthenticated")
+	ErrTransient       = errors.New("auth: transient backend error")
+)
+```
+
+The `IdentityStore` interface is deleted (Resolver replaces it).
+
+- [ ] **Step 5: Verify compile + tests**
+
+Run: `cd internal/auth && go build ./... && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/auth/auth.go internal/auth/store.go
+git commit -s -m "chore(auth): remove Identity.Permissions, HasPermission, legacy IdentityStore"
+```
+
+---
+
+## Task 32: Remove `"local"` Source value
+
+The implicit OS-user path is gone; `"local"` is no longer a valid `Identity.Source`.
+
+**Files:**
+
+- Modify: `internal/auth/auth.go` (update Source comment)
+- Modify: any test that asserted `Source == "local"`.
+
+- [ ] **Step 1: Update the Source comment**
+
+```go
+Source string // "apikey" | "oidc"
+```
+
+- [ ] **Step 2: Grep for "local" assertions**
+
+```bash
+grep -rn '"local"' internal/auth/ cmd/specgraph/
+```
+
+Update or remove any test/assertion still expecting `"local"`.
+
+- [ ] **Step 3: Verify compile + tests**
+
+Run: `cd internal/auth && go build ./... && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/auth/auth.go
+git commit -s -m "chore(auth): remove 'local' from valid Identity.Source values"
+```
+
+---
+
+## Task 33: Integration test — full resolve flow
+
+End-to-end test against a real `AuthStore`. Bootstraps an admin via direct SQL, mints a key with a known PHC hash, resolves the key, asserts the Identity.
+
+**Files:**
+
+- Create: `internal/auth/identitystore_integration_test.go`
+
+**Covers:** E2E (Resolver + UsersBackend + argon2id; one user lifecycle).
+
+- [ ] **Step 1: Write the test**
+
+```go
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/auth/usagetracker"
+	"github.com/specgraph/specgraph/internal/storage/postgres"
+	"github.com/specgraph/specgraph/internal/storage/postgres/postgrestest"
+)
+
+func TestIntegration_APIKeyResolve(t *testing.T) {
+	ctx := context.Background()
+	pool := postgrestest.SharedPool(t, ctx) // from postgres test harness
+	authStore, err := postgres.NewAuth(ctx, pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = authStore.Close(ctx) })
+
+	// Truncate then create a user + key.
+	_, err = pool.Exec(ctx, `TRUNCATE users RESTART IDENTITY CASCADE`)
+	require.NoError(t, err)
+
+	user := activeUser("aaaa0000-0000-0000-0000-000000000001", "writer", storage.KindHuman)
+	_, err = pool.Exec(ctx, `INSERT INTO users (id, kind, display_name, role)
+	                         VALUES ($1::uuid, 'human', $2, $3)`,
+		user.ID, user.DisplayName, user.Role)
+	require.NoError(t, err)
+
+	// PHC hash for plaintext "test-secret-32-chars-padding-aa".
+	_, err = pool.Exec(ctx, `INSERT INTO api_keys (id, user_id, prefix, phc_hash)
+	                         VALUES ('bbbb0000-0000-0000-0000-000000000002'::uuid,
+	                                 $1::uuid, 'abc12345', $2)`,
+		user.ID, stubPHCHash)
+	require.NoError(t, err)
+
+	tracker := usagetracker.NewManager(authStore, usagetracker.Config{})
+	t.Cleanup(func() { _ = tracker.Close(ctx) })
+
+	resolver, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users:   authStore,
+		Tracker: tracker,
+	})
+	require.NoError(t, err)
+
+	id, err := resolver.Resolve(ctx, stubAPIKeyToken("abc12345"))
+	require.NoError(t, err)
+	require.Equal(t, user.ID, id.UserID)
+	require.Equal(t, auth.Role("writer"), id.Role)
+	require.Equal(t, "apikey", id.Source)
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cd internal/auth && go test -tags integration -run 'TestIntegration_APIKeyResolve' -v`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/auth/identitystore_integration_test.go
+git commit -s -m "test(auth): integration test for end-to-end API-key resolve"
+```
+
+---
+
+## Task 34: Lifecycle smoke (auth-only)
+
+A multi-step lifecycle test: bootstrap admin authenticates, JIT a real OIDC user, revoke the bootstrap key, assert bootstrap can't auth but JIT'd user can.
+
+**Files:**
+
+- Modify: `internal/auth/identitystore_integration_test.go`
+
+**Covers:** E2E (multi-step lifecycle through Resolver + UsersBackend).
+
+- [ ] **Step 1: Write the test**
+
+```go
+func TestIntegration_Lifecycle(t *testing.T) {
+	ctx := context.Background()
+	pool := postgrestest.SharedPool(t, ctx)
+	authStore, err := postgres.NewAuth(ctx, pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = authStore.Close(ctx) })
+
+	_, err = pool.Exec(ctx, `TRUNCATE users RESTART IDENTITY CASCADE`)
+	require.NoError(t, err)
+
+	// Seed a bootstrap admin via direct SQL.
+	admin, err := authStore.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "admin", Role: "admin", Bootstrap: true,
+	}, nil)
+	require.NoError(t, err)
+
+	// Mint a key for admin.
+	adminKey, err := authStore.CreateAPIKey(ctx, &storage.APIKey{
+		UserID: admin.ID, PHCHash: stubPHCHash,
+	})
+	require.NoError(t, err)
+
+	// Build resolver.
+	tracker := usagetracker.NewManager(authStore, usagetracker.Config{})
+	t.Cleanup(func() { _ = tracker.Close(ctx) })
+	resolver, _ := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: authStore, Tracker: tracker,
+	})
+
+	// Bootstrap admin authenticates.
+	id, err := resolver.Resolve(ctx,
+		stubAPIKeyToken(adminKey.Prefix))
+	require.NoError(t, err)
+	require.Equal(t, admin.ID, id.UserID)
+
+	// Revoke the key.
+	require.NoError(t, authStore.RevokeAPIKey(ctx, adminKey.ID))
+
+	// Bootstrap can no longer authenticate.
+	_, err = resolver.Resolve(ctx,
+		stubAPIKeyToken(adminKey.Prefix))
+	require.ErrorIs(t, err, auth.ErrUnauthenticated)
+}
+```
+
+- [ ] **Step 2: Run all integration tests**
+
+Run: `cd internal/auth && go test -tags integration -v`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/auth/identitystore_integration_test.go
+git commit -s -m "test(auth): integration lifecycle smoke (bootstrap → revoke → reject)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+- [x] Single resolver replacing multi-store routing: Task 9 (scaffold) + 10–18 (impl).
+- [x] OIDC verifier split from user materialization: Tasks 5–6.
+- [x] No implicit OS-user identity: Task 28.
+- [x] JIT controls (rate limit + email allowlist): Tasks 19–20.
+- [x] Error categorization (3 categories → 3 codes): Tasks 11–18 (sentinel returns) + Task 26 (mapping).
+- [x] Authorizer interface seam: Tasks 3–4.
+- [x] ClaimsMapping at JIT-only: Task 21.
+- [x] Async last-used (usagetracker): Tasks 23–25.
+- [x] Dashboard cookie path preserved: Task 27.
+- [x] `cfg.Auth.Mode` removal: Task 29.
+- [x] Identity.Permissions removal: Task 31 (Phase C, after Cedar landing point is reachable from this plan).
+
+**Build discipline:**
+
+Every task ends with `go build ./... && go test ./...` green — at BOTH the `internal/auth/` package level AND the whole-project level. The Phase B cutover uses five V2-suffixed names to coexist with identically-named legacy functions during Phase A: `NewAuthInterceptorV2`/`RequireAuthV2` (Tasks 26–27) plus the package helpers `authenticateV2` (Task 26), `peekIssuerV2` (Task 16), and `matchClaimValueV2` (Task 21) — each collides by name with a legacy definition in `composite_store.go`/`oidc_store.go`/`middleware.go` that survives until Task 30. The new functions are added alongside the legacy ones; serve.go keeps calling the legacy interceptor until Task 29 switches; Task 30b deletes the remaining legacy functions and drops all five V2 suffixes after Task 30 removes the legacy files. This avoids the window where `serve.go` would fail to compile against a changed interceptor signature. Tasks 1–2 are additive to existing types. Tasks 3–8 add new files. Tasks 9–25 add `pgIdentityStore` + `usagetracker.Manager` alongside old code. Task 28b lands the nested OIDC/JIT config. Phase C (30, 30b, 31, 32) deletes obsolete code only after Phase B confirms nothing references it.
+
+**Placeholder scan:**
+
+All 35 tasks (1–34 plus 28b, 30b) fully expanded with TDD cycles (failing test → verify failure → impl → run to pass → commit). Two documented decision points are flagged inline as the executor's call, not as placeholders:
+
+- Task 20: three of the four allowlist sub-tests have their bodies summarized in a comment, with the first one shown in full. The executor copies the first into the other three with different email values.
+- Task 26: the existing `interceptor_test.go` harness is substantial; the plan describes the new V2 assertions but expects the executor to adapt the existing test scaffolding rather than re-write it from scratch.
+
+The PHC-secret harmonization that was previously a manual decision point is now mechanically solved: `stubPHCSecret`, `stubPHCHash`, and `stubAPIKeyToken` live in the Task 8 fixtures file; `TestStubSecretLength` guards the length; the verifier and fixture use identical argon2id parameters.
+
+**Type consistency:**
+
+`Identity`, `Resolver`, `Authorizer`, `Decision`, `OIDCVerifier`, `OIDCClaims`, `pgIdentityStore`, `LastUsedTracker`, `usagetracker.Manager`, `StaticTableAuthorizer`, `IdentityStoreConfig`, `OIDCClaims` referenced consistently across all 34 tasks. The `pgIdentityStore` implements `Resolver`; the compile-time assertion is implicit via the constructor's return type.
+
+**Build-discipline check (every task ends green):**
+
+- Tasks 1–8: additive (new files, new fields, shared test fixtures). Package compiles after each. `go mod tidy` in Task 9/10 promotes `golang.org/x/time` from indirect to direct.
+- Tasks 9–22: build out `pgIdentityStore` incrementally; each method-introducing task is a self-contained TDD cycle on the stub UsersBackend. Package compiles after each.
+- Tasks 23–25: add `usagetracker` package in isolation; wire docstring after.
+- Task 28b: lands nested `auth.oidc.jit_create` config so Task 29's serve.go references compile (with transparent legacy `auth.oidc_providers` migration).
+- Tasks 26–29: the Phase B cutover via the V2 transition. Task 26 ADDS `NewAuthInterceptorV2` (legacy `NewAuthInterceptor` untouched); Task 27 ADDS `RequireAuthV2`; Task 28 removes residual OS-user code; Task 29 switches serve.go to the V2 constructors. **Whole-project compiles at every commit** — serve.go calls the legacy interceptor until Task 29, then the V2 one. No signature-mismatch window.
+- Tasks 30, 30b, 31, 32: deletion phase. Legacy stores deleted (30), V2 renamed to canonical + legacy interceptor/middleware deleted (30b), `Identity.Permissions` + old sentinels + old interface removed (31), "local" Source value removed (32). Each task ends compiling.
+- Tasks 33–34: pure-additive integration tests (`//go:build integration`).
+
+---
+
+## Execution
+
+The plan supports both execution modes:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task. Tasks 1–22 are short, well-scoped TDD cycles ideal for a fleet. Tasks 23–25 (usagetracker), 28b (config), 26–30b (cutover + cleanup), and 33–34 (integration) form natural batches; a coordinator subagent can run each batch with checkpoint review between.
+2. **Inline Execution** — practical for the Phase B cutover (Tasks 26–30b) which involves coordinated changes across multiple files. The earlier and later phases work fine inline too.
+
+The Cedar plan follows this one. Per the Authorizer-interface seam established in Tasks 3–4, the Cedar plan adds `CedarAuthorizer` and deletes `StaticTableAuthorizer` + `internal/auth/permissions.go` + the `hasPermissionInternal` helper. The interceptor diff in Cedar is **zero** — that's the payoff of the seam.

--- a/docs/plans/2026-05-26-identity-bootstrap-ux-4a-rpc-surface-implementation-plan.md
+++ b/docs/plans/2026-05-26-identity-bootstrap-ux-4a-rpc-surface-implementation-plan.md
@@ -1,0 +1,2924 @@
+# Identity Bootstrap & UX — Plan 4a: IdentityService RPC Surface + CLI
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose the existing `storage.UsersBackend` as an `IdentityService` ConnectRPC API (users, service accounts, API keys, OIDC bindings, whoami), gate it in Cedar as admin-only (plus self-readable whoami), and surface it as the `specgraph auth` CLI subtree — so a hosted operator with RPC-only access can manage identity.
+
+**Architecture:** This is the FIRST of two plans split from the "Identity Bootstrap & Operator UX" design (`docs/plans/2026-05-22-identity-bootstrap-ux-design.md`). 4a builds the operator RPC surface + CLI; **Plan 4b** (bootstrap flows, credentials-file, force-flag protections) follows immediately and depends on these RPCs. The `IdentityService` is **global** (not project-scoped) — its handler holds a `storage.UsersBackend` directly, unlike the project-scoped handlers that take a `storage.Scoper`. Authorization is admin-only via a new Cedar `manage` verb (additive to the Cedar plan); `whoami` is self-scoped via the existing `read` verb. Self-service ownership (rotate *my own* key) is explicitly deferred to story #4 per the Cedar design's sequencing. Build-alongside discipline: every task ends with `go build ./... && go test ./...` green at package and whole-project level.
+
+**Tech Stack:** Go 1.26, ConnectRPC, Protobuf (buf via `task proto`), pgx v5 (via `UsersBackend`), `golang.org/x/crypto/argon2` (API-key minting), Cobra (CLI), `cedar-go` (authz, via the Cedar plan's engine).
+
+**Implements bead:** Part of approved design `spgr-g90r` (Identity Bootstrap & UX) under epic `spgr-rjrt`, sub-plan 4a. Depends on the Storage (`spgr-e82m`), Authn (`spgr-n2rw`), and Cedar (`spgr-rjrt.1`) plans being merged first.
+
+---
+
+## Dependency contract (what the prior plans provide)
+
+This plan builds on the **merged output** of the three prior plans. The symbols it consumes:
+
+- **Storage** — `storage.UsersBackend` (interface with `ListUsers`, `GetUserByID`, `CreateServiceAccount`, `UpdateUserRole`, `SoftDeleteUser`, `PurgeUser`, `CreateAPIKey`, `RevokeAPIKey`, `RotateAPIKey`, `ListAPIKeys`, `ListOIDCBindings`, `UnbindOIDC`, `GetBootstrap`); domain types `storage.User`, `storage.APIKey`, `storage.OIDCBinding`, `storage.Kind` (`KindHuman`/`KindServiceAccount`); filters `storage.ListUsersFilter`, `storage.ListAPIKeysFilter`; sentinels `storage.ErrUserNotFound`, `storage.ErrAPIKeyNotFound`, `storage.ErrOIDCBindingNotFound`, `storage.ErrBootstrapExists`, `storage.ErrAPIKeyPrefixExists`. The postgres `*AuthStore` (constructed via `postgres.NewAuth(ctx, pool)`) implements `UsersBackend`.
+  - **Key-generation contract (load-bearing for Tasks 7–8):** `CreateAPIKey(ctx, k)` and `RotateAPIKey(ctx, oldID, newKey)` **own prefix generation** — they call `s.genPrefix()` and IGNORE any `Prefix` the caller set, returning the key with the storage-assigned prefix. `RotateAPIKey` does NOT copy metadata from the old key; it inserts `newKey.UserID`, `newKey.PHCHash`, `newKey.RoleDowngrade`, `newKey.Label`, `newKey.ExpiresAt`, so the caller MUST supply `UserID` + metadata on `newKey` (there is no get-key-by-id backend method to look the old one up). This is why minting is split (`GenerateAPIKeySecret` + `FormatAPIKeyToken`) and `RotateAPIKeyRequest` carries `user_id`.
+- **Authn** — `auth.Identity` (fields `Subject`, `UserID`, `EffectiveRole`, `Email`, `DisplayName`, `Role`, `Source`); `auth.IdentityFromContext(ctx) (*Identity, bool)` and `auth.WithIdentity(ctx, *Identity) context.Context` (both in `internal/auth/context.go`); `auth.RoleReader`/`RoleWriter`/`RoleAdmin` (typed `auth.Role`; `RoleAdmin == "admin"`, so `string(id.Role)` yields `"admin"`); the post-cleanup interceptor constructor `auth.NewAuthInterceptor(resolver, authorizer)` (Authn Task 30b renames `NewAuthInterceptorV2`→`NewAuthInterceptor`); the API-key format constants in `internal/auth/identitystore.go`: `apiKeyPrefix = "spgr_sk_"`, `apiKeyPrefixLen = 8`, `apiKeySecretLen = 32` (unexported, same package), and the argon2id PHC scheme (`argon2.IDKey(secret, salt, 2, 19456, 1, 32)`, salt 16 bytes, format `$argon2id$v=19$m=19456,t=2,p=1$<b64salt>$<b64hash>`). `GenerateAPIKeySecret` reuses `apiKeyPrefix`/`apiKeySecretLen` but NOT `apiKeyPrefixLen` (storage owns the prefix).
+- **Cedar** — `auth.procedureActions` map + `auth.ActionForProcedure`/`auth.ActionNames`; `auth.knownVerbs`; the engine's `buildActionEntities`; `internal/auth/policies/base.cedar`; `CedarAuthorizer` (drives interceptor authz; an unconfigured procedure → `CodeInternal`).
+
+If any of these names differ in the merged code, adapt to the actual name — they are pinned here so the plan's code is concrete, not fictional.
+
+---
+
+## Testing approach
+
+Four categories (same framework as the prior plans). Each behavior task tags `**Covers:**`.
+
+- **Happy** — normal success per RPC / command.
+- **Invariants** — admin-only gating holds for every management RPC; minted keys verify against the Authn resolver; plaintext is returned exactly once and never persisted; whoami reflects the caller.
+- **Boundaries** — NotFound mapping, invalid arguments, unconfigured-procedure guard, empty lists.
+- **E2E** — interceptor → Cedar → handler → backend, and CLI → RPC.
+
+Handler unit tests use a hand-rolled `UsersBackend` stub (Task 3 introduces a server-package stub; it mirrors the Authn plan's `usersBackendStub` shape but lives in `internal/server`). Integration tests (`//go:build integration`) use the testcontainer `AuthStore` and the real interceptor.
+
+---
+
+## File Structure
+
+**Create:**
+
+- `proto/specgraph/v1/identity.proto` — `IdentityService` + messages. (`task proto` regenerates `gen/specgraph/v1/identity*.go` + `specgraphv1connect/identity.connect.go`.)
+- `internal/server/convert_identity.go` (+ `_test.go`) — `userToProto`, `apiKeyToProto`, `oidcBindingToProto`, `userKindToProto`, filter converters.
+- `internal/server/identity_handler.go` (+ `_test.go`) — `IdentityHandler`, all 13 RPCs, `identityError` mapper, `RegisterIdentityService`.
+- `internal/server/usersbackend_stub_test.go` — server-package `UsersBackend` stub for handler unit tests.
+- `internal/server/identity_integration_test.go` (`//go:build integration`) — interceptor→Cedar→handler.
+- `internal/auth/mint.go` (+ `_test.go`) — `GenerateAPIKeySecret` + `FormatAPIKeyToken` + `APIKeyTokenPrefix` (package `auth`, reuse the unexported key-format constants; storage owns the prefix).
+- `cmd/specgraph/identity_client.go` — `identityClient()` helper.
+- `cmd/specgraph/auth.go` — `specgraph auth` root + `whoami`.
+- `cmd/specgraph/auth_user.go` — `auth user list|show|set-role|delete|purge`.
+- `cmd/specgraph/auth_apikey.go` — `auth api-key list|create|revoke|rotate`.
+- `cmd/specgraph/auth_oidc.go` — `auth oidc list|unbind`.
+- `internal/render/identity.go` (+ `_test.go`) — table renderers for User / APIKey / OIDCBinding.
+
+**Modify:**
+
+- `internal/auth/engine.go` — add `"manage"` to `knownVerbs` (one line, additive).
+- `internal/auth/policies/base.cedar` — add the `manage → admin` policy.
+- `internal/auth/actions.go` — add the 13 identity procedure→action entries to `procedureActions`.
+- `cmd/specgraph/serve.go` — `server.RegisterIdentityService(mux, authStore, connectOpts...)`.
+
+**Do NOT touch:** the CedarAuthorizer/engine evaluation logic (only `knownVerbs` + the policy file change), the resolver, the interceptor (its zero-diff property holds — identity RPCs flow through the same interceptor).
+
+---
+
+## Symbol-lifetime sweep
+
+New package-level identifiers, checked against their target packages:
+
+| Identifier | Package | Collision? |
+|---|---|---|
+| `IdentityHandler`, `RegisterIdentityService`, `identityError`, `userToProto`, `apiKeyToProto`, `oidcBindingToProto`, `userKindToProto`, `usersBackendStub` (test), `defaultIdentityListLimit` | `server` | none — `server` has no identity symbols today; `usersBackendStub` is test-only and distinct from the Authn plan's same-named stub (different package). `defaultIdentityListLimit` is distinct from the existing `defaultListLimit`. The timestamp helper is named `tsOrNil` (the existing server helper is `timeToProto` — no clash). |
+| `GenerateAPIKeySecret`, `FormatAPIKeyToken`, `APIKeyTokenPrefix`, `mintArgon*` consts | `auth` | none — Authn provides parse/verify, not mint. Reuses `apiKeyPrefix`/`apiKeySecretLen` (same package, additive). Does NOT generate a prefix — storage owns that. |
+| `manage` (knownVerbs entry) | `auth` | additive map key; `actionVerb`'s reject-unknown test still passes (`frobnicate` still unknown). |
+| identity entries in `procedureActions` | `auth` | additive map keys (new procedure constants). |
+| `identityClient`, `authCmd`, `authUserCmd`, `authJSON` + flag vars, … | `main` (cmd) | none — no existing `auth` command subtree. There is no global `--json`; `authJSON` is a new shared var (Task 15) bound per-command. |
+| `UserList`/`APIKeyList`/`OIDCBindingList`/`userKindLabel` renderers | `render` | none. **BUT `truncate` already exists** (`render/slice.go:92`) — Task 14 REUSES it, does not redeclare it. |
+
+No deletions in this plan; no survivor analysis needed.
+
+---
+
+## Task 1: Define `identity.proto` and generate code
+
+**Files:**
+
+- Create: `proto/specgraph/v1/identity.proto`
+- Generated (committed): `gen/specgraph/v1/identity.pb.go`, `gen/specgraph/v1/specgraphv1connect/identity.connect.go`
+
+**Covers:** N/A (schema + codegen).
+
+- [ ] **Step 1: Write the proto**
+
+```proto
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+syntax = "proto3";
+
+package specgraph.v1;
+
+option go_package = "github.com/specgraph/specgraph/gen/specgraph/v1;specgraphv1";
+
+import "google/protobuf/timestamp.proto";
+
+// IdentityService manages users, service accounts, API keys, and OIDC
+// bindings. It is a GLOBAL service (not project-scoped). All RPCs except
+// Whoami require the admin role (enforced by Cedar via the "manage" verb);
+// Whoami is self-scoped and available to any authenticated principal.
+service IdentityService {
+  rpc Whoami(WhoamiRequest) returns (WhoamiResponse);
+
+  rpc ListUsers(ListUsersRequest) returns (ListUsersResponse);
+  rpc GetUser(GetUserRequest) returns (GetUserResponse);
+  rpc CreateServiceAccount(CreateServiceAccountRequest) returns (CreateServiceAccountResponse);
+  rpc UpdateUserRole(UpdateUserRoleRequest) returns (UpdateUserRoleResponse);
+  rpc SoftDeleteUser(SoftDeleteUserRequest) returns (SoftDeleteUserResponse);
+  rpc PurgeUser(PurgeUserRequest) returns (PurgeUserResponse);
+
+  rpc CreateAPIKey(CreateAPIKeyRequest) returns (CreateAPIKeyResponse);
+  rpc RevokeAPIKey(RevokeAPIKeyRequest) returns (RevokeAPIKeyResponse);
+  rpc RotateAPIKey(RotateAPIKeyRequest) returns (RotateAPIKeyResponse);
+  rpc ListAPIKeys(ListAPIKeysRequest) returns (ListAPIKeysResponse);
+
+  rpc ListOIDCBindings(ListOIDCBindingsRequest) returns (ListOIDCBindingsResponse);
+  rpc UnbindOIDC(UnbindOIDCRequest) returns (UnbindOIDCResponse);
+}
+
+enum UserKind {
+  USER_KIND_UNSPECIFIED = 0;
+  USER_KIND_HUMAN = 1;
+  USER_KIND_SERVICE_ACCOUNT = 2;
+}
+
+// User mirrors storage.User. deleted_at is unset for active users.
+message User {
+  string id = 1;
+  UserKind kind = 2;
+  string display_name = 3;
+  string email = 4;
+  string role = 5;
+  string owner_user_id = 6;
+  bool bootstrap = 7;
+  google.protobuf.Timestamp created_at = 8;
+  google.protobuf.Timestamp deleted_at = 9;
+}
+
+// APIKey mirrors storage.APIKey MINUS the secret material. The PHC hash is
+// never serialized; the plaintext token appears only in Create/Rotate
+// responses, never here.
+message APIKey {
+  string id = 1;
+  string user_id = 2;
+  string prefix = 3;
+  string role_downgrade = 4;
+  string label = 5;
+  google.protobuf.Timestamp expires_at = 6;
+  google.protobuf.Timestamp last_used_at = 7;
+  google.protobuf.Timestamp revoked_at = 8;
+  google.protobuf.Timestamp created_at = 9;
+}
+
+message OIDCBinding {
+  string id = 1;
+  string user_id = 2;
+  string issuer = 3;
+  string subject = 4;
+  string email_at_bind = 5;
+  google.protobuf.Timestamp created_at = 6;
+}
+
+message WhoamiRequest {}
+message WhoamiResponse {
+  string subject = 1;
+  string user_id = 2;
+  string display_name = 3;
+  string role = 4;
+  string effective_role = 5;
+  string email = 6;
+  string source = 7;
+}
+
+message ListUsersRequest {
+  UserKind kind = 1;          // UNSPECIFIED = all kinds
+  string role = 2;            // empty = all roles
+  bool include_deleted = 3;
+  int32 limit = 4;            // 0 = default
+  int32 offset = 5;
+}
+message ListUsersResponse { repeated User users = 1; }
+
+message GetUserRequest { string id = 1; }
+message GetUserResponse { User user = 1; }
+
+message CreateServiceAccountRequest {
+  string display_name = 1;
+  string role = 2;
+  string owner_user_id = 3;  // must reference an active Human
+}
+message CreateServiceAccountResponse { User user = 1; }
+
+message UpdateUserRoleRequest {
+  string id = 1;
+  string role = 2;
+}
+message UpdateUserRoleResponse { User user = 1; }
+
+// NOTE: Plan 4b adds a `bool force = 2;` field here plus the bootstrap-
+// protection guard. 4a implements the unguarded delete.
+message SoftDeleteUserRequest { string id = 1; }
+message SoftDeleteUserResponse {}
+
+// NOTE: Plan 4b adds `bool force = 2;` plus the bootstrap-purge guard.
+message PurgeUserRequest { string id = 1; }
+message PurgeUserResponse {}
+
+message CreateAPIKeyRequest {
+  string user_id = 1;
+  string label = 2;
+  string role_downgrade = 3;            // empty = no downgrade
+  google.protobuf.Timestamp expires_at = 4; // unset = no expiry
+}
+// plaintext is the full token (spgr_sk_<prefix>_<secret>); shown ONCE.
+message CreateAPIKeyResponse {
+  APIKey key = 1;
+  string plaintext = 2;
+}
+
+message RevokeAPIKeyRequest { string key_id = 1; }
+message RevokeAPIKeyResponse {}
+
+// RotateAPIKey revokes the old key and mints a replacement. storage's
+// RotateAPIKey requires the new key's UserID + metadata (it does NOT copy
+// from the old key, and there is no get-key-by-id backend method), so the
+// caller supplies user_id and the new key's metadata explicitly.
+message RotateAPIKeyRequest {
+  string key_id = 1;
+  string user_id = 2;        // owner of the key being rotated (required)
+  string label = 3;          // new key's label (caller-specified)
+  string role_downgrade = 4; // new key's role downgrade (empty = none)
+}
+message RotateAPIKeyResponse {
+  APIKey key = 1;
+  string plaintext = 2;
+}
+
+message ListAPIKeysRequest {
+  string user_id = 1;        // empty = all users (admin)
+  bool include_revoked = 2;
+  int32 limit = 3;
+  int32 offset = 4;
+}
+message ListAPIKeysResponse { repeated APIKey keys = 1; }
+
+message ListOIDCBindingsRequest { string user_id = 1; }
+message ListOIDCBindingsResponse { repeated OIDCBinding bindings = 1; }
+
+// NOTE: Plan 4b adds `bool force = 2;` plus the last-credential guard.
+message UnbindOIDCRequest { string binding_id = 1; }
+message UnbindOIDCResponse {}
+```
+
+- [ ] **Step 2: Generate**
+
+Run: `task proto`
+
+Expected: `gen/specgraph/v1/identity.pb.go` and `gen/specgraph/v1/specgraphv1connect/identity.connect.go` appear. The connect file declares `IdentityServiceClient`, `IdentityServiceHandler`, `NewIdentityServiceClient`, `NewIdentityServiceHandler`, and procedure constants (`IdentityServiceWhoamiProcedure`, `IdentityServiceListUsersProcedure`, … `IdentityServiceUnbindOIDCProcedure`).
+
+- [ ] **Step 3: Verify build**
+
+Run: `go build ./...`
+
+Expected: PASS (generated code compiles; nothing references it yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add proto/specgraph/v1/identity.proto gen/specgraph/v1/identity.pb.go gen/specgraph/v1/specgraphv1connect/identity.connect.go
+git commit -s -m "feat(proto): add IdentityService (users, keys, oidc, whoami)"
+```
+
+---
+
+## Task 2: Domain→proto converters
+
+**Files:**
+
+- Create: `internal/server/convert_identity.go`
+- Create: `internal/server/convert_identity_test.go`
+
+**Covers:** Happy (full round of fields) + Invariant (APIKey proto never carries the PHC hash) + Boundary (nil `*time.Time` → unset; unknown kind → error).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+func TestUserToProto_HumanActive(t *testing.T) {
+	created := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	u := &storage.User{
+		ID: "u1", Kind: storage.KindHuman, DisplayName: "Alice",
+		Email: "a@x.com", Role: "admin", CreatedAt: created,
+	}
+	pb, err := userToProto(u)
+	require.NoError(t, err)
+	require.Equal(t, "u1", pb.GetId())
+	require.Equal(t, specv1.UserKind_USER_KIND_HUMAN, pb.GetKind())
+	require.Equal(t, "Alice", pb.GetDisplayName())
+	require.Equal(t, "admin", pb.GetRole())
+	require.Equal(t, created.Unix(), pb.GetCreatedAt().GetSeconds())
+	require.Nil(t, pb.GetDeletedAt(), "active user has no deleted_at")
+}
+
+func TestUserToProto_SoftDeleted(t *testing.T) {
+	del := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+	u := &storage.User{ID: "u2", Kind: storage.KindServiceAccount, Role: "reader", DeletedAt: &del}
+	pb, err := userToProto(u)
+	require.NoError(t, err)
+	require.Equal(t, specv1.UserKind_USER_KIND_SERVICE_ACCOUNT, pb.GetKind())
+	require.Equal(t, del.Unix(), pb.GetDeletedAt().GetSeconds())
+}
+
+func TestUserToProto_UnknownKindErrors(t *testing.T) {
+	_, err := userToProto(&storage.User{ID: "u3", Kind: storage.Kind("alien")})
+	require.Error(t, err)
+}
+
+func TestAPIKeyToProto_NoSecretMaterial(t *testing.T) {
+	k := &storage.APIKey{
+		ID: "k1", UserID: "u1", Prefix: "abc12345",
+		PHCHash: "$argon2id$v=19$m=19456,t=2,p=1$c2FsdHNhbHRzYWx0c2E$aGFzaA",
+		Label:   "ci", CreatedAt: time.Now(),
+	}
+	pb := apiKeyToProto(k)
+	require.Equal(t, "k1", pb.GetId())
+	require.Equal(t, "abc12345", pb.GetPrefix())
+	require.Equal(t, "ci", pb.GetLabel())
+	// The proto type has no field that could carry the hash; assert the
+	// prefix is the only key-identifying string exposed.
+	require.NotContains(t, pb.String(), "argon2", "PHC hash must never be serialized")
+}
+
+func TestOIDCBindingToProto(t *testing.T) {
+	b := &storage.OIDCBinding{ID: "b1", UserID: "u1", Issuer: "https://idp", Subject: "sub", EmailAtBind: "a@x.com", CreatedAt: time.Now()}
+	pb := oidcBindingToProto(b)
+	require.Equal(t, "b1", pb.GetId())
+	require.Equal(t, "https://idp", pb.GetIssuer())
+	require.Equal(t, "sub", pb.GetSubject())
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/server && go test -run 'TestUserToProto|TestAPIKeyToProto|TestOIDCBindingToProto' -v`
+
+Expected: FAIL ("undefined: userToProto").
+
+- [ ] **Step 3: Write the converters**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"fmt"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// tsOrNil converts a *time.Time to a proto Timestamp, returning nil for nil.
+func tsOrNil(t *time.Time) *timestamppb.Timestamp {
+	if t == nil {
+		return nil
+	}
+	return timestamppb.New(*t)
+}
+
+// userKindToProto maps the storage Kind discriminator to the proto enum.
+func userKindToProto(k storage.Kind) (specv1.UserKind, error) {
+	switch k {
+	case storage.KindHuman:
+		return specv1.UserKind_USER_KIND_HUMAN, nil
+	case storage.KindServiceAccount:
+		return specv1.UserKind_USER_KIND_SERVICE_ACCOUNT, nil
+	default:
+		return specv1.UserKind_USER_KIND_UNSPECIFIED, fmt.Errorf("unknown user kind %q", k)
+	}
+}
+
+// userToProto converts a storage.User to its proto representation.
+func userToProto(u *storage.User) (*specv1.User, error) {
+	kind, err := userKindToProto(u.Kind)
+	if err != nil {
+		return nil, err
+	}
+	return &specv1.User{
+		Id:          u.ID,
+		Kind:        kind,
+		DisplayName: u.DisplayName,
+		Email:       u.Email,
+		Role:        u.Role,
+		OwnerUserId: u.OwnerUserID,
+		Bootstrap:   u.Bootstrap,
+		CreatedAt:   timestamppb.New(u.CreatedAt),
+		DeletedAt:   tsOrNil(u.DeletedAt),
+	}, nil
+}
+
+// usersToProto converts a slice, propagating the first conversion error.
+func usersToProto(us []*storage.User) ([]*specv1.User, error) {
+	out := make([]*specv1.User, 0, len(us))
+	for _, u := range us {
+		pb, err := userToProto(u)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, pb)
+	}
+	return out, nil
+}
+
+// apiKeyToProto converts a storage.APIKey, deliberately omitting PHCHash.
+// The proto APIKey message has no field for secret material.
+func apiKeyToProto(k *storage.APIKey) *specv1.APIKey {
+	return &specv1.APIKey{
+		Id:            k.ID,
+		UserId:        k.UserID,
+		Prefix:        k.Prefix,
+		RoleDowngrade: k.RoleDowngrade,
+		Label:         k.Label,
+		ExpiresAt:     tsOrNil(k.ExpiresAt),
+		LastUsedAt:    tsOrNil(k.LastUsedAt),
+		RevokedAt:     tsOrNil(k.RevokedAt),
+		CreatedAt:     timestamppb.New(k.CreatedAt),
+	}
+}
+
+func apiKeysToProto(ks []*storage.APIKey) []*specv1.APIKey {
+	out := make([]*specv1.APIKey, 0, len(ks))
+	for _, k := range ks {
+		out = append(out, apiKeyToProto(k))
+	}
+	return out
+}
+
+func oidcBindingToProto(b *storage.OIDCBinding) *specv1.OIDCBinding {
+	return &specv1.OIDCBinding{
+		Id:          b.ID,
+		UserId:      b.UserID,
+		Issuer:      b.Issuer,
+		Subject:     b.Subject,
+		EmailAtBind: b.EmailAtBind,
+		CreatedAt:   timestamppb.New(b.CreatedAt),
+	}
+}
+
+func oidcBindingsToProto(bs []*storage.OIDCBinding) []*specv1.OIDCBinding {
+	out := make([]*specv1.OIDCBinding, 0, len(bs))
+	for _, b := range bs {
+		out = append(out, oidcBindingToProto(b))
+	}
+	return out
+}
+
+// userKindFromProto maps the proto enum to the storage Kind (for filters).
+// UNSPECIFIED maps to empty Kind (= "all kinds" in ListUsersFilter).
+func userKindFromProto(k specv1.UserKind) storage.Kind {
+	switch k {
+	case specv1.UserKind_USER_KIND_HUMAN:
+		return storage.KindHuman
+	case specv1.UserKind_USER_KIND_SERVICE_ACCOUNT:
+		return storage.KindServiceAccount
+	default:
+		return ""
+	}
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/server && go build ./... && go test -run 'TestUserToProto|TestAPIKeyToProto|TestOIDCBindingToProto' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/convert_identity.go internal/server/convert_identity_test.go
+git commit -s -m "feat(server): identity domain↔proto converters (no secret material)"
+```
+
+---
+
+## Task 3: `UsersBackend` stub + `IdentityHandler` scaffold + `Whoami`
+
+**Files:**
+
+- Create: `internal/server/usersbackend_stub_test.go`
+- Create: `internal/server/identity_handler.go`
+- Create: `internal/server/identity_handler_test.go`
+
+**Covers:** Happy (Whoami returns the caller's identity) + Boundary (no identity in context → Unauthenticated).
+
+- [ ] **Step 1: Write the server-package `UsersBackend` stub**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"context"
+
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// usersBackendStub is a hand-rolled storage.UsersBackend for IdentityHandler
+// unit tests. Each field is a function the test sets; unset methods return a
+// loud "unexpected call" error so tests fail fast on unplanned access.
+type usersBackendStub struct {
+	listUsers            func(context.Context, storage.ListUsersFilter) ([]*storage.User, error)
+	getUserByID          func(context.Context, string) (*storage.User, error)
+	createServiceAccount func(context.Context, *storage.User) (*storage.User, error)
+	updateUserRole       func(context.Context, string, string) error
+	softDeleteUser       func(context.Context, string) error
+	purgeUser            func(context.Context, string) error
+	createAPIKey         func(context.Context, *storage.APIKey) (*storage.APIKey, error)
+	revokeAPIKey         func(context.Context, string) error
+	rotateAPIKey         func(context.Context, string, *storage.APIKey) (*storage.APIKey, error)
+	listAPIKeys          func(context.Context, storage.ListAPIKeysFilter) ([]*storage.APIKey, error)
+	listOIDCBindings     func(context.Context, string) ([]*storage.OIDCBinding, error)
+	unbindOIDC           func(context.Context, string) error
+}
+
+func (s *usersBackendStub) ListUsers(ctx context.Context, f storage.ListUsersFilter) ([]*storage.User, error) {
+	if s.listUsers == nil {
+		return nil, nil
+	}
+	return s.listUsers(ctx, f)
+}
+func (s *usersBackendStub) GetUserByID(ctx context.Context, id string) (*storage.User, error) {
+	if s.getUserByID == nil {
+		return nil, storage.ErrUserNotFound
+	}
+	return s.getUserByID(ctx, id)
+}
+func (s *usersBackendStub) CreateServiceAccount(ctx context.Context, u *storage.User) (*storage.User, error) {
+	if s.createServiceAccount == nil {
+		return nil, errUnexpected("CreateServiceAccount")
+	}
+	return s.createServiceAccount(ctx, u)
+}
+func (s *usersBackendStub) UpdateUserRole(ctx context.Context, id, role string) error {
+	if s.updateUserRole == nil {
+		return errUnexpected("UpdateUserRole")
+	}
+	return s.updateUserRole(ctx, id, role)
+}
+func (s *usersBackendStub) SoftDeleteUser(ctx context.Context, id string) error {
+	if s.softDeleteUser == nil {
+		return errUnexpected("SoftDeleteUser")
+	}
+	return s.softDeleteUser(ctx, id)
+}
+func (s *usersBackendStub) PurgeUser(ctx context.Context, id string) error {
+	if s.purgeUser == nil {
+		return errUnexpected("PurgeUser")
+	}
+	return s.purgeUser(ctx, id)
+}
+func (s *usersBackendStub) CreateAPIKey(ctx context.Context, k *storage.APIKey) (*storage.APIKey, error) {
+	if s.createAPIKey == nil {
+		return nil, errUnexpected("CreateAPIKey")
+	}
+	return s.createAPIKey(ctx, k)
+}
+func (s *usersBackendStub) RevokeAPIKey(ctx context.Context, id string) error {
+	if s.revokeAPIKey == nil {
+		return errUnexpected("RevokeAPIKey")
+	}
+	return s.revokeAPIKey(ctx, id)
+}
+func (s *usersBackendStub) RotateAPIKey(ctx context.Context, oldID string, k *storage.APIKey) (*storage.APIKey, error) {
+	if s.rotateAPIKey == nil {
+		return nil, errUnexpected("RotateAPIKey")
+	}
+	return s.rotateAPIKey(ctx, oldID, k)
+}
+func (s *usersBackendStub) ListAPIKeys(ctx context.Context, f storage.ListAPIKeysFilter) ([]*storage.APIKey, error) {
+	if s.listAPIKeys == nil {
+		return nil, nil
+	}
+	return s.listAPIKeys(ctx, f)
+}
+func (s *usersBackendStub) ListOIDCBindings(ctx context.Context, userID string) ([]*storage.OIDCBinding, error) {
+	if s.listOIDCBindings == nil {
+		return nil, nil
+	}
+	return s.listOIDCBindings(ctx, userID)
+}
+func (s *usersBackendStub) UnbindOIDC(ctx context.Context, id string) error {
+	if s.unbindOIDC == nil {
+		return errUnexpected("UnbindOIDC")
+	}
+	return s.unbindOIDC(ctx, id)
+}
+
+// Methods on UsersBackend not used by IdentityHandler — resolve-path and
+// bootstrap/JIT methods. They guard against unexpected handler access.
+func (s *usersBackendStub) LookupAPIKeyByPrefix(context.Context, string) (*storage.APIKey, error) {
+	return nil, errUnexpected("LookupAPIKeyByPrefix")
+}
+func (s *usersBackendStub) LookupOIDCBinding(context.Context, string, string) (*storage.OIDCBinding, error) {
+	return nil, errUnexpected("LookupOIDCBinding")
+}
+func (s *usersBackendStub) GetBootstrap(context.Context) (*storage.User, error) {
+	return nil, errUnexpected("GetBootstrap")
+}
+func (s *usersBackendStub) CreateHuman(context.Context, *storage.User, *storage.OIDCBinding) (*storage.User, error) {
+	return nil, errUnexpected("CreateHuman")
+}
+func (s *usersBackendStub) JITCreateHuman(context.Context, *storage.User, *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error) {
+	return nil, nil, errUnexpected("JITCreateHuman")
+}
+func (s *usersBackendStub) TouchLastUsed(context.Context, string) error {
+	return errUnexpected("TouchLastUsed")
+}
+
+func errUnexpected(method string) error {
+	return &unexpectedCallError{method: method}
+}
+
+type unexpectedCallError struct{ method string }
+
+func (e *unexpectedCallError) Error() string {
+	return "usersBackendStub: unexpected call to " + e.method
+}
+```
+
+> If `storage.UsersBackend` has methods beyond these in the merged code, add matching guard stubs (the compile-time assertion in Step 3 forces completeness). Compare against `internal/storage/users.go`.
+
+- [ ] **Step 2: Write the handler scaffold + Whoami + failing test**
+
+`identity_handler.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"connectrpc.com/connect"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// IdentityHandler implements the GLOBAL IdentityService. Unlike project-
+// scoped handlers, it holds a storage.UsersBackend directly (identity is not
+// project-scoped). Authorization is enforced upstream by the Cedar
+// interceptor; the handler trusts that an admin reached a management RPC.
+type IdentityHandler struct {
+	users  storage.UsersBackend
+	logger *slog.Logger
+}
+
+var _ specgraphv1connect.IdentityServiceHandler = (*IdentityHandler)(nil)
+
+// Whoami returns the caller's resolved identity from the request context.
+func (h *IdentityHandler) Whoami(ctx context.Context, _ *connect.Request[specv1.WhoamiRequest]) (*connect.Response[specv1.WhoamiResponse], error) {
+	id, ok := auth.IdentityFromContext(ctx)
+	if !ok {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
+	}
+	return connect.NewResponse(&specv1.WhoamiResponse{
+		Subject:       id.Subject,
+		UserId:        id.UserID,
+		DisplayName:   id.DisplayName,
+		Role:          string(id.Role),
+		EffectiveRole: string(id.EffectiveRole),
+		Email:         id.Email,
+		Source:        id.Source,
+	}), nil
+}
+
+// identityError maps storage sentinels to sanitized connect codes.
+func (h *IdentityHandler) identityError(ctx context.Context, err error) error {
+	var connErr *connect.Error
+	if errors.As(err, &connErr) {
+		return connErr
+	}
+	switch {
+	case errors.Is(err, storage.ErrUserNotFound):
+		return connect.NewError(connect.CodeNotFound, errors.New("user not found"))
+	case errors.Is(err, storage.ErrAPIKeyNotFound):
+		return connect.NewError(connect.CodeNotFound, errors.New("api key not found"))
+	case errors.Is(err, storage.ErrOIDCBindingNotFound):
+		return connect.NewError(connect.CodeNotFound, errors.New("oidc binding not found"))
+	case errors.Is(err, storage.ErrBootstrapExists):
+		return connect.NewError(connect.CodeAlreadyExists, errors.New("bootstrap user already exists"))
+	case errors.Is(err, storage.ErrAPIKeyPrefixExists):
+		return connect.NewError(connect.CodeAborted, errors.New("api key prefix collision — retry"))
+	default:
+		h.logger.ErrorContext(ctx, "identityError: internal error", slog.Any("error", err))
+		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
+}
+
+// RegisterIdentityService registers the IdentityService on the mux.
+func RegisterIdentityService(mux *http.ServeMux, users storage.UsersBackend, opts ...connect.HandlerOption) {
+	handler := &IdentityHandler{users: users, logger: slog.Default()}
+	path, h := specgraphv1connect.NewIdentityServiceHandler(handler, opts...)
+	mux.Handle(path, h)
+}
+```
+
+> The compile-time assertion `var _ specgraphv1connect.IdentityServiceHandler = (*IdentityHandler)(nil)` will FAIL to build until all 13 RPC methods exist. To keep this task green, add the remaining 12 methods as stubs returning `connect.NewError(connect.CodeUnimplemented, ...)`; they are replaced with real impls in Tasks 4–10. Add this block to `identity_handler.go`:
+
+```go
+// --- stubs replaced in Tasks 4–10 ---
+func (h *IdentityHandler) ListUsers(context.Context, *connect.Request[specv1.ListUsersRequest]) (*connect.Response[specv1.ListUsersResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+func (h *IdentityHandler) GetUser(context.Context, *connect.Request[specv1.GetUserRequest]) (*connect.Response[specv1.GetUserResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+func (h *IdentityHandler) CreateServiceAccount(context.Context, *connect.Request[specv1.CreateServiceAccountRequest]) (*connect.Response[specv1.CreateServiceAccountResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+func (h *IdentityHandler) UpdateUserRole(context.Context, *connect.Request[specv1.UpdateUserRoleRequest]) (*connect.Response[specv1.UpdateUserRoleResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+func (h *IdentityHandler) SoftDeleteUser(context.Context, *connect.Request[specv1.SoftDeleteUserRequest]) (*connect.Response[specv1.SoftDeleteUserResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+func (h *IdentityHandler) PurgeUser(context.Context, *connect.Request[specv1.PurgeUserRequest]) (*connect.Response[specv1.PurgeUserResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+func (h *IdentityHandler) CreateAPIKey(context.Context, *connect.Request[specv1.CreateAPIKeyRequest]) (*connect.Response[specv1.CreateAPIKeyResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+func (h *IdentityHandler) RevokeAPIKey(context.Context, *connect.Request[specv1.RevokeAPIKeyRequest]) (*connect.Response[specv1.RevokeAPIKeyResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+func (h *IdentityHandler) RotateAPIKey(context.Context, *connect.Request[specv1.RotateAPIKeyRequest]) (*connect.Response[specv1.RotateAPIKeyResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+func (h *IdentityHandler) ListAPIKeys(context.Context, *connect.Request[specv1.ListAPIKeysRequest]) (*connect.Response[specv1.ListAPIKeysResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+func (h *IdentityHandler) ListOIDCBindings(context.Context, *connect.Request[specv1.ListOIDCBindingsRequest]) (*connect.Response[specv1.ListOIDCBindingsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+func (h *IdentityHandler) UnbindOIDC(context.Context, *connect.Request[specv1.UnbindOIDCRequest]) (*connect.Response[specv1.UnbindOIDCResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+```
+
+`identity_handler_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/auth"
+)
+
+func newTestIdentityHandler(stub *usersBackendStub) *IdentityHandler {
+	return &IdentityHandler{users: stub, logger: slog.Default()}
+}
+
+func TestWhoami_ReturnsContextIdentity(t *testing.T) {
+	h := newTestIdentityHandler(&usersBackendStub{})
+	ctx := auth.WithIdentity(context.Background(), &auth.Identity{
+		Subject: "apikey:k1", UserID: "u1", DisplayName: "Alice",
+		Role: auth.RoleAdmin, EffectiveRole: auth.RoleAdmin, Email: "a@x.com", Source: "apikey",
+	})
+	resp, err := h.Whoami(ctx, connect.NewRequest(&specv1.WhoamiRequest{}))
+	require.NoError(t, err)
+	require.Equal(t, "u1", resp.Msg.GetUserId())
+	require.Equal(t, "admin", resp.Msg.GetRole())
+	require.Equal(t, "apikey", resp.Msg.GetSource())
+}
+
+func TestWhoami_NoIdentityUnauthenticated(t *testing.T) {
+	h := newTestIdentityHandler(&usersBackendStub{})
+	_, err := h.Whoami(context.Background(), connect.NewRequest(&specv1.WhoamiRequest{}))
+	require.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+```
+
+> `auth.WithIdentity(ctx, *Identity) context.Context` is the existing context setter (see `internal/auth/context.go`, used by the interceptor). If it is named differently in the merged code, use that name.
+
+- [ ] **Step 3: Run the tests**
+
+Run: `cd internal/server && go build ./... && go test -run 'TestWhoami' -v`
+
+Expected: PASS (the `var _` assertion compiles because all 13 methods exist as stubs).
+
+- [ ] **Step 4: Whole-project build**
+
+Run: `go build ./... && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/identity_handler.go internal/server/identity_handler_test.go internal/server/usersbackend_stub_test.go
+git commit -s -m "feat(server): IdentityHandler scaffold + Whoami + UsersBackend test stub"
+```
+
+---
+
+## Task 4: `ListUsers` + `GetUser`
+
+**Files:**
+
+- Modify: `internal/server/identity_handler.go` (replace the two stubs)
+- Modify: `internal/server/identity_handler_test.go`
+
+**Covers:** Happy (list maps rows; get returns one) + Boundary (GetUser NotFound; empty list).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `identity_handler_test.go`:
+
+```go
+import "github.com/specgraph/specgraph/internal/storage" // add to imports
+import "time"
+
+func TestListUsers_MapsRows(t *testing.T) {
+	stub := &usersBackendStub{
+		listUsers: func(_ context.Context, f storage.ListUsersFilter) ([]*storage.User, error) {
+			require.Equal(t, storage.KindHuman, f.Kind)
+			require.True(t, f.IncludeDeleted)
+			return []*storage.User{
+				{ID: "u1", Kind: storage.KindHuman, Role: "admin", CreatedAt: time.Now()},
+			}, nil
+		},
+	}
+	h := newTestIdentityHandler(stub)
+	resp, err := h.ListUsers(context.Background(), connect.NewRequest(&specv1.ListUsersRequest{
+		Kind: specv1.UserKind_USER_KIND_HUMAN, IncludeDeleted: true,
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.GetUsers(), 1)
+	require.Equal(t, "u1", resp.Msg.GetUsers()[0].GetId())
+}
+
+func TestGetUser_NotFound(t *testing.T) {
+	stub := &usersBackendStub{
+		getUserByID: func(context.Context, string) (*storage.User, error) {
+			return nil, storage.ErrUserNotFound
+		},
+	}
+	h := newTestIdentityHandler(stub)
+	_, err := h.GetUser(context.Background(), connect.NewRequest(&specv1.GetUserRequest{Id: "missing"}))
+	require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+}
+
+func TestGetUser_Found(t *testing.T) {
+	stub := &usersBackendStub{
+		getUserByID: func(_ context.Context, id string) (*storage.User, error) {
+			require.Equal(t, "u1", id)
+			return &storage.User{ID: "u1", Kind: storage.KindHuman, Role: "reader", CreatedAt: time.Now()}, nil
+		},
+	}
+	h := newTestIdentityHandler(stub)
+	resp, err := h.GetUser(context.Background(), connect.NewRequest(&specv1.GetUserRequest{Id: "u1"}))
+	require.NoError(t, err)
+	require.Equal(t, "reader", resp.Msg.GetUser().GetRole())
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/server && go test -run 'TestListUsers|TestGetUser' -v`
+
+Expected: FAIL — stubs return Unimplemented.
+
+- [ ] **Step 3: Replace the stubs**
+
+In `identity_handler.go`, delete the `ListUsers` and `GetUser` stub methods and add:
+
+```go
+const defaultIdentityListLimit = 100
+
+// ListUsers lists users matching the filter (admin-gated upstream).
+func (h *IdentityHandler) ListUsers(ctx context.Context, req *connect.Request[specv1.ListUsersRequest]) (*connect.Response[specv1.ListUsersResponse], error) {
+	msg := req.Msg
+	limit := int(msg.GetLimit())
+	if limit == 0 {
+		limit = defaultIdentityListLimit
+	}
+	users, err := h.users.ListUsers(ctx, storage.ListUsersFilter{
+		Kind:           userKindFromProto(msg.GetKind()),
+		Role:           msg.GetRole(),
+		IncludeDeleted: msg.GetIncludeDeleted(),
+		Limit:          limit,
+		Offset:         int(msg.GetOffset()),
+	})
+	if err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	pbs, err := usersToProto(users)
+	if err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	return connect.NewResponse(&specv1.ListUsersResponse{Users: pbs}), nil
+}
+
+// GetUser returns a single user by ID.
+func (h *IdentityHandler) GetUser(ctx context.Context, req *connect.Request[specv1.GetUserRequest]) (*connect.Response[specv1.GetUserResponse], error) {
+	if req.Msg.GetId() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("id is required"))
+	}
+	u, err := h.users.GetUserByID(ctx, req.Msg.GetId())
+	if err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	pb, err := userToProto(u)
+	if err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	return connect.NewResponse(&specv1.GetUserResponse{User: pb}), nil
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/server && go build ./... && go test -run 'TestListUsers|TestGetUser|TestWhoami' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/identity_handler.go internal/server/identity_handler_test.go
+git commit -s -m "feat(server): implement ListUsers and GetUser RPCs"
+```
+
+---
+
+## Task 5: `CreateServiceAccount` + `UpdateUserRole`
+
+**Files:**
+
+- Modify: `internal/server/identity_handler.go`
+- Modify: `internal/server/identity_handler_test.go`
+
+**Covers:** Happy (create SA returns row; update role returns updated) + Boundary (missing display_name / id → InvalidArgument; UpdateUserRole NotFound).
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```go
+func TestCreateServiceAccount_Happy(t *testing.T) {
+	stub := &usersBackendStub{
+		createServiceAccount: func(_ context.Context, u *storage.User) (*storage.User, error) {
+			require.Equal(t, storage.KindServiceAccount, u.Kind)
+			require.Equal(t, "ci-bot", u.DisplayName)
+			require.Equal(t, "owner-1", u.OwnerUserID)
+			u.ID = "sa1"
+			u.CreatedAt = time.Now()
+			return u, nil
+		},
+	}
+	h := newTestIdentityHandler(stub)
+	resp, err := h.CreateServiceAccount(context.Background(), connect.NewRequest(&specv1.CreateServiceAccountRequest{
+		DisplayName: "ci-bot", Role: "writer", OwnerUserId: "owner-1",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "sa1", resp.Msg.GetUser().GetId())
+	require.Equal(t, specv1.UserKind_USER_KIND_SERVICE_ACCOUNT, resp.Msg.GetUser().GetKind())
+}
+
+func TestCreateServiceAccount_RequiresDisplayName(t *testing.T) {
+	h := newTestIdentityHandler(&usersBackendStub{})
+	_, err := h.CreateServiceAccount(context.Background(), connect.NewRequest(&specv1.CreateServiceAccountRequest{Role: "writer"}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestUpdateUserRole_Happy(t *testing.T) {
+	stub := &usersBackendStub{
+		updateUserRole: func(_ context.Context, id, role string) error {
+			require.Equal(t, "u1", id)
+			require.Equal(t, "admin", role)
+			return nil
+		},
+		getUserByID: func(_ context.Context, id string) (*storage.User, error) {
+			return &storage.User{ID: id, Kind: storage.KindHuman, Role: "admin", CreatedAt: time.Now()}, nil
+		},
+	}
+	h := newTestIdentityHandler(stub)
+	resp, err := h.UpdateUserRole(context.Background(), connect.NewRequest(&specv1.UpdateUserRoleRequest{Id: "u1", Role: "admin"}))
+	require.NoError(t, err)
+	require.Equal(t, "admin", resp.Msg.GetUser().GetRole())
+}
+
+func TestUpdateUserRole_NotFound(t *testing.T) {
+	stub := &usersBackendStub{
+		updateUserRole: func(context.Context, string, string) error { return storage.ErrUserNotFound },
+	}
+	h := newTestIdentityHandler(stub)
+	_, err := h.UpdateUserRole(context.Background(), connect.NewRequest(&specv1.UpdateUserRoleRequest{Id: "x", Role: "admin"}))
+	require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/server && go test -run 'TestCreateServiceAccount|TestUpdateUserRole' -v`
+
+Expected: FAIL (Unimplemented).
+
+- [ ] **Step 3: Replace the stubs**
+
+Delete the `CreateServiceAccount` and `UpdateUserRole` stubs; add:
+
+```go
+// CreateServiceAccount creates a machine identity owned by a Human.
+func (h *IdentityHandler) CreateServiceAccount(ctx context.Context, req *connect.Request[specv1.CreateServiceAccountRequest]) (*connect.Response[specv1.CreateServiceAccountResponse], error) {
+	msg := req.Msg
+	if msg.GetDisplayName() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("display_name is required"))
+	}
+	if msg.GetRole() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("role is required"))
+	}
+	if msg.GetOwnerUserId() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("owner_user_id is required"))
+	}
+	u, err := h.users.CreateServiceAccount(ctx, &storage.User{
+		Kind:        storage.KindServiceAccount,
+		DisplayName: msg.GetDisplayName(),
+		Role:        msg.GetRole(),
+		OwnerUserID: msg.GetOwnerUserId(),
+	})
+	if err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	pb, err := userToProto(u)
+	if err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	return connect.NewResponse(&specv1.CreateServiceAccountResponse{User: pb}), nil
+}
+
+// UpdateUserRole sets the role then returns the refreshed user.
+func (h *IdentityHandler) UpdateUserRole(ctx context.Context, req *connect.Request[specv1.UpdateUserRoleRequest]) (*connect.Response[specv1.UpdateUserRoleResponse], error) {
+	msg := req.Msg
+	if msg.GetId() == "" || msg.GetRole() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("id and role are required"))
+	}
+	if err := h.users.UpdateUserRole(ctx, msg.GetId(), msg.GetRole()); err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	u, err := h.users.GetUserByID(ctx, msg.GetId())
+	if err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	pb, err := userToProto(u)
+	if err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	return connect.NewResponse(&specv1.UpdateUserRoleResponse{User: pb}), nil
+}
+```
+
+> Role validity (is `msg.Role` a known role?) is intentionally NOT checked here — the storage layer documents role validation as the caller's responsibility, and the canonical known-role set lives in `auth.KnownRolesFrom(cfg.Auth.Roles)` (Cedar plan), which the handler does not have. Validating against config is a follow-up; an unknown role simply authorizes nothing under Cedar (default-deny), which is safe.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/server && go build ./... && go test -run 'TestCreateServiceAccount|TestUpdateUserRole' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/identity_handler.go internal/server/identity_handler_test.go
+git commit -s -m "feat(server): implement CreateServiceAccount and UpdateUserRole RPCs"
+```
+
+---
+
+## Task 6: `SoftDeleteUser` + `PurgeUser` (unguarded; 4b adds protections)
+
+**Files:**
+
+- Modify: `internal/server/identity_handler.go`
+- Modify: `internal/server/identity_handler_test.go`
+
+**Covers:** Happy (both call through and return empty response) + Boundary (missing id → InvalidArgument; NotFound mapping).
+
+> Scope note: these are functional but UNGUARDED in 4a. The bootstrap-protection guards (refuse to delete/purge the bootstrap user without a `force` flag) and the `force` proto fields are added by **Plan 4b**. 4a and 4b land together; do not ship 4a to production without 4b.
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```go
+func TestSoftDeleteUser_Happy(t *testing.T) {
+	called := false
+	stub := &usersBackendStub{softDeleteUser: func(_ context.Context, id string) error {
+		require.Equal(t, "u1", id)
+		called = true
+		return nil
+	}}
+	h := newTestIdentityHandler(stub)
+	_, err := h.SoftDeleteUser(context.Background(), connect.NewRequest(&specv1.SoftDeleteUserRequest{Id: "u1"}))
+	require.NoError(t, err)
+	require.True(t, called)
+}
+
+func TestSoftDeleteUser_RequiresID(t *testing.T) {
+	h := newTestIdentityHandler(&usersBackendStub{})
+	_, err := h.SoftDeleteUser(context.Background(), connect.NewRequest(&specv1.SoftDeleteUserRequest{}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestPurgeUser_NotFound(t *testing.T) {
+	stub := &usersBackendStub{purgeUser: func(context.Context, string) error { return storage.ErrUserNotFound }}
+	h := newTestIdentityHandler(stub)
+	_, err := h.PurgeUser(context.Background(), connect.NewRequest(&specv1.PurgeUserRequest{Id: "x"}))
+	require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/server && go test -run 'TestSoftDeleteUser|TestPurgeUser' -v`
+
+Expected: FAIL (Unimplemented).
+
+- [ ] **Step 3: Replace the stubs**
+
+```go
+// SoftDeleteUser soft-deletes a user and revokes their keys. UNGUARDED in
+// 4a; 4b adds the bootstrap-protection force flag.
+func (h *IdentityHandler) SoftDeleteUser(ctx context.Context, req *connect.Request[specv1.SoftDeleteUserRequest]) (*connect.Response[specv1.SoftDeleteUserResponse], error) {
+	if req.Msg.GetId() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("id is required"))
+	}
+	if err := h.users.SoftDeleteUser(ctx, req.Msg.GetId()); err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	return connect.NewResponse(&specv1.SoftDeleteUserResponse{}), nil
+}
+
+// PurgeUser hard-deletes a user. UNGUARDED in 4a; 4b adds the bootstrap-
+// protection force flag.
+func (h *IdentityHandler) PurgeUser(ctx context.Context, req *connect.Request[specv1.PurgeUserRequest]) (*connect.Response[specv1.PurgeUserResponse], error) {
+	if req.Msg.GetId() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("id is required"))
+	}
+	if err := h.users.PurgeUser(ctx, req.Msg.GetId()); err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	return connect.NewResponse(&specv1.PurgeUserResponse{}), nil
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/server && go build ./... && go test -run 'TestSoftDeleteUser|TestPurgeUser' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/identity_handler.go internal/server/identity_handler_test.go
+git commit -s -m "feat(server): implement SoftDeleteUser and PurgeUser RPCs (unguarded; 4b hardens)"
+```
+
+---
+
+## Task 7: API-key minting helpers (package `auth`)
+
+> **Design reconciliation (was a review Critical):** the Storage plan's `AuthStore.CreateAPIKey`/`RotateAPIKey` **own prefix generation** — they call `s.genPrefix()` (8 random base32 chars) and IGNORE any `Prefix` the caller set, returning the key with the storage-generated prefix. So the minting helper must NOT generate a prefix or assemble the token before persisting. Instead: generate only the secret + PHC hash, persist (storage assigns the prefix), then assemble the token from the **storage-returned** prefix. Two helpers express this: `GenerateAPIKeySecret()` (secret + hash) and `FormatAPIKeyToken(prefix, secret)`. They live in package `auth` so they reuse the unexported format constants — zero drift from the verifier.
+
+**Files:**
+
+- Create: `internal/auth/mint.go`
+- Create: `internal/auth/mint_test.go`
+- Create: `internal/auth/mint_integration_test.go` (`//go:build integration`)
+
+**Covers:** Happy (secret length 32; token shape) + Invariant (PHC parses; storage-prefix round-trips through the real resolver) + Boundary (distinct secrets per call).
+
+- [ ] **Step 1: Write the failing unit test**
+
+`mint_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateAPIKeySecret_Shape(t *testing.T) {
+	secret, phc, err := GenerateAPIKeySecret()
+	require.NoError(t, err)
+	require.Len(t, secret, apiKeySecretLen, "secret length matches the resolver's parser expectation")
+	require.True(t, strings.HasPrefix(phc, "$argon2id$"), "PHC format")
+}
+
+func TestGenerateAPIKeySecret_DistinctEachCall(t *testing.T) {
+	s1, h1, err := GenerateAPIKeySecret()
+	require.NoError(t, err)
+	s2, h2, err := GenerateAPIKeySecret()
+	require.NoError(t, err)
+	require.NotEqual(t, s1, s2)
+	require.NotEqual(t, h1, h2)
+}
+
+func TestFormatAPIKeyToken(t *testing.T) {
+	// The token is assembled from the STORAGE-assigned prefix + the secret.
+	token := FormatAPIKeyToken("abc12345", "thirtytwocharsecretthirtytwocha0")
+	require.True(t, strings.HasPrefix(token, apiKeyPrefix))
+	require.Equal(t, apiKeyPrefix+"abc12345_thirtytwocharsecretthirtytwocha0", token)
+	require.Equal(t, apiKeyPrefix, APIKeyTokenPrefix())
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestGenerateAPIKeySecret|TestFormatAPIKeyToken' -v`
+
+Expected: FAIL ("undefined: GenerateAPIKeySecret").
+
+- [ ] **Step 3: Write the impl**
+
+`mint.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+
+	"golang.org/x/crypto/argon2"
+)
+
+// argon2id parameters — MUST match the resolver's verifier (identitystore.go
+// / the Authn plan). Kept here as named constants; the round-trip integration
+// test (mint_integration_test.go) is the guarantee that mint and verify agree.
+const (
+	mintArgonTime    = 2
+	mintArgonMemory  = 19456
+	mintArgonThreads = 1
+	mintArgonKeyLen  = 32
+	mintArgonSaltLen = 16
+)
+
+// GenerateAPIKeySecret generates a fresh API-key secret and its argon2id PHC
+// hash. It deliberately does NOT generate a prefix or assemble a token — the
+// storage layer (AuthStore.CreateAPIKey/RotateAPIKey) owns prefix generation
+// and ignores any caller-supplied prefix. The caller persists the hash, reads
+// back the storage-assigned prefix, then calls FormatAPIKeyToken to assemble
+// the credential.
+//
+//   - secret: the 32-char secret (hex of 16 bytes; matches apiKeySecretLen).
+//   - phcHash: the argon2id PHC string (store on APIKey.PHCHash; the secret is
+//     never persisted).
+func GenerateAPIKeySecret() (secret, phcHash string, err error) {
+	secretBytes := make([]byte, apiKeySecretLen/2) // hex doubles length
+	if _, err = rand.Read(secretBytes); err != nil {
+		return "", "", fmt.Errorf("generate secret: %w", err)
+	}
+	secret = hex.EncodeToString(secretBytes)
+
+	salt := make([]byte, mintArgonSaltLen)
+	if _, err = rand.Read(salt); err != nil {
+		return "", "", fmt.Errorf("generate salt: %w", err)
+	}
+	hash := argon2.IDKey([]byte(secret), salt, mintArgonTime, mintArgonMemory, mintArgonThreads, mintArgonKeyLen)
+	phcHash = fmt.Sprintf("$argon2id$v=19$m=%d,t=%d,p=%d$%s$%s",
+		mintArgonMemory, mintArgonTime, mintArgonThreads,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(hash))
+	return secret, phcHash, nil
+}
+
+// FormatAPIKeyToken assembles the full credential token from the prefix the
+// storage layer assigned and the secret from GenerateAPIKeySecret. The result
+// is what the resolver parses: spgr_sk_<prefix>_<secret>.
+func FormatAPIKeyToken(prefix, secret string) string {
+	return apiKeyPrefix + prefix + "_" + secret
+}
+
+// APIKeyTokenPrefix returns the vendor prefix all API-key tokens carry
+// (spgr_sk_). Exported so other packages can recognize a token without
+// depending on the unexported constant.
+func APIKeyTokenPrefix() string { return apiKeyPrefix }
+```
+
+> `apiKeyPrefix`, `apiKeySecretLen` are the Authn plan's unexported constants in `identitystore.go`. If `apiKeySecretLen` is not even (so `/2` for hex doesn't divide cleanly), generate `ceil(n/2)` bytes and slice the hex string to length `n`. Confirm the value (32) is even — it is. Note we do NOT reference `apiKeyPrefixLen` here — storage owns the prefix.
+
+- [ ] **Step 4: Write the round-trip integration test**
+
+This is the contract that proves the storage-owned prefix + caller secret + the resolver's verifier all agree.
+
+`mint_integration_test.go`:
+
+```go
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/auth/usagetracker"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage/postgres"
+	"github.com/specgraph/specgraph/internal/storage/postgres/postgrestest"
+)
+
+// TestAPIKeyMint_RoundTrip proves the full issuance path: generate a secret,
+// persist WITHOUT a prefix (storage assigns one), assemble the token from the
+// STORAGE-RETURNED prefix, and verify it resolves. This is the contract that
+// catches any drift between minting and the resolver's verifier.
+func TestAPIKeyMint_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	pool := postgrestest.SharedPool(t, ctx) // from the postgres test harness
+	authStore, err := postgres.NewAuth(ctx, pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = authStore.Close(ctx) })
+
+	_, err = pool.Exec(ctx, `TRUNCATE users RESTART IDENTITY CASCADE`)
+	require.NoError(t, err)
+
+	user, err := authStore.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "minter", Role: "writer",
+	}, nil)
+	require.NoError(t, err)
+
+	secret, phc, err := auth.GenerateAPIKeySecret()
+	require.NoError(t, err)
+	// Persist WITHOUT a prefix — storage assigns it.
+	created, err := authStore.CreateAPIKey(ctx, &storage.APIKey{UserID: user.ID, PHCHash: phc})
+	require.NoError(t, err)
+	require.NotEmpty(t, created.Prefix, "storage assigns the prefix")
+
+	token := auth.FormatAPIKeyToken(created.Prefix, secret)
+
+	tracker := usagetracker.NewManager(authStore, usagetracker.Config{})
+	t.Cleanup(func() { _ = tracker.Close(ctx) })
+	resolver, err := auth.NewIdentityStore(auth.IdentityStoreConfig{Users: authStore, Tracker: tracker})
+	require.NoError(t, err)
+
+	id, err := resolver.Resolve(ctx, token)
+	require.NoError(t, err, "a token built from the storage prefix + minted secret must resolve")
+	require.Equal(t, user.ID, id.UserID)
+}
+```
+
+> Reuses the integration harness: the **exported** `postgrestest.SharedPool(t, ctx)` (Storage plan Task 32; the in-package `sharedTestPool` is not importable from `auth_test`), plus `usagetracker`, `postgres.NewAuth`, `NewIdentityStore`. Match the actual helper names from the merged tests.
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+cd internal/auth && go build ./... && go test -run 'TestGenerateAPIKeySecret|TestFormatAPIKeyToken' -v
+go test -tags integration -run TestAPIKeyMint_RoundTrip -v
+```
+
+Expected: PASS (unit + integration round-trip).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/auth/mint.go internal/auth/mint_test.go internal/auth/mint_integration_test.go
+git commit -s -m "feat(auth): add GenerateAPIKeySecret + FormatAPIKeyToken (storage owns prefix)"
+```
+
+---
+
+## Task 8: `CreateAPIKey` + `RotateAPIKey` (return plaintext once)
+
+**Files:**
+
+- Modify: `internal/server/identity_handler.go`
+- Modify: `internal/server/identity_handler_test.go`
+
+**Covers:** Happy (create/rotate return key + plaintext) + Invariant (plaintext present in response, absent from the persisted key; token is assembled from the storage-assigned prefix) + Boundary (missing user_id / key_id → InvalidArgument).
+
+- [ ] **Step 1: Write the failing test**
+
+Append (the test imports `auth` to assert the vendor prefix via `auth.APIKeyTokenPrefix()`, defined in Task 7). Note the create/rotate flow: the handler persists WITHOUT a prefix, storage assigns one, and the token is built from the storage-returned prefix — so the stub must populate `k.Prefix` to mimic storage:
+
+```go
+import "github.com/specgraph/specgraph/internal/auth" // add to imports
+
+func TestCreateAPIKey_ReturnsPlaintextOnce(t *testing.T) {
+	var stored *storage.APIKey
+	stub := &usersBackendStub{
+		createAPIKey: func(_ context.Context, k *storage.APIKey) (*storage.APIKey, error) {
+			// storage owns the prefix: the caller passes none, storage assigns it.
+			require.Empty(t, k.Prefix, "handler must not pre-set the prefix")
+			require.True(t, strings.HasPrefix(k.PHCHash, "$argon2id$"))
+			require.Equal(t, "u1", k.UserID)
+			k.ID = "k1"
+			k.Prefix = "stor1234" // simulate storage-assigned prefix
+			k.CreatedAt = time.Now()
+			stored = k
+			return k, nil
+		},
+	}
+	h := newTestIdentityHandler(stub)
+	resp, err := h.CreateAPIKey(context.Background(), connect.NewRequest(&specv1.CreateAPIKeyRequest{
+		UserId: "u1", Label: "ci",
+	}))
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Msg.GetPlaintext(), "plaintext returned once")
+	require.True(t, strings.HasPrefix(resp.Msg.GetPlaintext(), auth.APIKeyTokenPrefix()))
+	require.Equal(t, "k1", resp.Msg.GetKey().GetId())
+	require.Equal(t, "stor1234", resp.Msg.GetKey().GetPrefix())
+	// The plaintext token embeds the STORAGE-assigned prefix.
+	require.Contains(t, resp.Msg.GetPlaintext(), stored.Prefix)
+}
+
+func TestCreateAPIKey_RequiresUserID(t *testing.T) {
+	h := newTestIdentityHandler(&usersBackendStub{})
+	_, err := h.CreateAPIKey(context.Background(), connect.NewRequest(&specv1.CreateAPIKeyRequest{}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestRotateAPIKey_ReturnsNewPlaintext(t *testing.T) {
+	stub := &usersBackendStub{
+		rotateAPIKey: func(_ context.Context, oldID string, k *storage.APIKey) (*storage.APIKey, error) {
+			require.Equal(t, "old1", oldID)
+			// storage needs UserID + metadata on newKey; the handler supplies them.
+			require.Equal(t, "u1", k.UserID)
+			require.Empty(t, k.Prefix, "handler must not pre-set the prefix")
+			k.ID = "new1"
+			k.Prefix = "stor5678" // simulate storage-assigned prefix
+			k.CreatedAt = time.Now()
+			return k, nil
+		},
+	}
+	h := newTestIdentityHandler(stub)
+	resp, err := h.RotateAPIKey(context.Background(), connect.NewRequest(&specv1.RotateAPIKeyRequest{
+		KeyId: "old1", UserId: "u1", Label: "ci",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "new1", resp.Msg.GetKey().GetId())
+	require.NotEmpty(t, resp.Msg.GetPlaintext())
+	require.Contains(t, resp.Msg.GetPlaintext(), "stor5678")
+}
+
+func TestRotateAPIKey_RequiresKeyAndUser(t *testing.T) {
+	h := newTestIdentityHandler(&usersBackendStub{})
+	_, err := h.RotateAPIKey(context.Background(), connect.NewRequest(&specv1.RotateAPIKeyRequest{KeyId: "old1"}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err), "user_id required for rotate")
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/server && go test -run 'TestCreateAPIKey|TestRotateAPIKey' -v`
+
+Expected: FAIL (Unimplemented).
+
+- [ ] **Step 3: Replace the handler stubs**
+
+In `identity_handler.go` delete the `CreateAPIKey`/`RotateAPIKey` stubs and add. The flow honors storage's prefix-ownership: generate the secret + hash, persist WITHOUT a prefix, then build the token from the storage-returned prefix.
+
+```go
+// CreateAPIKey generates a new key for a user and returns the plaintext token
+// exactly once. The secret is never persisted (only the PHC hash); storage
+// assigns the prefix, and the token is assembled from it.
+func (h *IdentityHandler) CreateAPIKey(ctx context.Context, req *connect.Request[specv1.CreateAPIKeyRequest]) (*connect.Response[specv1.CreateAPIKeyResponse], error) {
+	msg := req.Msg
+	if msg.GetUserId() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("user_id is required"))
+	}
+	secret, phc, err := auth.GenerateAPIKeySecret()
+	if err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	k := &storage.APIKey{
+		UserID:        msg.GetUserId(),
+		PHCHash:       phc, // no Prefix — storage assigns it
+		Label:         msg.GetLabel(),
+		RoleDowngrade: msg.GetRoleDowngrade(),
+	}
+	if msg.GetExpiresAt() != nil {
+		exp := msg.GetExpiresAt().AsTime()
+		k.ExpiresAt = &exp
+	}
+	created, err := h.users.CreateAPIKey(ctx, k)
+	if err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	return connect.NewResponse(&specv1.CreateAPIKeyResponse{
+		Key:       apiKeyToProto(created),
+		Plaintext: auth.FormatAPIKeyToken(created.Prefix, secret),
+	}), nil
+}
+
+// RotateAPIKey revokes the old key and generates a replacement. storage's
+// RotateAPIKey requires the new key's UserID + metadata (it does not copy from
+// the old key, and there is no get-key-by-id method), so the request carries
+// user_id and the new key's label/role_downgrade explicitly.
+func (h *IdentityHandler) RotateAPIKey(ctx context.Context, req *connect.Request[specv1.RotateAPIKeyRequest]) (*connect.Response[specv1.RotateAPIKeyResponse], error) {
+	msg := req.Msg
+	if msg.GetKeyId() == "" || msg.GetUserId() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("key_id and user_id are required"))
+	}
+	secret, phc, err := auth.GenerateAPIKeySecret()
+	if err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	rotated, err := h.users.RotateAPIKey(ctx, msg.GetKeyId(), &storage.APIKey{
+		UserID:        msg.GetUserId(),
+		PHCHash:       phc, // no Prefix — storage assigns it
+		Label:         msg.GetLabel(),
+		RoleDowngrade: msg.GetRoleDowngrade(),
+	})
+	if err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	return connect.NewResponse(&specv1.RotateAPIKeyResponse{
+		Key:       apiKeyToProto(rotated),
+		Plaintext: auth.FormatAPIKeyToken(rotated.Prefix, secret),
+	}), nil
+}
+```
+
+`identity_handler.go` already imports `auth` (for `IdentityFromContext`, Task 3), so no import change is needed.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/server && go build ./... && go test -run 'TestCreateAPIKey|TestRotateAPIKey' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/identity_handler.go internal/server/identity_handler_test.go
+git commit -s -m "feat(server): implement CreateAPIKey and RotateAPIKey (storage-owned prefix)"
+```
+
+---
+
+## Task 9: `RevokeAPIKey` + `ListAPIKeys`
+
+**Files:**
+
+- Modify: `internal/server/identity_handler.go`
+- Modify: `internal/server/identity_handler_test.go`
+
+**Covers:** Happy (revoke calls through; list maps + passes filter) + Boundary (missing key_id → InvalidArgument; list excludes revoked unless requested).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestRevokeAPIKey_Happy(t *testing.T) {
+	called := false
+	stub := &usersBackendStub{revokeAPIKey: func(_ context.Context, id string) error {
+		require.Equal(t, "k1", id)
+		called = true
+		return nil
+	}}
+	h := newTestIdentityHandler(stub)
+	_, err := h.RevokeAPIKey(context.Background(), connect.NewRequest(&specv1.RevokeAPIKeyRequest{KeyId: "k1"}))
+	require.NoError(t, err)
+	require.True(t, called)
+}
+
+func TestRevokeAPIKey_RequiresID(t *testing.T) {
+	h := newTestIdentityHandler(&usersBackendStub{})
+	_, err := h.RevokeAPIKey(context.Background(), connect.NewRequest(&specv1.RevokeAPIKeyRequest{}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestListAPIKeys_PassesFilter(t *testing.T) {
+	stub := &usersBackendStub{
+		listAPIKeys: func(_ context.Context, f storage.ListAPIKeysFilter) ([]*storage.APIKey, error) {
+			require.Equal(t, "u1", f.UserID)
+			require.True(t, f.IncludeRevoked)
+			return []*storage.APIKey{{ID: "k1", UserID: "u1", Prefix: "abc12345", CreatedAt: time.Now()}}, nil
+		},
+	}
+	h := newTestIdentityHandler(stub)
+	resp, err := h.ListAPIKeys(context.Background(), connect.NewRequest(&specv1.ListAPIKeysRequest{
+		UserId: "u1", IncludeRevoked: true,
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.GetKeys(), 1)
+	require.Equal(t, "abc12345", resp.Msg.GetKeys()[0].GetPrefix())
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/server && go test -run 'TestRevokeAPIKey|TestListAPIKeys' -v`
+
+Expected: FAIL (Unimplemented).
+
+- [ ] **Step 3: Replace the stubs**
+
+```go
+// RevokeAPIKey marks a key revoked (idempotent).
+func (h *IdentityHandler) RevokeAPIKey(ctx context.Context, req *connect.Request[specv1.RevokeAPIKeyRequest]) (*connect.Response[specv1.RevokeAPIKeyResponse], error) {
+	if req.Msg.GetKeyId() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("key_id is required"))
+	}
+	if err := h.users.RevokeAPIKey(ctx, req.Msg.GetKeyId()); err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	return connect.NewResponse(&specv1.RevokeAPIKeyResponse{}), nil
+}
+
+// ListAPIKeys lists keys, optionally scoped to a user and including revoked.
+func (h *IdentityHandler) ListAPIKeys(ctx context.Context, req *connect.Request[specv1.ListAPIKeysRequest]) (*connect.Response[specv1.ListAPIKeysResponse], error) {
+	msg := req.Msg
+	limit := int(msg.GetLimit())
+	if limit == 0 {
+		limit = defaultIdentityListLimit
+	}
+	keys, err := h.users.ListAPIKeys(ctx, storage.ListAPIKeysFilter{
+		UserID:         msg.GetUserId(),
+		IncludeRevoked: msg.GetIncludeRevoked(),
+		Limit:          limit,
+		Offset:         int(msg.GetOffset()),
+	})
+	if err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	return connect.NewResponse(&specv1.ListAPIKeysResponse{Keys: apiKeysToProto(keys)}), nil
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/server && go build ./... && go test -run 'TestRevokeAPIKey|TestListAPIKeys' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/identity_handler.go internal/server/identity_handler_test.go
+git commit -s -m "feat(server): implement RevokeAPIKey and ListAPIKeys RPCs"
+```
+
+---
+
+## Task 10: `ListOIDCBindings` + `UnbindOIDC` (unguarded; 4b adds last-credential guard)
+
+**Files:**
+
+- Modify: `internal/server/identity_handler.go`
+- Modify: `internal/server/identity_handler_test.go`
+
+**Covers:** Happy (list maps; unbind calls through) + Boundary (missing binding_id → InvalidArgument; NotFound mapping).
+
+> Scope note: `UnbindOIDC` is unguarded in 4a. The last-credential protection (refuse to unbind a user's only credential without `force`) and the `force` proto field are **Plan 4b**.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestListOIDCBindings_Happy(t *testing.T) {
+	stub := &usersBackendStub{
+		listOIDCBindings: func(_ context.Context, userID string) ([]*storage.OIDCBinding, error) {
+			require.Equal(t, "u1", userID)
+			return []*storage.OIDCBinding{{ID: "b1", UserID: "u1", Issuer: "https://idp", Subject: "s", CreatedAt: time.Now()}}, nil
+		},
+	}
+	h := newTestIdentityHandler(stub)
+	resp, err := h.ListOIDCBindings(context.Background(), connect.NewRequest(&specv1.ListOIDCBindingsRequest{UserId: "u1"}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.GetBindings(), 1)
+	require.Equal(t, "b1", resp.Msg.GetBindings()[0].GetId())
+}
+
+func TestUnbindOIDC_Happy(t *testing.T) {
+	called := false
+	stub := &usersBackendStub{unbindOIDC: func(_ context.Context, id string) error {
+		require.Equal(t, "b1", id)
+		called = true
+		return nil
+	}}
+	h := newTestIdentityHandler(stub)
+	_, err := h.UnbindOIDC(context.Background(), connect.NewRequest(&specv1.UnbindOIDCRequest{BindingId: "b1"}))
+	require.NoError(t, err)
+	require.True(t, called)
+}
+
+func TestUnbindOIDC_NotFound(t *testing.T) {
+	stub := &usersBackendStub{unbindOIDC: func(context.Context, string) error { return storage.ErrOIDCBindingNotFound }}
+	h := newTestIdentityHandler(stub)
+	_, err := h.UnbindOIDC(context.Background(), connect.NewRequest(&specv1.UnbindOIDCRequest{BindingId: "x"}))
+	require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/server && go test -run 'TestListOIDCBindings|TestUnbindOIDC' -v`
+
+Expected: FAIL (Unimplemented).
+
+- [ ] **Step 3: Replace the stubs**
+
+```go
+// ListOIDCBindings lists a user's OIDC bindings.
+func (h *IdentityHandler) ListOIDCBindings(ctx context.Context, req *connect.Request[specv1.ListOIDCBindingsRequest]) (*connect.Response[specv1.ListOIDCBindingsResponse], error) {
+	if req.Msg.GetUserId() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("user_id is required"))
+	}
+	bindings, err := h.users.ListOIDCBindings(ctx, req.Msg.GetUserId())
+	if err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	return connect.NewResponse(&specv1.ListOIDCBindingsResponse{Bindings: oidcBindingsToProto(bindings)}), nil
+}
+
+// UnbindOIDC removes an OIDC binding. UNGUARDED in 4a; 4b adds the last-
+// credential force flag.
+func (h *IdentityHandler) UnbindOIDC(ctx context.Context, req *connect.Request[specv1.UnbindOIDCRequest]) (*connect.Response[specv1.UnbindOIDCResponse], error) {
+	if req.Msg.GetBindingId() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("binding_id is required"))
+	}
+	if err := h.users.UnbindOIDC(ctx, req.Msg.GetBindingId()); err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	return connect.NewResponse(&specv1.UnbindOIDCResponse{}), nil
+}
+```
+
+- [ ] **Step 4: Run the tests + whole-project**
+
+```bash
+cd internal/server && go build ./... && go test ./...
+go build ./... && go test ./...
+```
+
+Expected: PASS. All 13 RPCs are now real; no Unimplemented stubs remain.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/identity_handler.go internal/server/identity_handler_test.go
+git commit -s -m "feat(server): implement ListOIDCBindings and UnbindOIDC RPCs"
+```
+
+---
+
+## Task 11: Cedar — add the `manage` verb and admin policy
+
+**Files:**
+
+- Modify: `internal/auth/engine.go` (add `"manage"` to `knownVerbs`)
+- Modify: `internal/auth/policies/base.cedar` (add the manage→admin policy)
+- Modify: `internal/auth/engine_evaluate_test.go` (add manage matrix cases)
+
+**Covers:** Happy (admin allowed manage) + Invariant (writer/reader denied manage; manage doesn't leak through read/write/delete).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/auth/engine_evaluate_test.go`. First extend the shared `basePolicies` const used by the engine tests to include the manage policy — but that const lives in `engine_test.go` (Task 6 of the Cedar plan). Rather than edit the shared const, add a dedicated test with its own policy text:
+
+```go
+const basePoliciesWithManage = basePolicies + `
+permit (principal, action in SpecGraph::Action::"manage", resource)
+when { principal has role && principal.role == "admin" };
+`
+
+func TestEvaluate_ManageVerbAdminOnly(t *testing.T) {
+	eng, err := auth.NewCedarEngine(context.Background(),
+		[]auth.PolicySource{stubSource{name: "test", docs: []auth.PolicyDocument{{Source: "test:base.cedar", Text: basePoliciesWithManage}}}},
+		[]string{"spec.read", "spec.write", "graph.delete", "user.manage"})
+	require.NoError(t, err)
+
+	check := func(role auth.Role) bool {
+		dec, evalErr := eng.Evaluate(context.Background(), auth.EvalRequest{
+			Identity: &auth.Identity{UserID: "u1", EffectiveRole: role, Role: role},
+			Action:   "user.manage",
+			Resource: auth.ResourceRef{Type: "user"},
+		})
+		require.NoError(t, evalErr)
+		return dec.Allowed
+	}
+	require.True(t, check(auth.RoleAdmin), "admin allowed manage")
+	require.False(t, check(auth.RoleWriter), "writer denied manage")
+	require.False(t, check(auth.RoleReader), "reader denied manage")
+}
+```
+
+> This test depends on `buildActionEntities` accepting `"user.manage"` — i.e. `manage` being a known verb. It fails until Step 3.
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run TestEvaluate_ManageVerbAdminOnly -v`
+
+Expected: FAIL — `NewCedarEngine` errors (`action "user.manage" has unknown verb "manage"`) because `manage` isn't in `knownVerbs` yet.
+
+- [ ] **Step 3: Add `manage` to `knownVerbs`**
+
+In `internal/auth/engine.go`, change:
+
+```go
+var knownVerbs = map[string]bool{"read": true, "write": true, "delete": true}
+```
+
+to:
+
+```go
+var knownVerbs = map[string]bool{"read": true, "write": true, "delete": true, "manage": true}
+```
+
+- [ ] **Step 4: Add the manage policy to the embedded base policies**
+
+Append to `internal/auth/policies/base.cedar`:
+
+```
+// Identity-management operations (IdentityService): admin-only. The "manage"
+// verb is reserved for sensitive operations that must NOT inherit the
+// read/write/delete role gates (e.g. ListUsers is a read but must be admin).
+permit (
+	principal,
+	action in SpecGraph::Action::"manage",
+	resource
+) when {
+	principal has role && principal.role == "admin"
+};
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cd internal/auth && go build ./... && go test -run 'TestEvaluate|TestBuildActionEntities' -v`
+
+Expected: PASS — `manage` is a known verb; the admin policy gates it; the Cedar plan's existing `TestBuildActionEntities_RejectsUnknownVerb` (frobnicate) still passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/auth/engine.go internal/auth/policies/base.cedar internal/auth/engine_evaluate_test.go
+git commit -s -m "feat(auth): add Cedar 'manage' verb + admin-only base policy for identity ops"
+```
+
+---
+
+## Task 12: Map identity procedures to Cedar actions
+
+**Files:**
+
+- Modify: `internal/auth/actions.go` (add identity entries to `procedureActions`)
+- Modify: `internal/auth/actions_test.go`
+
+**Covers:** Happy (each identity procedure maps) + Invariant (whoami→identity.read; all mgmt→a `.manage` action; no method-name leakage).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/auth/actions_test.go`:
+
+```go
+func TestActionForProcedure_Identity(t *testing.T) {
+	cases := map[string]string{
+		specgraphv1connect.IdentityServiceWhoamiProcedure:               "identity.read",
+		specgraphv1connect.IdentityServiceListUsersProcedure:            "user.manage",
+		specgraphv1connect.IdentityServiceGetUserProcedure:              "user.manage",
+		specgraphv1connect.IdentityServiceUpdateUserRoleProcedure:       "user.manage",
+		specgraphv1connect.IdentityServiceSoftDeleteUserProcedure:       "user.manage",
+		specgraphv1connect.IdentityServicePurgeUserProcedure:            "user.manage",
+		specgraphv1connect.IdentityServiceCreateServiceAccountProcedure: "serviceaccount.manage",
+		specgraphv1connect.IdentityServiceCreateAPIKeyProcedure:         "apikey.manage",
+		specgraphv1connect.IdentityServiceRevokeAPIKeyProcedure:         "apikey.manage",
+		specgraphv1connect.IdentityServiceRotateAPIKeyProcedure:         "apikey.manage",
+		specgraphv1connect.IdentityServiceListAPIKeysProcedure:          "apikey.manage",
+		specgraphv1connect.IdentityServiceListOIDCBindingsProcedure:     "oidc.manage",
+		specgraphv1connect.IdentityServiceUnbindOIDCProcedure:           "oidc.manage",
+	}
+	for proc, want := range cases {
+		got, ok := auth.ActionForProcedure(proc)
+		require.Truef(t, ok, "procedure %s must map", proc)
+		require.Equalf(t, want, got, "procedure %s", proc)
+	}
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run TestActionForProcedure_Identity -v`
+
+Expected: FAIL — the identity procedures aren't in `procedureActions` yet.
+
+- [ ] **Step 3: Add the entries**
+
+In `internal/auth/actions.go`, add to the `procedureActions` map literal (before the closing brace):
+
+```go
+	// IdentityService — whoami is self-scoped (read); all management ops are
+	// admin-gated via the "manage" verb.
+	specgraphv1connect.IdentityServiceWhoamiProcedure:               "identity.read",
+	specgraphv1connect.IdentityServiceListUsersProcedure:            "user.manage",
+	specgraphv1connect.IdentityServiceGetUserProcedure:              "user.manage",
+	specgraphv1connect.IdentityServiceUpdateUserRoleProcedure:       "user.manage",
+	specgraphv1connect.IdentityServiceSoftDeleteUserProcedure:       "user.manage",
+	specgraphv1connect.IdentityServicePurgeUserProcedure:            "user.manage",
+	specgraphv1connect.IdentityServiceCreateServiceAccountProcedure: "serviceaccount.manage",
+	specgraphv1connect.IdentityServiceCreateAPIKeyProcedure:         "apikey.manage",
+	specgraphv1connect.IdentityServiceRevokeAPIKeyProcedure:         "apikey.manage",
+	specgraphv1connect.IdentityServiceRotateAPIKeyProcedure:         "apikey.manage",
+	specgraphv1connect.IdentityServiceListAPIKeysProcedure:          "apikey.manage",
+	specgraphv1connect.IdentityServiceListOIDCBindingsProcedure:     "oidc.manage",
+	specgraphv1connect.IdentityServiceUnbindOIDCProcedure:           "oidc.manage",
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/auth && go build ./... && go test -run 'TestActionForProcedure|TestActionNames' -v`
+
+Expected: PASS. `ActionNames()` now includes `identity.read`, `user.manage`, `serviceaccount.manage`, `apikey.manage`, `oidc.manage` (the `.manage` ones group under the new `manage` verb; `identity.read` under `read`). The Cedar plan's `TestActionNames_AllParseToKnownVerb` still passes (all suffixes are known, including `manage`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/actions.go internal/auth/actions_test.go
+git commit -s -m "feat(auth): map IdentityService procedures to Cedar actions"
+```
+
+---
+
+## Task 13: Register `IdentityService` in `serve.go`
+
+**Files:**
+
+- Modify: `cmd/specgraph/serve.go`
+
+**Covers:** E2E (the service is wired with the auth interceptor and the real `AuthStore` backend).
+
+- [ ] **Step 1: Add the registration**
+
+In `cmd/specgraph/serve.go`, alongside the other `server.Register*Service(...)` calls, add the identity registration. The siblings pass two trailing `connect.HandlerOption` values — `opts` (`connect.WithInterceptors(interceptor)`) and `maxBytes` (`connect.WithReadMaxBytes(4<<20)`) — into the variadic; mirror that exactly so identity RPCs get both the auth interceptor AND the body-size limit:
+
+```go
+	server.RegisterIdentityService(mux, authStore, opts, maxBytes)
+```
+
+> `RegisterIdentityService(mux, users storage.UsersBackend, opts ...connect.HandlerOption)` (Task 3) takes the variadic, matching the sibling `Register*Service` signatures (e.g. `RegisterGraphService(mux, scoper, opts ...connect.HandlerOption)`, called as `RegisterGraphService(mux, store, opts, maxBytes)`). Match the merged serve.go's variable names: `authStore` (the `*postgres.AuthStore`, which implements `storage.UsersBackend`), `opts`, `maxBytes` (all present in the post-Authn/Cedar serve.go). The IdentityService MUST receive `opts` — otherwise its RPCs would be unauthenticated.
+
+- [ ] **Step 2: Verify whole-project build + test**
+
+Run: `go build ./... && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/specgraph/serve.go
+git commit -s -m "feat(serve): register IdentityService with the auth interceptor"
+```
+
+---
+
+## Task 14: Render helpers for identity entities
+
+**Files:**
+
+- Create: `internal/render/identity.go`
+- Create: `internal/render/identity_test.go`
+
+**Covers:** Happy (renders a user table, key table, binding table) + Boundary (empty slice → "no X" message).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package render_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/render"
+)
+
+func TestUserList_RendersRows(t *testing.T) {
+	out := render.UserList([]*specv1.User{
+		{Id: "u1", Kind: specv1.UserKind_USER_KIND_HUMAN, DisplayName: "Alice", Role: "admin", CreatedAt: timestamppb.Now()},
+	})
+	require.Contains(t, out, "u1")
+	require.Contains(t, out, "Alice")
+	require.Contains(t, out, "admin")
+}
+
+func TestUserList_Empty(t *testing.T) {
+	require.Contains(t, strings.ToLower(render.UserList(nil)), "no users")
+}
+
+func TestAPIKeyList_RedactsSecret(t *testing.T) {
+	out := render.APIKeyList([]*specv1.APIKey{{Id: "k1", Prefix: "abc12345", Label: "ci"}})
+	require.Contains(t, out, "abc12345")
+	require.Contains(t, out, "ci")
+}
+
+func TestOIDCBindingList_RendersRows(t *testing.T) {
+	out := render.OIDCBindingList([]*specv1.OIDCBinding{{Id: "b1", Issuer: "https://idp", Subject: "sub"}})
+	require.Contains(t, out, "https://idp")
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/render && go test -run 'TestUserList|TestAPIKeyList|TestOIDCBindingList' -v`
+
+Expected: FAIL ("undefined: render.UserList").
+
+- [ ] **Step 3: Write the renderers**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package render
+
+import (
+	"fmt"
+	"strings"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+)
+
+// UserList renders a table of users.
+func UserList(users []*specv1.User) string {
+	if len(users) == 0 {
+		return "No users found.\n"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%-38s  %-16s  %-20s  %-8s  %s\n", "ID", "KIND", "DISPLAY NAME", "ROLE", "STATUS")
+	for _, u := range users {
+		status := "active"
+		if u.GetDeletedAt() != nil {
+			status = "deleted"
+		}
+		fmt.Fprintf(&b, "%-38s  %-16s  %-20s  %-8s  %s\n",
+			u.GetId(), userKindLabel(u.GetKind()), truncate(u.GetDisplayName(), 20), u.GetRole(), status)
+	}
+	return b.String()
+}
+
+func userKindLabel(k specv1.UserKind) string {
+	switch k {
+	case specv1.UserKind_USER_KIND_HUMAN:
+		return "human"
+	case specv1.UserKind_USER_KIND_SERVICE_ACCOUNT:
+		return "service_account"
+	default:
+		return "unspecified"
+	}
+}
+
+// APIKeyList renders a table of API keys. Only the prefix is shown; the
+// secret is never available here.
+func APIKeyList(keys []*specv1.APIKey) string {
+	if len(keys) == 0 {
+		return "No API keys found.\n"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%-38s  %-10s  %-20s  %s\n", "ID", "PREFIX", "LABEL", "STATUS")
+	for _, k := range keys {
+		status := "active"
+		if k.GetRevokedAt() != nil {
+			status = "revoked"
+		}
+		fmt.Fprintf(&b, "%-38s  %-10s  %-20s  %s\n",
+			k.GetId(), k.GetPrefix(), truncate(k.GetLabel(), 20), status)
+	}
+	return b.String()
+}
+
+// OIDCBindingList renders a table of OIDC bindings.
+func OIDCBindingList(bindings []*specv1.OIDCBinding) string {
+	if len(bindings) == 0 {
+		return "No OIDC bindings found.\n"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%-38s  %-30s  %s\n", "ID", "ISSUER", "SUBJECT")
+	for _, bd := range bindings {
+		fmt.Fprintf(&b, "%-38s  %-30s  %s\n", bd.GetId(), truncate(bd.GetIssuer(), 30), bd.GetSubject())
+	}
+	return b.String()
+}
+```
+
+> **Reuse the existing `truncate`.** `internal/render/slice.go:92` already defines `func truncate(s string, maxLen int) string` in package `render` — do NOT redeclare it (same-package redeclaration is a build error). The calls above resolve to that existing helper (signature `(s, maxLen)` is call-compatible). These renderers follow the existing `render.*` "return a string" convention used by other commands.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/render && go build ./... && go test -run 'TestUserList|TestAPIKeyList|TestOIDCBindingList' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/render/identity.go internal/render/identity_test.go
+git commit -s -m "feat(render): identity table renderers (user, api-key, oidc binding)"
+```
+
+---
+
+## Task 15: CLI — `identityClient` + `specgraph auth` root + `whoami`
+
+**Files:**
+
+- Create: `cmd/specgraph/identity_client.go`
+- Create: `cmd/specgraph/auth.go`
+
+**Covers:** Happy (whoami prints identity) — exercised manually; the command wiring is verified by `go build` + a `--help` smoke.
+
+- [ ] **Step 1: Write the client helper**
+
+`identity_client.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+)
+
+// identityClient builds an authenticated IdentityService client using the
+// shared credential/base-URL resolution (newClient).
+func identityClient() (specgraphv1connect.IdentityServiceClient, error) {
+	return newClient(specgraphv1connect.NewIdentityServiceClient)
+}
+```
+
+> `newClient[C any](ctor)` is the existing generic client builder in `cmd/specgraph/client.go` (it resolves base URL + project + API key and wraps the transport). Confirm its signature; the spec/decision commands use the same pattern.
+
+- [ ] **Step 2: Write the auth root + whoami**
+
+`auth.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"fmt"
+
+	"connectrpc.com/connect"
+	"github.com/spf13/cobra"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+)
+
+var authCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Manage identity: users, service accounts, API keys, and OIDC bindings",
+}
+
+// authJSON backs the --json flag across the auth subtree. There is no global
+// --json flag in this CLI (each command declares its own — see spec.go's
+// per-command showJSON/listJSON pattern). Cobra binds a distinct --json flag
+// on each leaf command to this shared var; only one command runs per
+// invocation, so sharing is safe and keeps the registrations terse.
+var authJSON bool
+
+var authWhoamiCmd = &cobra.Command{
+	Use:   "whoami",
+	Short: "Show the identity of the current credential",
+	RunE:  runAuthWhoami,
+}
+
+func runAuthWhoami(cmd *cobra.Command, _ []string) error {
+	client, err := identityClient()
+	if err != nil {
+		return err
+	}
+	resp, err := client.Whoami(cmd.Context(), connect.NewRequest(&specv1.WhoamiRequest{}))
+	if err != nil {
+		return fmt.Errorf("whoami: %w", err)
+	}
+	if authJSON {
+		return printJSON(cmd.OutOrStdout(), resp.Msg)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Subject:        %s\n", resp.Msg.GetSubject())
+	fmt.Fprintf(cmd.OutOrStdout(), "User ID:        %s\n", resp.Msg.GetUserId())
+	fmt.Fprintf(cmd.OutOrStdout(), "Display name:   %s\n", resp.Msg.GetDisplayName())
+	fmt.Fprintf(cmd.OutOrStdout(), "Role:           %s\n", resp.Msg.GetRole())
+	fmt.Fprintf(cmd.OutOrStdout(), "Effective role: %s\n", resp.Msg.GetEffectiveRole())
+	fmt.Fprintf(cmd.OutOrStdout(), "Source:         %s\n", resp.Msg.GetSource())
+	return nil
+}
+
+func init() {
+	authWhoamiCmd.Flags().BoolVar(&authJSON, "json", false, "output as JSON")
+	authCmd.AddCommand(authWhoamiCmd)
+	rootCmd.AddCommand(authCmd)
+}
+```
+
+> `printJSON(w io.Writer, msg proto.Message)` is the existing helper (`cmd/specgraph/output.go`). There is NO global `--json` var — each command registers its own (`spec.go` uses `showJSON`/`listJSON` bound via `cmd.Flags().BoolVar(&x, "json", false, ...)`). Tasks 15–18 share the package-level `authJSON` var declared here and register a `--json` flag on every JSON-emitting leaf command.
+
+- [ ] **Step 3: Verify build + help smoke**
+
+Run: `go build ./... && go run ./cmd/specgraph auth --help`
+
+Expected: build PASS; `--help` lists `whoami`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/specgraph/identity_client.go cmd/specgraph/auth.go
+git commit -s -m "feat(cli): add 'specgraph auth' root + whoami"
+```
+
+---
+
+## Task 16: CLI — `specgraph auth user`
+
+**Files:**
+
+- Create: `cmd/specgraph/auth_user.go`
+
+**Covers:** Command wiring (build + help smoke). Behavior is covered by the handler tests (Tasks 4–6) and the integration test (Task 19).
+
+- [ ] **Step 1: Write the user subcommands**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"fmt"
+
+	"connectrpc.com/connect"
+	"github.com/spf13/cobra"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/render"
+)
+
+var (
+	userListKind        string
+	userListRole        string
+	userListIncludeDel  bool
+)
+
+var authUserCmd = &cobra.Command{Use: "user", Short: "Manage users"}
+
+var authUserListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List users",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		client, err := identityClient()
+		if err != nil {
+			return err
+		}
+		req := &specv1.ListUsersRequest{
+			Role:           userListRole,
+			IncludeDeleted: userListIncludeDel,
+		}
+		switch userListKind {
+		case "human":
+			req.Kind = specv1.UserKind_USER_KIND_HUMAN
+		case "service_account":
+			req.Kind = specv1.UserKind_USER_KIND_SERVICE_ACCOUNT
+		case "":
+			// all kinds
+		default:
+			return fmt.Errorf("invalid --kind %q (want human|service_account)", userListKind)
+		}
+		resp, err := client.ListUsers(cmd.Context(), connect.NewRequest(req))
+		if err != nil {
+			return fmt.Errorf("list users: %w", err)
+		}
+		if authJSON {
+			return printJSON(cmd.OutOrStdout(), resp.Msg)
+		}
+		fmt.Fprint(cmd.OutOrStdout(), render.UserList(resp.Msg.GetUsers()))
+		return nil
+	},
+}
+
+var authUserShowCmd = &cobra.Command{
+	Use:   "show <user-id>",
+	Short: "Show a single user",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := identityClient()
+		if err != nil {
+			return err
+		}
+		resp, err := client.GetUser(cmd.Context(), connect.NewRequest(&specv1.GetUserRequest{Id: args[0]}))
+		if err != nil {
+			return fmt.Errorf("get user: %w", err)
+		}
+		if authJSON {
+			return printJSON(cmd.OutOrStdout(), resp.Msg)
+		}
+		fmt.Fprint(cmd.OutOrStdout(), render.UserList([]*specv1.User{resp.Msg.GetUser()}))
+		return nil
+	},
+}
+
+var authUserSetRoleCmd = &cobra.Command{
+	Use:   "set-role <user-id> <role>",
+	Short: "Change a user's role",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := identityClient()
+		if err != nil {
+			return err
+		}
+		resp, err := client.UpdateUserRole(cmd.Context(), connect.NewRequest(&specv1.UpdateUserRoleRequest{Id: args[0], Role: args[1]}))
+		if err != nil {
+			return fmt.Errorf("set role: %w", err)
+		}
+		if authJSON {
+			return printJSON(cmd.OutOrStdout(), resp.Msg)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Updated %s → role %s\n", args[0], resp.Msg.GetUser().GetRole())
+		return nil
+	},
+}
+
+var authUserDeleteCmd = &cobra.Command{
+	Use:   "delete <user-id>",
+	Short: "Soft-delete a user (revokes their keys)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := identityClient()
+		if err != nil {
+			return err
+		}
+		if _, err := client.SoftDeleteUser(cmd.Context(), connect.NewRequest(&specv1.SoftDeleteUserRequest{Id: args[0]})); err != nil {
+			return fmt.Errorf("delete user: %w", err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Soft-deleted %s\n", args[0])
+		return nil
+	},
+}
+
+var authUserPurgeCmd = &cobra.Command{
+	Use:   "purge <user-id>",
+	Short: "Permanently delete a user (irreversible)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := identityClient()
+		if err != nil {
+			return err
+		}
+		if _, err := client.PurgeUser(cmd.Context(), connect.NewRequest(&specv1.PurgeUserRequest{Id: args[0]})); err != nil {
+			return fmt.Errorf("purge user: %w", err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Purged %s\n", args[0])
+		return nil
+	},
+}
+
+func init() {
+	authUserListCmd.Flags().StringVar(&userListKind, "kind", "", "filter by kind: human|service_account")
+	authUserListCmd.Flags().StringVar(&userListRole, "role", "", "filter by role")
+	authUserListCmd.Flags().BoolVar(&userListIncludeDel, "include-deleted", false, "include soft-deleted users")
+	// --json on the JSON-emitting commands (shared authJSON var from auth.go).
+	authUserListCmd.Flags().BoolVar(&authJSON, "json", false, "output as JSON")
+	authUserShowCmd.Flags().BoolVar(&authJSON, "json", false, "output as JSON")
+	authUserSetRoleCmd.Flags().BoolVar(&authJSON, "json", false, "output as JSON")
+	authUserCmd.AddCommand(authUserListCmd, authUserShowCmd, authUserSetRoleCmd, authUserDeleteCmd, authUserPurgeCmd)
+	authCmd.AddCommand(authUserCmd)
+}
+```
+
+> Plan 4b adds `--force` to `delete` and `purge` (wired to the proto `force` field it introduces).
+
+- [ ] **Step 2: Verify build + help**
+
+Run: `go build ./... && go run ./cmd/specgraph auth user --help`
+
+Expected: build PASS; lists `list`, `show`, `set-role`, `delete`, `purge`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/specgraph/auth_user.go
+git commit -s -m "feat(cli): add 'specgraph auth user' subcommands"
+```
+
+---
+
+## Task 17: CLI — `specgraph auth api-key`
+
+**Files:**
+
+- Create: `cmd/specgraph/auth_apikey.go`
+
+**Covers:** Command wiring (build + help smoke); the create/rotate plaintext-once behavior is asserted by the handler tests (Task 8).
+
+- [ ] **Step 1: Write the api-key subcommands**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"fmt"
+
+	"connectrpc.com/connect"
+	"github.com/spf13/cobra"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/render"
+)
+
+var (
+	apiKeyListUser    string
+	apiKeyListRevoked bool
+	apiKeyCreateUser  string
+	apiKeyCreateLabel string
+	apiKeyCreateDown  string
+	apiKeyRotateUser  string
+	apiKeyRotateLabel string
+	apiKeyRotateDown  string
+)
+
+var authAPIKeyCmd = &cobra.Command{Use: "api-key", Short: "Manage API keys"}
+
+var authAPIKeyListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List API keys",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		client, err := identityClient()
+		if err != nil {
+			return err
+		}
+		resp, err := client.ListAPIKeys(cmd.Context(), connect.NewRequest(&specv1.ListAPIKeysRequest{
+			UserId: apiKeyListUser, IncludeRevoked: apiKeyListRevoked,
+		}))
+		if err != nil {
+			return fmt.Errorf("list api keys: %w", err)
+		}
+		if authJSON {
+			return printJSON(cmd.OutOrStdout(), resp.Msg)
+		}
+		fmt.Fprint(cmd.OutOrStdout(), render.APIKeyList(resp.Msg.GetKeys()))
+		return nil
+	},
+}
+
+var authAPIKeyCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create an API key (prints the secret once)",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if apiKeyCreateUser == "" {
+			return fmt.Errorf("--user is required")
+		}
+		client, err := identityClient()
+		if err != nil {
+			return err
+		}
+		resp, err := client.CreateAPIKey(cmd.Context(), connect.NewRequest(&specv1.CreateAPIKeyRequest{
+			UserId: apiKeyCreateUser, Label: apiKeyCreateLabel, RoleDowngrade: apiKeyCreateDown,
+		}))
+		if err != nil {
+			return fmt.Errorf("create api key: %w", err)
+		}
+		if authJSON {
+			return printJSON(cmd.OutOrStdout(), resp.Msg)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Created API key %s (prefix %s).\n", resp.Msg.GetKey().GetId(), resp.Msg.GetKey().GetPrefix())
+		fmt.Fprintf(cmd.OutOrStdout(), "\n  %s\n\n", resp.Msg.GetPlaintext())
+		fmt.Fprintln(cmd.OutOrStdout(), "Store this token now — it will not be shown again.")
+		return nil
+	},
+}
+
+var authAPIKeyRevokeCmd = &cobra.Command{
+	Use:   "revoke <key-id>",
+	Short: "Revoke an API key",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := identityClient()
+		if err != nil {
+			return err
+		}
+		if _, err := client.RevokeAPIKey(cmd.Context(), connect.NewRequest(&specv1.RevokeAPIKeyRequest{KeyId: args[0]})); err != nil {
+			return fmt.Errorf("revoke api key: %w", err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Revoked %s\n", args[0])
+		return nil
+	},
+}
+
+var authAPIKeyRotateCmd = &cobra.Command{
+	Use:   "rotate <key-id>",
+	Short: "Rotate an API key (revokes the old, prints the new secret once)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// storage's RotateAPIKey requires the new key's owner + metadata (it
+		// does not copy from the old key; there is no get-key-by-id method).
+		if apiKeyRotateUser == "" {
+			return fmt.Errorf("--user is required (owner of the key being rotated)")
+		}
+		client, err := identityClient()
+		if err != nil {
+			return err
+		}
+		resp, err := client.RotateAPIKey(cmd.Context(), connect.NewRequest(&specv1.RotateAPIKeyRequest{
+			KeyId: args[0], UserId: apiKeyRotateUser, Label: apiKeyRotateLabel, RoleDowngrade: apiKeyRotateDown,
+		}))
+		if err != nil {
+			return fmt.Errorf("rotate api key: %w", err)
+		}
+		if authJSON {
+			return printJSON(cmd.OutOrStdout(), resp.Msg)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Rotated → new key %s (prefix %s).\n", resp.Msg.GetKey().GetId(), resp.Msg.GetKey().GetPrefix())
+		fmt.Fprintf(cmd.OutOrStdout(), "\n  %s\n\n", resp.Msg.GetPlaintext())
+		fmt.Fprintln(cmd.OutOrStdout(), "Store this token now — it will not be shown again.")
+		return nil
+	},
+}
+
+func init() {
+	authAPIKeyListCmd.Flags().StringVar(&apiKeyListUser, "user", "", "filter by user ID")
+	authAPIKeyListCmd.Flags().BoolVar(&apiKeyListRevoked, "include-revoked", false, "include revoked keys")
+	authAPIKeyListCmd.Flags().BoolVar(&authJSON, "json", false, "output as JSON")
+	authAPIKeyCreateCmd.Flags().StringVar(&apiKeyCreateUser, "user", "", "user ID to own the key (required)")
+	authAPIKeyCreateCmd.Flags().StringVar(&apiKeyCreateLabel, "label", "", "human-friendly label")
+	authAPIKeyCreateCmd.Flags().StringVar(&apiKeyCreateDown, "role-downgrade", "", "cap the key's effective role")
+	authAPIKeyCreateCmd.Flags().BoolVar(&authJSON, "json", false, "output as JSON")
+	authAPIKeyRotateCmd.Flags().StringVar(&apiKeyRotateUser, "user", "", "owner of the key being rotated (required)")
+	authAPIKeyRotateCmd.Flags().StringVar(&apiKeyRotateLabel, "label", "", "label for the new key")
+	authAPIKeyRotateCmd.Flags().StringVar(&apiKeyRotateDown, "role-downgrade", "", "role downgrade for the new key")
+	authAPIKeyRotateCmd.Flags().BoolVar(&authJSON, "json", false, "output as JSON")
+	authAPIKeyCmd.AddCommand(authAPIKeyListCmd, authAPIKeyCreateCmd, authAPIKeyRevokeCmd, authAPIKeyRotateCmd)
+	authCmd.AddCommand(authAPIKeyCmd)
+}
+```
+
+- [ ] **Step 2: Verify build + help**
+
+Run: `go build ./... && go run ./cmd/specgraph auth api-key --help`
+
+Expected: build PASS; lists `list`, `create`, `revoke`, `rotate`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/specgraph/auth_apikey.go
+git commit -s -m "feat(cli): add 'specgraph auth api-key' subcommands"
+```
+
+---
+
+## Task 18: CLI — `specgraph auth oidc`
+
+**Files:**
+
+- Create: `cmd/specgraph/auth_oidc.go`
+
+**Covers:** Command wiring (build + help smoke).
+
+- [ ] **Step 1: Write the oidc subcommands**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"fmt"
+
+	"connectrpc.com/connect"
+	"github.com/spf13/cobra"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/render"
+)
+
+var oidcListUser string
+
+var authOIDCCmd = &cobra.Command{Use: "oidc", Short: "Manage OIDC bindings"}
+
+var authOIDCListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List a user's OIDC bindings",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if oidcListUser == "" {
+			return fmt.Errorf("--user is required")
+		}
+		client, err := identityClient()
+		if err != nil {
+			return err
+		}
+		resp, err := client.ListOIDCBindings(cmd.Context(), connect.NewRequest(&specv1.ListOIDCBindingsRequest{UserId: oidcListUser}))
+		if err != nil {
+			return fmt.Errorf("list oidc bindings: %w", err)
+		}
+		if authJSON {
+			return printJSON(cmd.OutOrStdout(), resp.Msg)
+		}
+		fmt.Fprint(cmd.OutOrStdout(), render.OIDCBindingList(resp.Msg.GetBindings()))
+		return nil
+	},
+}
+
+var authOIDCUnbindCmd = &cobra.Command{
+	Use:   "unbind <binding-id>",
+	Short: "Remove an OIDC binding",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := identityClient()
+		if err != nil {
+			return err
+		}
+		if _, err := client.UnbindOIDC(cmd.Context(), connect.NewRequest(&specv1.UnbindOIDCRequest{BindingId: args[0]})); err != nil {
+			return fmt.Errorf("unbind oidc: %w", err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Unbound %s\n", args[0])
+		return nil
+	},
+}
+
+func init() {
+	authOIDCListCmd.Flags().StringVar(&oidcListUser, "user", "", "user ID (required)")
+	authOIDCListCmd.Flags().BoolVar(&authJSON, "json", false, "output as JSON")
+	authOIDCCmd.AddCommand(authOIDCListCmd, authOIDCUnbindCmd)
+	authCmd.AddCommand(authOIDCCmd)
+}
+```
+
+> Plan 4b adds `--force` to `unbind` (last-credential protection).
+
+- [ ] **Step 2: Verify build + help + whole-project test**
+
+```bash
+go build ./... && go run ./cmd/specgraph auth oidc --help
+go test ./...
+```
+
+Expected: build PASS; lists `list`, `unbind`; all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/specgraph/auth_oidc.go
+git commit -s -m "feat(cli): add 'specgraph auth oidc' subcommands"
+```
+
+---
+
+## Task 19: Integration test — interceptor → Cedar → IdentityHandler
+
+End-to-end through the real auth interceptor and Cedar engine: admin can manage, reader is denied management but can whoami.
+
+**Files:**
+
+- Create: `internal/server/identity_integration_test.go`
+
+**Covers:** E2E (auth + authz + handler) + Invariant (manage gated to admin; whoami open to reader).
+
+- [ ] **Step 1: Write the test**
+
+```go
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/auth/usagetracker"
+	"github.com/specgraph/specgraph/internal/server"
+	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage/postgres"
+	"github.com/specgraph/specgraph/internal/storage/postgres/postgrestest"
+)
+
+// buildIdentityTestServer wires the real interceptor (resolver + Cedar
+// authorizer) and the IdentityService over an httptest server. Returns the
+// base URL and a helper to mint a token for a user of a given role.
+func buildIdentityTestServer(t *testing.T, ctx context.Context) (string, *postgres.AuthStore) {
+	t.Helper()
+	pool := postgrestest.SharedPool(t, ctx) // postgres harness
+	authStore, err := postgres.NewAuth(ctx, pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = authStore.Close(ctx) })
+	_, err = pool.Exec(ctx, `TRUNCATE users RESTART IDENTITY CASCADE`)
+	require.NoError(t, err)
+
+	tracker := usagetracker.NewManager(authStore, usagetracker.Config{})
+	t.Cleanup(func() { _ = tracker.Close(ctx) })
+	resolver, err := auth.NewIdentityStore(auth.IdentityStoreConfig{Users: authStore, Tracker: tracker})
+	require.NoError(t, err)
+
+	engine, err := auth.NewCedarEngine(ctx, []auth.PolicySource{auth.NewEmbeddedPolicySource()}, auth.ActionNames())
+	require.NoError(t, err)
+	authorizer := auth.NewCedarAuthorizer(engine)
+	interceptor := auth.NewAuthInterceptor(resolver, authorizer)
+
+	mux := http.NewServeMux()
+	server.RegisterIdentityService(mux, authStore, connect.WithInterceptors(interceptor))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL, authStore
+}
+
+// mintFor creates a user of the given role + an API key, returning the token.
+func mintFor(t *testing.T, ctx context.Context, store *postgres.AuthStore, role string, bootstrap bool) string {
+	t.Helper()
+	u, err := store.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: role + "-user", Role: role, Bootstrap: bootstrap}, nil)
+	require.NoError(t, err)
+	secret, phc, err := auth.GenerateAPIKeySecret()
+	require.NoError(t, err)
+	created, err := store.CreateAPIKey(ctx, &storage.APIKey{UserID: u.ID, PHCHash: phc}) // storage assigns the prefix
+	require.NoError(t, err)
+	return auth.FormatAPIKeyToken(created.Prefix, secret)
+}
+
+func tokenClient(baseURL, token string) specgraphv1connect.IdentityServiceClient {
+	httpc := &http.Client{Transport: &bearerTransport{token: token, base: http.DefaultTransport}}
+	return specgraphv1connect.NewIdentityServiceClient(httpc, baseURL)
+}
+
+type bearerTransport struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (b *bearerTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r2 := r.Clone(r.Context())
+	r2.Header.Set("Authorization", "Bearer "+b.token)
+	return b.base.RoundTrip(r2)
+}
+
+func TestIntegration_IdentityAdminCanManage(t *testing.T) {
+	ctx := context.Background()
+	baseURL, store := buildIdentityTestServer(t, ctx)
+	adminToken := mintFor(t, ctx, store, "admin", true)
+
+	client := tokenClient(baseURL, adminToken)
+	resp, err := client.ListUsers(ctx, connect.NewRequest(&specv1.ListUsersRequest{}))
+	require.NoError(t, err, "admin may ListUsers (user.manage)")
+	require.GreaterOrEqual(t, len(resp.Msg.GetUsers()), 1)
+}
+
+func TestIntegration_IdentityReaderDeniedManage(t *testing.T) {
+	ctx := context.Background()
+	baseURL, store := buildIdentityTestServer(t, ctx)
+	_ = mintFor(t, ctx, store, "admin", true) // ensure a bootstrap exists
+	readerToken := mintFor(t, ctx, store, "reader", false)
+
+	client := tokenClient(baseURL, readerToken)
+	_, err := client.ListUsers(ctx, connect.NewRequest(&specv1.ListUsersRequest{}))
+	require.Error(t, err)
+	require.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err), "reader denied user.manage")
+}
+
+func TestIntegration_IdentityWhoamiOpenToReader(t *testing.T) {
+	ctx := context.Background()
+	baseURL, store := buildIdentityTestServer(t, ctx)
+	_ = mintFor(t, ctx, store, "admin", true)
+	readerToken := mintFor(t, ctx, store, "reader", false)
+
+	client := tokenClient(baseURL, readerToken)
+	resp, err := client.Whoami(ctx, connect.NewRequest(&specv1.WhoamiRequest{}))
+	require.NoError(t, err, "any authenticated principal may whoami (identity.read)")
+	require.Equal(t, "reader", resp.Msg.GetEffectiveRole())
+}
+```
+
+> Match the merged harness: `postgrestest.SharedPool` (exported; Storage plan Task 32), `postgres.NewAuth`, `auth.NewAuthInterceptor` (post-Authn-cleanup name), `auth.NewIdentityStore`, `usagetracker`. If `CreateHuman` rejects a second `Bootstrap:true`, the reader is created with `bootstrap=false` (as written). The bootstrap admin is created first so `mintFor(...,"admin",true)` is the sole bootstrap.
+
+- [ ] **Step 2: Run**
+
+Run: `cd internal/server && go test -tags integration -run 'TestIntegration_Identity' -v`
+
+Expected: PASS — admin manages, reader denied (PermissionDenied), reader whoami works.
+
+- [ ] **Step 3: Full suites**
+
+```bash
+# from the repository root:
+go build ./... && go test ./...
+go test -tags integration ./internal/server/... ./internal/auth/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/server/identity_integration_test.go
+git commit -s -m "test(server): integration test for identity authz (admin/reader/whoami)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (against the design's "CLI shape" + the RPC surface 4a owns):
+
+- [x] User management (list, show, change role, delete, purge): Tasks 4, 5, 6 (RPCs) + 16 (CLI).
+- [x] ServiceAccount management: Task 5 (RPC) + 16 (`user list --kind service_account`; create via api-key/user flows — SA creation RPC in Task 5, surfaced as a follow-up CLI command if desired; the design says SA creation is "a normal admin RPC", delivered).
+- [x] API-key management (list, create, revoke, rotate): Tasks 8, 9 (RPCs) + 17 (CLI), with mint helper Task 7.
+- [x] OIDC binding management (list, unbind): Task 10 (RPC) + 18 (CLI).
+- [x] Identity introspection (`whoami`): Task 3 (RPC) + 15 (CLI).
+- [x] All identity commands under one root, discoverable via `specgraph auth --help`: Tasks 15–18.
+- [x] Admin-role gating expressed as Cedar policies (not handler flags): Tasks 11–12.
+- [x] Plaintext key shown once, never persisted: Tasks 7, 8 (assertions) + 17 (UX).
+- [x] (Deferred to 4b, explicitly): force-flag protections + `force` proto fields + credential-file/bootstrap. Tasks 6, 10 note the boundary.
+
+> ServiceAccount *creation* has an RPC (Task 5) but Task 16's CLI doesn't add a dedicated `service-account create` command. If the design wants that surfaced, add an `auth service-account create` command mirroring Task 16's pattern — flagged here as the one CLI affordance not yet wired (RPC exists; CLI command is a trivial follow-up). Listing SAs is covered by `auth user list --kind service_account`.
+
+**2. Placeholder scan:** No TODO/TBD/"similar to above". The Unimplemented stubs in Task 3 are explicitly temporary and each is replaced in Tasks 4–10 with a "delete the stub" instruction. Every handler method shows complete code; every test shows complete code.
+
+**3. Type consistency:** `IdentityHandler`, `userToProto`/`apiKeyToProto`/`oidcBindingToProto`, `usersBackendStub`, `GenerateAPIKeySecret`/`FormatAPIKeyToken`/`APIKeyTokenPrefix`, `RegisterIdentityService`, `identityClient`, the shared `authJSON` flag var, the `auth*Cmd` cobra vars, and the `render.UserList`/`APIKeyList`/`OIDCBindingList` renderers are referenced identically across tasks. The `var _ specgraphv1connect.IdentityServiceHandler = (*IdentityHandler)(nil)` assertion (Task 3) guarantees the method set matches the generated interface. The API-key minting split (`GenerateAPIKeySecret` returns secret+hash; storage assigns the prefix; `FormatAPIKeyToken` assembles the token from the storage-returned prefix) is applied consistently in Tasks 7, 8, and the Task 19 `mintFor` helper.
+
+**4. Build discipline:** Every task ends with `go build ./... && go test ./...` green at package level; Tasks 3, 6, 10, 13, 18, 19 add whole-project build+test. No task leaves the project non-building: Task 3's `var _` assertion is satisfied by Unimplemented stubs from the start, so the handler compiles before any RPC is real. The Cedar changes (Tasks 11–12) are additive (`manage` verb, new policy, new map entries) and don't disturb the migration matrix. serve.go registration (Task 13) only runs after the handler (3–10) and Cedar wiring (11–12) exist, so the interceptor never hits an unconfigured identity procedure.
+
+**5. Symbol-lifetime sweep:** Completed in the dedicated section. No collisions; the only cross-plan touch is additive (`manage` ∈ `knownVerbs`; identity entries in `procedureActions`; one base.cedar policy). No deletions. The Cedar plan's `TestBuildActionEntities_RejectsUnknownVerb` and `TestActionNames_AllParseToKnownVerb` both still pass (manage is now a known verb; frobnicate still isn't).
+
+**6. Dependency-name risk:** Every consumed prior-plan symbol is listed in the "Dependency contract" with a note to adapt if the merged name differs. The two highest-risk assumptions — the API-key format constants (`apiKeyPrefixLen`/`apiKeySecretLen`/argon2 params) and `auth.NewAuthInterceptor`'s post-cleanup name — are pinned and exercised by the Task 7 round-trip integration test and the Task 19 interceptor test respectively.
+
+---
+
+## Execution
+
+1. **Subagent-Driven (recommended)** — Tasks 1–10 are short TDD cycles (proto, converters, one-or-two RPCs each). Tasks 11–12 (Cedar) and 13 (serve) are a small wiring batch. Tasks 14–18 (render + CLI) are mechanical. Task 19 (integration) is the capstone. Fresh subagent per task; the "delete the Unimplemented stub" steps in 4–10 are explicit to avoid redeclaration.
+2. **Inline Execution** — practical for 11–13 (Cedar + serve wiring) and 14–18 (CLI) as batches.
+
+**Plan 4b follows immediately** and depends on this plan: it adds the bootstrap DB helper (reusing `GenerateAPIKeySecret` + `FormatAPIKeyToken`), the `specgraph init` local path and `serve.go` hosted path, the credentials-file multi-server schema, and the force-flag / last-credential protections (adding `force` to `SoftDeleteUserRequest`/`PurgeUserRequest`/`UnbindOIDCRequest` + the guard logic + `--force` CLI flags). 4a and 4b should land together; do not deploy 4a's unguarded delete/purge/unbind without 4b's protections.

--- a/docs/plans/2026-05-26-identity-bootstrap-ux-4b-bootstrap-protections-implementation-plan.md
+++ b/docs/plans/2026-05-26-identity-bootstrap-ux-4b-bootstrap-protections-implementation-plan.md
@@ -1,0 +1,1399 @@
+# Identity Bootstrap & UX — Plan 4b: Bootstrap Flows, Credentials File & Protections
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the first admin exist and be reachable: a shared DB-backed bootstrap helper (idempotent, race-safe) driven by `specgraph init` (local, direct-DB) and `serve.go` first-start (hosted, log-banner); a multi-server credentials file the CLI reads; and the operator-protection guards (force-flag on bootstrap soft-delete/purge, last-credential guard on `UnbindOIDC`).
+
+**Architecture:** Second of two plans split from the "Identity Bootstrap & Operator UX" design (`docs/plans/2026-05-22-identity-bootstrap-ux-design.md`). **Depends on Plan 4a** (IdentityService RPCs, `auth.GenerateAPIKeySecret`/`FormatAPIKeyToken`, the `force`-less delete/purge/unbind handlers it leaves for 4b to harden). The bootstrap user is a **system identity** (`display_name = "admin"`, `bootstrap = true`, no OIDC binding) — never derived from environment. Two bootstrap paths share one `bootstrap.Ensure` helper; they differ only in whether they write the credentials file. Build-alongside discipline: every task ends green at package and whole-project level.
+
+**Tech Stack:** Go 1.26, pgx v5 (via `UsersBackend` / `postgres.New`), `gopkg.in/yaml.v3` (credentials file), Cobra (CLI), ConnectRPC (protections in handlers).
+
+**Implements bead:** Approved design `spgr-g90r` (Identity Bootstrap & UX) under epic `spgr-rjrt`, sub-plan 4b. Depends on Storage (`spgr-e82m`), Authn (`spgr-n2rw`), Cedar (`spgr-rjrt.1`), and **4a** being merged first.
+
+---
+
+## Dependency contract (consumed symbols)
+
+- **4a / Authn** — `auth.GenerateAPIKeySecret() (secret, phcHash string, err error)`, `auth.FormatAPIKeyToken(prefix, secret string) string`, `auth.APIKeyTokenPrefix() string` (package `auth`). The IdentityService proto messages `SoftDeleteUserRequest`/`PurgeUserRequest`/`UnbindOIDCRequest` (4b adds fields). The `IdentityHandler` (4b adds guards to three methods). The `specgraph auth` CLI commands (4b adds `--force`/`--user` flags).
+- **Storage** — `storage.UsersBackend` (`GetBootstrap`, `CreateHuman`, `CreateAPIKey`, `GetUserByID`, `SoftDeleteUser`, `PurgeUser`, `UnbindOIDC`, `ListOIDCBindings`, `ListAPIKeys`); domain types `storage.User`/`storage.APIKey`/`storage.OIDCBinding`; `storage.ListAPIKeysFilter`; sentinels `storage.ErrUserNotFound`, `storage.ErrBootstrapExists`. `postgres.New(ctx, url, opts...) (*postgres.Store, error)` and `(*Store).Pool()`; `postgres.NewAuth(ctx, pool) (*AuthStore, error)`. `CreateHuman` returns `storage.ErrBootstrapExists` when a bootstrap already exists (the `users_one_bootstrap` unique index).
+- **CLI** — `resolveBaseURL() (baseURL, project string, err error)`, `newClient[C]`, `printJSON`, the shared `authJSON` flag var (4a), `cmd/specgraph/client.go`'s transport plumbing. `internal/xdg.CredentialsFile() string` (`~/.config/specgraph/credentials.yaml`).
+- **Config** — `cfg.Server.Postgres.URL` (the connection string; defaulted to a localhost dev value by `loadGlobalCfg`, so rarely empty); `cfg.Server.Listen`.
+- **Test harness** — the exported `postgrestest.SharedPool(t, ctx) *pgxpool.Pool` from `internal/storage/postgres/postgrestest`, created by **Storage plan Task 32**. (The in-package `sharedTestPool` is unexported `package postgres_test` and not importable cross-package; Task 32 exists precisely so `internal/bootstrap`, `internal/auth`, and `internal/server` integration tests share one harness.) Task 4 imports it.
+
+**Note on the deleted `auth.ReadDefaultKey`:** the Authn plan deletes `internal/auth/bootstrap.go` (which held `ReadDefaultKey`, `CheckCredentialPermissions`, the old single-key `CredentialsFile`). The current `cmd/specgraph/client.go` `resolveAPIKey` calls `auth.ReadDefaultKey`. **4b takes ownership of all credential read/write** via the new `internal/credentials` package and rewrites `resolveAPIKey` (Task 2) — which also resolves that post-Authn dangling reference.
+
+---
+
+## Testing approach
+
+Four categories; each behavior task tags `**Covers:**`.
+
+- **Happy** — bootstrap creates the admin + key; credentials round-trip; guards allow with force.
+- **Invariants** — bootstrap is idempotent and race-safe (one bootstrap row); the bootstrap user is never derived from environment; credentials file never clobbers unrelated server entries; plaintext written 0600.
+- **Boundaries** — bootstrap when one already exists (no-op); credentials file missing/old-shape (empty, no error); guards refuse without force; unbind last credential refused.
+- **E2E** — `init` → bootstrap → credentials file → CLI authenticates; protections through the real interceptor.
+
+Unit tests use the 4a server-package `usersBackendStub` and a bootstrap-package stub. Integration tests (`//go:build integration`) use the testcontainer `AuthStore`.
+
+---
+
+## File Structure
+
+**Create:**
+
+- `internal/credentials/credentials.go` (+ `_test.go`) — `File` (multi-server), `Load`, `Save`, `TokenFor`, `Upsert`, `CheckPermissions`.
+- `internal/bootstrap/bootstrap.go` (+ `_test.go`, + `_integration_test.go`) — `Ensure` (shared DB helper) + `Options`/`Result`.
+
+**Modify:**
+
+- `cmd/specgraph/client.go` — `resolveAPIKey` → use `credentials.TokenFor(serverURL)`; thread the resolved base URL through `newAuthenticatedHTTPClient`/`newClient`.
+- `cmd/specgraph/init.go` — local bootstrap path (detect Postgres → `bootstrap.Ensure` + write credentials; else hint).
+- `cmd/specgraph/serve.go` — hosted bootstrap path (first-start → `bootstrap.Ensure` → log banner).
+- `proto/specgraph/v1/identity.proto` — add `force` to `SoftDeleteUserRequest`/`PurgeUserRequest`; add `user_id`+`force` to `UnbindOIDCRequest`. (`task proto`.)
+- `internal/server/identity_handler.go` (+ `_test.go`) — bootstrap guard on `SoftDeleteUser`/`PurgeUser`; last-credential guard on `UnbindOIDC`.
+- `cmd/specgraph/auth_user.go` / `auth_oidc.go` — `--force` flags (+ `--user` on unbind).
+
+**Do NOT touch:** the Cedar engine, the resolver, the interceptor, the 4a converters/minting.
+
+---
+
+## Symbol-lifetime sweep
+
+| Identifier | Package | Collision? |
+|---|---|---|
+| `credentials.File`, `ServerCreds`, `Load`, `Save`, `TokenFor`, `Upsert`, `CheckPermissions` | `credentials` (new) | none — new package. |
+| `bootstrap.Ensure`, `Options`, `Result` | `bootstrap` (new) | none — new package. **Distinct from the deleted `auth.Bootstrap`** (different package, different signature). |
+| `resolveAPIKey` (signature change), `bootstrapOnInit`, `initSkipBootstrap` | `main` (cmd) | `resolveAPIKey` already exists — Task 2 changes its signature + body and updates all three callers (`newClient`, `newClientWithProject`, `read_mcp_resource.go`). |
+| `force`/`user_id` proto fields | generated | additive proto fields (new field numbers); backward-compatible. |
+| `requireForceForBootstrap`, `containsBindingID` | `server` | new unexported helpers; no collision. |
+| `userForce`, `oidcUnbindUser`, `oidcUnbindForce` (CLI flag vars) | `main` (cmd) | new; no collision. |
+
+No deletions in this plan (the Authn plan already deleted `auth/bootstrap.go`). No survivor analysis needed beyond confirming `resolveAPIKey`'s new body compiles against `credentials`.
+
+---
+
+## Task 1: `internal/credentials` — multi-server credentials file
+
+**Files:**
+
+- Create: `internal/credentials/credentials.go`
+- Create: `internal/credentials/credentials_test.go`
+
+**Covers:** Happy (save → load → TokenFor) + Invariant (Upsert preserves other servers; Save is 0600) + Boundary (missing file → empty, no error; old `api_keys:` shape → empty servers, no error).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package credentials_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/credentials"
+)
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "credentials.yaml")
+	f := credentials.File{}
+	f.Upsert("http://localhost:8080", credentials.ServerCreds{Token: "spgr_sk_abc_secret", Label: "local"})
+	require.NoError(t, credentials.Save(path, f))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "credentials file must be 0600")
+
+	loaded, err := credentials.Load(path)
+	require.NoError(t, err)
+	require.Equal(t, "spgr_sk_abc_secret", loaded.TokenFor("http://localhost:8080"))
+}
+
+func TestUpsertPreservesOtherServers(t *testing.T) {
+	f := credentials.File{}
+	f.Upsert("http://a", credentials.ServerCreds{Token: "tok-a"})
+	f.Upsert("http://b", credentials.ServerCreds{Token: "tok-b"})
+	f.Upsert("http://a", credentials.ServerCreds{Token: "tok-a2"}) // refresh a
+	require.Equal(t, "tok-a2", f.TokenFor("http://a"))
+	require.Equal(t, "tok-b", f.TokenFor("http://b"), "unrelated entry untouched")
+}
+
+func TestLoadMissingFileIsEmpty(t *testing.T) {
+	f, err := credentials.Load(filepath.Join(t.TempDir(), "nope.yaml"))
+	require.NoError(t, err)
+	require.Empty(t, f.TokenFor("http://anything"))
+}
+
+func TestLoadOldShapeYieldsNoServers(t *testing.T) {
+	// The pre-identity credentials.yaml used `api_keys:`. Lenient YAML parse
+	// ignores it; TokenFor returns empty (operator re-bootstraps / creates a
+	// key). This is the documented, release-noted migration.
+	path := filepath.Join(t.TempDir(), "credentials.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("api_keys:\n  - key: spgr_sk_old\n    role: admin\n"), 0o600))
+	f, err := credentials.Load(path)
+	require.NoError(t, err)
+	require.Empty(t, f.TokenFor("http://localhost:8080"))
+}
+
+func TestTokenForNormalizesTrailingSlash(t *testing.T) {
+	f := credentials.File{}
+	f.Upsert("http://localhost:8080", credentials.ServerCreds{Token: "tok"})
+	require.Equal(t, "tok", f.TokenFor("http://localhost:8080/"), "trailing slash ignored")
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/credentials && go test ./...`
+
+Expected: FAIL (package doesn't exist).
+
+- [ ] **Step 3: Write the impl**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+// Package credentials manages the CLI's local credentials file — a
+// per-operator artifact mapping server URLs to bearer tokens. It is read by
+// the CLI for outgoing auth and written by the local bootstrap path. It is
+// NOT read by the server (the server resolves credentials from the database).
+package credentials
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// File is the on-disk credentials structure. It holds entries for multiple
+// server URLs so a single CLI install can authenticate against several
+// deployments without rewriting the file.
+type File struct {
+	Servers map[string]ServerCreds `yaml:"servers"`
+}
+
+// ServerCreds is one server's credential.
+type ServerCreds struct {
+	Token string `yaml:"token"`
+	Label string `yaml:"label,omitempty"`
+}
+
+// normalize trims a trailing slash so "http://h:8080" and "http://h:8080/"
+// resolve to the same entry.
+func normalize(serverURL string) string {
+	return strings.TrimRight(serverURL, "/")
+}
+
+// TokenFor returns the token for the given server URL, or "" if none.
+func (f File) TokenFor(serverURL string) string {
+	if f.Servers == nil {
+		return ""
+	}
+	return f.Servers[normalize(serverURL)].Token
+}
+
+// Upsert sets (or refreshes) the entry for serverURL without disturbing
+// other entries.
+func (f *File) Upsert(serverURL string, creds ServerCreds) {
+	if f.Servers == nil {
+		f.Servers = make(map[string]ServerCreds)
+	}
+	f.Servers[normalize(serverURL)] = creds
+}
+
+// Load reads the credentials file. A missing file returns an empty File with
+// no error. Unknown legacy fields (the old `api_keys:` shape) are ignored by
+// the lenient YAML parse, yielding no servers.
+func Load(path string) (File, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // operator-owned path under XDG config
+	if errors.Is(err, fs.ErrNotExist) {
+		return File{}, nil
+	}
+	if err != nil {
+		return File{}, fmt.Errorf("read credentials %s: %w", path, err)
+	}
+	var f File
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return File{}, fmt.Errorf("parse credentials %s: %w", path, err)
+	}
+	return f, nil
+}
+
+// Save atomically writes the credentials file with 0600 permissions
+// (temp-file + rename so a partial write never replaces a good file).
+func Save(path string, f File) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create credentials dir: %w", err)
+	}
+	data, err := yaml.Marshal(f)
+	if err != nil {
+		return fmt.Errorf("marshal credentials: %w", err)
+	}
+	header := "# SpecGraph CLI credentials. Per-operator; do not commit.\n"
+	content := append([]byte(header), data...)
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".credentials-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp credentials: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op if rename succeeded
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp credentials: %w", err)
+	}
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp credentials: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp credentials: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename credentials into place: %w", err)
+	}
+	return nil
+}
+
+// CheckPermissions returns a warning string if the file is more permissive
+// than 0600, or "" if it's fine or absent.
+func CheckPermissions(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return ""
+	}
+	// Warn only when group/other bits are set (a real leak). Using perm&0o077
+	// — NOT perm&^0o600 — so stricter owner-only modes like 0o400/0o700 are
+	// accepted rather than wrongly flagged.
+	if perm := info.Mode().Perm(); perm&0o077 != 0 {
+		return fmt.Sprintf("credentials file %s is group/other-accessible (%04o); tighten to 0600", path, perm)
+	}
+	return ""
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/credentials && go build ./... && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/credentials/credentials.go internal/credentials/credentials_test.go
+git commit -s -m "feat(credentials): multi-server credentials file (load/save/upsert)"
+```
+
+---
+
+## Task 2: Rewrite CLI `resolveAPIKey` to use the credentials package
+
+**Files:**
+
+- Modify: `cmd/specgraph/client.go`
+- Modify: `cmd/specgraph/read_mcp_resource.go` (a second caller of `newAuthenticatedHTTPClient`)
+
+**Covers:** Happy (token resolved for the active server URL) + Boundary (env var precedence; missing file → "").
+
+> Context: the Authn plan deletes `auth.ReadDefaultKey`, which the current `resolveAPIKey` calls — so post-Authn this file does not compile until this task lands. 4b owns the fix.
+
+- [ ] **Step 1: Identify the current code and ALL callers**
+
+The current `resolveAPIKey()` (no args) returns `os.Getenv("SPECGRAPH_API_KEY")` or `auth.ReadDefaultKey(xdg.CredentialsFile())`. The signature change to `resolveAPIKey(serverURL string)` ripples through `newAuthenticatedHTTPClient`, which has **three** callers — grep to confirm before editing:
+
+```bash
+grep -rn 'newAuthenticatedHTTPClient\|resolveAPIKey' cmd/specgraph/
+```
+
+Expected callers: `client.go`'s `newClient` AND `newClientWithProject` (both build a client after resolving a base URL), plus `read_mcp_resource.go`. Each must pass the resolved `serverURL`. All three have a base URL in scope at the call site (or can call `resolveBaseURL()`).
+
+- [ ] **Step 2: Rewrite credential resolution to be server-scoped**
+
+Replace `resolveAPIKey()` with a server-URL-aware version and thread the URL through:
+
+```go
+// resolveAPIKey returns the bearer token for the given server URL.
+// Precedence: SPECGRAPH_API_KEY env var > credentials file entry for
+// serverURL > "" (no auth).
+func resolveAPIKey(serverURL string) string {
+	if key := os.Getenv("SPECGRAPH_API_KEY"); key != "" {
+		return key
+	}
+	f, err := credentials.Load(xdg.CredentialsFile())
+	if err != nil {
+		return ""
+	}
+	return f.TokenFor(serverURL)
+}
+```
+
+Update `newAuthenticatedHTTPClient` to take the server URL and pass it through:
+
+```go
+func newAuthenticatedHTTPClient(project, serverURL string) *http.Client {
+	return &http.Client{Transport: &staticTokenTransport{
+		inner: &clientTransport{
+			base:    http.DefaultTransport,
+			project: project,
+		},
+		token: resolveAPIKey(serverURL),
+	}}
+}
+```
+
+Update `newClient` to pass `baseURL` into `newAuthenticatedHTTPClient`:
+
+```go
+func newClient[C any](ctor func(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) C) (C, error) {
+	baseURL, project, err := resolveBaseURL()
+	if err != nil {
+		var zero C
+		return zero, err
+	}
+	return ctor(newAuthenticatedHTTPClient(project, baseURL), baseURL), nil
+}
+```
+
+Update the **other two** call sites:
+
+- `client.go`'s `newClientWithProject` (used by `constitution.go`): it resolves a base URL too — pass it as the second arg, e.g. `newAuthenticatedHTTPClient(derivedProject, baseURL)`. If it doesn't currently capture the base URL, add `baseURL, _, _ := resolveBaseURL()` (or thread the value it already computes).
+- `cmd/specgraph/read_mcp_resource.go`: it calls `newAuthenticatedHTTPClient(project)` — change to `newAuthenticatedHTTPClient(project, serverURL)` where `serverURL` is the base URL it resolves (it already builds a client against a URL; pass that URL).
+
+Add `internal/credentials` to client.go's imports. **Keep the `internal/auth` import** — `clientTransport.RoundTrip` still uses `auth.WithBearerToken`/`auth.ProjectFromContext` (unchanged; only `auth.ReadDefaultKey` is dropped). `newHTTPClient` (unauthenticated MCP calls) is separate — leave it.
+
+- [ ] **Step 3: Verify build + tests**
+
+Run: `go build ./... && go test ./...`
+
+Expected: PASS (and the post-Authn dangling `auth.ReadDefaultKey` reference is gone).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/specgraph/client.go cmd/specgraph/read_mcp_resource.go
+git commit -s -m "feat(cli): resolve API key per server URL from the credentials package"
+```
+
+---
+
+## Task 3: `internal/bootstrap.Ensure` — the shared DB helper
+
+**Files:**
+
+- Create: `internal/bootstrap/bootstrap.go`
+- Create: `internal/bootstrap/bootstrap_test.go`
+
+**Covers:** Happy (creates admin + key, returns token) + Invariant (idempotent: existing bootstrap → no-op; system identity has display_name="admin", no OIDC binding) + Boundary (race: CreateHuman returns ErrBootstrapExists → re-fetch, no-op).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package bootstrap_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/bootstrap"
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// stub implements the narrow bootstrap.Backend (GetBootstrap, CreateHuman,
+// CreateAPIKey) that bootstrap.Ensure depends on.
+type stub struct {
+	bootstrapUser *storage.User
+	createHuman   func(*storage.User) (*storage.User, error)
+	createdKey    *storage.APIKey
+}
+
+func (s *stub) GetBootstrap(context.Context) (*storage.User, error) {
+	if s.bootstrapUser == nil {
+		return nil, storage.ErrUserNotFound
+	}
+	return s.bootstrapUser, nil
+}
+func (s *stub) CreateHuman(_ context.Context, u *storage.User, _ *storage.OIDCBinding) (*storage.User, error) {
+	return s.createHuman(u)
+}
+func (s *stub) CreateAPIKey(_ context.Context, k *storage.APIKey) (*storage.APIKey, error) {
+	k.ID = "key-1"
+	k.Prefix = "boot1234" // simulate storage-assigned prefix
+	s.createdKey = k
+	return k, nil
+}
+
+// stub satisfies bootstrap.Backend with exactly these three methods — no
+// other UsersBackend methods are needed because Ensure depends on the narrow
+// Backend interface (Step 3).
+
+func TestEnsure_CreatesBootstrapAdmin(t *testing.T) {
+	var created *storage.User
+	s := &stub{createHuman: func(u *storage.User) (*storage.User, error) {
+		require.Equal(t, "admin", u.DisplayName, "system identity, not env-derived")
+		require.True(t, u.Bootstrap)
+		require.Equal(t, storage.KindHuman, u.Kind)
+		u.ID = "boot-user"
+		created = u
+		return u, nil
+	}}
+	res, err := bootstrap.Ensure(context.Background(), s, bootstrap.Options{})
+	require.NoError(t, err)
+	require.True(t, res.Created)
+	require.NotEmpty(t, res.Token, "a new bootstrap returns the plaintext token")
+	require.True(t, strings.HasPrefix(res.Token, auth.APIKeyTokenPrefix()))
+	require.Contains(t, res.Token, "boot1234", "token embeds the storage-assigned prefix")
+	require.Equal(t, "admin", created.Role)
+}
+
+func TestEnsure_IdempotentWhenExists(t *testing.T) {
+	s := &stub{bootstrapUser: &storage.User{ID: "boot-user", DisplayName: "admin", Bootstrap: true, Role: "admin"}}
+	res, err := bootstrap.Ensure(context.Background(), s, bootstrap.Options{})
+	require.NoError(t, err)
+	require.False(t, res.Created, "existing bootstrap is a no-op")
+	require.Empty(t, res.Token, "no token minted when bootstrap already exists")
+}
+
+// raceStub models losing the create race: GetBootstrap misses first (so
+// Ensure proceeds to CreateHuman), CreateHuman returns ErrBootstrapExists
+// (the winner created it concurrently), and the re-fetch GetBootstrap returns
+// the winner.
+type raceStub struct {
+	winner   *storage.User
+	getCalls int
+}
+
+func (r *raceStub) GetBootstrap(context.Context) (*storage.User, error) {
+	r.getCalls++
+	if r.getCalls == 1 {
+		return nil, storage.ErrUserNotFound
+	}
+	return r.winner, nil
+}
+func (r *raceStub) CreateHuman(context.Context, *storage.User, *storage.OIDCBinding) (*storage.User, error) {
+	return nil, storage.ErrBootstrapExists
+}
+func (r *raceStub) CreateAPIKey(context.Context, *storage.APIKey) (*storage.APIKey, error) {
+	panic("CreateAPIKey must not be called when the create race is lost")
+}
+
+func TestEnsure_RaceLosesGracefully(t *testing.T) {
+	r := &raceStub{winner: &storage.User{ID: "winner", DisplayName: "admin", Bootstrap: true}}
+	res, err := bootstrap.Ensure(context.Background(), r, bootstrap.Options{})
+	require.NoError(t, err)
+	require.False(t, res.Created, "race loser observes the winner's bootstrap")
+	require.Equal(t, "winner", res.UserID)
+	require.Empty(t, res.Token, "loser mints no key")
+}
+```
+
+> Add a `strings` import (used by `TestEnsure_CreatesBootstrapAdmin`). Because `Ensure` takes the narrow `bootstrap.Backend` interface (3 methods — see Step 3), both `*stub` and `*raceStub` satisfy it with only those methods; no `unusedBackend` boilerplate is needed. The `errors` import is only needed if a test uses `errors.Is` — drop it otherwise.
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/bootstrap && go test ./...`
+
+Expected: FAIL (package doesn't exist).
+
+- [ ] **Step 3: Write the impl**
+
+To keep the stub small and the dependency honest, `Ensure` depends on a **narrow interface** (only the methods it needs), which `storage.UsersBackend` satisfies structurally:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+// Package bootstrap creates the first admin identity. It is the shared DB
+// helper behind both bootstrap paths: `specgraph init` (local, direct DB) and
+// the server's first start (hosted). The bootstrap user is a SYSTEM identity
+// (display_name "admin", bootstrap=true, no OIDC binding) — never derived
+// from the OS user, hostname, or any environmental signal.
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// Backend is the narrow slice of storage.UsersBackend that Ensure needs.
+// storage.UsersBackend (and the postgres *AuthStore) satisfy it structurally.
+type Backend interface {
+	GetBootstrap(ctx context.Context) (*storage.User, error)
+	CreateHuman(ctx context.Context, u *storage.User, binding *storage.OIDCBinding) (*storage.User, error)
+	CreateAPIKey(ctx context.Context, k *storage.APIKey) (*storage.APIKey, error)
+}
+
+// Options parametrizes Ensure.
+type Options struct {
+	// Role for the bootstrap admin. Defaults to "admin".
+	Role string
+}
+
+// Result reports what Ensure did.
+type Result struct {
+	Created bool   // true if this call created the bootstrap user + key
+	Token   string // plaintext token (only set when Created; show once)
+	UserID  string // bootstrap user id (set whether created or pre-existing)
+}
+
+// Ensure creates the bootstrap admin + an admin API key if no bootstrap user
+// exists, and is a no-op otherwise. Idempotent and race-safe: concurrent
+// callers converge to one bootstrap row (CreateHuman returns
+// ErrBootstrapExists for the loser, which re-reads the winner).
+func Ensure(ctx context.Context, b Backend, opts Options) (Result, error) {
+	role := opts.Role
+	if role == "" {
+		role = "admin"
+	}
+
+	// Idempotency check.
+	if existing, err := b.GetBootstrap(ctx); err == nil {
+		return Result{Created: false, UserID: existing.ID}, nil
+	} else if !errors.Is(err, storage.ErrUserNotFound) {
+		return Result{}, fmt.Errorf("check bootstrap: %w", err)
+	}
+
+	// Create the system admin (no OIDC binding — backstop identity).
+	user, err := b.CreateHuman(ctx, &storage.User{
+		Kind:        storage.KindHuman,
+		DisplayName: "admin", // literal; NOT env-derived
+		Role:        role,
+		Bootstrap:   true,
+	}, nil)
+	if err != nil {
+		// Lost a race: another caller created the bootstrap first.
+		if errors.Is(err, storage.ErrBootstrapExists) {
+			existing, getErr := b.GetBootstrap(ctx)
+			if getErr != nil {
+				return Result{}, fmt.Errorf("re-read bootstrap after race: %w", getErr)
+			}
+			return Result{Created: false, UserID: existing.ID}, nil
+		}
+		return Result{}, fmt.Errorf("create bootstrap user: %w", err)
+	}
+
+	// Mint an admin key. Storage owns the prefix (see 4a Task 7); build the
+	// token from the storage-assigned prefix.
+	secret, phc, err := auth.GenerateAPIKeySecret()
+	if err != nil {
+		return Result{}, fmt.Errorf("generate bootstrap key: %w", err)
+	}
+	key, err := b.CreateAPIKey(ctx, &storage.APIKey{
+		UserID:  user.ID,
+		PHCHash: phc,
+		Label:   "bootstrap admin key",
+	})
+	if err != nil {
+		return Result{}, fmt.Errorf("create bootstrap key: %w", err)
+	}
+	return Result{
+		Created: true,
+		Token:   auth.FormatAPIKeyToken(key.Prefix, secret),
+		UserID:  user.ID,
+	}, nil
+}
+```
+
+> Because `Ensure` takes the narrow `Backend`, the test stub only needs three methods (`GetBootstrap`, `CreateHuman`, `CreateAPIKey`) — no `unusedBackend` boilerplate. Simplify the Task-1 test stub accordingly (drop the panicking-base note; the three-method `stub`/`raceStub` already satisfy `Backend`).
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/bootstrap && go build ./... && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/bootstrap/bootstrap.go internal/bootstrap/bootstrap_test.go
+git commit -s -m "feat(bootstrap): idempotent, race-safe Ensure (system admin + key)"
+```
+
+---
+
+## Task 4: Bootstrap integration test (idempotent + resolvable)
+
+**Files:**
+
+- Create: `internal/bootstrap/bootstrap_integration_test.go`
+
+**Covers:** E2E (Ensure against real AuthStore; token resolves; second call is a no-op).
+
+- [ ] **Step 1: Write the test**
+
+```go
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package bootstrap_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/auth/usagetracker"
+	"github.com/specgraph/specgraph/internal/bootstrap"
+	"github.com/specgraph/specgraph/internal/storage/postgres"
+	"github.com/specgraph/specgraph/internal/storage/postgres/postgrestest"
+)
+
+func TestIntegration_EnsureIdempotentAndResolvable(t *testing.T) {
+	ctx := context.Background()
+	pool := postgrestest.SharedPool(t, ctx) // EXPORTED cross-package harness — see note below
+	authStore, err := postgres.NewAuth(ctx, pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = authStore.Close(ctx) })
+	_, err = pool.Exec(ctx, `TRUNCATE users RESTART IDENTITY CASCADE`)
+	require.NoError(t, err)
+
+	res, err := bootstrap.Ensure(ctx, authStore, bootstrap.Options{})
+	require.NoError(t, err)
+	require.True(t, res.Created)
+	require.NotEmpty(t, res.Token)
+
+	// The minted token resolves to the bootstrap admin.
+	tracker := usagetracker.NewManager(authStore, usagetracker.Config{})
+	t.Cleanup(func() { _ = tracker.Close(ctx) })
+	resolver, err := auth.NewIdentityStore(auth.IdentityStoreConfig{Users: authStore, Tracker: tracker})
+	require.NoError(t, err)
+	id, err := resolver.Resolve(ctx, res.Token)
+	require.NoError(t, err)
+	require.Equal(t, res.UserID, id.UserID)
+	require.Equal(t, auth.Role("admin"), id.Role)
+
+	// Second call is a no-op.
+	res2, err := bootstrap.Ensure(ctx, authStore, bootstrap.Options{})
+	require.NoError(t, err)
+	require.False(t, res2.Created)
+	require.Empty(t, res2.Token)
+	require.Equal(t, res.UserID, res2.UserID)
+}
+```
+
+> **Test pool helper:** `postgrestest.SharedPool(t, ctx)` is the exported cross-package harness created by **Storage plan Task 32** (the in-package `sharedTestPool` is `package postgres_test` and not importable here). The Authn and 4a integration tests use the same helper. This task depends on Task 32 having landed.
+
+- [ ] **Step 2: Run**
+
+Run: `cd internal/bootstrap && go test -tags integration -run TestIntegration_EnsureIdempotentAndResolvable -v`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/bootstrap/bootstrap_integration_test.go
+git commit -s -m "test(bootstrap): integration test for Ensure (idempotent + resolvable)"
+```
+
+---
+
+## Task 5: `specgraph init` local bootstrap path
+
+**Files:**
+
+- Modify: `cmd/specgraph/init.go`
+
+**Covers:** Happy (DB reachable → bootstrap + write credentials) + Boundary (no DB URL / unreachable → hint, no error).
+
+- [ ] **Step 1: Add the local-bootstrap step**
+
+After `init` finishes its managed-file sync, add a bootstrap step. Add a helper `bootstrapOnInit` and call it near the end of `runInit` (before the final success message):
+
+```go
+// bootstrapOnInit runs the local-mode bootstrap when a Postgres connection is
+// available: creates the first admin (idempotent) and writes the resulting
+// token into the local credentials file for the resolved server URL. When no
+// DB is configured or reachable, it prints a hint that the server's first
+// start will handle bootstrap, and returns nil (init never fails on this).
+func bootstrapOnInit(ctx context.Context, w io.Writer) error {
+	cfg, err := loadGlobalCfg()
+	if err != nil {
+		return nil // config problems are surfaced elsewhere; don't block init
+	}
+	url := cfg.Server.Postgres.URL
+	if url == "" {
+		// Defensive: loadGlobalCfg() normally defaults this to a localhost dev
+		// URL, so this branch rarely fires — the unreachable-DB branch below is
+		// the real "no local Postgres" path.
+		fmt.Fprintln(w, "  No Postgres URL configured; the server's first start will create the admin.")
+		return nil
+	}
+
+	// Short dial timeout: a developer without local Postgres should not wait
+	// long for `specgraph init`. 2s is enough for a healthy local DB; a miss
+	// falls through to the hint quickly.
+	connectCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	store, err := postgres.New(connectCtx, url, postgres.WithProject("_server"))
+	if err != nil {
+		fmt.Fprintf(w, "  Postgres not reachable (%v); the server's first start will create the admin.\n", err)
+		return nil
+	}
+	// Close with a non-timed context: connectCtx's 2s deadline is for the dial
+	// only and may already be expired by the time these deferred closes run.
+	defer func() { _ = store.Close(context.Background()) }()
+
+	authStore, err := postgres.NewAuth(connectCtx, store.Pool())
+	if err != nil {
+		fmt.Fprintf(w, "  Could not open identity store (%v); skipping local bootstrap.\n", err)
+		return nil
+	}
+	defer func() { _ = authStore.Close(context.Background()) }()
+
+	res, err := bootstrap.Ensure(connectCtx, authStore, bootstrap.Options{})
+	if err != nil {
+		return fmt.Errorf("bootstrap: %w", err)
+	}
+	if !res.Created {
+		fmt.Fprintln(w, "  Admin already exists; leaving credentials untouched.")
+		return nil
+	}
+
+	// Write the token into the credentials file for the resolved server URL.
+	serverURL, _, err := resolveBaseURL()
+	if err != nil || serverURL == "" {
+		// Fall back to the local listen address.
+		serverURL = "http://" + cfg.Server.Listen
+	}
+	credPath := xdg.CredentialsFile()
+	f, _ := credentials.Load(credPath)
+	f.Upsert(serverURL, credentials.ServerCreds{Token: res.Token, Label: "bootstrap"})
+	if err := credentials.Save(credPath, f); err != nil {
+		return fmt.Errorf("write credentials: %w", err)
+	}
+	fmt.Fprintf(w, "\n  Created admin and saved its API key to %s (server %s).\n", credPath, serverURL)
+	fmt.Fprintln(w, "  Rotate it after configuring OIDC: specgraph auth api-key rotate <id> --user <admin-id>")
+	return nil
+}
+```
+
+Wire it into `runInit`, guarded by a new `--skip-bootstrap` flag for operators who want managed-file-only init. **The current `runInit` signature is `func runInit(_ *cobra.Command, args []string) error` — rename the `_` to `cmd`** so `cmd.Context()`/`cmd.OutOrStdout()` resolve:
+
+```go
+	if !initSkipBootstrap {
+		if err := bootstrapOnInit(cmd.Context(), cmd.OutOrStdout()); err != nil {
+			return err
+		}
+	}
+```
+
+Add imports: `context`, `io`, `time`, `internal/bootstrap`, `internal/credentials`, `internal/storage/postgres`, `internal/xdg`. Register the flag in `init()`: `initCmd.Flags().BoolVar(&initSkipBootstrap, "skip-bootstrap", false, "skip local admin bootstrap (managed files only)")`, and declare `var initSkipBootstrap bool`.
+
+> Match the merged `init.go`'s actual run-function name (it is `runInit` in the current code) and confirm `loadGlobalCfg()` exists (it's used by `resolveBaseURL`). `(*postgres.Store).Close(ctx)` and `(*postgres.AuthStore).Close(ctx)` both take a context (verified against the current/merged signatures).
+
+- [ ] **Step 2: Verify build**
+
+Run: `go build ./... && go run ./cmd/specgraph init --help`
+
+Expected: build PASS; `--skip-bootstrap` listed.
+
+- [ ] **Step 3: Verify local-bootstrap degrades gracefully without a DB**
+
+Because `loadGlobalCfg()` defaults `Server.Postgres.URL` to a localhost dev value, `init` on a machine with no local Postgres takes the unreachable-DB branch: it prints "Postgres not reachable … the server's first start will create the admin" after a ≤2s dial and exits 0.
+
+Run (in a temp dir, no Postgres running): `time go run ./cmd/specgraph init demo-project 2>&1 | grep -i 'not reachable\|create the admin'` — expect the hint, exit 0, and the run to finish within a couple seconds. (Operators who want to skip the dial entirely use `--skip-bootstrap`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/specgraph/init.go
+git commit -s -m "feat(init): local-mode admin bootstrap when Postgres is reachable"
+```
+
+---
+
+## Task 6: `serve.go` hosted bootstrap path (log banner)
+
+**Files:**
+
+- Modify: `cmd/specgraph/serve.go`
+
+**Covers:** Happy (first start with no bootstrap → create + banner) + Invariant (no filesystem write in hosted path; idempotent on restart).
+
+- [ ] **Step 1: Add the hosted-bootstrap step**
+
+In the post-Authn `serve.go`, after `authStore` is constructed (the `postgres.NewAuth(...)` value) and before/around the existing `warnIfNoAuthOnPublicListen` call, add:
+
+```go
+	// Hosted bootstrap: create the first admin on first start. Unlike the
+	// local path (specgraph init), the server does NOT write a credentials
+	// file the operator can read — it surfaces the key in the log banner.
+	if res, bErr := bootstrap.Ensure(ctx, authStore, bootstrap.Options{}); bErr != nil {
+		return fmt.Errorf("bootstrap admin: %w", bErr)
+	} else if res.Created {
+		serverURL := "http://" + cfg.Server.Listen
+		fmt.Fprintf(os.Stderr,
+			"\n  SpecGraph created a bootstrap admin API key:\n\n    %s\n\n"+
+				"  Server: %s\n"+
+				"  Copy it into your local credentials (the CLI reads ~/.config/specgraph/credentials.yaml),\n"+
+				"  then rotate it after configuring OIDC. It will not be shown again.\n\n",
+			res.Token, serverURL)
+	}
+```
+
+- [ ] **Step 2: Verify whole-project build**
+
+Run: `go build ./...`
+
+Expected: PASS. Add `internal/bootstrap` to serve.go's imports.
+
+> Match the merged serve.go: `authStore` (the `*postgres.AuthStore`), `ctx`, `cfg.Server.Listen`, and the `fmt`/`os` imports (both already present). The hosted path runs unconditionally each start; `Ensure` is idempotent, so restarts after the first are silent no-ops.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/specgraph/serve.go
+git commit -s -m "feat(serve): hosted admin bootstrap with log-banner on first start"
+```
+
+---
+
+## Task 7: Proto — `force` flags + `user_id` on unbind
+
+**Files:**
+
+- Modify: `proto/specgraph/v1/identity.proto`
+
+**Covers:** N/A (schema + codegen).
+
+- [ ] **Step 1: Add the fields**
+
+In `identity.proto`, update the three messages (4a left field numbers free):
+
+```proto
+message SoftDeleteUserRequest {
+  string id = 1;
+  bool force = 2; // required to soft-delete the bootstrap admin
+}
+
+message PurgeUserRequest {
+  string id = 1;
+  bool force = 2; // required to purge the bootstrap admin
+}
+
+message UnbindOIDCRequest {
+  string binding_id = 1;
+  string user_id = 2; // owner of the binding (required for the last-credential check)
+  bool force = 3;     // required to remove a user's only credential
+}
+```
+
+- [ ] **Step 2: Generate + build**
+
+Run: `task proto && go build ./...`
+
+Expected: generated getters `GetForce()`, `GetUserId()` appear; build PASS (4a handlers ignore the new fields until Tasks 8–9).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add proto/specgraph/v1/identity.proto gen/specgraph/v1/identity.pb.go gen/specgraph/v1/specgraphv1connect/identity.connect.go
+git commit -s -m "feat(proto): add force flags + unbind user_id for identity protections"
+```
+
+---
+
+## Task 8: Bootstrap-protection guard on `SoftDeleteUser` + `PurgeUser`
+
+**Files:**
+
+- Modify: `internal/server/identity_handler.go`
+- Modify: `internal/server/identity_handler_test.go`
+
+**Covers:** Happy (force allows; non-bootstrap unaffected) + Invariant (bootstrap user refused without force) + Boundary (NotFound from GetUserByID propagates).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestSoftDeleteUser_RefusesBootstrapWithoutForce(t *testing.T) {
+	stub := &usersBackendStub{
+		getUserByID: func(_ context.Context, id string) (*storage.User, error) {
+			return &storage.User{ID: id, Kind: storage.KindHuman, Bootstrap: true, Role: "admin"}, nil
+		},
+		// softDeleteUser intentionally unset — must NOT be called.
+	}
+	h := newTestIdentityHandler(stub)
+	_, err := h.SoftDeleteUser(context.Background(), connect.NewRequest(&specv1.SoftDeleteUserRequest{Id: "boot"}))
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+
+func TestSoftDeleteUser_AllowsBootstrapWithForce(t *testing.T) {
+	deleted := false
+	stub := &usersBackendStub{
+		getUserByID:    func(_ context.Context, id string) (*storage.User, error) { return &storage.User{ID: id, Bootstrap: true}, nil },
+		softDeleteUser: func(context.Context, string) error { deleted = true; return nil },
+	}
+	h := newTestIdentityHandler(stub)
+	_, err := h.SoftDeleteUser(context.Background(), connect.NewRequest(&specv1.SoftDeleteUserRequest{Id: "boot", Force: true}))
+	require.NoError(t, err)
+	require.True(t, deleted)
+}
+
+func TestSoftDeleteUser_NonBootstrapNoForceNeeded(t *testing.T) {
+	deleted := false
+	stub := &usersBackendStub{
+		getUserByID:    func(_ context.Context, id string) (*storage.User, error) { return &storage.User{ID: id, Bootstrap: false}, nil },
+		softDeleteUser: func(context.Context, string) error { deleted = true; return nil },
+	}
+	h := newTestIdentityHandler(stub)
+	_, err := h.SoftDeleteUser(context.Background(), connect.NewRequest(&specv1.SoftDeleteUserRequest{Id: "u1"}))
+	require.NoError(t, err)
+	require.True(t, deleted)
+}
+
+func TestPurgeUser_RefusesBootstrapWithoutForce(t *testing.T) {
+	stub := &usersBackendStub{
+		getUserByID: func(_ context.Context, id string) (*storage.User, error) {
+			return &storage.User{ID: id, Bootstrap: true}, nil
+		},
+	}
+	h := newTestIdentityHandler(stub)
+	_, err := h.PurgeUser(context.Background(), connect.NewRequest(&specv1.PurgeUserRequest{Id: "boot"}))
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/server && go test -run 'TestSoftDeleteUser_RefusesBootstrap|TestPurgeUser_RefusesBootstrap' -v`
+
+Expected: FAIL — 4a's handlers don't read `Force` and don't fetch the user; they soft-delete/purge unconditionally.
+
+- [ ] **Step 3: Add the guard**
+
+Add a shared helper and call it from both methods. In `identity_handler.go`:
+
+```go
+// requireForceForBootstrap fetches the target user and refuses a destructive
+// operation on the bootstrap admin unless force is set. Returns a connect
+// error ready to return, or nil to proceed.
+func (h *IdentityHandler) requireForceForBootstrap(ctx context.Context, id string, force bool) error {
+	u, err := h.users.GetUserByID(ctx, id)
+	if err != nil {
+		return h.identityError(ctx, err)
+	}
+	if u.Bootstrap && !force {
+		return connect.NewError(connect.CodeFailedPrecondition,
+			errors.New("refusing to delete the bootstrap admin without force; pass --force to confirm"))
+	}
+	return nil
+}
+```
+
+Update `SoftDeleteUser` (insert the guard after the id check, before the backend call):
+
+```go
+	if err := h.requireForceForBootstrap(ctx, req.Msg.GetId(), req.Msg.GetForce()); err != nil {
+		return nil, err
+	}
+```
+
+Update `PurgeUser` identically (same guard line after its id check).
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/server && go build ./... && go test -run 'TestSoftDeleteUser|TestPurgeUser' -v`
+
+Expected: PASS (new guard tests + the 4a tests, after the one stub fix below).
+
+> **Cross-task note (ripple into 4a tests):** The guard adds a `GetUserByID` call before the backend mutation. Auditing 4a's three delete/purge tests:
+> - `TestSoftDeleteUser_Happy` — its stub sets only `softDeleteUser`; the default `getUserByID` returns `ErrUserNotFound`, so the guard now returns `CodeNotFound` and the test fails. **Fix:** add `getUserByID: func(_ context.Context, id string) (*storage.User, error) { return &storage.User{ID: id, Bootstrap: false}, nil }` to its stub.
+> - `TestSoftDeleteUser_RequiresID` — unaffected (the empty-id check runs before the guard).
+> - `TestPurgeUser_NotFound` — still passes unchanged: the guard's `GetUserByID` hits the default `ErrUserNotFound` and returns `CodeNotFound`, which is exactly what the test asserts (the `purgeUser` stub is simply never reached).
+> That single `TestSoftDeleteUser_Happy` stub addition is the only required edit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/identity_handler.go internal/server/identity_handler_test.go
+git commit -s -m "feat(server): bootstrap-protection guard on SoftDeleteUser and PurgeUser"
+```
+
+---
+
+## Task 9: Last-credential guard on `UnbindOIDC`
+
+**Files:**
+
+- Modify: `internal/server/identity_handler.go`
+- Modify: `internal/server/identity_handler_test.go`
+
+**Covers:** Happy (force allows; user with other credentials unaffected) + Invariant (removing the only credential refused without force) + Boundary (missing user_id → InvalidArgument).
+
+> Design: `UnbindOIDC` carries the last-credential protection; `RevokeAPIKey` deliberately does NOT (revoking the last key is a normal rotate-by-hand step, and OIDC remains). The handler counts the user's OIDC bindings + active API keys; if this unbind would leave zero credentials and `force` is unset, it refuses. The request carries `user_id` because there is no get-binding-by-id backend method.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestUnbindOIDC_RefusesLastCredentialWithoutForce(t *testing.T) {
+	stub := &usersBackendStub{
+		listOIDCBindings: func(context.Context, string) ([]*storage.OIDCBinding, error) {
+			return []*storage.OIDCBinding{{ID: "b1", UserID: "u1"}}, nil // exactly one binding
+		},
+		listAPIKeys: func(context.Context, storage.ListAPIKeysFilter) ([]*storage.APIKey, error) {
+			return nil, nil // no active keys
+		},
+		// unbindOIDC unset — must NOT be called.
+	}
+	h := newTestIdentityHandler(stub)
+	_, err := h.UnbindOIDC(context.Background(), connect.NewRequest(&specv1.UnbindOIDCRequest{BindingId: "b1", UserId: "u1"}))
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+
+func TestUnbindOIDC_AllowsLastWithForce(t *testing.T) {
+	unbound := false
+	stub := &usersBackendStub{
+		listOIDCBindings: func(context.Context, string) ([]*storage.OIDCBinding, error) {
+			return []*storage.OIDCBinding{{ID: "b1", UserID: "u1"}}, nil
+		},
+		listAPIKeys: func(context.Context, storage.ListAPIKeysFilter) ([]*storage.APIKey, error) { return nil, nil },
+		unbindOIDC:  func(context.Context, string) error { unbound = true; return nil },
+	}
+	h := newTestIdentityHandler(stub)
+	_, err := h.UnbindOIDC(context.Background(), connect.NewRequest(&specv1.UnbindOIDCRequest{BindingId: "b1", UserId: "u1", Force: true}))
+	require.NoError(t, err)
+	require.True(t, unbound)
+}
+
+func TestUnbindOIDC_AllowsWhenOtherCredentialsExist(t *testing.T) {
+	unbound := false
+	stub := &usersBackendStub{
+		listOIDCBindings: func(context.Context, string) ([]*storage.OIDCBinding, error) {
+			return []*storage.OIDCBinding{{ID: "b1", UserID: "u1"}, {ID: "b2", UserID: "u1"}}, nil // two bindings
+		},
+		listAPIKeys: func(context.Context, storage.ListAPIKeysFilter) ([]*storage.APIKey, error) { return nil, nil },
+		unbindOIDC:  func(context.Context, string) error { unbound = true; return nil },
+	}
+	h := newTestIdentityHandler(stub)
+	_, err := h.UnbindOIDC(context.Background(), connect.NewRequest(&specv1.UnbindOIDCRequest{BindingId: "b1", UserId: "u1"}))
+	require.NoError(t, err)
+	require.True(t, unbound)
+}
+
+func TestUnbindOIDC_RequiresUserID(t *testing.T) {
+	h := newTestIdentityHandler(&usersBackendStub{})
+	_, err := h.UnbindOIDC(context.Background(), connect.NewRequest(&specv1.UnbindOIDCRequest{BindingId: "b1"}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+// Ownership check: a credential-rich user_id must NOT let a caller remove a
+// binding that doesn't belong to that user (closes the trust-the-caller gap).
+func TestUnbindOIDC_RejectsBindingNotOwnedByUser(t *testing.T) {
+	stub := &usersBackendStub{
+		listOIDCBindings: func(context.Context, string) ([]*storage.OIDCBinding, error) {
+			// u1 has two bindings, but NOT the one being removed ("other").
+			return []*storage.OIDCBinding{{ID: "b1", UserID: "u1"}, {ID: "b2", UserID: "u1"}}, nil
+		},
+		// unbindOIDC unset — must NOT be called.
+	}
+	h := newTestIdentityHandler(stub)
+	_, err := h.UnbindOIDC(context.Background(), connect.NewRequest(&specv1.UnbindOIDCRequest{BindingId: "other", UserId: "u1", Force: true}))
+	require.Equal(t, connect.CodeNotFound, connect.CodeOf(err), "binding not owned by user → NotFound, even with force")
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/server && go test -run 'TestUnbindOIDC' -v`
+
+Expected: FAIL — 4a's `UnbindOIDC` unbinds unconditionally and doesn't require `user_id`.
+
+- [ ] **Step 3: Replace the `UnbindOIDC` handler**
+
+```go
+// UnbindOIDC removes an OIDC binding, refusing to remove a user's ONLY
+// credential unless force is set. It first verifies the binding belongs to
+// user_id (there is no get-binding-by-id backend method, so the caller names
+// the owner and we confirm it against the user's binding list — this prevents
+// a credential-rich user_id from masking the removal of a different user's
+// last binding). Then it counts the user's active credentials (bindings +
+// non-revoked keys) and gates on force.
+func (h *IdentityHandler) UnbindOIDC(ctx context.Context, req *connect.Request[specv1.UnbindOIDCRequest]) (*connect.Response[specv1.UnbindOIDCResponse], error) {
+	msg := req.Msg
+	if msg.GetBindingId() == "" || msg.GetUserId() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("binding_id and user_id are required"))
+	}
+	// Fetch the user's bindings once — used to verify ownership AND to count.
+	bindings, err := h.users.ListOIDCBindings(ctx, msg.GetUserId())
+	if err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	if !containsBindingID(bindings, msg.GetBindingId()) {
+		return nil, connect.NewError(connect.CodeNotFound,
+			errors.New("binding not found for the given user"))
+	}
+	if !msg.GetForce() {
+		keys, keyErr := h.users.ListAPIKeys(ctx, storage.ListAPIKeysFilter{UserID: msg.GetUserId(), IncludeRevoked: false})
+		if keyErr != nil {
+			return nil, h.identityError(ctx, keyErr)
+		}
+		if len(bindings)+len(keys) <= 1 {
+			return nil, connect.NewError(connect.CodeFailedPrecondition,
+				errors.New("refusing to remove the user's only credential without force; pass --force to confirm"))
+		}
+	}
+	if err := h.users.UnbindOIDC(ctx, msg.GetBindingId()); err != nil {
+		return nil, h.identityError(ctx, err)
+	}
+	return connect.NewResponse(&specv1.UnbindOIDCResponse{}), nil
+}
+
+// containsBindingID reports whether bindingID is among the user's bindings.
+func containsBindingID(bindings []*storage.OIDCBinding, bindingID string) bool {
+	for _, b := range bindings {
+		if b.ID == bindingID {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/server && go build ./... && go test -run 'TestUnbindOIDC|TestListOIDCBindings' -v`
+
+Expected: PASS.
+
+> **Cross-task note (ripple into 4a tests):** 4a's `TestUnbindOIDC_Happy` sends only `BindingId: "b1"`. The guard now (a) requires `UserId`, and (b) verifies the binding is in `ListOIDCBindings(user_id)`. Update that 4a test's request to `{BindingId: "b1", UserId: "u1", Force: true}` AND give its stub a `listOIDCBindings` returning `[]*storage.OIDCBinding{{ID: "b1", UserID: "u1"}}` so the ownership check passes (force then bypasses the count). 4a's `TestUnbindOIDC_NotFound` (binding "x", default stub `listOIDCBindings` returns nil) still yields `CodeNotFound` — now from the ownership check rather than the backend — so its assertion holds; add `UserId: "u1"` to its request so it passes the arg check. The `unbindOIDC` stub func in that test is simply never reached (fine).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/identity_handler.go internal/server/identity_handler_test.go
+git commit -s -m "feat(server): last-credential guard on UnbindOIDC"
+```
+
+---
+
+## Task 10: CLI `--force` / `--user` flags for protected operations
+
+**Files:**
+
+- Modify: `cmd/specgraph/auth_user.go`
+- Modify: `cmd/specgraph/auth_oidc.go`
+
+**Covers:** Command wiring (build + help smoke); guard behavior covered by Tasks 8–9 + the integration test (Task 11).
+
+- [ ] **Step 1: Add `--force` to user delete/purge**
+
+In `auth_user.go`, add a package-level `var userForce bool`, thread it into the delete/purge requests, and register the flag.
+
+Update the delete command's request:
+
+```go
+		if _, err := client.SoftDeleteUser(cmd.Context(), connect.NewRequest(&specv1.SoftDeleteUserRequest{Id: args[0], Force: userForce})); err != nil {
+```
+
+Update the purge command's request:
+
+```go
+		if _, err := client.PurgeUser(cmd.Context(), connect.NewRequest(&specv1.PurgeUserRequest{Id: args[0], Force: userForce})); err != nil {
+```
+
+In `auth_user.go`'s `init()`, add:
+
+```go
+	authUserDeleteCmd.Flags().BoolVar(&userForce, "force", false, "allow deleting the bootstrap admin")
+	authUserPurgeCmd.Flags().BoolVar(&userForce, "force", false, "allow purging the bootstrap admin")
+```
+
+- [ ] **Step 2: Add `--user` + `--force` to oidc unbind**
+
+In `auth_oidc.go`, add `var (oidcUnbindUser string; oidcUnbindForce bool)`, update the unbind command:
+
+```go
+var authOIDCUnbindCmd = &cobra.Command{
+	Use:   "unbind <binding-id>",
+	Short: "Remove an OIDC binding",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if oidcUnbindUser == "" {
+			return fmt.Errorf("--user is required (owner of the binding)")
+		}
+		client, err := identityClient()
+		if err != nil {
+			return err
+		}
+		if _, err := client.UnbindOIDC(cmd.Context(), connect.NewRequest(&specv1.UnbindOIDCRequest{
+			BindingId: args[0], UserId: oidcUnbindUser, Force: oidcUnbindForce,
+		})); err != nil {
+			return fmt.Errorf("unbind oidc: %w", err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Unbound %s\n", args[0])
+		return nil
+	},
+}
+```
+
+In `auth_oidc.go`'s `init()`, add:
+
+```go
+	authOIDCUnbindCmd.Flags().StringVar(&oidcUnbindUser, "user", "", "owner of the binding (required)")
+	authOIDCUnbindCmd.Flags().BoolVar(&oidcUnbindForce, "force", false, "allow removing the user's only credential")
+```
+
+- [ ] **Step 3: Verify build + help**
+
+Run:
+
+```bash
+go build ./...
+go run ./cmd/specgraph auth user delete --help
+go run ./cmd/specgraph auth oidc unbind --help
+```
+
+Expected: build PASS; `--force` on delete/purge; `--user`/`--force` on unbind.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/specgraph/auth_user.go cmd/specgraph/auth_oidc.go
+git commit -s -m "feat(cli): --force on user delete/purge; --user/--force on oidc unbind"
+```
+
+---
+
+## Task 11: Integration test — protections through the interceptor
+
+**Files:**
+
+- Modify: `internal/server/identity_integration_test.go` (the 4a file)
+
+**Covers:** E2E (bootstrap-delete refused without force, allowed with; last-credential unbind refused without force).
+
+- [ ] **Step 1: Write the test**
+
+Append to `internal/server/identity_integration_test.go` (reuses the 4a `buildIdentityTestServer`/`mintFor`/`tokenClient` helpers):
+
+```go
+func TestIntegration_BootstrapDeleteProtected(t *testing.T) {
+	ctx := context.Background()
+	baseURL, store := buildIdentityTestServer(t, ctx)
+	adminToken := mintFor(t, ctx, store, "admin", true) // bootstrap admin
+	client := tokenClient(baseURL, adminToken)
+
+	// Find the bootstrap admin's id.
+	boot, err := store.GetBootstrap(ctx)
+	require.NoError(t, err)
+
+	// Without force: refused.
+	_, err = client.SoftDeleteUser(ctx, connect.NewRequest(&specv1.SoftDeleteUserRequest{Id: boot.ID}))
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+	// With force: allowed.
+	_, err = client.SoftDeleteUser(ctx, connect.NewRequest(&specv1.SoftDeleteUserRequest{Id: boot.ID, Force: true}))
+	require.NoError(t, err)
+}
+
+func TestIntegration_LastCredentialUnbindProtected(t *testing.T) {
+	ctx := context.Background()
+	baseURL, store := buildIdentityTestServer(t, ctx)
+	adminToken := mintFor(t, ctx, store, "admin", true)
+	client := tokenClient(baseURL, adminToken)
+
+	// Create a Human with exactly one OIDC binding and no API keys.
+	u, err := store.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "person", Role: "reader"},
+		&storage.OIDCBinding{Issuer: "https://idp", Subject: "sub-1"})
+	require.NoError(t, err)
+	bindings, err := store.ListOIDCBindings(ctx, u.ID)
+	require.NoError(t, err)
+	require.Len(t, bindings, 1)
+
+	// Without force: refused (only credential).
+	_, err = client.UnbindOIDC(ctx, connect.NewRequest(&specv1.UnbindOIDCRequest{BindingId: bindings[0].ID, UserId: u.ID}))
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+	// With force: allowed.
+	_, err = client.UnbindOIDC(ctx, connect.NewRequest(&specv1.UnbindOIDCRequest{BindingId: bindings[0].ID, UserId: u.ID, Force: true}))
+	require.NoError(t, err)
+}
+```
+
+> `CreateHuman` with a binding: per the Storage plan, `CreateHuman(ctx, u, binding)` creates the Human + binding atomically. If the merged signature differs, adapt. The admin token's user is the bootstrap admin (created by `mintFor(...,"admin",true)`), so `GetBootstrap` finds it.
+
+- [ ] **Step 2: Run**
+
+Run: `cd internal/server && go test -tags integration -run 'TestIntegration_BootstrapDeleteProtected|TestIntegration_LastCredentialUnbindProtected' -v`
+
+Expected: PASS.
+
+- [ ] **Step 3: Full suites**
+
+```bash
+# from the repository root:
+go build ./... && go test ./...
+go test -tags integration ./internal/server/... ./internal/auth/... ./internal/bootstrap/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/server/identity_integration_test.go
+git commit -s -m "test(server): integration tests for bootstrap + last-credential protections"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (against `docs/plans/2026-05-22-identity-bootstrap-ux-design.md`):
+
+- [x] Local-mode bootstrap via `specgraph init` (direct DB → create admin + write credentials): Tasks 3, 5.
+- [x] Hosted bootstrap via server first-start (create admin + log banner, no file write): Tasks 3, 6.
+- [x] Both paths idempotent + race-safe via a single shared helper: Task 3 (`bootstrap.Ensure`).
+- [x] `init` detects which path from a working Postgres connection: Task 5 (`bootstrapOnInit`).
+- [x] Credentials file is CLI-read-only, multi-server, doesn't clobber other entries: Tasks 1, 2, 5.
+- [x] Bootstrap user is a system identity (`display_name="admin"`, no OIDC binding, never env-derived): Task 3 (asserted in `TestEnsure_CreatesBootstrapAdmin`).
+- [x] Bootstrap soft-delete/purge force-flag protection: Tasks 7, 8, 10.
+- [x] Last-credential `UnbindOIDC` protection; `RevokeAPIKey` deliberately NOT protected: Task 9 (and Task 9's docstring records the asymmetry; `RevokeAPIKey` is untouched). The guard also verifies the binding belongs to the named `user_id` (`containsBindingID`) so a credential-rich `user_id` can't mask removing another user's last binding — covered by `TestUnbindOIDC_RejectsBindingNotOwnedByUser`.
+- [x] CLI under `specgraph auth` (4a) with `--force`/`--user` for protected ops: Task 10.
+- [x] Credentials-file behavior change is release-noted: Task 1 (old `api_keys:` → empty; documented).
+
+**2. Placeholder scan:** No TODO/TBD. The Task 3 test stub is sketched with a note, then Step 3 narrows `Ensure`'s dependency to a 3-method `Backend` interface so the stub needs no boilerplate — the note explicitly tells the executor to simplify. Every impl + test step shows complete code.
+
+**3. Type consistency:** `credentials.File`/`ServerCreds`/`Load`/`Save`/`TokenFor`/`Upsert`, `bootstrap.Ensure`/`Options`/`Result`/`Backend`, `resolveAPIKey(serverURL)`, `requireForceForBootstrap`, `containsBindingID`, and the proto `GetForce()`/`GetUserId()` getters are referenced consistently. `bootstrap.Ensure` takes the narrow `Backend` interface (satisfied by `*postgres.AuthStore` and the test stubs). The token-assembly (`auth.GenerateAPIKeySecret` + `auth.FormatAPIKeyToken` over the storage-assigned prefix) matches 4a exactly.
+
+**4. Build discipline:** Tasks 1, 3, 4 are isolated new packages. Task 2 fixes the post-Authn dangling reference (whole project builds after it) and updates all three `newAuthenticatedHTTPClient` callers (`newClient`, `newClientWithProject`, `read_mcp_resource.go`). Task 7 adds proto fields (backward-compatible; 4a handlers ignore them until 8–9). Tasks 8–9 add guards and explicitly flag the ripple into 4a's existing tests (the cross-task notes give the exact stub edits). Task 10 is CLI wiring. Every task ends with `go build ./... && go test ./...` green; Tasks 4, 11 add integration coverage. **Task 4 depends on Storage plan Task 32** (the exported `postgrestest.SharedPool` cross-package test-pool helper); see the Dependency contract. The `init` local-bootstrap (Task 5) uses a 2s dial timeout so the common no-local-DB `init` degrades quickly rather than stalling.
+
+**5. Cross-plan ripple (called out, not hidden):** Adding the `GetUserByID` call in Task 8 and the credential-count in Task 9 changes what 4a's `TestSoftDeleteUser_Happy`/`TestPurgeUser_*`/`TestUnbindOIDC_Happy`/`_NotFound` stubs must provide. Tasks 8 and 9 each carry an explicit "Cross-task note" instructing the exact stub additions (`getUserByID` returning a non-bootstrap user; `UserId`+`Force` on the unbind happy/notfound tests). This is the one place 4b reaches back into 4a's tests; it is deliberate and enumerated.
+
+**6. Symbol-lifetime sweep:** Completed above. Two new packages (`credentials`, `bootstrap`) — no collisions. `resolveAPIKey` signature change (not a new symbol). Additive proto fields. No deletions (the Authn plan already removed `auth/bootstrap.go`; Task 2 removes the last consumer of the deleted `auth.ReadDefaultKey`).
+
+---
+
+## Execution
+
+1. **Subagent-Driven (recommended)** — Tasks 1, 3 (new packages) and 4 (integration) are clean isolated units. Task 2 (client.go) + Tasks 5–6 (init/serve wiring) are a small batch. Tasks 7–10 (proto + guards + CLI) form the protections batch; run 8–9 together since they touch the same handler + ripple into 4a tests. Task 11 is the capstone.
+2. **Inline Execution** — practical for 7–10 (proto + guards + CLI) as one coordinated change.
+
+**Epic completion:** 4b is the last of the four identity plans (Storage → Authn → Cedar → Bootstrap-UX-4a → 4b). With it merged, the epic delivers: database-backed identity, a single resolver, Cedar authorization, the operator RPC surface + CLI, and a working first-admin story for both local and hosted deployments. **Release notes MUST call out** the credentials-file schema change (old `api_keys:` no longer provisions server keys; operators use `specgraph auth api-key create` and the new multi-server `servers:` file) and the removal of YAML-driven key provisioning.

--- a/docs/plans/2026-05-26-identity-policy-engine-implementation-plan.md
+++ b/docs/plans/2026-05-26-identity-policy-engine-implementation-plan.md
@@ -1,0 +1,2509 @@
+# Identity Policy Engine (Cedar) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adopt `cedar-policy/cedar-go` as SpecGraph's embedded authorization engine, replacing the `StaticTableAuthorizer` introduced by the Authn plan with a `CedarAuthorizer` that slots into the existing `auth.Authorizer` seam — so the interceptor diff is **zero**.
+
+**Architecture:** Build-alongside-then-switch-then-delete. Cedar is wrapped behind a SpecGraph-owned `auth.PolicyEngine` interface; only the engine wrapper imports cedar-go. Policies load from an ordered list of `PolicySource`s (embedded built-ins + operator directories). A `(service, method) → stable action name` map decouples policy from RPC method names. The static `rpcPermissions` table and the whole `StaticTableAuthorizer` are deleted in one Phase-C task once `serve.go` is switched and nothing references them. Every task ends with a compiling, testable package at BOTH package and whole-project level.
+
+**Tech Stack:** Go 1.26, ConnectRPC, `github.com/cedar-policy/cedar-go v1.7.0` (new dep), `embed` (built-in policies), `log/slog` (decision logging).
+
+**Implements bead:** Implementation of approved design `spgr-rjrt.1` (`docs/plans/2026-05-26-identity-policy-engine-design.md`) under epic `spgr-rjrt`. Depends on the Authn plan (`spgr-n2rw`) being merged first — it builds on the `Authorizer`/`Decision` seam, the `Resolver`/`Identity` shape, and the `StaticTableAuthorizer` that this plan deletes.
+
+---
+
+## Verified cedar-go v1.7.0 API (the code below is written against this, not an imagined API)
+
+```go
+// github.com/cedar-policy/cedar-go
+func NewPolicySetFromBytes(fileName string, document []byte) (*cedar.PolicySet, error)
+func NewPolicySet() *cedar.PolicySet
+func (p *cedar.PolicySet) Add(id cedar.PolicyID, policy *cedar.Policy) bool
+func (p *cedar.PolicySet) All() iter.Seq2[cedar.PolicyID, *cedar.Policy] // range-over-func (Go 1.23+)
+func Authorize(policies cedar.PolicyIterator, entities types.EntityGetter, req cedar.Request) (cedar.Decision, cedar.Diagnostic)
+func NewEntityUID(typ cedar.EntityType, id cedar.String) cedar.EntityUID
+func NewEntityUIDSet(args ...cedar.EntityUID) cedar.EntityUIDSet
+func NewRecord(m cedar.RecordMap) cedar.Record
+
+type Request   = types.Request    // struct{ Principal, Action, Resource types.EntityUID; Context types.Record }
+type Decision  = types.Decision   // bool; cedar.Allow == Decision(true)
+type Diagnostic = types.Diagnostic // struct{ Reasons []DiagnosticReason; Errors []DiagnosticError }
+type PolicyID  = types.PolicyID   // string
+type EntityMap = types.EntityMap  // map[EntityUID]Entity; implements EntityGetter
+type Entity    = types.Entity     // struct{ UID EntityUID; Parents EntityUIDSet; Attributes Record; Tags Record }
+type RecordMap = types.RecordMap  // map[String]Value
+type String, Boolean, Long        // value types
+```
+
+Two API facts that shape the plan:
+
+1. **No schema-based type checking in v1.** cedar-go's schema validation lives in the experimental `x/exp/schema` package. We rely on parse-time validation (`NewPolicySetFromBytes` returns an error on malformed policy text), not schema typechecking. The design's "static type checking on policies at load time" is therefore *partially* realized; full schema validation is a deliberate follow-up, gated on cedar-go promoting it out of `x/exp`.
+2. **`Authorize` is context-free and infallible at the cedar layer** — it returns `(Decision, Diagnostic)`, no `error`. Our `PolicyEngine.Evaluate` wrapper owns `context` handling and the error channel (e.g. unconfigured action).
+
+Note: the design (written 2026-05-26) calls cedar-go "younger than the Rust original." As of this plan it is **v1.7.0** — post-1.0 and actively maintained — so that caveat is stale. The wrapper indirection is retained anyway, for the swap-point value the design describes.
+
+---
+
+## Testing approach
+
+Four categories (same framework as the Storage and Authn plans). Each behavior-introducing task tags `**Covers:**`.
+
+- **Happy** — normal success per code path (reader reads, admin deletes, policy loads).
+- **Invariants** — system-wide rules (explicit `forbid` beats any `permit`; the built-in source MUST load or the engine refuses construction; action name is decoupled from RPC method name; the interceptor diff is zero).
+- **Boundaries** — edges (unconfigured procedure → error; malformed policy text → load error; missing operator dir → error; empty dir → no error; unknown role → deny by default).
+- **E2E** — full flows through interceptor → `CedarAuthorizer` → `PolicyEngine` → cedar.
+
+Unit tests use an inline `stubSource` (Task 6) so the engine is exercised independently of the embedded file. Integration tests (`//go:build integration`) drive the real interceptor with the embedded policies. All `go test` run-commands carry `-tags integration` where they exercise tagged suites; package-level cycles run plain `go test`.
+
+---
+
+## File Structure
+
+**Create (Phase A — alongside the StaticTableAuthorizer, which still serves auth until Task 16):**
+
+- `internal/auth/policysource.go` — `PolicyDocument` struct + `PolicySource` interface.
+- `internal/auth/embedded_source.go` — `EmbeddedPolicySource` + `//go:embed policies/*.cedar`.
+- `internal/auth/policies/base.cedar` — the built-in base policies (migrated `rpcPermissions`).
+- `internal/auth/directory_source.go` — `DirectoryPolicySource`.
+- `internal/auth/engine.go` — `PolicyEngine` interface, `EvalRequest`, `ResourceRef`, `PolicyDecision`, `cedarEngine` impl. **`engine.go` is the sole cedar-go importer** — `embedded_source.go`/`directory_source.go` import only `embed`/`os`/`io/fs`, never cedar. This keeps Cedar types out of every other file.
+- `internal/auth/actions.go` — `procedureActions` map (`(service,method) → action name`), `ActionNames()`, `actionForProcedure`, `actionVerb`, `actionDomain`.
+- `internal/auth/exempt.go` — `exemptProcedures` + `IsExempt`, **relocated** out of `permissions.go` so they survive `permissions.go`'s deletion.
+- `internal/auth/cedar_authorizer.go` — `CedarAuthorizer` implementing `auth.Authorizer`; `NewCedarAuthorizer`.
+- `internal/auth/known_roles.go` — `KnownRolesFrom([]string) map[Role]bool` (replaces the role-name set previously derived from `LoadRolePerms`).
+- Test files for each of the above (`*_test.go`), plus `internal/auth/cedar_integration_test.go` (`//go:build integration`).
+
+**Modify (Phase B — the switch):**
+
+- `internal/config/global.go` — change `AuthConfig.Roles` from `map[string]RoleConfig` to `[]string`; delete the `RoleConfig` type; add `AuthConfig.Policies PolicyConfig{ ExtraDirs []string }`.
+- `cmd/specgraph/serve.go` — replace the `LoadRolePerms` + `NewStaticTableAuthorizer` block with policy-source + `NewCedarEngine` + `NewCedarAuthorizer` construction; derive `KnownRoles` via `KnownRolesFrom`. **The `auth.NewAuthInterceptor(resolver, authorizer)` line is byte-for-byte unchanged.**
+
+**Delete (Phase C — once nothing references them):**
+
+- `internal/auth/static_authorizer.go` + `static_authorizer_test.go` (`StaticTableAuthorizer`, `NewStaticTableAuthorizer`, `DefaultRolePermissions`, `hasPermissionInternal`, `LoadRolePerms`).
+- `internal/auth/permissions.go` (`rpcPermissions`, `RPCPermission`) — deleted in the SAME task as `static_authorizer.go`, because `StaticTableAuthorizer.Authorize` is `rpcPermissions`' only consumer; removing one without the other leaves an `unused` lint failure. `exemptProcedures`/`IsExempt` already moved to `exempt.go` in Task 12.
+- The `rpcPermissions`-specific tests in `permissions_test.go` (the exempt tests move to `exempt_test.go` in Task 12).
+
+**Do NOT touch:** `interceptor.go`, `middleware.go`, `resolver.go`, `identitystore.go`, `oidc_verifier.go`, `auth.go`, `store.go`, `context.go` — Cedar changes none of them. That invariance is the design's headline payoff and is asserted in Task 16 and Task 18.
+
+---
+
+## Symbol-lifetime sweep (the bug class that bit the Authn plan three times)
+
+Go has one namespace per package and no overloading. Before finalizing, every NEW package-level identifier Cedar introduces was greppe�d against the post-Authn `internal/auth/*.go` surface. Results:
+
+| New identifier | Collision? | Notes |
+|---|---|---|
+| `PolicyEngine`, `cedarEngine`, `NewCedarEngine` | none | — |
+| `EvalRequest`, `ResourceRef`, `PolicyDecision` | none | `PolicyDecision` is deliberately **not** `Decision` — `auth.Decision{Allowed,Reason}` already exists (Authn). `CedarAuthorizer` returns the existing `auth.Decision`; the engine returns the richer `PolicyDecision`. |
+| `PolicySource`, `PolicyDocument` | none | `PolicyDocument` (not `Policy`) chosen to avoid reader confusion with `cedar.Policy` in `engine.go`. |
+| `EmbeddedPolicySource`, `DirectoryPolicySource`, `NewEmbeddedPolicySource`, `NewDirectoryPolicySource` | none | — |
+| `CedarAuthorizer`, `NewCedarAuthorizer` | none | — |
+| `procedureActions`, `ActionNames`, `actionForProcedure`, `actionVerb`, `actionDomain` | none | `rpcPermissions`/`RPCPermission` still exist until Task 17 but have different names. |
+| `exemptProcedures`, `IsExempt` | **moved, not new** | Relocated from `permissions.go` → `exempt.go` in Task 12. The post-Authn interceptor (`interceptor.go`) calls `IsExempt`; it MUST keep resolving. |
+| `KnownRolesFrom` | none | Replaces the role-name extraction `serve.go` did from `LoadRolePerms`. |
+| `embeddedPolicyFS` (embed var) | none | — |
+
+Survivor-after-deletion check (Task 17 deletes `static_authorizer.go` + `permissions.go`):
+
+- `StaticTableAuthorizer` / `NewStaticTableAuthorizer` — only consumers: `serve.go` (switched in Task 16) and `static_authorizer_test.go` (deleted with the file). ✓
+- `DefaultRolePermissions`, `LoadRolePerms` — only consumers: `serve.go` (switched) and the deleted test. (Authn's Phase C already removed `config_store.go`'s usage.) ✓
+- `hasPermissionInternal` — only consumer: `StaticTableAuthorizer.Authorize` (deleted). (Authn's Phase C already removed the exported `HasPermission`.) ✓
+- `rpcPermissions` / `RPCPermission` — only consumer: `StaticTableAuthorizer.Authorize` (deleted in the same task). The post-Authn interceptor uses `authorizer.Authorize`, **not** `RPCPermission`. ✓
+- `IsExempt` / `exemptProcedures` — consumer `interceptor.go` survives; symbols relocated to `exempt.go` (Task 12) BEFORE `permissions.go` is deleted. ✓
+
+---
+
+## Task 1: Add the cedar-go dependency and pin the core API with a smoke test
+
+Before building anything on cedar-go, prove the three calls the whole plan rests on — parse policy text, build entities, authorize — work exactly as the API docs claim. This test is throwaway scaffolding for confidence; it lives in a temporary file deleted at the end of the task.
+
+**Files:**
+
+- Modify: `go.mod`, `go.sum`
+- Create (temporary): `internal/auth/cedar_smoke_test.go`
+
+**Covers:** Happy (parse + authorize allow) + Invariant (cedar-go API shape is what the plan assumes).
+
+- [ ] **Step 1: Add the dependency**
+
+Run:
+
+```bash
+go get github.com/cedar-policy/cedar-go@v1.7.0
+go mod tidy
+```
+
+Expected: `go.mod` gains `github.com/cedar-policy/cedar-go v1.7.0` as a direct dependency; `go.sum` updated.
+
+- [ ] **Step 2: Write the smoke test**
+
+Create `internal/auth/cedar_smoke_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"testing"
+
+	cedar "github.com/cedar-policy/cedar-go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCedarSmoke pins the three cedar-go calls the plan depends on:
+// parse policy text, build an EntityMap (incl. an action group via Parents),
+// and Authorize. If cedar-go's API differs from the plan's assumptions, this
+// fails first — before any real code is written against a wrong API.
+func TestCedarSmoke(t *testing.T) {
+	policy := `permit (
+		principal,
+		action in SpecGraph::Action::"read",
+		resource
+	) when { principal has role && principal.role == "reader" };`
+
+	ps, err := cedar.NewPolicySetFromBytes("smoke:base.cedar", []byte(policy))
+	require.NoError(t, err)
+
+	readGroup := cedar.NewEntityUID("SpecGraph::Action", "read")
+	specRead := cedar.NewEntityUID("SpecGraph::Action", "spec.read")
+	principal := cedar.NewEntityUID("SpecGraph::User", "u1")
+	resource := cedar.NewEntityUID("SpecGraph::Resource", "spec")
+
+	// Construct Parents explicitly (even empty) rather than relying on the
+	// zero value of EntityUIDSet — so a failure here is about the action-group
+	// mechanism, not about whether Authorize tolerates a nil-backed set.
+	entities := cedar.EntityMap{
+		readGroup: {UID: readGroup, Parents: cedar.NewEntityUIDSet(), Attributes: cedar.NewRecord(nil)},
+		specRead:  {UID: specRead, Parents: cedar.NewEntityUIDSet(readGroup), Attributes: cedar.NewRecord(nil)},
+		principal: {
+			UID:        principal,
+			Parents:    cedar.NewEntityUIDSet(),
+			Attributes: cedar.NewRecord(cedar.RecordMap{"role": cedar.String("reader")}),
+		},
+		resource: {UID: resource, Parents: cedar.NewEntityUIDSet(), Attributes: cedar.NewRecord(nil)},
+	}
+
+	req := cedar.Request{
+		Principal: principal,
+		Action:    specRead,
+		Resource:  resource,
+		Context:   cedar.NewRecord(nil),
+	}
+
+	dec, diag := cedar.Authorize(ps, entities, req)
+	require.Equal(t, cedar.Allow, dec)
+	require.NotEmpty(t, diag.Reasons, "an allow decision must cite the matching policy")
+
+	// A writer-only request against the same read policy must NOT match.
+	entities[principal] = cedar.Entity{
+		UID:        principal,
+		Attributes: cedar.NewRecord(cedar.RecordMap{"role": cedar.String("nobody")}),
+	}
+	dec, _ = cedar.Authorize(ps, entities, req)
+	require.Equal(t, cedar.Deny, dec)
+}
+```
+
+- [ ] **Step 2b: Verify failure first (sanity)**
+
+Temporarily break the policy text (e.g. change `principal.role == "reader"` to `principal.role == "admin"`) and run:
+
+Run: `cd internal/auth && go test -run TestCedarSmoke -v`
+
+Expected: FAIL on `require.Equal(t, cedar.Allow, dec)` — confirms the test actually exercises evaluation. Then revert the edit.
+
+- [ ] **Step 3: Run the smoke test**
+
+Run: `cd internal/auth && go test -run TestCedarSmoke -v`
+
+Expected: PASS. This is the proof the action-group-via-`Parents` mechanism works in cedar-go v1.7.0. **If this fails**, do not proceed — the action model assumption is wrong; revisit the design's entity model before writing `engine.go`.
+
+- [ ] **Step 4: Delete the smoke test and verify the build**
+
+```bash
+rm internal/auth/cedar_smoke_test.go
+go build ./... && go test ./...
+```
+
+Expected: PASS. (The dependency stays in `go.mod`; the throwaway test is gone — the real engine tests in later tasks supersede it.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go.mod go.sum
+git commit -s -m "build(auth): add cedar-policy/cedar-go v1.7.0 dependency"
+```
+
+---
+
+## Task 2: Define `PolicyDocument` and the `PolicySource` interface
+
+The seam that lets policy storage evolve (embedded → directory → DB → URL) without touching the engine.
+
+**Files:**
+
+- Create: `internal/auth/policysource.go`
+
+**Covers:** N/A (definitions only).
+
+- [ ] **Step 1: Write the file**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import "context"
+
+// PolicyDocument is one unit of Cedar policy text plus a stable identifier
+// for diagnostics and decision logs. Named PolicyDocument (not Policy) to
+// avoid confusion with cedar.Policy inside engine.go.
+type PolicyDocument struct {
+	// Source identifies where this document came from, e.g.
+	// "embedded:base.cedar" or "dir:/etc/specgraph/policies/extra.cedar".
+	// Used as the filename argument to cedar.NewPolicySetFromBytes and as a
+	// prefix on merged policy IDs so a decision log can name the origin.
+	Source string
+	// Text is the raw Cedar policy text (one or more policies).
+	Text string
+}
+
+// PolicySource yields Cedar policy documents from some backing store.
+// Implementations: EmbeddedPolicySource (built-ins), DirectoryPolicySource
+// (operator files). DB- and URL-backed sources are deliberate follow-ups
+// requiring no engine change — only a new PolicySource.
+type PolicySource interface {
+	// Load returns this source's policy documents. A source MAY return an
+	// empty slice with no error (it simply contributes nothing).
+	Load(ctx context.Context) ([]PolicyDocument, error)
+	// Name returns a short identifier for diagnostics and decision logs.
+	Name() string
+}
+```
+
+- [ ] **Step 2: Verify compile**
+
+Run: `cd internal/auth && go build ./...`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/auth/policysource.go
+git commit -s -m "feat(auth): define PolicyDocument and PolicySource interface"
+```
+
+---
+
+## Task 3: Implement `EmbeddedPolicySource` with the migrated base policies
+
+The built-in policies, compiled into the binary. This is also where the `rpcPermissions` table's behavior is re-expressed as three Cedar policies (verb action-groups).
+
+**Files:**
+
+- Create: `internal/auth/policies/base.cedar`
+- Create: `internal/auth/embedded_source.go`
+- Create: `internal/auth/embedded_source_test.go`
+
+**Covers:** Happy (loads the embedded document) + Invariant (built-in policies are present and parseable).
+
+- [ ] **Step 1: Write the base policy file**
+
+Create `internal/auth/policies/base.cedar` (no SPDX header — `.cedar` is not a license-checked extension):
+
+```
+// SpecGraph base authorization policies.
+//
+// Migrated from the static rpcPermissions table. Roles gate VERBS via action
+// groups: every concrete action (e.g. SpecGraph::Action::"spec.read") is a
+// member of its verb group (SpecGraph::Action::"read") via the entity graph
+// the engine builds at construction. New RPCs join a group by being added to
+// internal/auth/actions.go — these policies do not change.
+//
+// Cedar semantics: default-deny; any matching permit allows; an explicit
+// forbid (none here) would beat every permit. Discrete per-action and
+// ownership policies for later stories layer on top via additional sources.
+
+permit (
+	principal,
+	action in SpecGraph::Action::"read",
+	resource
+) when {
+	principal has role &&
+	(principal.role == "reader" || principal.role == "writer" || principal.role == "admin")
+};
+
+permit (
+	principal,
+	action in SpecGraph::Action::"write",
+	resource
+) when {
+	principal has role &&
+	(principal.role == "writer" || principal.role == "admin")
+};
+
+permit (
+	principal,
+	action in SpecGraph::Action::"delete",
+	resource
+) when {
+	principal has role && principal.role == "admin"
+};
+```
+
+> Semantics check against the old table: the only `delete` permission was `graph:delete` (RemoveEdge). Old writer = `{*:read, *:write}` (no delete); old admin = `{*:*}`. So under the migration: read → reader∪writer∪admin; write → writer∪admin; delete → admin only. Identical behavior.
+
+- [ ] **Step 2: Write the embedded source**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"io/fs"
+	"strings"
+)
+
+//go:embed policies/*.cedar
+var embeddedPolicyFS embed.FS
+
+// EmbeddedPolicySource serves the built-in policies compiled into the
+// binary. The built-in source MUST load successfully; a failure here means
+// the binary was built wrong (the engine refuses to start — see
+// NewCedarEngine).
+type EmbeddedPolicySource struct{}
+
+// NewEmbeddedPolicySource returns the built-in policy source.
+func NewEmbeddedPolicySource() EmbeddedPolicySource { return EmbeddedPolicySource{} }
+
+// Name implements PolicySource.
+func (EmbeddedPolicySource) Name() string { return "embedded" }
+
+// Load implements PolicySource. Reads every *.cedar file under policies/.
+func (EmbeddedPolicySource) Load(_ context.Context) ([]PolicyDocument, error) {
+	entries, err := fs.ReadDir(embeddedPolicyFS, "policies")
+	if err != nil {
+		return nil, fmt.Errorf("read embedded policies dir: %w", err)
+	}
+	docs := make([]PolicyDocument, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".cedar") {
+			continue
+		}
+		b, readErr := embeddedPolicyFS.ReadFile("policies/" + e.Name())
+		if readErr != nil {
+			return nil, fmt.Errorf("read embedded policy %s: %w", e.Name(), readErr)
+		}
+		docs = append(docs, PolicyDocument{Source: "embedded:" + e.Name(), Text: string(b)})
+	}
+	return docs, nil
+}
+```
+
+- [ ] **Step 3: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cedar "github.com/cedar-policy/cedar-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/auth"
+)
+
+func TestEmbeddedPolicySource_LoadsBasePolicies(t *testing.T) {
+	docs, err := auth.NewEmbeddedPolicySource().Load(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, docs, "embedded base policies must be present")
+
+	var combined strings.Builder
+	for _, d := range docs {
+		require.True(t, strings.HasPrefix(d.Source, "embedded:"), "source tag: %s", d.Source)
+		combined.WriteString(d.Text)
+		combined.WriteString("\n")
+	}
+
+	// The embedded text must parse as valid Cedar.
+	_, err = cedar.NewPolicySetFromBytes("embedded:test", []byte(combined.String()))
+	require.NoError(t, err, "embedded base policies must parse")
+
+	// Behavior anchor: the three verb groups are referenced.
+	text := combined.String()
+	require.Contains(t, text, `action in SpecGraph::Action::"read"`)
+	require.Contains(t, text, `action in SpecGraph::Action::"write"`)
+	require.Contains(t, text, `action in SpecGraph::Action::"delete"`)
+}
+
+func TestEmbeddedPolicySource_Name(t *testing.T) {
+	require.Equal(t, "embedded", auth.NewEmbeddedPolicySource().Name())
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/auth && go build ./... && go test -run TestEmbeddedPolicySource -v`
+
+Expected: PASS (impl from Step 2 is real; the embed directive picks up `policies/base.cedar`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/policies/base.cedar internal/auth/embedded_source.go internal/auth/embedded_source_test.go
+git commit -s -m "feat(auth): embed base Cedar policies migrated from rpcPermissions"
+```
+
+---
+
+## Task 4: Implement `DirectoryPolicySource`
+
+Operator-supplied policy files (configured later via `auth.policies.extra_dirs`). Required-by-default semantics: a missing/unreadable dir is an error; an empty dir is fine.
+
+**Files:**
+
+- Create: `internal/auth/directory_source.go`
+- Create: `internal/auth/directory_source_test.go`
+
+**Covers:** Happy (reads `.cedar` files) + Boundary (missing dir → error; empty dir → no error, no docs; non-`.cedar` files ignored).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/auth"
+)
+
+func TestDirectoryPolicySource_ReadsCedarFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.cedar"),
+		[]byte(`permit (principal, action, resource) when { principal has role && principal.role == "admin" };`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.txt"),
+		[]byte("ignored"), 0o600))
+
+	docs, err := auth.NewDirectoryPolicySource(dir).Load(context.Background())
+	require.NoError(t, err)
+	require.Len(t, docs, 1, "only .cedar files are loaded")
+	require.Contains(t, docs[0].Source, "extra.cedar")
+}
+
+func TestDirectoryPolicySource_MissingDirIsError(t *testing.T) {
+	_, err := auth.NewDirectoryPolicySource("/no/such/dir/specgraph").Load(context.Background())
+	require.Error(t, err)
+}
+
+func TestDirectoryPolicySource_EmptyDirIsOK(t *testing.T) {
+	docs, err := auth.NewDirectoryPolicySource(t.TempDir()).Load(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, docs)
+}
+
+func TestDirectoryPolicySource_Name(t *testing.T) {
+	require.Equal(t, "dir:/etc/x", auth.NewDirectoryPolicySource("/etc/x").Name())
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run TestDirectoryPolicySource -v`
+
+Expected: FAIL ("undefined: auth.NewDirectoryPolicySource").
+
+- [ ] **Step 3: Write the impl**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DirectoryPolicySource serves Cedar policy files from a filesystem
+// directory. Required-by-default: a missing or unreadable directory is an
+// error (operators who configure a policy dir mean it). An existing but
+// empty directory (no *.cedar files) returns no documents and no error.
+type DirectoryPolicySource struct {
+	dir string
+}
+
+// NewDirectoryPolicySource returns a source rooted at dir.
+func NewDirectoryPolicySource(dir string) DirectoryPolicySource {
+	return DirectoryPolicySource{dir: dir}
+}
+
+// Name implements PolicySource.
+func (s DirectoryPolicySource) Name() string { return "dir:" + s.dir }
+
+// Load implements PolicySource. Reads every *.cedar file in the directory
+// (non-recursive; nested dirs are ignored).
+func (s DirectoryPolicySource) Load(_ context.Context) ([]PolicyDocument, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return nil, fmt.Errorf("read policy dir %s: %w", s.dir, err)
+	}
+	docs := make([]PolicyDocument, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".cedar") {
+			continue
+		}
+		path := filepath.Join(s.dir, e.Name())
+		b, readErr := os.ReadFile(path) //nolint:gosec // operator-configured policy dir
+		if readErr != nil {
+			return nil, fmt.Errorf("read policy %s: %w", path, readErr)
+		}
+		docs = append(docs, PolicyDocument{Source: "dir:" + path, Text: string(b)})
+	}
+	return docs, nil
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/auth && go build ./... && go test -run TestDirectoryPolicySource -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/directory_source.go internal/auth/directory_source_test.go
+git commit -s -m "feat(auth): add DirectoryPolicySource for operator policy files"
+```
+
+---
+
+## Task 5: Define the engine types — `PolicyEngine`, `EvalRequest`, `ResourceRef`, `PolicyDecision`
+
+The SpecGraph-owned vocabulary the rest of the codebase uses. No cedar types here.
+
+**Files:**
+
+- Create: `internal/auth/engine.go` (types only in this task; impl in Tasks 6–10)
+
+**Covers:** N/A (definitions only).
+
+- [ ] **Step 1: Write the type declarations**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import "context"
+
+// PolicyEngine evaluates an authorization request against a loaded policy
+// set. Cedar is wrapped behind this interface so the rest of the codebase
+// never imports cedar-go directly. The only implementation is cedarEngine
+// (this file); the only file importing cedar-go is engine.go.
+type PolicyEngine interface {
+	// Evaluate decides the request. Returns an error only for operational
+	// failures (the engine could not reach a decision); a clean Deny is a
+	// successful evaluation with PolicyDecision.Allowed == false.
+	Evaluate(ctx context.Context, req EvalRequest) (PolicyDecision, error)
+	// Reload re-reads every PolicySource and atomically swaps the active
+	// policy set. Not wired to any signal in v1 (restart applies policy
+	// changes); present for the future reload story and exercised by tests.
+	Reload(ctx context.Context) error
+}
+
+// EvalRequest is a SpecGraph-shaped authorization question, mapped to a
+// cedar.Request inside the engine.
+type EvalRequest struct {
+	// Identity is the resolved principal. Its EffectiveRole becomes the
+	// Cedar principal's "role" attribute.
+	Identity *Identity
+	// Action is the stable action name (e.g. "spec.read"), already mapped
+	// from the RPC procedure by the caller. Decoupled from method names.
+	Action string
+	// Resource describes what is being acted on. For the migration this is
+	// a placeholder derived from the action's domain; stories #3/#4 populate
+	// real resource attributes here.
+	Resource ResourceRef
+	// Context carries transient request attributes (e.g. project slug).
+	// Empty for the migration; the Cedar context Record is built from it.
+	Context map[string]string
+}
+
+// ResourceRef projects a resource into Cedar's (type, id, attributes) shape.
+type ResourceRef struct {
+	Type       string            // Cedar resource entity id namespace, e.g. "spec"
+	ID         string            // resource id; "" → "unspecified"
+	Attributes map[string]string // e.g. {"owner_user_id": "..."}; empty in migration
+}
+
+// PolicyDecision is the engine's full result: the allow/deny plus the
+// policy IDs that drove it (for decision logs / future audit) and any
+// evaluation errors Cedar surfaced.
+type PolicyDecision struct {
+	Allowed         bool
+	MatchedPolicies []string // cedar policy IDs from Diagnostic.Reasons
+	Errors          []string // stringified Diagnostic.Errors (rare; bad policy/attr)
+}
+```
+
+- [ ] **Step 2: Verify compile**
+
+Run: `cd internal/auth && go build ./...`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/auth/engine.go
+git commit -s -m "feat(auth): define PolicyEngine, EvalRequest, ResourceRef, PolicyDecision"
+```
+
+---
+
+## Task 6: Implement `cedarEngine` construction and `Reload` (policy loading)
+
+`NewCedarEngine` loads all sources into one merged `*cedar.PolicySet`, stored in an `atomic.Pointer` so the eval hot path is lock-free. The built-in source MUST yield at least one parseable policy.
+
+**Files:**
+
+- Modify: `internal/auth/engine.go`
+- Create: `internal/auth/engine_test.go`
+
+**Covers:** Happy (loads from a source) + Invariant (empty/unparseable built-in refuses construction) + Boundary (source Load error propagates) + (Reload swaps the set).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/auth"
+)
+
+// stubSource is an in-memory PolicySource for engine unit tests, so the
+// engine is exercised independently of the embedded file.
+type stubSource struct {
+	name    string
+	docs    []auth.PolicyDocument
+	loadErr error
+}
+
+func (s stubSource) Name() string { return s.name }
+func (s stubSource) Load(context.Context) ([]auth.PolicyDocument, error) {
+	if s.loadErr != nil {
+		return nil, s.loadErr
+	}
+	return s.docs, nil
+}
+
+// basePolicies is the three-policy verb-group set reused across engine tests.
+const basePolicies = `
+permit (principal, action in SpecGraph::Action::"read", resource)
+when { principal has role && (principal.role == "reader" || principal.role == "writer" || principal.role == "admin") };
+permit (principal, action in SpecGraph::Action::"write", resource)
+when { principal has role && (principal.role == "writer" || principal.role == "admin") };
+permit (principal, action in SpecGraph::Action::"delete", resource)
+when { principal has role && principal.role == "admin" };
+`
+
+func baseSource() auth.PolicySource {
+	return stubSource{name: "test", docs: []auth.PolicyDocument{{Source: "test:base.cedar", Text: basePolicies}}}
+}
+
+func testActions() []string { return []string{"spec.read", "spec.write", "graph.delete"} }
+
+func TestNewCedarEngine_LoadsPolicies(t *testing.T) {
+	eng, err := auth.NewCedarEngine(context.Background(),
+		[]auth.PolicySource{baseSource()}, testActions())
+	require.NoError(t, err)
+	require.NotNil(t, eng)
+}
+
+func TestNewCedarEngine_NoPoliciesIsError(t *testing.T) {
+	empty := stubSource{name: "empty", docs: nil}
+	_, err := auth.NewCedarEngine(context.Background(),
+		[]auth.PolicySource{empty}, testActions())
+	require.Error(t, err, "no loaded policies must refuse construction")
+}
+
+func TestNewCedarEngine_BadPolicyTextIsError(t *testing.T) {
+	bad := stubSource{name: "bad", docs: []auth.PolicyDocument{{Source: "bad:x.cedar", Text: "this is not cedar"}}}
+	_, err := auth.NewCedarEngine(context.Background(),
+		[]auth.PolicySource{bad}, testActions())
+	require.Error(t, err)
+}
+
+func TestNewCedarEngine_SourceLoadErrorPropagates(t *testing.T) {
+	sentinel := errors.New("boom")
+	failing := stubSource{name: "failing", loadErr: sentinel}
+	_, err := auth.NewCedarEngine(context.Background(),
+		[]auth.PolicySource{failing}, testActions())
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestCedarEngine_Reload(t *testing.T) {
+	eng, err := auth.NewCedarEngine(context.Background(),
+		[]auth.PolicySource{baseSource()}, testActions())
+	require.NoError(t, err)
+	require.NoError(t, eng.Reload(context.Background()))
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestNewCedarEngine|TestCedarEngine_Reload' -v`
+
+Expected: FAIL ("undefined: auth.NewCedarEngine").
+
+- [ ] **Step 3: Write the construction + loading impl**
+
+Append to `internal/auth/engine.go`:
+
+```go
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	cedar "github.com/cedar-policy/cedar-go"
+)
+```
+
+> Replace the existing minimal import block (`"context"`) with the block above — `engine.go` now needs `fmt`, `sync/atomic`, and the cedar-go import.
+
+```go
+// cedarEngine is the sole PolicyEngine implementation and the sole file
+// importing cedar-go. Policies live in an atomic.Pointer for a lock-free
+// eval hot path; Reload builds a fresh set and swaps it.
+type cedarEngine struct {
+	sources        []PolicySource
+	actionEntities cedar.EntityMap // precomputed action + verb-group entities
+	policies       atomic.Pointer[cedar.PolicySet]
+}
+
+// NewCedarEngine loads every source into one merged policy set and
+// precomputes the action-group entity graph from actionNames. The built-in
+// source MUST contribute at least one parseable policy: a zero-policy result
+// is a build error (the binary shipped without its base policies) and
+// construction fails.
+func NewCedarEngine(ctx context.Context, sources []PolicySource, actionNames []string) (*cedarEngine, error) {
+	if len(sources) == 0 {
+		return nil, fmt.Errorf("cedar: NewCedarEngine: at least one PolicySource required")
+	}
+	actionEntities, err := buildActionEntities(actionNames)
+	if err != nil {
+		return nil, fmt.Errorf("cedar: build action entities: %w", err)
+	}
+	eng := &cedarEngine{sources: sources, actionEntities: actionEntities}
+	if err := eng.Reload(ctx); err != nil {
+		return nil, err
+	}
+	return eng, nil
+}
+
+// Reload re-reads all sources, parses + merges them, and atomically swaps
+// the active policy set. Safe to call concurrently with Evaluate.
+func (e *cedarEngine) Reload(ctx context.Context) error {
+	set, err := loadPolicySet(ctx, e.sources)
+	if err != nil {
+		return err
+	}
+	count := 0
+	for range set.All() {
+		count++
+	}
+	if count == 0 {
+		return fmt.Errorf("cedar: no policies loaded from %d source(s); refusing to start", len(e.sources))
+	}
+	e.policies.Store(set)
+	return nil
+}
+
+// loadPolicySet parses each source's documents and merges them into one
+// PolicySet. Policy IDs are prefixed with the document source so decision
+// logs can name the origin and IDs never collide across documents.
+func loadPolicySet(ctx context.Context, sources []PolicySource) (*cedar.PolicySet, error) {
+	combined := cedar.NewPolicySet()
+	for _, src := range sources {
+		docs, err := src.Load(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("cedar: load source %s: %w", src.Name(), err)
+		}
+		for _, doc := range docs {
+			ps, parseErr := cedar.NewPolicySetFromBytes(doc.Source, []byte(doc.Text))
+			if parseErr != nil {
+				return nil, fmt.Errorf("cedar: parse %s: %w", doc.Source, parseErr)
+			}
+			for id, p := range ps.All() {
+				// Prefix the per-document policy id with the source so ids are
+				// globally unique and a decision log names the origin.
+				// PolicySet.Add returns false if the id already exists; that
+				// would mean a policy was silently dropped, so treat it as a
+				// programming error rather than ignoring the result.
+				mergedID := cedar.PolicyID(doc.Source + "#" + string(id))
+				if !combined.Add(mergedID, p) {
+					return nil, fmt.Errorf("cedar: duplicate policy id %q while merging %s", mergedID, doc.Source)
+				}
+			}
+		}
+	}
+	return combined, nil
+}
+```
+
+> `buildActionEntities` and `Evaluate` are added in Tasks 7 and 9. To keep this task compiling, add a temporary stub for `buildActionEntities` and `Evaluate` at the end of `engine.go`:
+>
+> ```go
+> // Temporary stubs — real impls land in Tasks 7 and 9.
+> func buildActionEntities(_ []string) (cedar.EntityMap, error) { return cedar.EntityMap{}, nil }
+> func (e *cedarEngine) Evaluate(_ context.Context, _ EvalRequest) (PolicyDecision, error) {
+> 	return PolicyDecision{}, fmt.Errorf("Evaluate not implemented")
+> }
+> ```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/auth && go build ./... && go test -run 'TestNewCedarEngine|TestCedarEngine_Reload' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Whole-project build + test**
+
+Run: `cd /Volumes/Code/github.com/specgraph-identity-plans && go build ./... && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/auth/engine.go internal/auth/engine_test.go
+git commit -s -m "feat(auth): cedarEngine construction + lock-free Reload"
+```
+
+---
+
+## Task 7: Implement action-entity construction (verb groups)
+
+Turn `["spec.read", "graph.delete", ...]` into the cedar entity graph: each concrete action parented to its verb group. This is what makes `action in SpecGraph::Action::"read"` resolve.
+
+**Files:**
+
+- Modify: `internal/auth/engine.go` (replace the `buildActionEntities` stub)
+- Create: `internal/auth/engine_actions_test.go`
+
+**Covers:** Happy (builds groups + concrete actions) + Boundary (unknown verb suffix → error).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"testing"
+
+	cedar "github.com/cedar-policy/cedar-go"
+	"github.com/stretchr/testify/require"
+)
+
+// In-package test (package auth, not auth_test) because buildActionEntities
+// and actionVerb are unexported.
+
+func TestBuildActionEntities_GroupsByVerb(t *testing.T) {
+	ents, err := buildActionEntities([]string{"spec.read", "spec.write", "graph.delete"})
+	require.NoError(t, err)
+
+	readGroup := cedar.NewEntityUID("SpecGraph::Action", "read")
+	specRead := cedar.NewEntityUID("SpecGraph::Action", "spec.read")
+
+	require.Contains(t, ents, readGroup, "verb group entity must exist")
+	require.Contains(t, ents, specRead, "concrete action entity must exist")
+
+	specReadEnt := ents[specRead]
+	require.True(t, specReadEnt.Parents.Contains(readGroup),
+		"spec.read must be a member of the read group")
+}
+
+func TestBuildActionEntities_RejectsUnknownVerb(t *testing.T) {
+	_, err := buildActionEntities([]string{"spec.frobnicate"})
+	require.Error(t, err)
+}
+```
+
+> `EntityUIDSet.Contains(EntityUID) bool` is part of cedar-go's `types.EntityUIDSet`. If the method name differs in v1.7.0, the Task 1 smoke test would not have caught it (it used `NewEntityUIDSet` only) — if `Contains` is undefined, substitute the membership check the API provides (iterate the set) and note it. The plan assumes `Contains` per the v1.7.0 `types` docs.
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run TestBuildActionEntities -v`
+
+Expected: FAIL — the stub returns an empty map, so `require.Contains` fails.
+
+- [ ] **Step 3: Replace the stub with the real impl**
+
+**FIRST, locate and delete the Task 6 temporary stub** — Go has no overloading, so leaving it produces a "buildActionEntities redeclared" compile error. It is the two-line block at the bottom of `engine.go`:
+
+```go
+func buildActionEntities(_ []string) (cedar.EntityMap, error) { return cedar.EntityMap{}, nil }
+```
+
+(Leave the `Evaluate` stub for now — Task 9 removes it.) THEN add to `engine.go`:
+
+```go
+import "strings" // add to engine.go's import block
+```
+
+```go
+// Cedar entity-type namespaces. Defined here (first use) and reused by the
+// principal/resource helpers in Task 8 and Evaluate in Task 9.
+const (
+	entityTypeUser     = "SpecGraph::User"
+	entityTypeResource = "SpecGraph::Resource"
+	entityTypeAction   = "SpecGraph::Action"
+)
+
+// knownVerbs are the action suffixes that map to verb groups. The base
+// policies gate roles per verb; an action whose suffix is not here cannot be
+// authorized and is a programming error (caught at engine construction).
+var knownVerbs = map[string]bool{"read": true, "write": true, "delete": true}
+
+// actionVerb returns the verb suffix of an action name ("spec.read" -> "read").
+func actionVerb(action string) (string, error) {
+	idx := strings.LastIndex(action, ".")
+	if idx < 0 || idx == len(action)-1 {
+		return "", fmt.Errorf("action %q has no verb suffix", action)
+	}
+	verb := action[idx+1:]
+	if !knownVerbs[verb] {
+		return "", fmt.Errorf("action %q has unknown verb %q", action, verb)
+	}
+	return verb, nil
+}
+
+// actionDomain returns the domain prefix of an action name
+// ("spec.read" -> "spec"). Used to derive the placeholder resource id.
+func actionDomain(action string) string {
+	if idx := strings.Index(action, "."); idx >= 0 {
+		return action[:idx]
+	}
+	return action
+}
+
+// buildActionEntities turns action names into the cedar entity graph: each
+// verb group (SpecGraph::Action::"read") and each concrete action
+// (SpecGraph::Action::"spec.read") parented to its group. cedar resolves
+// "action in <group>" through these Parents at Authorize time.
+func buildActionEntities(actionNames []string) (cedar.EntityMap, error) {
+	ents := cedar.EntityMap{}
+	for _, name := range actionNames {
+		verb, err := actionVerb(name)
+		if err != nil {
+			return nil, err
+		}
+		groupUID := cedar.NewEntityUID(entityTypeAction, cedar.String(verb))
+		if _, ok := ents[groupUID]; !ok {
+			ents[groupUID] = cedar.Entity{
+				UID:        groupUID,
+				Parents:    cedar.NewEntityUIDSet(),
+				Attributes: cedar.NewRecord(nil),
+			}
+		}
+		actionUID := cedar.NewEntityUID(entityTypeAction, cedar.String(name))
+		ents[actionUID] = cedar.Entity{
+			UID:        actionUID,
+			Parents:    cedar.NewEntityUIDSet(groupUID),
+			Attributes: cedar.NewRecord(nil),
+		}
+	}
+	return ents, nil
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/auth && go build ./... && go test -run 'TestBuildActionEntities|TestNewCedarEngine|TestCedarEngine_Reload' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/engine.go internal/auth/engine_actions_test.go
+git commit -s -m "feat(auth): build Cedar action-group entity graph from action names"
+```
+
+---
+
+## Task 8: Implement principal and resource entity construction
+
+Project the resolved `Identity` and the `ResourceRef` into cedar entities. Unexported helpers tested in-package.
+
+**Files:**
+
+- Modify: `internal/auth/engine.go`
+- Modify: `internal/auth/engine_actions_test.go` (add cases — same in-package test file)
+
+**Covers:** Happy (principal carries role/id/email; resource carries attributes) + Boundary (empty UserID falls back to Subject; empty resource id → "unspecified").
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/auth/engine_actions_test.go`:
+
+```go
+func TestPrincipalEntity_CarriesRoleAndID(t *testing.T) {
+	id := &Identity{UserID: "u1", EffectiveRole: RoleWriter, Email: "a@example.com", Subject: "apikey:k1"}
+	uid, ent := principalEntity(id)
+
+	require.Equal(t, cedar.NewEntityUID("SpecGraph::User", "u1"), uid)
+	role, ok := ent.Attributes.Get("role")
+	require.True(t, ok)
+	require.Equal(t, cedar.String("writer"), role)
+	email, ok := ent.Attributes.Get("email")
+	require.True(t, ok)
+	require.Equal(t, cedar.String("a@example.com"), email)
+}
+
+func TestPrincipalEntity_FallsBackToSubject(t *testing.T) {
+	id := &Identity{UserID: "", EffectiveRole: RoleReader, Subject: "apikey:k9"}
+	uid, _ := principalEntity(id)
+	require.Equal(t, cedar.NewEntityUID("SpecGraph::User", "apikey:k9"), uid)
+}
+
+func TestResourceEntity_Defaults(t *testing.T) {
+	uid, ent := resourceEntity(ResourceRef{Type: "spec"})
+	require.Equal(t, cedar.NewEntityUID("SpecGraph::Resource", "unspecified"), uid)
+	_ = ent
+}
+
+func TestResourceEntity_CarriesAttributes(t *testing.T) {
+	_, ent := resourceEntity(ResourceRef{Type: "apikey", ID: "key-1", Attributes: map[string]string{"owner_user_id": "u1"}})
+	owner, ok := ent.Attributes.Get("owner_user_id")
+	require.True(t, ok)
+	require.Equal(t, cedar.String("u1"), owner)
+}
+```
+
+> `cedar.Record.Get` has signature `Get(key cedar.String) (cedar.Value, bool)` in v1.7.0 — the key is `cedar.String`, NOT a plain `string`. The test calls above pass string *literals* (`"role"`, `"email"`), which assign to the `cedar.String` parameter as untyped constants, so they compile. A string *variable* would need an explicit `cedar.String(...)` conversion. Returned values are `cedar.Value`; compare against `cedar.String("...")`.
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestPrincipalEntity|TestResourceEntity' -v`
+
+Expected: FAIL ("undefined: principalEntity").
+
+- [ ] **Step 3: Write the impl**
+
+Append to `internal/auth/engine.go`:
+
+The entity-type constants (`entityTypeUser`, `entityTypeResource`, `entityTypeAction`) were defined in Task 7; reuse them here.
+
+```go
+// principalEntity projects the resolved Identity into a Cedar principal.
+// principal.role is EffectiveRole (the authz-relevant, possibly-downgraded
+// role). UserID is the entity id; legacy/edge identities without a UserID
+// fall back to Subject so the principal still has a stable id.
+func principalEntity(id *Identity) (cedar.EntityUID, cedar.Entity) {
+	pid := id.UserID
+	if pid == "" {
+		pid = id.Subject
+	}
+	uid := cedar.NewEntityUID(entityTypeUser, cedar.String(pid))
+	attrs := cedar.NewRecord(cedar.RecordMap{
+		"role":  cedar.String(string(id.EffectiveRole)),
+		"id":    cedar.String(id.UserID),
+		"email": cedar.String(id.Email),
+	})
+	return uid, cedar.Entity{UID: uid, Parents: cedar.NewEntityUIDSet(), Attributes: attrs}
+}
+
+// resourceEntity projects a ResourceRef into a Cedar resource. For the
+// migration the id is a placeholder ("unspecified"); stories #3/#4 pass real
+// ids and attributes (e.g. owner_user_id) that ownership policies read.
+func resourceEntity(r ResourceRef) (cedar.EntityUID, cedar.Entity) {
+	id := r.ID
+	if id == "" {
+		id = "unspecified"
+	}
+	uid := cedar.NewEntityUID(entityTypeResource, cedar.String(id))
+	rm := make(cedar.RecordMap, len(r.Attributes))
+	for k, v := range r.Attributes {
+		rm[cedar.String(k)] = cedar.String(v)
+	}
+	return uid, cedar.Entity{UID: uid, Parents: cedar.NewEntityUIDSet(), Attributes: cedar.NewRecord(rm)}
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/auth && go build ./... && go test -run 'TestPrincipalEntity|TestResourceEntity|TestBuildActionEntities' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/engine.go internal/auth/engine_actions_test.go
+git commit -s -m "feat(auth): build Cedar principal and resource entities from Identity"
+```
+
+---
+
+## Task 9: Implement `Evaluate` and pin the role × verb authorization matrix
+
+The heart of the engine: build the cedar.Request, merge entities, call `cedar.Authorize`, map the result. This task's test is the contract for the entire action-group model.
+
+**Files:**
+
+- Modify: `internal/auth/engine.go` (replace the `Evaluate` stub)
+- Create: `internal/auth/engine_evaluate_test.go`
+
+**Covers:** Happy (each role's allowed verbs) + Invariant (role × verb matrix matches the old table exactly) + Boundary (unknown role → deny).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/auth"
+)
+
+func newMatrixEngine(t *testing.T) auth.PolicyEngine {
+	t.Helper()
+	eng, err := auth.NewCedarEngine(context.Background(),
+		[]auth.PolicySource{baseSource()}, testActions())
+	require.NoError(t, err)
+	return eng
+}
+
+func evalRole(t *testing.T, eng auth.PolicyEngine, role auth.Role, action string) bool {
+	t.Helper()
+	dec, err := eng.Evaluate(context.Background(), auth.EvalRequest{
+		Identity: &auth.Identity{UserID: "u1", EffectiveRole: role, Role: role},
+		Action:   action,
+		Resource: auth.ResourceRef{Type: "spec"},
+	})
+	require.NoError(t, err)
+	return dec.Allowed
+}
+
+func TestEvaluate_RoleVerbMatrix(t *testing.T) {
+	eng := newMatrixEngine(t)
+	cases := []struct {
+		role    auth.Role
+		action  string
+		allowed bool
+	}{
+		{auth.RoleReader, "spec.read", true},
+		{auth.RoleReader, "spec.write", false},
+		{auth.RoleReader, "graph.delete", false},
+		{auth.RoleWriter, "spec.read", true},
+		{auth.RoleWriter, "spec.write", true},
+		{auth.RoleWriter, "graph.delete", false},
+		{auth.RoleAdmin, "spec.read", true},
+		{auth.RoleAdmin, "spec.write", true},
+		{auth.RoleAdmin, "graph.delete", true},
+	}
+	for _, c := range cases {
+		require.Equalf(t, c.allowed, evalRole(t, eng, c.role, c.action),
+			"role=%s action=%s", c.role, c.action)
+	}
+}
+
+func TestEvaluate_UnknownRoleDenied(t *testing.T) {
+	eng := newMatrixEngine(t)
+	require.False(t, evalRole(t, eng, auth.Role("auditor"), "spec.read"),
+		"a role with no matching policy is denied by default")
+}
+
+func TestEvaluate_AllowCitesPolicy(t *testing.T) {
+	eng := newMatrixEngine(t)
+	dec, err := eng.Evaluate(context.Background(), auth.EvalRequest{
+		Identity: &auth.Identity{UserID: "u1", EffectiveRole: auth.RoleAdmin, Role: auth.RoleAdmin},
+		Action:   "graph.delete",
+		Resource: auth.ResourceRef{Type: "graph"},
+	})
+	require.NoError(t, err)
+	require.True(t, dec.Allowed)
+	require.NotEmpty(t, dec.MatchedPolicies, "an allow must cite the matching policy id")
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run TestEvaluate -v`
+
+Expected: FAIL — `Evaluate` stub returns `"Evaluate not implemented"`.
+
+- [ ] **Step 3: Write the real `Evaluate`**
+
+**FIRST, locate and delete the Task 6 temporary `Evaluate` stub** — leaving it produces an "Evaluate redeclared" compile error. It is the block at the bottom of `engine.go`:
+
+```go
+func (e *cedarEngine) Evaluate(_ context.Context, _ EvalRequest) (PolicyDecision, error) {
+	return PolicyDecision{}, fmt.Errorf("Evaluate not implemented")
+}
+```
+
+(After this, no temporary stubs remain in `engine.go`.) THEN add the real impl (the import block already has `cedar`):
+
+```go
+// Evaluate maps the EvalRequest into a cedar.Request, merges the principal,
+// resource, and precomputed action entities, and calls cedar.Authorize
+// against the current policy set (loaded lock-free from the atomic pointer).
+func (e *cedarEngine) Evaluate(_ context.Context, req EvalRequest) (PolicyDecision, error) {
+	if req.Identity == nil {
+		return PolicyDecision{}, fmt.Errorf("cedar: Evaluate: nil Identity")
+	}
+	ps := e.policies.Load()
+	if ps == nil {
+		return PolicyDecision{}, fmt.Errorf("cedar: Evaluate: no policy set loaded")
+	}
+
+	principalUID, principalEnt := principalEntity(req.Identity)
+	resourceUID, resourceEnt := resourceEntity(req.Resource)
+	actionUID := cedar.NewEntityUID(entityTypeAction, cedar.String(req.Action))
+
+	// Merge precomputed action entities (immutable) with the per-request
+	// principal and resource into a fresh EntityMap.
+	entities := make(cedar.EntityMap, len(e.actionEntities)+2)
+	for uid, ent := range e.actionEntities {
+		entities[uid] = ent
+	}
+	entities[principalUID] = principalEnt
+	entities[resourceUID] = resourceEnt
+
+	ctxRecord := make(cedar.RecordMap, len(req.Context))
+	for k, v := range req.Context {
+		ctxRecord[cedar.String(k)] = cedar.String(v)
+	}
+
+	cedarReq := cedar.Request{
+		Principal: principalUID,
+		Action:    actionUID,
+		Resource:  resourceUID,
+		Context:   cedar.NewRecord(ctxRecord),
+	}
+
+	decision, diag := cedar.Authorize(ps, entities, cedarReq)
+
+	matched := make([]string, 0, len(diag.Reasons))
+	for _, r := range diag.Reasons {
+		matched = append(matched, string(r.PolicyID))
+	}
+	var evalErrs []string
+	for _, de := range diag.Errors {
+		evalErrs = append(evalErrs, fmt.Sprintf("%v", de))
+	}
+
+	return PolicyDecision{
+		Allowed:         decision == cedar.Allow,
+		MatchedPolicies: matched,
+		Errors:          evalErrs,
+	}, nil
+}
+```
+
+> `diag.Errors` elements are stringified with `%v` rather than accessing fields, so the code does not bet on `DiagnosticError`'s field names.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/auth && go build ./... && go test -run TestEvaluate -v`
+
+Expected: PASS — the full role × verb matrix authorizes correctly through real cedar evaluation.
+
+- [ ] **Step 5: Whole-project build + test**
+
+Run: `cd /Volumes/Code/github.com/specgraph-identity-plans && go build ./... && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/auth/engine.go internal/auth/engine_evaluate_test.go
+git commit -s -m "feat(auth): implement cedarEngine.Evaluate + pin role×verb matrix"
+```
+
+---
+
+## Task 10: Add decision logging
+
+Every evaluation emits a structured `slog.Debug` line — the natural source for audit-log story #1. Until that story lands a real sink, Debug is the trace-level observability.
+
+**Files:**
+
+- Modify: `internal/auth/engine.go` (add the log call in `Evaluate`)
+- Create: `internal/auth/engine_logging_test.go`
+
+**Covers:** Happy (a decision emits a structured log with action, principal, allowed, policies).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/auth"
+)
+
+func TestEvaluate_EmitsDecisionLog(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	eng, err := auth.NewCedarEngine(context.Background(),
+		[]auth.PolicySource{baseSource()}, testActions())
+	require.NoError(t, err)
+
+	_, err = eng.Evaluate(context.Background(), auth.EvalRequest{
+		Identity: &auth.Identity{UserID: "u1", EffectiveRole: auth.RoleAdmin, Subject: "apikey:k1"},
+		Action:   "graph.delete",
+		Resource: auth.ResourceRef{Type: "graph"},
+	})
+	require.NoError(t, err)
+
+	out := buf.String()
+	require.True(t, strings.Contains(out, "cedar decision"), "log: %s", out)
+	require.Contains(t, out, "graph.delete")
+	require.Contains(t, out, "allowed=true")
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run TestEvaluate_EmitsDecisionLog -v`
+
+Expected: FAIL — no log emitted yet.
+
+- [ ] **Step 3: Add the log call**
+
+In `Evaluate` (engine.go), add `"log/slog"` to the import block, and immediately before the `return PolicyDecision{...}`:
+
+```go
+	slog.Debug("cedar decision",
+		"action", req.Action,
+		"principal", req.Identity.Subject,
+		"role", string(req.Identity.EffectiveRole),
+		"allowed", decision == cedar.Allow,
+		"policies", matched,
+	)
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/auth && go build ./... && go test -run TestEvaluate -v`
+
+Expected: PASS (logging test + matrix tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/engine.go internal/auth/engine_logging_test.go
+git commit -s -m "feat(auth): emit slog.Debug decision log per Cedar evaluation"
+```
+
+---
+
+## Task 11: Build the `(service, method) → action name` map
+
+The stable action vocabulary that replaces `rpcPermissions`. Same procedure keys; values are domain.verb action names decoupled from RPC method names.
+
+**Files:**
+
+- Create: `internal/auth/actions.go`
+- Create: `internal/auth/actions_test.go`
+
+**Covers:** Happy (procedure → action lookup) + Invariant (every action name parses to a known verb; action names are NOT method names) + Boundary (unconfigured procedure → not found).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/auth"
+)
+
+func TestActionForProcedure_KnownProcedure(t *testing.T) {
+	action, ok := auth.ActionForProcedure(specgraphv1connect.SpecServiceGetSpecProcedure)
+	require.True(t, ok)
+	require.Equal(t, "spec.read", action)
+}
+
+func TestActionForProcedure_DeleteProcedure(t *testing.T) {
+	action, ok := auth.ActionForProcedure(specgraphv1connect.GraphServiceRemoveEdgeProcedure)
+	require.True(t, ok)
+	require.Equal(t, "graph.delete", action)
+}
+
+func TestActionForProcedure_Unconfigured(t *testing.T) {
+	_, ok := auth.ActionForProcedure("/no.such/Procedure")
+	require.False(t, ok)
+}
+
+func TestActionNames_AllParseToKnownVerb(t *testing.T) {
+	names := auth.ActionNames()
+	require.NotEmpty(t, names)
+	for _, n := range names {
+		idx := strings.LastIndex(n, ".")
+		require.Greater(t, idx, 0, "action %q must be domain.verb", n)
+		verb := n[idx+1:]
+		require.Contains(t, []string{"read", "write", "delete"}, verb, "action %q", n)
+	}
+}
+
+func TestActionNames_DecoupledFromMethodNames(t *testing.T) {
+	// The whole point: action names are domain.verb, never Service.Method.
+	for _, n := range auth.ActionNames() {
+		require.NotContains(t, n, "Service", "action %q leaks an RPC service name", n)
+	}
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run 'TestActionForProcedure|TestActionNames' -v`
+
+Expected: FAIL ("undefined: auth.ActionForProcedure").
+
+- [ ] **Step 3: Write the impl**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"sort"
+
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+)
+
+// procedureActions maps each RPC procedure to a stable, RPC-method-decoupled
+// action name (domain.verb). It replaces the rpcPermissions table: where
+// rpcPermissions held "spec:read", this holds "spec.read", which the Cedar
+// policies gate via the verb action-group. Renaming an RPC method changes
+// only this map, not any policy.
+var procedureActions = map[string]string{
+	// SpecService
+	specgraphv1connect.SpecServiceGetSpecProcedure:         "spec.read",
+	specgraphv1connect.SpecServiceListSpecsProcedure:       "spec.read",
+	specgraphv1connect.SpecServiceCreateSpecProcedure:      "spec.write",
+	specgraphv1connect.SpecServiceUpdateSpecProcedure:      "spec.write",
+	specgraphv1connect.SpecServiceListChangesProcedure:     "spec.read",
+	specgraphv1connect.SpecServiceCompareVersionsProcedure: "spec.read",
+	// DecisionService
+	specgraphv1connect.DecisionServiceGetDecisionProcedure:    "decision.read",
+	specgraphv1connect.DecisionServiceListDecisionsProcedure:  "decision.read",
+	specgraphv1connect.DecisionServiceCreateDecisionProcedure: "decision.write",
+	specgraphv1connect.DecisionServiceUpdateDecisionProcedure: "decision.write",
+	// GraphService
+	specgraphv1connect.GraphServiceGetFullGraphProcedure:      "graph.read",
+	specgraphv1connect.GraphServiceGetDependenciesProcedure:   "graph.read",
+	specgraphv1connect.GraphServiceGetTransitiveDepsProcedure: "graph.read",
+	specgraphv1connect.GraphServiceGetImpactProcedure:         "graph.read",
+	specgraphv1connect.GraphServiceGetReadyProcedure:          "graph.read",
+	specgraphv1connect.GraphServiceGetCriticalPathProcedure:   "graph.read",
+	specgraphv1connect.GraphServiceListEdgesProcedure:         "graph.read",
+	specgraphv1connect.GraphServiceAddEdgeProcedure:           "graph.write",
+	specgraphv1connect.GraphServiceRemoveEdgeProcedure:        "graph.delete",
+	// ClaimService
+	specgraphv1connect.ClaimServiceClaimSpecProcedure:   "claim.write",
+	specgraphv1connect.ClaimServiceHeartbeatProcedure:   "claim.write",
+	specgraphv1connect.ClaimServiceUnclaimSpecProcedure: "claim.write",
+	// ConstitutionService
+	specgraphv1connect.ConstitutionServiceGetConstitutionProcedure:          "constitution.read",
+	specgraphv1connect.ConstitutionServiceUpdateConstitutionProcedure:       "constitution.write",
+	specgraphv1connect.ConstitutionServiceEmitToolFilesProcedure:            "constitution.read",
+	specgraphv1connect.ConstitutionServiceRefreshConstitutionLayerProcedure: "constitution.write",
+	// AuthoringService
+	specgraphv1connect.AuthoringServiceGetPromptsProcedure:         "authoring.read",
+	specgraphv1connect.AuthoringServiceSparkProcedure:              "authoring.write",
+	specgraphv1connect.AuthoringServiceShapeProcedure:              "authoring.write",
+	specgraphv1connect.AuthoringServiceSpecifyProcedure:            "authoring.write",
+	specgraphv1connect.AuthoringServiceDecomposeProcedure:          "authoring.write",
+	specgraphv1connect.AuthoringServiceApproveProcedure:            "authoring.write",
+	specgraphv1connect.AuthoringServiceAmendProcedure:              "authoring.write",
+	specgraphv1connect.AuthoringServiceSupersedeProcedure:          "authoring.write",
+	specgraphv1connect.AuthoringServiceRecordConversationProcedure: "authoring.write",
+	specgraphv1connect.AuthoringServiceListConversationsProcedure:  "authoring.read",
+	// ExecutionService
+	specgraphv1connect.ExecutionServiceGenerateBundleProcedure:     "execution.read",
+	specgraphv1connect.ExecutionServiceGetPrimeProcedure:           "execution.read",
+	specgraphv1connect.ExecutionServiceGetExecutionEventsProcedure: "execution.read",
+	specgraphv1connect.ExecutionServiceReportProgressProcedure:     "execution.write",
+	specgraphv1connect.ExecutionServiceReportBlockerProcedure:      "execution.write",
+	specgraphv1connect.ExecutionServiceReportCompletionProcedure:   "execution.write",
+	// LifecycleService
+	specgraphv1connect.LifecycleServiceCheckDriftProcedure:          "lifecycle.read",
+	specgraphv1connect.LifecycleServiceLintProcedure:                "lifecycle.read",
+	specgraphv1connect.LifecycleServiceAcknowledgeDriftProcedure:    "lifecycle.write",
+	specgraphv1connect.LifecycleServiceTransitionAmendProcedure:     "lifecycle.write",
+	specgraphv1connect.LifecycleServiceTransitionSupersedeProcedure: "lifecycle.write",
+	specgraphv1connect.LifecycleServiceTransitionAbandonProcedure:   "lifecycle.write",
+	// SyncService
+	specgraphv1connect.SyncServiceGetSyncStatusProcedure: "sync.read",
+	specgraphv1connect.SyncServiceSyncBeadsProcedure:     "sync.write",
+	specgraphv1connect.SyncServiceSyncGitHubProcedure:    "sync.write",
+	// AnalyticalPassService
+	specgraphv1connect.AnalyticalPassServiceRunAnalyticalPassProcedure:   "analytical_pass.write",
+	specgraphv1connect.AnalyticalPassServiceStoreFindingsProcedure:       "analytical_pass.write",
+	specgraphv1connect.AnalyticalPassServiceListFindingsProcedure:        "analytical_pass.read",
+	specgraphv1connect.AnalyticalPassServiceListProjectFindingsProcedure: "analytical_pass.read",
+	// ExportService
+	specgraphv1connect.ExportServiceExportProjectProcedure: "export.read",
+	specgraphv1connect.ExportServiceImportProjectProcedure: "export.write",
+	specgraphv1connect.ExportServiceVerifyExportProcedure:  "export.read",
+	// SliceService
+	specgraphv1connect.SliceServiceListSlicesProcedure:    "slice.read",
+	specgraphv1connect.SliceServiceGetSliceProcedure:      "slice.read",
+	specgraphv1connect.SliceServiceClaimSliceProcedure:    "slice.write",
+	specgraphv1connect.SliceServiceCompleteSliceProcedure: "slice.write",
+}
+
+// ActionForProcedure returns the stable action name for an RPC procedure.
+func ActionForProcedure(procedure string) (string, bool) {
+	a, ok := procedureActions[procedure]
+	return a, ok
+}
+
+// ActionNames returns the distinct action names, sorted. Passed to
+// NewCedarEngine to build the action-group entity graph.
+func ActionNames() []string {
+	seen := make(map[string]bool, len(procedureActions))
+	for _, a := range procedureActions {
+		seen[a] = true
+	}
+	names := make([]string, 0, len(seen))
+	for a := range seen {
+		names = append(names, a)
+	}
+	sort.Strings(names)
+	return names
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/auth && go build ./... && go test -run 'TestActionForProcedure|TestActionNames' -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Sanity — every action name is buildable**
+
+The action names feed `buildActionEntities`. Confirm they all carry a known verb:
+
+Run: `cd internal/auth && go test -run TestActionNames_AllParseToKnownVerb -v`
+
+Expected: PASS (every value ends in `.read`/`.write`/`.delete`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/auth/actions.go internal/auth/actions_test.go
+git commit -s -m "feat(auth): add procedure→action map (replaces rpcPermissions)"
+```
+
+---
+
+## Task 12: Relocate `IsExempt`/`exemptProcedures` to `exempt.go`
+
+`permissions.go` is deleted in Phase C, but the post-Authn interceptor calls `IsExempt`. Move those two symbols to their own file FIRST so the interceptor keeps resolving after `permissions.go` is gone. This task changes no behavior — it relocates code.
+
+**Files:**
+
+- Create: `internal/auth/exempt.go`
+- Create: `internal/auth/exempt_test.go`
+- Modify: `internal/auth/permissions.go` (remove the relocated symbols)
+- Modify: `internal/auth/permissions_test.go` (remove the relocated tests)
+
+**Covers:** Happy (Health is exempt) + Boundary (a normal procedure is not exempt).
+
+- [ ] **Step 1: Write `exempt.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+)
+
+// exemptProcedures lists procedures that bypass authentication AND
+// authorization entirely (health checks). Consulted by the interceptor
+// before any Resolver/Authorizer work. Relocated from permissions.go (which
+// the Cedar plan deletes); IsExempt is the interceptor's only dependency on
+// this file.
+var exemptProcedures = map[string]bool{
+	specgraphv1connect.ServerServiceHealthProcedure: true,
+}
+
+// IsExempt reports whether a procedure bypasses auth.
+func IsExempt(procedure string) bool {
+	return exemptProcedures[procedure]
+}
+```
+
+- [ ] **Step 2: Write `exempt_test.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/auth"
+)
+
+func TestIsExempt_Health(t *testing.T) {
+	require.True(t, auth.IsExempt(specgraphv1connect.ServerServiceHealthProcedure))
+}
+
+func TestIsExempt_NormalProcedureNotExempt(t *testing.T) {
+	require.False(t, auth.IsExempt(specgraphv1connect.SpecServiceGetSpecProcedure))
+}
+```
+
+- [ ] **Step 3: Remove the relocated symbols from `permissions.go`**
+
+Delete the `exemptProcedures` var and the `IsExempt` func from `internal/auth/permissions.go`. After this edit `permissions.go` contains only `rpcPermissions` and `RPCPermission`. `rpcPermissions` is still read by `StaticTableAuthorizer.Authorize` (which indexes the map directly), so it stays live until Task 17. `RPCPermission` (exported) may already be unreferenced post-Authn — that's fine: exported symbols don't trip the `unused` linter, and it's deleted with the file in Task 17. The `specgraphv1connect` import is still needed by `rpcPermissions`' keys — leave it.
+
+- [ ] **Step 4: Move the exempt tests out of `permissions_test.go`**
+
+Delete any `TestIsExempt*` / `exemptProcedures` tests from `permissions_test.go` (they now live in `exempt_test.go`). Leave the `rpcPermissions`/`RPCPermission` tests in place — they're deleted with the file in Task 17.
+
+- [ ] **Step 5: Verify compile + tests**
+
+Run: `cd internal/auth && go build ./... && go test ./...`
+
+Expected: PASS — `IsExempt` resolves from `exempt.go`; the interceptor (unchanged) still compiles.
+
+- [ ] **Step 6: Whole-project build + test**
+
+Run: `cd /Volumes/Code/github.com/specgraph-identity-plans && go build ./... && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/auth/exempt.go internal/auth/exempt_test.go internal/auth/permissions.go internal/auth/permissions_test.go
+git commit -s -m "refactor(auth): relocate IsExempt/exemptProcedures to exempt.go"
+```
+
+---
+
+## Task 13: Implement `CedarAuthorizer` (implements `auth.Authorizer`)
+
+The drop-in replacement for `StaticTableAuthorizer`. Same interface, returns the same `auth.Decision`. This is what makes the interceptor diff zero.
+
+**Files:**
+
+- Create: `internal/auth/cedar_authorizer.go`
+- Create: `internal/auth/cedar_authorizer_test.go`
+
+**Covers:** Happy (allow returns `auth.Decision{Allowed:true}`) + Boundary (unconfigured procedure → error; deny → `Allowed:false` with reason) + Invariant (engine error → authorizer error).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/auth"
+)
+
+// fakeEngine lets the authorizer tests control decisions without real cedar.
+type fakeEngine struct {
+	dec auth.PolicyDecision
+	err error
+	got auth.EvalRequest
+}
+
+func (f *fakeEngine) Evaluate(_ context.Context, req auth.EvalRequest) (auth.PolicyDecision, error) {
+	f.got = req
+	return f.dec, f.err
+}
+func (f *fakeEngine) Reload(context.Context) error { return nil }
+
+func TestCedarAuthorizer_Allow(t *testing.T) {
+	eng := &fakeEngine{dec: auth.PolicyDecision{Allowed: true, MatchedPolicies: []string{"embedded:base.cedar#policy0"}}}
+	a := auth.NewCedarAuthorizer(eng)
+	id := &auth.Identity{UserID: "u1", EffectiveRole: auth.RoleReader}
+
+	d, err := a.Authorize(context.Background(), id, specgraphv1connect.SpecServiceGetSpecProcedure, nil)
+	require.NoError(t, err)
+	require.True(t, d.Allowed)
+	require.Contains(t, d.Reason, "cedar-allow")
+	// The engine received the mapped action name, not the RPC method name.
+	require.Equal(t, "spec.read", eng.got.Action)
+}
+
+func TestCedarAuthorizer_Deny(t *testing.T) {
+	eng := &fakeEngine{dec: auth.PolicyDecision{Allowed: false}}
+	a := auth.NewCedarAuthorizer(eng)
+	id := &auth.Identity{UserID: "u1", EffectiveRole: auth.RoleReader}
+
+	d, err := a.Authorize(context.Background(), id, specgraphv1connect.SpecServiceCreateSpecProcedure, nil)
+	require.NoError(t, err)
+	require.False(t, d.Allowed)
+	require.Contains(t, d.Reason, "cedar-deny")
+}
+
+func TestCedarAuthorizer_UnconfiguredProcedureIsError(t *testing.T) {
+	a := auth.NewCedarAuthorizer(&fakeEngine{})
+	_, err := a.Authorize(context.Background(), &auth.Identity{}, "/no.such/Procedure", nil)
+	require.Error(t, err)
+}
+
+func TestCedarAuthorizer_EngineErrorPropagates(t *testing.T) {
+	sentinel := errors.New("engine down")
+	a := auth.NewCedarAuthorizer(&fakeEngine{err: sentinel})
+	_, err := a.Authorize(context.Background(), &auth.Identity{EffectiveRole: auth.RoleReader},
+		specgraphv1connect.SpecServiceGetSpecProcedure, nil)
+	require.ErrorIs(t, err, sentinel)
+}
+
+// Compile-time assertion that CedarAuthorizer satisfies Authorizer.
+var _ auth.Authorizer = (*auth.CedarAuthorizer)(nil)
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run TestCedarAuthorizer -v`
+
+Expected: FAIL ("undefined: auth.NewCedarAuthorizer").
+
+- [ ] **Step 3: Write the impl**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// CedarAuthorizer implements Authorizer by delegating to a PolicyEngine.
+// It replaces StaticTableAuthorizer; because both satisfy Authorizer, the
+// interceptor and serve.go wiring change only in which constructor is called
+// — the interceptor's Authorize call site is byte-identical.
+type CedarAuthorizer struct {
+	engine PolicyEngine
+}
+
+// NewCedarAuthorizer wraps a PolicyEngine as an Authorizer.
+func NewCedarAuthorizer(engine PolicyEngine) *CedarAuthorizer {
+	return &CedarAuthorizer{engine: engine}
+}
+
+// Authorize maps the RPC procedure to a stable action name, builds an
+// EvalRequest, and asks the engine. An unconfigured procedure is an error
+// (mirrors StaticTableAuthorizer; the interceptor maps it to CodeInternal),
+// which is deliberately distinct from a clean Deny.
+//
+// req (the unmarshaled request body) is accepted for the Authorizer
+// interface and future ownership rules; the migration's role-only policies
+// do not inspect it.
+func (a *CedarAuthorizer) Authorize(ctx context.Context, id *Identity, procedure string, _ any) (Decision, error) {
+	action, ok := ActionForProcedure(procedure)
+	if !ok {
+		return Decision{}, fmt.Errorf("cedar: unconfigured procedure %q", procedure)
+	}
+	domain := actionDomain(action)
+	dec, err := a.engine.Evaluate(ctx, EvalRequest{
+		Identity: id,
+		Action:   action,
+		Resource: ResourceRef{Type: domain, ID: domain},
+	})
+	if err != nil {
+		return Decision{}, fmt.Errorf("cedar: evaluate %s: %w", action, err)
+	}
+	if dec.Allowed {
+		return Decision{
+			Allowed: true,
+			Reason:  "cedar-allow:" + strings.Join(dec.MatchedPolicies, ","),
+		}, nil
+	}
+	return Decision{
+		Allowed: false,
+		Reason:  "cedar-deny:" + action,
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/auth && go build ./... && go test -run TestCedarAuthorizer -v`
+
+Expected: PASS, including the `var _ auth.Authorizer = (*auth.CedarAuthorizer)(nil)` compile-time assertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/cedar_authorizer.go internal/auth/cedar_authorizer_test.go
+git commit -s -m "feat(auth): add CedarAuthorizer implementing the Authorizer seam"
+```
+
+---
+
+## Task 14: Add `KnownRolesFrom`
+
+`serve.go` derives `KnownRoles` (for JIT role validation) from `LoadRolePerms` today. Cedar deletes `LoadRolePerms`, so the role-name set needs a new, perm-free home.
+
+**Files:**
+
+- Create: `internal/auth/known_roles.go`
+- Create: `internal/auth/known_roles_test.go`
+
+**Covers:** Happy (built-ins ∪ custom names) + Boundary (nil/empty custom → just built-ins).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/auth"
+)
+
+func TestKnownRolesFrom_BuiltinsPlusCustom(t *testing.T) {
+	known := auth.KnownRolesFrom([]string{"auditor", "releaser"})
+	require.True(t, known[auth.RoleAdmin])
+	require.True(t, known[auth.RoleWriter])
+	require.True(t, known[auth.RoleReader])
+	require.True(t, known[auth.Role("auditor")])
+	require.True(t, known[auth.Role("releaser")])
+	require.False(t, known[auth.Role("nope")])
+}
+
+func TestKnownRolesFrom_NilCustom(t *testing.T) {
+	known := auth.KnownRolesFrom(nil)
+	require.Len(t, known, 3)
+	require.True(t, known[auth.RoleAdmin])
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/auth && go test -run TestKnownRolesFrom -v`
+
+Expected: FAIL ("undefined: auth.KnownRolesFrom").
+
+- [ ] **Step 3: Write the impl**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+// KnownRolesFrom returns the set of role names valid for assignment:
+// the built-in roles plus any operator-defined custom role NAMES. Under
+// Cedar, custom roles carry no permission list — their authorization is
+// expressed as Cedar policies (e.g. in a DirectoryPolicySource). This set
+// exists only so the resolver can reject JIT/claims-mapping references to
+// roles that don't exist. A known role with no matching policy authorizes
+// nothing (default-deny), which is the intended behavior.
+func KnownRolesFrom(custom []string) map[Role]bool {
+	known := map[Role]bool{
+		RoleAdmin:  true,
+		RoleWriter: true,
+		RoleReader: true,
+	}
+	for _, name := range custom {
+		if name != "" {
+			known[Role(name)] = true
+		}
+	}
+	return known
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd internal/auth && go build ./... && go test -run TestKnownRolesFrom -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Whole-project build + test**
+
+Run: `cd /Volumes/Code/github.com/specgraph-identity-plans && go build ./... && go test ./...`
+
+Expected: PASS. All Phase-A pieces exist; `StaticTableAuthorizer` still serves auth (nothing switched yet).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/auth/known_roles.go internal/auth/known_roles_test.go
+git commit -s -m "feat(auth): add KnownRolesFrom (built-ins ∪ custom role names)"
+```
+
+---
+
+## Task 15: Reshape config — `Roles []string`, drop `RoleConfig`, add `Policies`
+
+No vestigial cruft: the permission lists are gone entirely, not left as an ignored field. `cfg.Auth.Roles` becomes a list of role names; `auth.policies.extra_dirs` is added.
+
+**Files:**
+
+- Modify: `internal/config/global.go`
+- Modify: `internal/config/global_test.go` (or the relevant config test file)
+
+**Covers:** Happy (parse names + extra_dirs) + Boundary (old map-shaped `roles:` hard-fails at parse — deliberate, not silent).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the config test file (the package that loads `AuthConfig`):
+
+```go
+func TestAuthConfig_RolesAreNames(t *testing.T) {
+	const y = `
+auth:
+  roles: [auditor, releaser]
+  policies:
+    extra_dirs: ["/etc/specgraph/policies"]
+`
+	var c config.GlobalConfig
+	require.NoError(t, yaml.Unmarshal([]byte(y), &c))
+	require.Equal(t, []string{"auditor", "releaser"}, c.Auth.Roles)
+	require.Equal(t, []string{"/etc/specgraph/policies"}, c.Auth.Policies.ExtraDirs)
+}
+
+func TestAuthConfig_LegacyMapRolesRejected(t *testing.T) {
+	// The old map-with-permissions shape must NOT silently parse — Cedar
+	// removed permission lists, and a silent drop would strip authorization
+	// without warning. A type mismatch (map vs sequence) is the honest fail.
+	const y = `
+auth:
+  roles:
+    auditor:
+      permissions: ["spec:read"]
+`
+	var c config.GlobalConfig
+	require.Error(t, yaml.Unmarshal([]byte(y), &c))
+}
+```
+
+> Match the test's package, import path for `config`, the YAML library actually used (`gopkg.in/yaml.v3` or sigs.k8s.io/yaml — check the existing config tests), and the real top-level config type name (shown as `GlobalConfig` here — use whatever `global.go` declares). If config loading goes through a loader function rather than raw `yaml.Unmarshal`, call that loader instead.
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/config && go test -run 'TestAuthConfig_RolesAreNames|TestAuthConfig_LegacyMapRolesRejected' -v`
+
+Expected: FAIL — `c.Auth.Roles` is still `map[string]RoleConfig`; `c.Auth.Policies` doesn't exist.
+
+- [ ] **Step 3: Reshape the config types**
+
+In `internal/config/global.go`:
+
+1. Change the `Roles` field in `AuthConfig` from:
+   ```go
+   Roles map[string]RoleConfig `yaml:"roles"`
+   ```
+   to:
+   ```go
+   Roles    []string     `yaml:"roles"`
+   Policies PolicyConfig `yaml:"policies"`
+   ```
+
+2. Delete the `RoleConfig` type entirely:
+   ```go
+   // DELETE:
+   // RoleConfig defines a custom role with explicit permissions.
+   // type RoleConfig struct {
+   // 	Permissions []string `yaml:"permissions"`
+   // }
+   ```
+
+3. Add the `PolicyConfig` type near the other auth config types:
+   ```go
+   // PolicyConfig configures the Cedar authorization engine's policy
+   // sources. Built-in policies are always loaded; ExtraDirs adds operator
+   // policy directories (each *.cedar file becomes a DirectoryPolicySource).
+   type PolicyConfig struct {
+   	ExtraDirs []string `yaml:"extra_dirs"`
+   }
+   ```
+
+- [ ] **Step 4: Fix any in-package references to `RoleConfig`**
+
+Run: `grep -rn 'RoleConfig\|\.Permissions' internal/config/` and remove/adapt any validation or defaulting code that referenced the deleted type or the permissions field. (The cross-package consumer `serve.go` is fixed in Task 16; in-package config tests that built `RoleConfig` literals must be updated to the `[]string` shape now.)
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cd internal/config && go build ./... && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 6: Whole-project build**
+
+Run: `cd /Volumes/Code/github.com/specgraph-identity-plans && go build ./...`
+
+Expected: **FAIL** — `serve.go` still references `cfg.Auth.Roles` as a map and `rc.Permissions`. That's expected; Task 16 fixes serve.go. Do NOT commit a broken whole-project build: this task and Task 16 are a coupled pair. If executing inline, proceed directly to Task 16 before the next push. If executing via subagents, run Tasks 15 and 16 in one batch.
+
+- [ ] **Step 7: Commit (package-local)**
+
+```bash
+git add internal/config/global.go internal/config/global_test.go
+git commit -s -m "feat(config): Roles->[]string, drop RoleConfig, add auth.policies.extra_dirs"
+```
+
+---
+
+## Task 16: Switch `serve.go` to Cedar (the zero-diff-interceptor payoff)
+
+Replace the `LoadRolePerms` + `NewStaticTableAuthorizer` block with policy-source + engine + `CedarAuthorizer` construction, and derive `KnownRoles` via `KnownRolesFrom`. The interceptor construction line is unchanged.
+
+**Files:**
+
+- Modify: `cmd/specgraph/serve.go`
+
+**Covers:** E2E (whole project builds and the server wires Cedar) + Invariant (interceptor call site unchanged).
+
+- [ ] **Step 1: Replace the role-perms + authorizer block**
+
+In `cmd/specgraph/serve.go`, find the post-Authn block (Authn plan Task 29):
+
+```go
+// Role→permissions snapshot (built-ins ∪ cfg.Auth.Roles). Shared by the
+// authorizer and used to derive KnownRoles for JIT validation.
+rolePerms := auth.LoadRolePerms(cfg.Auth.Roles)
+knownRoles := make(map[auth.Role]bool, len(rolePerms))
+for r := range rolePerms {
+	knownRoles[r] = true
+}
+```
+
+Replace it with:
+
+```go
+// KnownRoles for JIT validation (built-ins ∪ custom role names). Under
+// Cedar, custom roles carry no permission list; their authorization is
+// expressed as Cedar policies, not YAML.
+knownRoles := auth.KnownRolesFrom(cfg.Auth.Roles)
+```
+
+Then find:
+
+```go
+// Authorizer (static table for now; Cedar plan swaps).
+authorizer := auth.NewStaticTableAuthorizer(rolePerms)
+```
+
+Replace it with:
+
+```go
+// Authorizer: Cedar policy engine. Built-in policies are always loaded;
+// operators add directories via auth.policies.extra_dirs.
+policySources := []auth.PolicySource{auth.NewEmbeddedPolicySource()}
+for _, dir := range cfg.Auth.Policies.ExtraDirs {
+	policySources = append(policySources, auth.NewDirectoryPolicySource(dir))
+}
+engine, err := auth.NewCedarEngine(ctx, policySources, auth.ActionNames())
+if err != nil {
+	return fmt.Errorf("policy engine: %w", err)
+}
+authorizer := auth.NewCedarAuthorizer(engine)
+```
+
+> Import check: this block uses `fmt.Errorf`. Confirm `cmd/specgraph/serve.go` already imports `"fmt"` — the post-Authn serve.go does (its OIDC-verifier and auth-store construction use `fmt.Errorf`), so no import change is expected. If a `go build` after Step 1 reports `undefined: fmt`, add `"fmt"` to the import block. `err` is already a declared variable in this scope (the post-Authn wiring assigns `resolver, err := ...`), so `engine, err := ...` reuses it via `:=` with the new `engine` on the left — no shadowing concern.
+
+- [ ] **Step 2: Confirm the interceptor line is unchanged**
+
+The construction line remains exactly:
+
+```go
+interceptor := auth.NewAuthInterceptor(resolver, authorizer)
+```
+
+> If the Authn cleanup task (30b) has not yet renamed `NewAuthInterceptorV2` back to `NewAuthInterceptor`, this line reads `auth.NewAuthInterceptorV2(...)` instead — leave whichever name the merged Authn code uses. Cedar changes neither the name nor the arguments; `authorizer` is now a `*CedarAuthorizer` instead of a `*StaticTableAuthorizer`, and both satisfy `auth.Authorizer`. **This non-change is the design's headline result.**
+
+- [ ] **Step 3: Verify whole-project compile + test**
+
+Run: `cd /Volumes/Code/github.com/specgraph-identity-plans && go build ./... && go test ./...`
+
+Expected: PASS. (`StaticTableAuthorizer`, `LoadRolePerms`, `DefaultRolePermissions`, `rpcPermissions` are now unreferenced by non-test code, but still present — deleted in Task 17. They are exported or mutually-referenced, so `go build`/`go test` stay green.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/specgraph/serve.go
+git commit -s -m "feat(serve): swap StaticTableAuthorizer for Cedar (interceptor diff is zero)"
+```
+
+---
+
+## Task 17: Delete `StaticTableAuthorizer` and the static `rpcPermissions` table
+
+Phase C. With `serve.go` switched, the static authorizer and its table are dead. Delete them together — `StaticTableAuthorizer.Authorize` is `rpcPermissions`' only consumer, so removing the file orphans the table and would trip the `unused` linter if `permissions.go` lingered.
+
+**Files:**
+
+- Delete: `internal/auth/static_authorizer.go`
+- Delete: `internal/auth/static_authorizer_test.go`
+- Delete: `internal/auth/permissions.go`
+- Delete: `internal/auth/permissions_test.go` (only the `rpcPermissions`/`RPCPermission` tests remain there after Task 12; the exempt tests already moved to `exempt_test.go`)
+
+**Covers:** Invariant (no surviving reference to the deleted symbols).
+
+- [ ] **Step 1: Pre-deletion survivor grep**
+
+```bash
+grep -rn 'StaticTableAuthorizer\|NewStaticTableAuthorizer\|LoadRolePerms\|DefaultRolePermissions\|hasPermissionInternal\|rpcPermissions\|RPCPermission' \
+  --include='*.go' internal/ cmd/
+```
+
+Expected: matches ONLY inside the four files being deleted in this task. If anything else matches (e.g. a stray reference in `serve.go` or a test), fix that first — a surviving consumer of a to-be-deleted symbol is the exact bug class this plan guards against.
+
+- [ ] **Step 2: Delete the files**
+
+```bash
+rm internal/auth/static_authorizer.go internal/auth/static_authorizer_test.go \
+   internal/auth/permissions.go internal/auth/permissions_test.go
+```
+
+- [ ] **Step 3: Verify compile + tests**
+
+Run: `cd internal/auth && go build ./... && go test ./...`
+
+Expected: PASS. `IsExempt` resolves from `exempt.go`; authorization runs through `CedarAuthorizer`.
+
+- [ ] **Step 4: Post-deletion grep (confirm clean)**
+
+```bash
+grep -rn 'StaticTableAuthorizer\|LoadRolePerms\|DefaultRolePermissions\|hasPermissionInternal\|rpcPermissions\|RPCPermission' \
+  --include='*.go' internal/ cmd/
+```
+
+Expected: NO matches anywhere.
+
+- [ ] **Step 5: Whole-project build + test + lint**
+
+Run:
+
+```bash
+cd /Volumes/Code/github.com/specgraph-identity-plans
+go build ./... && go test ./...
+task lint
+```
+
+Expected: PASS. `task lint` here catches `unused` (staticcheck) — confirms no orphaned unexported symbols remain.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -s -m "refactor(auth): delete StaticTableAuthorizer and static rpcPermissions table"
+```
+
+---
+
+## Task 18: Integration test — interceptor → CedarAuthorizer → engine
+
+End-to-end through the real interceptor with the real embedded policies. Proves the zero-diff seam works in situ and the embedded `base.cedar` authorizes correctly.
+
+**Files:**
+
+- Create: `internal/auth/cedar_integration_test.go`
+
+**Covers:** E2E (full authz path: reader allowed read, denied write; admin allowed delete; exempt bypass).
+
+- [ ] **Step 1: Write the test**
+
+```go
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+	"github.com/specgraph/specgraph/internal/auth"
+)
+
+// newRealCedarAuthorizer builds the production authorizer: embedded policies,
+// real engine, real action map.
+func newRealCedarAuthorizer(t *testing.T) auth.Authorizer {
+	t.Helper()
+	engine, err := auth.NewCedarEngine(context.Background(),
+		[]auth.PolicySource{auth.NewEmbeddedPolicySource()}, auth.ActionNames())
+	require.NoError(t, err)
+	return auth.NewCedarAuthorizer(engine)
+}
+
+func TestIntegration_CedarAuthorizer_EmbeddedPolicies(t *testing.T) {
+	a := newRealCedarAuthorizer(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		role      auth.Role
+		procedure string
+		allowed   bool
+	}{
+		{auth.RoleReader, specgraphv1connect.SpecServiceGetSpecProcedure, true},
+		{auth.RoleReader, specgraphv1connect.SpecServiceCreateSpecProcedure, false},
+		{auth.RoleReader, specgraphv1connect.GraphServiceRemoveEdgeProcedure, false},
+		{auth.RoleWriter, specgraphv1connect.SpecServiceCreateSpecProcedure, true},
+		{auth.RoleWriter, specgraphv1connect.GraphServiceRemoveEdgeProcedure, false},
+		{auth.RoleAdmin, specgraphv1connect.GraphServiceRemoveEdgeProcedure, true},
+	}
+	for _, c := range cases {
+		id := &auth.Identity{UserID: "u1", EffectiveRole: c.role, Role: c.role, Subject: "apikey:k1"}
+		d, err := a.Authorize(ctx, id, c.procedure, nil)
+		require.NoErrorf(t, err, "role=%s proc=%s", c.role, c.procedure)
+		require.Equalf(t, c.allowed, d.Allowed, "role=%s proc=%s reason=%s", c.role, c.procedure, d.Reason)
+	}
+}
+
+func TestIntegration_HealthIsExempt(t *testing.T) {
+	// Exempt procedures never reach the authorizer; assert the interceptor's
+	// gate directly.
+	require.True(t, auth.IsExempt(specgraphv1connect.ServerServiceHealthProcedure))
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cd internal/auth && go test -tags integration -run 'TestIntegration_CedarAuthorizer|TestIntegration_HealthIsExempt' -v`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/auth/cedar_integration_test.go
+git commit -s -m "test(auth): integration test for Cedar authorizer with embedded policies"
+```
+
+---
+
+## Task 19: Integration test — discrete policy layering (the design payoff)
+
+Prove that a discrete, owner-based policy from a `DirectoryPolicySource` layers on top of the role-only base — granting access the base would deny — without any code change. This is the property stories #3/#4 depend on, and it exercises `DirectoryPolicySource` end-to-end.
+
+**Files:**
+
+- Modify: `internal/auth/cedar_integration_test.go`
+
+**Covers:** E2E (composed sources; discrete permit broadens beyond the base) + Invariant (a layered permit is additive — base denials for others are unaffected).
+
+- [ ] **Step 1: Write the test**
+
+Append to `internal/auth/cedar_integration_test.go`:
+
+```go
+import (
+	"os"
+	"path/filepath"
+)
+
+// TestIntegration_DiscretePolicyLayering shows a directory-sourced ownership
+// policy granting a reader access to a write action on their OWN resource —
+// something the role-only base policy denies — while a non-owner reader is
+// still denied. New behavior arrives as a new policy file, no code change.
+func TestIntegration_DiscretePolicyLayering(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	// Owner may rotate their own resource regardless of role.
+	ownerPolicy := `permit (
+		principal,
+		action in SpecGraph::Action::"write",
+		resource
+	) when {
+		resource has owner_user_id && principal has id && resource.owner_user_id == principal.id
+	};`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ownership.cedar"), []byte(ownerPolicy), 0o600))
+
+	engine, err := auth.NewCedarEngine(ctx,
+		[]auth.PolicySource{auth.NewEmbeddedPolicySource(), auth.NewDirectoryPolicySource(dir)},
+		auth.ActionNames())
+	require.NoError(t, err)
+
+	// Reader who owns the resource: base denies write, ownership permit allows.
+	ownerDec, err := engine.Evaluate(ctx, auth.EvalRequest{
+		Identity: &auth.Identity{UserID: "u1", EffectiveRole: auth.RoleReader},
+		Action:   "spec.write",
+		Resource: auth.ResourceRef{Type: "spec", ID: "s1", Attributes: map[string]string{"owner_user_id": "u1"}},
+	})
+	require.NoError(t, err)
+	require.True(t, ownerDec.Allowed, "owner reader should be allowed by the layered ownership policy")
+
+	// Reader who does NOT own the resource: neither base nor ownership matches.
+	otherDec, err := engine.Evaluate(ctx, auth.EvalRequest{
+		Identity: &auth.Identity{UserID: "u2", EffectiveRole: auth.RoleReader},
+		Action:   "spec.write",
+		Resource: auth.ResourceRef{Type: "spec", ID: "s1", Attributes: map[string]string{"owner_user_id": "u1"}},
+	})
+	require.NoError(t, err)
+	require.False(t, otherDec.Allowed, "non-owner reader stays denied — layering is additive, not blanket")
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cd internal/auth && go test -tags integration -run TestIntegration_DiscretePolicyLayering -v`
+
+Expected: PASS — the owner is allowed via the directory policy; the non-owner stays denied.
+
+- [ ] **Step 3: Run the full auth suite (unit + integration)**
+
+Run: `cd internal/auth && go test ./... && go test -tags integration ./...`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/auth/cedar_integration_test.go
+git commit -s -m "test(auth): integration test for discrete ownership policy layering"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (against `docs/plans/2026-05-26-identity-policy-engine-design.md`):
+
+- [x] Cedar embedded, one binary, no sidecar — `engine.go` (`cedarEngine`), Tasks 1, 6, 9.
+- [x] Wrapped behind SpecGraph-owned `PolicyEngine`; only the wrapper imports cedar-go — Task 5 (interface), Task 6/9 (impl); `engine.go` is the sole cedar-go importer (asserted by the File Structure and the "do not touch" list).
+- [x] `EvalRequest` / `PolicyDecision` are SpecGraph types, not cedar types — Task 5.
+- [x] `PolicySource` interface; `EmbeddedPolicySource` + `DirectoryPolicySource` ship; composable, ordered — Tasks 2, 3, 4, 6 (`loadPolicySet` merges in order).
+- [x] Built-in source MUST load or refuse start — Task 6 (`Reload` zero-policy error; `NewCedarEngine` propagates).
+- [x] Filesystem sources required-by-default — Task 4 (missing dir → error; empty dir → OK).
+- [x] No hot-reload (restart applies changes); `Reload` present for the future story, lock-free hot path — Tasks 5, 6 (`atomic.Pointer`).
+- [x] Entity model: principal `SpecGraph::User` with `role`/`id`/`email`; resource per-domain; actions namespaced + decoupled from method names — Tasks 7, 8, 9, 11.
+- [x] Actions decoupled from RPC method names via `(service,method)→action` map — Task 11 (`procedureActions`, tested by `TestActionForProcedure*` and `TestActionNames_DecoupledFromMethodNames`).
+- [x] Migration of `rpcPermissions` to policies + action declarations, in one landing — base policies (Task 3) + action map (Task 11); semantics-equivalence argued in Task 3 and pinned by Task 9 matrix + Task 18.
+- [x] Static table deleted: `StaticTableAuthorizer`, `permissions.go`, `hasPermissionInternal`, `LoadRolePerms`, `DefaultRolePermissions` — Task 17 (with Task 12 preserving `IsExempt`).
+- [x] Decision logging at `slog.Debug` until audit story #1 — Task 10.
+- [x] `CedarAuthorizer` implements existing `Authorizer`; interceptor diff zero — Task 13 + Task 16 (Step 2 asserts the unchanged call site).
+- [x] Self-service / ownership rules expressible without handler code — demonstrated by Task 19 (discrete ownership permit layered via `DirectoryPolicySource`).
+- [x] Custom-role decision: names-only, no vestigial permission lists — Task 14 (`KnownRolesFrom`) + Task 15 (config reshape, `RoleConfig` deleted).
+
+**2. Placeholder scan:** No `TBD`/`TODO`/"similar to above"/"add error handling" left. The two temporary stubs in Task 6 (`buildActionEntities`, `Evaluate`) are explicitly labeled temporary and are replaced with full real code in Tasks 7 and 9 respectively, each with its own failing-test-first cycle. The Task 1 smoke test is intentionally throwaway and deleted in its own Step 4. Every code step shows complete code; every run step shows the exact command and expected result.
+
+**3. Type consistency:** `PolicyEngine`, `cedarEngine`, `NewCedarEngine`, `EvalRequest`, `ResourceRef`, `PolicyDecision`, `PolicyDocument`, `PolicySource`, `EmbeddedPolicySource`, `DirectoryPolicySource`, `CedarAuthorizer`, `NewCedarAuthorizer`, `ActionForProcedure`, `ActionNames`, `actionVerb`, `actionDomain`, `buildActionEntities`, `principalEntity`, `resourceEntity`, `KnownRolesFrom`, `IsExempt` are referenced identically across Tasks 1–19. `CedarAuthorizer.Authorize` returns the existing `auth.Decision` (compile-time assertion in Task 13); the engine returns `PolicyDecision` (distinct, no collision). Entity-type constants (`entityTypeUser`/`entityTypeResource`/`entityTypeAction`) defined in Task 8 and back-applied to Task 7's literals.
+
+**4. Build-discipline check:** Every task ends with `go build ./... && go test ./...` green at the package level; Tasks 6, 9, 14, 16, 17 additionally run the whole-project build+test (and Task 17 runs `task lint`). The one deliberate exception is Task 15 → 16: Task 15 leaves the whole project non-building (serve.go still references the old config shape) and is explicitly flagged as a coupled pair with Task 16 — they execute in one batch / before the next push. Phase A (1–14) is purely additive: `StaticTableAuthorizer` continues to serve authorization the entire time. Phase B (15–16) switches `serve.go` with a byte-identical interceptor line. Phase C (17) deletes the now-dead static authorizer and table together, after a pre-deletion survivor grep and a post-deletion clean grep plus `task lint` to catch any orphaned unexported symbol. Integration tests (18–19) are additive `//go:build integration` files.
+
+**5. Symbol-lifetime sweep:** Completed in the dedicated section above — every new identifier greppe�d against the post-Authn surface (no collisions; `PolicyDecision` and `PolicyDocument` chosen specifically to avoid `Decision`/`cedar.Policy` clashes), and every deleted symbol's consumers verified to be either switched (`serve.go`) or co-deleted (the four Task-17 files). The single survivor that the handoff's literal "delete permissions.go" would have broken — `IsExempt`/`exemptProcedures`, called by the interceptor — is relocated to `exempt.go` in Task 12 before `permissions.go` is deleted in Task 17.
+
+---
+
+## Execution
+
+Two options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task. Tasks 1–14 are short, well-scoped TDD cycles ideal for a fleet. **Tasks 15–16 MUST run as one batch** (Task 15 alone leaves the whole project non-building, by design). Task 17 (deletion) and Tasks 18–19 (integration) are natural standalone units with checkpoint review.
+2. **Inline Execution** — practical especially for the 15–16 config/serve coupling and the 17 deletion, which touch multiple files at once.
+
+After execution, the Bootstrap & UX plan is the last of the four; it is unaffected at the design level by this plan (the entity model projects cleanly into Cedar). Stories #3 (project-scoped RBAC) and #4 (resource ownership) build on this foundation as separate epics — each adds resource attributes and discrete/group policies, with no new authorization code paths in handlers, exactly as Task 19 demonstrates.

--- a/docs/plans/2026-05-26-identity-storage-implementation-plan.md
+++ b/docs/plans/2026-05-26-identity-storage-implementation-plan.md
@@ -1,0 +1,3408 @@
+# Identity Storage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the Identity Storage layer specified in `docs/plans/2026-05-22-identity-storage-design.md` — Postgres-backed `UsersBackend` for global identity tables, sibling to but independent of the per-project `*Store`.
+
+**Architecture:** A separate `*AuthStore` type in `internal/storage/postgres/` shares the existing pgxpool but skips the project-scoping requirement. Single `UsersBackend` interface in `internal/storage/users.go` (package `storage`). Single `User` domain struct with a `Kind` enum (Human / ServiceAccount). Goose migrations live in a separate directory with a separate version table to avoid collision with project migrations. Tests share the existing testcontainers pattern; the Postgres container is reused across project and auth stores.
+
+**Tech Stack:** Go 1.x, pgx v5 (pgxpool), goose v3, testcontainers-go, argon2id (`golang.org/x/crypto/argon2`).
+
+**Implements bead:** Implementation of approved design `spgr-e82m` under epic `spgr-rjrt`.
+
+---
+
+## Testing approach
+
+Tests in this plan fall into four categories. Each task tags which categories it covers (under **Covers:** near the test step). When you find yourself wanting to add a new test mid-task, decide which category it belongs to — that frames whether it goes with the current task or belongs in the sweep tasks at the end.
+
+### Happy
+
+The normal success path: input is well-formed, preconditions are met, the operation does its primary thing. **Every task that introduces a method has at least one happy test.** If you can't articulate the happy case in one sentence, the method's contract isn't clear yet — stop and clarify before writing tests.
+
+Example: "CreateHuman with a valid User struct returns the inserted row with a populated ID."
+
+### Invariants
+
+Properties that must always hold regardless of input: structural rules enforced by the system. Invariants come from the design (e.g., "at most one bootstrap admin"); they're not method-specific — they're system-wide. Often invariants need their own dedicated tests rather than fitting inside a happy-path test.
+
+Examples:
+- *Bootstrap uniqueness* — at most one user has `bootstrap=true AND deleted_at IS NULL`. Tested via concurrent CreateHuman calls in Task 27.
+- *(issuer, subject) globally unique* — two providers with the same `sub` for different people can't collide. Tested via concurrent JIT calls in Task 28.
+- *Soft-delete cascades to key revocation in one tx* — never an intermediate state where the user is deleted but their keys still pass auth. Tested in Task 16.
+- *ServiceAccounts have no OIDC bindings* — convention enforced at the write API surface. Tested in Task 30 (sweep).
+
+When in doubt: if the property is "always true regardless of which method you called," it's an invariant.
+
+### Boundaries
+
+Edges of the input space and behavior space: NotFound, idempotent re-calls, missing-required-fields, pagination edges (limit=0, very large offset, empty result), empty-vs-null distinctions, very-long strings. Boundary tests catch the "what if" cases that happy tests skip.
+
+Examples:
+- *NotFound* — every Lookup/Get method returns the appropriate sentinel error.
+- *Idempotent re-call* — calling Revoke / SoftDelete / Purge / Unbind twice is not an error.
+- *Empty filter* — ListUsers with no filter returns all (non-deleted) rows; an empty filter is not "no rows."
+- *Default limit* — `ListUsersFilter{Limit: 0}` uses the default (100), not literal zero.
+
+### E2E (integration here)
+
+Multi-method flows that exercise the storage layer as a whole rather than one method at a time. For the Storage plan, "E2E" means a single test that walks through bootstrap → JIT-create-real-user → mint-key → rotate-key → promote-role → soft-delete-bootstrap and asserts the final state is coherent. True system-E2E (CLI → RPC → storage → response) is out of scope for this plan; it lives in the Authn and Bootstrap & UX plans.
+
+There's one E2E test in this plan (Task 29). Add more if real flows surface during implementation that aren't already covered by category-1–3 tests.
+
+### How to use these categories
+
+When you write a task's failing test (TDD step 1), start with **Happy**. If implementing the happy path reveals that you need to also assert an invariant or a boundary, either add it to the same task (if it's small and method-local) or note it for the sweep tasks at the end (if it's cross-cutting). Don't let a single test cover all four categories — it makes the assertion clutter the intent.
+
+The sweep tasks (Task 30 invariants, Task 31 boundaries) exist explicitly for the cross-cutting properties that don't belong to any single method.
+
+---
+
+## File Structure
+
+**Create:**
+
+- `internal/storage/users.go` — `UsersBackend` interface (package `storage`).
+- `internal/storage/users_domain.go` — `User`, `OIDCBinding`, `APIKey` domain types + `Kind` enum + sentinel errors specific to this domain.
+- `internal/storage/postgres/auth.go` — `AuthStore` type + `NewAuth` constructor + goose migration runner + pool accessor.
+- `internal/storage/postgres/users.go` — methods on `*AuthStore` implementing `UsersBackend` (resolve-path queries, CRUD).
+- `internal/storage/postgres/auth_migrations/001_initial.sql` — schema for `users`, `oidc_bindings`, `api_keys`, indexes.
+- `internal/storage/postgres/auth_migrations/embed.go` — goose `embed.FS` registration for the auth migrations.
+- `internal/storage/postgres/users_test.go` — integration tests using testcontainers.
+
+**Modify:**
+
+- `internal/storage/postgres/postgres.go` — add `(s *Store) Pool() *pgxpool.Pool` accessor (~5 lines).
+
+**No changes to:** existing `*Store` semantics or behavior; existing migrations directory; existing interceptor or auth resolver (those land in the Authn plan).
+
+---
+
+## Task 1: Define the `Kind` enum and `User` domain type
+
+**Files:**
+
+- Create: `internal/storage/users_domain.go`
+
+- [ ] **Step 1: Write the User type and Kind enum**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package storage
+
+import (
+	"time"
+)
+
+// Kind discriminates a User row as a Human (OIDC-backed person) or a
+// ServiceAccount (machine identity owned by a Human). The kind constrains
+// which credentials and ownership relationships are valid (see UsersBackend
+// invariants); it does NOT change lifecycle semantics — soft-delete behaves
+// identically for both kinds.
+type Kind string
+
+const (
+	KindHuman          Kind = "human"
+	KindServiceAccount Kind = "service_account"
+)
+
+// User is the identity row for a Human or ServiceAccount. Single table with
+// a Kind discriminator; lifecycle is uniform across kinds.
+//
+// Invariants enforced at the schema or store layer (see UsersBackend):
+//   - ServiceAccounts MUST have OwnerUserID set; Humans MUST NOT.
+//   - At most one User has Bootstrap=true AND DeletedAt=nil.
+//   - ServiceAccounts MUST NOT have rows in oidc_bindings (store-layer).
+type User struct {
+	ID           string     // uuid
+	Kind         Kind
+	DisplayName  string
+	Email        string     // nullable; empty when not set
+	Role         string     // role assignment; built-in or custom (validated against config)
+	OwnerUserID  string     // ServiceAccount owner; empty for Humans
+	Bootstrap    bool       // true for the system bootstrap admin
+	CreatedAt    time.Time
+	DeletedAt    *time.Time // nil = active
+}
+
+// IsHuman reports whether the user is a Human kind.
+func (u *User) IsHuman() bool { return u.Kind == KindHuman }
+
+// IsServiceAccount reports whether the user is a ServiceAccount kind.
+func (u *User) IsServiceAccount() bool { return u.Kind == KindServiceAccount }
+
+// IsActive reports whether the user has not been soft-deleted.
+func (u *User) IsActive() bool { return u.DeletedAt == nil }
+```
+
+- [ ] **Step 2: Verify the package compiles**
+
+Run: `cd internal/storage && go build ./...`
+Expected: no output (success).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/storage/users_domain.go
+git commit -s -m "feat(storage): add User domain type with Kind discriminator"
+```
+
+---
+
+## Task 2: Define `OIDCBinding` and `APIKey` domain types
+
+**Files:**
+
+- Modify: `internal/storage/users_domain.go`
+
+- [ ] **Step 1: Append the binding and key types**
+
+```go
+// OIDCBinding links a User to an external OIDC subject. The (Issuer, Subject)
+// pair is globally unique across providers to prevent same-sub collisions
+// between IdPs.
+type OIDCBinding struct {
+	ID          string
+	UserID      string
+	Issuer      string
+	Subject     string
+	EmailAtBind string // captured at JIT bind; nullable
+	CreatedAt   time.Time
+}
+
+// APIKey is an issued credential owned by a single User (Human or
+// ServiceAccount). Plaintext is never persisted; only the argon2id PHC
+// hash. The prefix is queryable for O(log N) lookup; the secret is
+// constant-time-verified against PHCHash.
+//
+// RoleDowngrade, when set, caps the EffectiveRole at request time to at most
+// the named role (subject to the partial-ordering rules in the design).
+type APIKey struct {
+	ID            string
+	UserID        string
+	Prefix        string
+	PHCHash       string     // argon2id PHC-format string
+	RoleDowngrade string     // empty = no downgrade
+	Label         string
+	ExpiresAt     *time.Time // nil = no expiry (used by bootstrap key)
+	LastUsedAt    *time.Time // nil = never used
+	RevokedAt     *time.Time // nil = active
+	CreatedAt     time.Time
+}
+
+// IsActive reports whether the key is neither revoked nor expired (as of now).
+func (k *APIKey) IsActive(now time.Time) bool {
+	if k.RevokedAt != nil {
+		return false
+	}
+	if k.ExpiresAt != nil && !k.ExpiresAt.After(now) {
+		return false
+	}
+	return true
+}
+```
+
+- [ ] **Step 2: Verify compile**
+
+Run: `cd internal/storage && go build ./...`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/storage/users_domain.go
+git commit -s -m "feat(storage): add OIDCBinding and APIKey domain types"
+```
+
+---
+
+## Task 3: Add domain-specific sentinel errors
+
+**Files:**
+
+- Modify: `internal/storage/users_domain.go`
+
+- [ ] **Step 1: Append sentinel errors**
+
+```go
+import (
+	"errors"
+	"time"
+)
+
+// Sentinel errors returned by UsersBackend. Callers use errors.Is to detect.
+var (
+	ErrUserNotFound        = errors.New("storage: user not found")
+	ErrAPIKeyNotFound      = errors.New("storage: api key not found")
+	ErrOIDCBindingNotFound = errors.New("storage: oidc binding not found")
+	ErrBootstrapExists     = errors.New("storage: bootstrap user already exists")
+	ErrAPIKeyPrefixExists  = errors.New("storage: api key prefix collision")
+)
+```
+
+> Note: the existing `internal/storage/errors.go` holds cross-domain errors. These are domain-specific to identity, so they live alongside the domain types per the project convention (see `internal/storage/decision.go` for the precedent — sentinel errors next to domain types).
+
+- [ ] **Step 2: Verify compile**
+
+Run: `cd internal/storage && go build ./...`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/storage/users_domain.go
+git commit -s -m "feat(storage): add sentinel errors for identity storage"
+```
+
+---
+
+## Task 4: Define `UsersBackend` interface
+
+**Files:**
+
+- Create: `internal/storage/users.go`
+
+- [ ] **Step 1: Write the interface**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+// Package storage defines storage backend interfaces. UsersBackend is the
+// identity-domain interface — global, not project-scoped, intentionally
+// distinct from ScopedBackend.
+package storage
+
+import (
+	"context"
+	"time"
+)
+
+// UsersBackend defines storage operations for the identity domain (users,
+// API keys, OIDC bindings). It is the canonical cross-domain seam for any
+// other domain that needs to ask identity questions (story #3, #4).
+//
+// Implementations MUST honor the invariants stated on User and the design
+// document (docs/plans/2026-05-22-identity-storage-design.md).
+type UsersBackend interface {
+	// --- resolve-path queries (hot) ---
+
+	// LookupAPIKeyByPrefix returns the key with the given prefix. Returns
+	// ErrAPIKeyNotFound on miss. Does not verify the secret; callers must.
+	LookupAPIKeyByPrefix(ctx context.Context, prefix string) (*APIKey, error)
+
+	// LookupOIDCBinding returns the binding for the (issuer, subject) pair.
+	// Returns ErrOIDCBindingNotFound on miss.
+	LookupOIDCBinding(ctx context.Context, issuer, subject string) (*OIDCBinding, error)
+
+	// GetUserByID returns the user with the given ID, including soft-deleted.
+	// Callers gate on User.IsActive() per their semantics. Returns
+	// ErrUserNotFound on miss.
+	GetUserByID(ctx context.Context, id string) (*User, error)
+
+	// GetBootstrap returns the active bootstrap user, or ErrUserNotFound if
+	// none exists. Used by bootstrap path to detect idempotency.
+	GetBootstrap(ctx context.Context) (*User, error)
+
+	// --- user CRUD ---
+
+	// CreateHuman inserts a Human row. The OIDCBinding is created in the
+	// same transaction; pass binding=nil for admin-created Humans (rare).
+	// Returns ErrBootstrapExists if u.Bootstrap is true AND a bootstrap
+	// already exists.
+	CreateHuman(ctx context.Context, u *User, binding *OIDCBinding) (*User, error)
+
+	// CreateServiceAccount inserts a ServiceAccount row. u.OwnerUserID
+	// must reference an existing active Human.
+	CreateServiceAccount(ctx context.Context, u *User) (*User, error)
+
+	// UpdateUserRole sets the role on an active user. Role validation
+	// against the YAML config is the caller's responsibility.
+	UpdateUserRole(ctx context.Context, userID, role string) error
+
+	// SoftDeleteUser sets deleted_at and revokes all active keys in one tx.
+	// Idempotent (re-deleting already-deleted user is a no-op).
+	SoftDeleteUser(ctx context.Context, userID string) error
+
+	// PurgeUser hard-deletes the user; cascades through bindings and keys.
+	PurgeUser(ctx context.Context, userID string) error
+
+	// ListUsers returns users matching the filter, optionally including
+	// soft-deleted rows. Pagination is offset/limit; impl may add cursor
+	// later.
+	ListUsers(ctx context.Context, filter ListUsersFilter) ([]*User, error)
+
+	// --- API key CRUD ---
+
+	// CreateAPIKey inserts a new key. Retries on prefix-uniqueness violation
+	// up to 3 times before returning ErrAPIKeyPrefixExists.
+	CreateAPIKey(ctx context.Context, k *APIKey) (*APIKey, error)
+
+	// RevokeAPIKey marks the key revoked. Idempotent on already-revoked keys.
+	RevokeAPIKey(ctx context.Context, keyID string) error
+
+	// RotateAPIKey revokes the old key and creates a new one with the same
+	// metadata (label, role_downgrade, expires_at) in one transaction.
+	// Returns the new key.
+	RotateAPIKey(ctx context.Context, oldKeyID string, newKey *APIKey) (*APIKey, error)
+
+	// ListAPIKeys returns keys for the given user; pass userID="" to list
+	// across all users (admin operation). Excludes revoked keys unless
+	// IncludeRevoked is set.
+	ListAPIKeys(ctx context.Context, filter ListAPIKeysFilter) ([]*APIKey, error)
+
+	// TouchLastUsed sets last_used_at = now() for the key. Fire-and-forget
+	// from caller's perspective; impl is fast and ignores errors silently
+	// (but returns them for tests).
+	TouchLastUsed(ctx context.Context, keyID string) error
+
+	// --- OIDC binding CRUD ---
+
+	// JITCreateHuman creates a Human + its OIDCBinding atomically. Used by
+	// the OIDC resolver when a binding lookup misses. On (issuer, subject)
+	// uniqueness violation, returns the existing user via a re-lookup
+	// (race-safe).
+	JITCreateHuman(ctx context.Context, u *User, binding *OIDCBinding) (*User, *OIDCBinding, error)
+
+	// ListOIDCBindings returns bindings for the given user.
+	ListOIDCBindings(ctx context.Context, userID string) ([]*OIDCBinding, error)
+
+	// UnbindOIDC removes the given binding. Last-credential protection is
+	// the caller's responsibility (handler-level policy, not storage).
+	UnbindOIDC(ctx context.Context, bindingID string) error
+}
+
+// ListUsersFilter narrows ListUsers results.
+type ListUsersFilter struct {
+	Kind            Kind   // empty = all kinds
+	Role            string // empty = all roles
+	IncludeDeleted  bool
+	CreatedAfter    *time.Time
+	Limit           int    // 0 = default 100
+	Offset          int
+}
+
+// ListAPIKeysFilter narrows ListAPIKeys results.
+type ListAPIKeysFilter struct {
+	UserID         string // empty = all users (admin)
+	IncludeRevoked bool
+	Limit          int
+	Offset         int
+}
+```
+
+- [ ] **Step 2: Verify compile**
+
+Run: `cd internal/storage && go build ./...`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/storage/users.go
+git commit -s -m "feat(storage): add UsersBackend interface"
+```
+
+---
+
+## Task 5: Add `Pool()` accessor on `*Store`
+
+**Files:**
+
+- Modify: `internal/storage/postgres/postgres.go`
+
+- [ ] **Step 1: Add the accessor**
+
+Locate the existing `*Store` type definition and add:
+
+```go
+// Pool returns the underlying pgxpool.Pool. Intended for the AuthStore
+// constructor to share the database connection without owning a second
+// pool. NOT a general-purpose escape hatch — code outside the auth and
+// project storage layers should never reach into the pool directly.
+func (s *Store) Pool() *pgxpool.Pool {
+	return s.pool
+}
+```
+
+> Cross-reference: see `internal/storage/postgres/postgres.go:30` (or wherever `*Store` is defined) for the existing struct that holds `pool *pgxpool.Pool`. The accessor is a 3-liner.
+
+- [ ] **Step 2: Verify compile**
+
+Run: `cd internal/storage/postgres && go build ./...`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/storage/postgres/postgres.go
+git commit -s -m "feat(postgres): expose pgxpool via Store.Pool() for AuthStore sharing"
+```
+
+---
+
+## Task 6: Author the initial auth migration
+
+Mirrors the existing `internal/storage/postgres/migrate.go` pattern: SQL files live in a sibling subdirectory (`auth_migrations/`) of the `postgres` package and are embedded by the `postgres` package itself via `//go:embed`. No separate subpackage. This matches how the existing `migrations/` directory is wired (see `migrate.go:17`).
+
+**Files:**
+
+- Create: `internal/storage/postgres/auth_migrations/001_initial.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 Sean Brandt
+
+-- +goose Up
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE users (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    kind            text NOT NULL CHECK (kind IN ('human','service_account')),
+    display_name    text NOT NULL CHECK (length(display_name) <= 255),
+    email           text NOT NULL DEFAULT '' CHECK (length(email) <= 320),
+    role            text NOT NULL CHECK (length(role) <= 64),
+    owner_user_id   uuid REFERENCES users(id),
+    bootstrap       boolean NOT NULL DEFAULT false,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    deleted_at      timestamptz,
+
+    CHECK (kind = 'service_account' OR owner_user_id IS NULL),
+    CHECK (kind = 'human'           OR owner_user_id IS NOT NULL)
+);
+
+CREATE UNIQUE INDEX users_one_bootstrap ON users(bootstrap)
+    WHERE bootstrap = true AND deleted_at IS NULL;
+
+CREATE TABLE oidc_bindings (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    issuer          text NOT NULL CHECK (length(issuer) <= 512),
+    subject         text NOT NULL CHECK (length(subject) <= 255),
+    email_at_bind   text NOT NULL DEFAULT '' CHECK (length(email_at_bind) <= 320),
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (issuer, subject)
+);
+
+CREATE TABLE api_keys (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    prefix          text NOT NULL UNIQUE CHECK (length(prefix) >= 8 AND length(prefix) <= 16),
+    phc_hash        text NOT NULL CHECK (length(phc_hash) >= 32 AND length(phc_hash) <= 256),
+    role_downgrade  text NOT NULL DEFAULT '' CHECK (length(role_downgrade) <= 64),
+    label           text NOT NULL DEFAULT '' CHECK (length(label) <= 128),
+    expires_at      timestamptz,
+    last_used_at    timestamptz,
+    revoked_at      timestamptz,
+    created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX api_keys_active ON api_keys(user_id)
+    WHERE revoked_at IS NULL;
+
+-- +goose Down
+
+DROP INDEX IF EXISTS api_keys_active;
+DROP TABLE IF EXISTS api_keys;
+DROP TABLE IF EXISTS oidc_bindings;
+DROP INDEX IF EXISTS users_one_bootstrap;
+DROP TABLE IF EXISTS users;
+```
+
+Length `CHECK`s pin the entropy floor for `prefix` (≥8 chars; the design's "blind-enumeration impractical" claim depends on this) and provide defense-in-depth caps against malicious or buggy callers shoving multi-MB strings into `subject`, `email`, etc. The `phc_hash` lower bound rejects obviously-corrupt entries; argon2id PHC strings are ~95–120 chars typically, leaving comfortable margin.
+
+- [ ] **Step 2: Verify the migration is well-formed**
+
+The SQL file embeds into the `postgres` package via `//go:embed` declared in `auth.go` (next task) — there is no separate `embed.go` needed (this is how the existing `migrate.go` does it too: see line 17 with `//go:embed migrations/*.sql`). No build step here yet; the SQL is exercised by the migration runner in Task 7 and the test harness in Task 8.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/storage/postgres/auth_migrations/
+git commit -s -m "feat(postgres): add identity storage migrations"
+```
+
+---
+
+## Task 7: Create `AuthStore` scaffold with `NewAuth` constructor
+
+**Files:**
+
+- Create: `internal/storage/postgres/auth.go`
+
+**Lifecycle contract pinned by this task:**
+
+- `postgres.New` owns the `*pgxpool.Pool`. `postgres.NewAuth` borrows it.
+- Caller (typically `cmd/specgraph/serve.go`) must close `*AuthStore` BEFORE closing `*Store`. `*AuthStore.Close()` is a no-op today, but the ordering rule lets future flush-on-shutdown work (e.g., draining a usagetracker queue) slot in without breaking shutdowns.
+- Both `New` and `NewAuth` use goose, which sets package-global state (`goose.SetBaseFS`, `goose.SetTableName`). **They MUST NOT be called concurrently.** The expected call order is `New(...)` first → its migrations run → returns → `NewAuth(store.Pool(), ...)` → its migrations run. This is the natural call chain in `serve.go`; the comment on `NewAuth` will spell it out so future contributors don't try to parallelize startup.
+- Clock override (`WithAuthClock`) affects only mutation timestamps that the Go code passes explicitly (e.g., `deleted_at` in `SoftDeleteUser`, `revoked_at` in `RevokeAPIKey`). Insert timestamps come from the SQL `DEFAULT now()` clause and bypass the override. Tests that need to fake time across the board should pin all timestamps from outside, or alternatively the impl can be refactored to pass `s.now()` everywhere (deferred follow-up).
+
+- [ ] **Step 1: Write the AuthStore type and constructor**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"embed"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/pressly/goose/v3"
+
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+//go:embed auth_migrations/*.sql
+var authMigrations embed.FS
+
+// Compile-time assertion that *AuthStore implements UsersBackend.
+// Mirrors the convention used by *Store for ConstitutionBackend etc.
+// Note: this assertion forces every UsersBackend method to exist on
+// *AuthStore. Stubs for every method are declared further down in this
+// file to satisfy the assertion; real implementations land in tasks 9–26
+// which replace the stubs one at a time.
+var _ storage.UsersBackend = (*AuthStore)(nil)
+
+// AuthStore is the Postgres implementation of UsersBackend. It is a sibling
+// to *Store: shares the database pool, holds no project scope, owns the
+// identity tables exclusively.
+//
+// Pool ownership: *Store owns the pool; *AuthStore borrows it. Callers
+// MUST close *AuthStore before *Store at shutdown. Today AuthStore.Close
+// is a no-op for the pool, but this ordering rule lets future flush-on-
+// shutdown work (usagetracker drain etc.) slot in cleanly.
+//
+// Migration safety: NewAuth runs auth migrations using a separate goose
+// version table (goose_db_version_auth) to avoid colliding with project
+// migrations. Goose mutates package-global state (BaseFS, TableName,
+// Dialect) so NewAuth and the existing postgres.New MUST NOT be called
+// concurrently. The expected pattern is sequential startup: New first,
+// then NewAuth, both single-threaded.
+type AuthStore struct {
+	pool    *pgxpool.Pool
+	nowFunc func() time.Time
+}
+
+// AuthOption configures an AuthStore.
+type AuthOption func(*AuthStore)
+
+// WithAuthClock overrides the wall clock used for explicit mutation
+// timestamps (deleted_at, revoked_at). Test-only. Does NOT affect insert
+// timestamps that come from SQL DEFAULT now().
+func WithAuthClock(fn func() time.Time) AuthOption {
+	return func(s *AuthStore) { s.nowFunc = fn }
+}
+
+// WithAuthKeyPrefixGenerator overrides the API-key prefix generator.
+// Test-only — used to force collision scenarios in CreateAPIKey tests.
+// Production code does not call WithAuthKeyPrefixGenerator.
+func WithAuthKeyPrefixGenerator(fn func() (string, error)) AuthOption {
+	return func(s *AuthStore) { s.genPrefix = fn }
+}
+
+// NewAuth constructs an AuthStore wrapping the given pool. The caller
+// retains ownership of the pool; AuthStore.Close is a no-op for the pool.
+// Auth migrations run inline using a dedicated goose version table.
+//
+// MUST be called after postgres.New and never concurrently with it
+// (goose uses package-global state). See type docstring.
+func NewAuth(ctx context.Context, pool *pgxpool.Pool, opts ...AuthOption) (*AuthStore, error) {
+	if pool == nil {
+		return nil, errors.New("postgres: NewAuth: pool must not be nil")
+	}
+	s := &AuthStore{
+		pool:      pool,
+		nowFunc:   time.Now,
+		genPrefix: defaultGenerateKeyPrefix,
+	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if err := s.runAuthMigrations(ctx); err != nil {
+		return nil, fmt.Errorf("postgres: auth migrations: %w", err)
+	}
+	return s, nil
+}
+
+// runAuthMigrations runs the embedded auth migrations using a dedicated
+// goose version table. Goose state is package-global; do not call
+// concurrently with the existing runMigrations from migrate.go.
+func (s *AuthStore) runAuthMigrations(ctx context.Context) error {
+	db := stdlib.OpenDBFromPool(s.pool)
+	// stdlib.OpenDBFromPool wraps the pool in a *sql.DB facade; closing
+	// the *sql.DB does NOT close the underlying pgxpool. Verified via pgx
+	// docs (jackc/pgx#1023) — pool ownership stays with the original
+	// caller.
+	defer func() { _ = db.Close() }()
+
+	goose.SetBaseFS(authMigrations)
+	if err := goose.SetDialect("postgres"); err != nil {
+		return fmt.Errorf("set dialect: %w", err)
+	}
+	goose.SetTableName("goose_db_version_auth")
+	defer goose.SetTableName("goose_db_version") // restore default for any subsequent caller
+
+	if err := goose.UpContext(ctx, db, "auth_migrations"); err != nil {
+		return fmt.Errorf("run auth migrations: %w", err)
+	}
+	return nil
+}
+
+// Close releases AuthStore resources. Today this is a no-op (the pool is
+// borrowed; no other resources held). Future flush-on-shutdown work
+// (usagetracker drain etc.) will hook here. Callers MUST call Close
+// before closing the underlying *Store.
+func (s *AuthStore) Close(_ context.Context) error {
+	return nil
+}
+
+// now returns the wall clock time used for explicit mutation timestamps.
+func (s *AuthStore) now() time.Time { return s.nowFunc() }
+```
+
+- [ ] **Step 2: Add all method stubs**
+
+The compile-time assertion `var _ storage.UsersBackend = (*AuthStore)(nil)` requires every interface method to exist on `*AuthStore`. Add all 17 stubs at the bottom of `auth.go` BEFORE running the compile in Step 3:
+
+```go
+// --- UsersBackend method stubs ---
+// These satisfy the compile-time assertion above; real implementations land
+// in tasks 9–26, which replace each stub with a SQL-backed method one at a
+// time. Stubs return errors.New("not implemented") so that accidental use
+// in tests fails loudly with a recognizable message rather than returning
+// a zero value.
+
+func (s *AuthStore) LookupAPIKeyByPrefix(ctx context.Context, prefix string) (*storage.APIKey, error) {
+	return nil, errors.New("LookupAPIKeyByPrefix not implemented")
+}
+
+func (s *AuthStore) LookupOIDCBinding(ctx context.Context, issuer, subject string) (*storage.OIDCBinding, error) {
+	return nil, errors.New("LookupOIDCBinding not implemented")
+}
+
+func (s *AuthStore) GetUserByID(ctx context.Context, id string) (*storage.User, error) {
+	return nil, errors.New("GetUserByID not implemented")
+}
+
+func (s *AuthStore) GetBootstrap(ctx context.Context) (*storage.User, error) {
+	return nil, errors.New("GetBootstrap not implemented")
+}
+
+func (s *AuthStore) CreateHuman(ctx context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, error) {
+	return nil, errors.New("CreateHuman not implemented")
+}
+
+func (s *AuthStore) CreateServiceAccount(ctx context.Context, u *storage.User) (*storage.User, error) {
+	return nil, errors.New("CreateServiceAccount not implemented")
+}
+
+func (s *AuthStore) UpdateUserRole(ctx context.Context, userID, role string) error {
+	return errors.New("UpdateUserRole not implemented")
+}
+
+func (s *AuthStore) SoftDeleteUser(ctx context.Context, userID string) error {
+	return errors.New("SoftDeleteUser not implemented")
+}
+
+func (s *AuthStore) PurgeUser(ctx context.Context, userID string) error {
+	return errors.New("PurgeUser not implemented")
+}
+
+func (s *AuthStore) ListUsers(ctx context.Context, f storage.ListUsersFilter) ([]*storage.User, error) {
+	return nil, errors.New("ListUsers not implemented")
+}
+
+func (s *AuthStore) CreateAPIKey(ctx context.Context, k *storage.APIKey) (*storage.APIKey, error) {
+	return nil, errors.New("CreateAPIKey not implemented")
+}
+
+func (s *AuthStore) RevokeAPIKey(ctx context.Context, keyID string) error {
+	return errors.New("RevokeAPIKey not implemented")
+}
+
+func (s *AuthStore) RotateAPIKey(ctx context.Context, oldKeyID string, newKey *storage.APIKey) (*storage.APIKey, error) {
+	return nil, errors.New("RotateAPIKey not implemented")
+}
+
+func (s *AuthStore) ListAPIKeys(ctx context.Context, f storage.ListAPIKeysFilter) ([]*storage.APIKey, error) {
+	return nil, errors.New("ListAPIKeys not implemented")
+}
+
+func (s *AuthStore) TouchLastUsed(ctx context.Context, keyID string) error {
+	return errors.New("TouchLastUsed not implemented")
+}
+
+func (s *AuthStore) JITCreateHuman(ctx context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error) {
+	return nil, nil, errors.New("JITCreateHuman not implemented")
+}
+
+func (s *AuthStore) ListOIDCBindings(ctx context.Context, userID string) ([]*storage.OIDCBinding, error) {
+	return nil, errors.New("ListOIDCBindings not implemented")
+}
+
+func (s *AuthStore) UnbindOIDC(ctx context.Context, bindingID string) error {
+	return errors.New("UnbindOIDC not implemented")
+}
+```
+
+Also add the prefix-generator default at the bottom (used by `CreateAPIKey` in Task 19):
+
+```go
+// defaultGenerateKeyPrefix produces 8 random URL-safe base32 characters.
+// Overridable via WithAuthKeyPrefixGenerator. Per-instance (not package-
+// global) so parallel tests do not race.
+func defaultGenerateKeyPrefix() (string, error) {
+	const prefixLen = 8
+	buf := make([]byte, 5) // 5 bytes -> 8 base32 chars
+	if _, err := cryptorand.Read(buf); err != nil {
+		return "", err
+	}
+	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(buf)[:prefixLen], nil
+}
+```
+
+Imports to add at this step: `cryptorand "crypto/rand"`, `"encoding/base32"`.
+
+Add a `genPrefix` field to the `AuthStore` struct definition (initialized in `NewAuth`):
+
+```go
+type AuthStore struct {
+	pool      *pgxpool.Pool
+	nowFunc   func() time.Time
+	genPrefix func() (string, error)
+}
+```
+
+- [ ] **Step 3: Verify compile**
+
+Run: `cd internal/storage/postgres && go build ./...`
+Expected: success. The compile-time assertion is satisfied by the stubs.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/storage/postgres/auth.go internal/storage/postgres/auth_migrations/
+git commit -s -m "feat(postgres): add AuthStore scaffold with goose migration runner"
+```
+
+---
+
+## Task 8: Wire testcontainers harness for AuthStore
+
+**Files:**
+
+- Create: `internal/storage/postgres/auth_helpers_test.go`
+- Create: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (the harness produces a working AuthStore against a fresh DB).
+
+**Important — build tag:** existing tests in this package (`postgres_test.go`, `constitution_test.go`, etc.) are gated with `//go:build integration` so they only run under `task test:integration` (testcontainers requires Docker). Both new files in this task MUST carry the same tag, or they will fail to compile under `go test` (no `connString`) AND silently skip the testcontainer.
+
+- [ ] **Step 1: Write the helpers file**
+
+```go
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/storage/postgres"
+)
+
+// sharedTestPool returns a fresh pgxpool against the testcontainers Postgres
+// started in postgres_test.go's TestMain. The pool is closed via t.Cleanup;
+// callers do not need to manage lifecycle.
+//
+// Each call opens a new pool. This is the same pattern clearDatabase uses
+// (see postgres_test.go:108). The container is shared; the pools are not.
+func sharedTestPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+	pool, err := pgxpool.New(ctx, connString)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// authTestSetup constructs an AuthStore against the test container's
+// Postgres. It uses sharedTestPool internally and registers AuthStore.Close
+// via t.Cleanup. The returned store has the auth migrations applied.
+func authTestSetup(t *testing.T) *postgres.AuthStore {
+	t.Helper()
+	ctx := context.Background()
+	pool := sharedTestPool(t, ctx)
+
+	auth, err := postgres.NewAuth(ctx, pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = auth.Close(ctx) })
+
+	return auth
+}
+
+// truncateAuthTables wipes identity tables between tests. FK CASCADE on
+// oidc_bindings.user_id and api_keys.user_id handles cleanup of child rows.
+func truncateAuthTables(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := pool.Exec(ctx, `TRUNCATE users RESTART IDENTITY CASCADE`)
+	require.NoError(t, err)
+}
+```
+
+- [ ] **Step 2: Write the test file with the migration smoke test**
+
+```go
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/storage/postgres"
+)
+
+// TestAuthStore_NewAuth_RunsMigrations asserts the constructor brings the
+// schema up.
+func TestAuthStore_NewAuth_RunsMigrations(t *testing.T) {
+	ctx := context.Background()
+	pool := sharedTestPool(t, ctx)
+	auth, err := postgres.NewAuth(ctx, pool)
+	require.NoError(t, err)
+	defer auth.Close(ctx)
+
+	// Tables exist?
+	var exists bool
+	row := pool.QueryRow(ctx, `SELECT EXISTS (
+		SELECT 1 FROM information_schema.tables
+		WHERE table_name = 'users')`)
+	require.NoError(t, row.Scan(&exists))
+	require.True(t, exists, "users table should exist after migrations")
+}
+```
+
+- [ ] **Step 3: Run the test**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_NewAuth_RunsMigrations -v`
+Expected: PASS (Docker required — the testcontainer comes up via the existing `TestMain` in `postgres_test.go`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/storage/postgres/auth_helpers_test.go internal/storage/postgres/users_test.go
+git commit -s -m "test(postgres): add AuthStore test harness sharing the existing testcontainer"
+```
+
+---
+
+## Task 9: Implement `LookupAPIKeyByPrefix` (resolve-path)
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go` (create file on first method)
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (lookup by known prefix) + Boundary (unknown prefix returns `ErrAPIKeyNotFound`).
+
+> **Cross-spec boundary:** this method does NOT verify the PHC hash — that's the resolver's job in the Authn plan. A corrupted `phc_hash` value (e.g., the column was tampered with) surfaces during `argon2id.Verify` at the Authn layer, which maps it to `ErrUnauthenticated`. Storage's contract is: "return the row as stored." Length CHECKs on `phc_hash` (Task 6) reject obvious truncation at write time; mid-string corruption is the verifier's concern.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `users_test.go`:
+
+```go
+func TestAuthStore_LookupAPIKeyByPrefix(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// Seed: a Human + one APIKey via direct SQL (CRUD methods come later).
+	_, err := pool.Exec(ctx, `
+		INSERT INTO users (id, kind, display_name, role, bootstrap)
+		VALUES ('00000000-0000-0000-0000-000000000001'::uuid,
+		        'human', 'alice', 'reader', false)`)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO api_keys (id, user_id, prefix, phc_hash, label)
+		VALUES ('00000000-0000-0000-0000-000000000002'::uuid,
+		        '00000000-0000-0000-0000-000000000001'::uuid,
+		        'abc12345', 'phc-stub', 'test-key')`)
+	require.NoError(t, err)
+
+	key, err := auth.LookupAPIKeyByPrefix(ctx, "abc12345")
+	require.NoError(t, err)
+	require.Equal(t, "abc12345", key.Prefix)
+	require.Equal(t, "00000000-0000-0000-0000-000000000001", key.UserID)
+	require.Equal(t, "test-key", key.Label)
+
+	// Miss returns ErrAPIKeyNotFound.
+	_, err = auth.LookupAPIKeyByPrefix(ctx, "no-such-prefix")
+	require.ErrorIs(t, err, storage.ErrAPIKeyNotFound)
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_LookupAPIKeyByPrefix -v`
+Expected: FAIL with `"not implemented"` (the stub).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/storage/postgres/users.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package postgres
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// LookupAPIKeyByPrefix returns the api_keys row whose prefix matches.
+func (s *AuthStore) LookupAPIKeyByPrefix(ctx context.Context, prefix string) (*storage.APIKey, error) {
+	const q = `
+		SELECT id, user_id, prefix, phc_hash, role_downgrade, label,
+		       expires_at, last_used_at, revoked_at, created_at
+		FROM api_keys
+		WHERE prefix = $1`
+	row := s.pool.QueryRow(ctx, q, prefix)
+
+	var k storage.APIKey
+	err := row.Scan(
+		&k.ID, &k.UserID, &k.Prefix, &k.PHCHash, &k.RoleDowngrade, &k.Label,
+		&k.ExpiresAt, &k.LastUsedAt, &k.RevokedAt, &k.CreatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, storage.ErrAPIKeyNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &k, nil
+}
+```
+
+Remove the stub for `LookupAPIKeyByPrefix` from `auth.go`.
+
+- [ ] **Step 4: Run the test**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_LookupAPIKeyByPrefix -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement LookupAPIKeyByPrefix"
+```
+
+---
+
+## Task 10: Implement `LookupOIDCBinding` (resolve-path)
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (lookup by known issuer+subject) + Boundary (unknown returns `ErrOIDCBindingNotFound`).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestAuthStore_LookupOIDCBinding(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	_, err := pool.Exec(ctx, `
+		INSERT INTO users (id, kind, display_name, role)
+		VALUES ('00000000-0000-0000-0000-000000000001'::uuid,
+		        'human', 'alice', 'reader')`)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO oidc_bindings (id, user_id, issuer, subject)
+		VALUES ('00000000-0000-0000-0000-000000000003'::uuid,
+		        '00000000-0000-0000-0000-000000000001'::uuid,
+		        'https://login.microsoftonline.com/tenant/v2.0',
+		        'sub-12345')`)
+	require.NoError(t, err)
+
+	b, err := auth.LookupOIDCBinding(ctx, "https://login.microsoftonline.com/tenant/v2.0", "sub-12345")
+	require.NoError(t, err)
+	require.Equal(t, "00000000-0000-0000-0000-000000000001", b.UserID)
+
+	_, err = auth.LookupOIDCBinding(ctx, "https://github.com", "sub-12345")
+	require.ErrorIs(t, err, storage.ErrOIDCBindingNotFound)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_LookupOIDCBinding -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Append to `users.go`:
+
+```go
+// LookupOIDCBinding returns the binding for (issuer, subject).
+func (s *AuthStore) LookupOIDCBinding(ctx context.Context, issuer, subject string) (*storage.OIDCBinding, error) {
+	const q = `
+		SELECT id, user_id, issuer, subject, email_at_bind, created_at
+		FROM oidc_bindings
+		WHERE issuer = $1 AND subject = $2`
+	row := s.pool.QueryRow(ctx, q, issuer, subject)
+
+	var b storage.OIDCBinding
+	err := row.Scan(&b.ID, &b.UserID, &b.Issuer, &b.Subject, &b.EmailAtBind, &b.CreatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, storage.ErrOIDCBindingNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &b, nil
+}
+```
+
+Remove the stub from `auth.go`.
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_LookupOIDCBinding -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement LookupOIDCBinding"
+```
+
+---
+
+## Task 11: Implement `GetUserByID` (resolve-path)
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (active user) + Boundary (NotFound) + Invariant (soft-deleted users are returned with `DeletedAt` set so callers can gate; the data shape never hides a deleted row).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestAuthStore_GetUserByID(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	_, err := pool.Exec(ctx, `
+		INSERT INTO users (id, kind, display_name, email, role, bootstrap, created_at, deleted_at)
+		VALUES ('00000000-0000-0000-0000-000000000001'::uuid,
+		        'human', 'alice', 'alice@example.com', 'reader',
+		        false, $1, NULL),
+		       ('00000000-0000-0000-0000-000000000002'::uuid,
+		        'human', 'bob', '', 'writer', false, $1, $2)`,
+		now, now.Add(time.Hour))
+	require.NoError(t, err)
+
+	// Active user.
+	u, err := auth.GetUserByID(ctx, "00000000-0000-0000-0000-000000000001")
+	require.NoError(t, err)
+	require.Equal(t, "alice", u.DisplayName)
+	require.True(t, u.IsActive())
+
+	// Soft-deleted user — still returned (caller gates).
+	u, err = auth.GetUserByID(ctx, "00000000-0000-0000-0000-000000000002")
+	require.NoError(t, err)
+	require.False(t, u.IsActive())
+	require.NotNil(t, u.DeletedAt)
+
+	// Miss.
+	_, err = auth.GetUserByID(ctx, "00000000-0000-0000-0000-aaaaaaaaaaaa")
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+
+	// ServiceAccount round-trip: owner_user_id is populated, scan handles
+	// the nullable-FK column via coalesce. Seed via direct SQL (Task 14
+	// implements CreateServiceAccount; this test verifies the read path
+	// independently).
+	_, err = pool.Exec(ctx, `
+		INSERT INTO users (id, kind, display_name, role, owner_user_id)
+		VALUES ('00000000-0000-0000-0000-000000000003'::uuid,
+		        'service_account', 'ci-bot', 'writer',
+		        '00000000-0000-0000-0000-000000000001'::uuid)`)
+	require.NoError(t, err)
+	sa, err := auth.GetUserByID(ctx, "00000000-0000-0000-0000-000000000003")
+	require.NoError(t, err)
+	require.True(t, sa.IsServiceAccount())
+	require.Equal(t, "00000000-0000-0000-0000-000000000001", sa.OwnerUserID)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_GetUserByID -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// GetUserByID returns the user row (including soft-deleted).
+func (s *AuthStore) GetUserByID(ctx context.Context, id string) (*storage.User, error) {
+	const q = `
+		SELECT id, kind, display_name, email, role,
+		       coalesce(owner_user_id::text, ''), bootstrap,
+		       created_at, deleted_at
+		FROM users
+		WHERE id = $1::uuid`
+	row := s.pool.QueryRow(ctx, q, id)
+
+	var u storage.User
+	var kindStr string
+	err := row.Scan(
+		&u.ID, &kindStr, &u.DisplayName, &u.Email, &u.Role,
+		&u.OwnerUserID, &u.Bootstrap, &u.CreatedAt, &u.DeletedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, storage.ErrUserNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	u.Kind = storage.Kind(kindStr)
+	return &u, nil
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_GetUserByID -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement GetUserByID"
+```
+
+---
+
+## Task 12: Implement `GetBootstrap`
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (existing bootstrap returned) + Boundary (no bootstrap returns `ErrUserNotFound`).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestAuthStore_GetBootstrap(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// No bootstrap yet.
+	_, err := auth.GetBootstrap(ctx)
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+
+	// Insert active bootstrap.
+	_, err = pool.Exec(ctx, `
+		INSERT INTO users (id, kind, display_name, role, bootstrap)
+		VALUES ('00000000-0000-0000-0000-000000000001'::uuid,
+		        'human', 'admin', 'admin', true)`)
+	require.NoError(t, err)
+
+	u, err := auth.GetBootstrap(ctx)
+	require.NoError(t, err)
+	require.True(t, u.Bootstrap)
+	require.Equal(t, "admin", u.DisplayName)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_GetBootstrap -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// GetBootstrap returns the active bootstrap admin, or ErrUserNotFound.
+func (s *AuthStore) GetBootstrap(ctx context.Context) (*storage.User, error) {
+	const q = `
+		SELECT id, kind, display_name, email, role,
+		       coalesce(owner_user_id::text, ''), bootstrap,
+		       created_at, deleted_at
+		FROM users
+		WHERE bootstrap = true AND deleted_at IS NULL
+		LIMIT 1`
+	row := s.pool.QueryRow(ctx, q)
+
+	var u storage.User
+	var kindStr string
+	err := row.Scan(
+		&u.ID, &kindStr, &u.DisplayName, &u.Email, &u.Role,
+		&u.OwnerUserID, &u.Bootstrap, &u.CreatedAt, &u.DeletedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, storage.ErrUserNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	u.Kind = storage.Kind(kindStr)
+	return &u, nil
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_GetBootstrap -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement GetBootstrap"
+```
+
+---
+
+## Task 13: Implement `CreateHuman` (transactional with optional binding)
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (insert Human; insert Human+binding atomically) + Invariant (bootstrap uniqueness — second bootstrap insert returns `ErrBootstrapExists`; concurrent verification is in Task 27).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestAuthStore_CreateHuman(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u := &storage.User{
+		Kind:        storage.KindHuman,
+		DisplayName: "alice",
+		Email:       "alice@example.com",
+		Role:        "reader",
+	}
+	created, err := auth.CreateHuman(ctx, u, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, created.ID)
+	require.Equal(t, "alice", created.DisplayName)
+	require.True(t, created.IsHuman())
+	require.True(t, created.IsActive())
+
+	// With binding atomically.
+	u2 := &storage.User{Kind: storage.KindHuman, DisplayName: "bob", Role: "reader"}
+	b := &storage.OIDCBinding{
+		Issuer: "https://login.microsoftonline.com/t/v2.0", Subject: "sub-bob",
+		EmailAtBind: "bob@example.com",
+	}
+	created2, err := auth.CreateHuman(ctx, u2, b)
+	require.NoError(t, err)
+
+	// Verify the binding via direct SQL — ListOIDCBindings is implemented
+	// later in Task 25, so we don't depend on it here.
+	var bindingCount int
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM oidc_bindings
+		WHERE user_id = $1::uuid AND subject = 'sub-bob'`, created2.ID).
+		Scan(&bindingCount))
+	require.Equal(t, 1, bindingCount)
+
+	// Bootstrap dedup: first bootstrap insert succeeds.
+	boot := &storage.User{Kind: storage.KindHuman, DisplayName: "admin", Role: "admin", Bootstrap: true}
+	_, err = auth.CreateHuman(ctx, boot, nil)
+	require.NoError(t, err)
+	// Second bootstrap insert fails.
+	boot2 := &storage.User{Kind: storage.KindHuman, DisplayName: "admin", Role: "admin", Bootstrap: true}
+	_, err = auth.CreateHuman(ctx, boot2, nil)
+	require.ErrorIs(t, err, storage.ErrBootstrapExists)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_CreateHuman -v`
+Expected: FAIL with `"not implemented"`.
+
+- [ ] **Step 3: Implement**
+
+Append to `internal/storage/postgres/users.go`:
+
+```go
+import (
+	"github.com/jackc/pgx/v5/pgconn" // for PgError code matching
+)
+
+// CreateHuman inserts a Human row and (optionally) an OIDCBinding in one tx.
+// Returns ErrBootstrapExists if u.Bootstrap is true and another active
+// bootstrap user already exists (caught via the partial unique index).
+func (s *AuthStore) CreateHuman(ctx context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, error) {
+	if u.Kind != "" && u.Kind != storage.KindHuman {
+		return nil, errors.New("CreateHuman: u.Kind must be KindHuman or empty")
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	const insertUser = `
+		INSERT INTO users (kind, display_name, email, role, bootstrap)
+		VALUES ('human', $1, $2, $3, $4)
+		RETURNING id, created_at`
+	var id string
+	var createdAt time.Time
+	err = tx.QueryRow(ctx, insertUser, u.DisplayName, u.Email, u.Role, u.Bootstrap).
+		Scan(&id, &createdAt)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" /* unique_violation */ &&
+			pgErr.ConstraintName == "users_one_bootstrap" {
+			return nil, storage.ErrBootstrapExists
+		}
+		return nil, fmt.Errorf("insert user: %w", err)
+	}
+
+	if b != nil {
+		const insertBinding = `
+			INSERT INTO oidc_bindings (user_id, issuer, subject, email_at_bind)
+			VALUES ($1::uuid, $2, $3, $4)`
+		_, err = tx.Exec(ctx, insertBinding, id, b.Issuer, b.Subject, b.EmailAtBind)
+		if err != nil {
+			return nil, fmt.Errorf("insert binding: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	u.ID = id
+	u.Kind = storage.KindHuman
+	u.CreatedAt = createdAt
+	return u, nil
+}
+```
+
+Remove `CreateHuman` stub from `auth.go`.
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_CreateHuman -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement CreateHuman with transactional binding"
+```
+
+---
+
+## Task 14: Implement `CreateServiceAccount`
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (SA inserted with owner) + Invariant (FK enforcement — missing/empty owner is rejected before the FK violation; FK is the schema-level backstop).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestAuthStore_CreateServiceAccount(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// Owner first.
+	owner, err := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "owner", Role: "admin",
+	}, nil)
+	require.NoError(t, err)
+
+	sa, err := auth.CreateServiceAccount(ctx, &storage.User{
+		Kind: storage.KindServiceAccount, DisplayName: "ci-bot",
+		Role: "writer", OwnerUserID: owner.ID,
+	})
+	require.NoError(t, err)
+	require.True(t, sa.IsServiceAccount())
+	require.Equal(t, owner.ID, sa.OwnerUserID)
+
+	// Missing owner rejected.
+	_, err = auth.CreateServiceAccount(ctx, &storage.User{
+		Kind: storage.KindServiceAccount, DisplayName: "no-owner", Role: "writer",
+	})
+	require.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_CreateServiceAccount -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// CreateServiceAccount inserts a ServiceAccount row. OwnerUserID must
+// reference an existing user (FK enforced).
+func (s *AuthStore) CreateServiceAccount(ctx context.Context, u *storage.User) (*storage.User, error) {
+	if u.OwnerUserID == "" {
+		return nil, errors.New("CreateServiceAccount: OwnerUserID required")
+	}
+	const q = `
+		INSERT INTO users (kind, display_name, email, role, owner_user_id)
+		VALUES ('service_account', $1, $2, $3, $4::uuid)
+		RETURNING id, created_at`
+	var id string
+	var createdAt time.Time
+	err := s.pool.QueryRow(ctx, q, u.DisplayName, u.Email, u.Role, u.OwnerUserID).
+		Scan(&id, &createdAt)
+	if err != nil {
+		return nil, fmt.Errorf("insert service account: %w", err)
+	}
+	u.ID = id
+	u.Kind = storage.KindServiceAccount
+	u.CreatedAt = createdAt
+	return u, nil
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_CreateServiceAccount -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement CreateServiceAccount"
+```
+
+---
+
+## Task 15: Implement `UpdateUserRole`
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (role changes for active user) + Boundary (NotFound for unknown ID; NotFound for soft-deleted user — write-blocked, not silent).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestAuthStore_UpdateUserRole(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, err := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "reader",
+	}, nil)
+	require.NoError(t, err)
+
+	err = auth.UpdateUserRole(ctx, u.ID, "writer")
+	require.NoError(t, err)
+
+	reloaded, err := auth.GetUserByID(ctx, u.ID)
+	require.NoError(t, err)
+	require.Equal(t, "writer", reloaded.Role)
+
+	// Soft-deleted user is not updateable. Set deleted_at via direct SQL
+	// rather than calling SoftDeleteUser (Task 16) to avoid a forward
+	// reference; soft-delete cascade semantics are exercised in Task 16's
+	// own test.
+	_, err = pool.Exec(ctx, `UPDATE users SET deleted_at = now() WHERE id = $1::uuid`, u.ID)
+	require.NoError(t, err)
+	err = auth.UpdateUserRole(ctx, u.ID, "admin")
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+
+	// Nonexistent.
+	err = auth.UpdateUserRole(ctx, "00000000-0000-0000-0000-aaaaaaaaaaaa", "reader")
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_UpdateUserRole -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// UpdateUserRole sets the role on an active user. Returns ErrUserNotFound
+// if no active user has the given ID.
+func (s *AuthStore) UpdateUserRole(ctx context.Context, userID, role string) error {
+	const q = `
+		UPDATE users SET role = $1
+		WHERE id = $2::uuid AND deleted_at IS NULL`
+	tag, err := s.pool.Exec(ctx, q, role, userID)
+	if err != nil {
+		return fmt.Errorf("update role: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return storage.ErrUserNotFound
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_UpdateUserRole -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement UpdateUserRole"
+```
+
+---
+
+## Task 16: Implement `SoftDeleteUser` (transactional cascade)
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (deleted_at set; keys revoked) + Invariant (cascade is atomic — both UPDATEs in one tx; same `now()` timestamp) + Invariant (OIDC bindings persist after soft-delete) + Boundary (re-deleting already-deleted is a no-op).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestAuthStore_SoftDeleteUser(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, err := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "reader",
+	}, &storage.OIDCBinding{Issuer: "iss1", Subject: "sub1"})
+	require.NoError(t, err)
+
+	// Seed two API keys directly.
+	_, err = pool.Exec(ctx, `
+		INSERT INTO api_keys (user_id, prefix, phc_hash, label)
+		VALUES ($1::uuid, 'pre00001', 'phc1', 'k1'),
+		       ($1::uuid, 'pre00002', 'phc2', 'k2')`, u.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, auth.SoftDeleteUser(ctx, u.ID))
+
+	// User deleted_at set.
+	reloaded, err := auth.GetUserByID(ctx, u.ID)
+	require.NoError(t, err)
+	require.False(t, reloaded.IsActive())
+
+	// Both keys revoked in the same tx (same revoked_at timestamp).
+	var count int
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM api_keys
+		WHERE user_id = $1::uuid AND revoked_at IS NOT NULL`, u.ID).Scan(&count))
+	require.Equal(t, 2, count)
+
+	// Bindings rows remain (they're history).
+	var bindingCount int
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM oidc_bindings WHERE user_id = $1::uuid`, u.ID).Scan(&bindingCount))
+	require.Equal(t, 1, bindingCount)
+
+	// Idempotent: re-deleting is a no-op.
+	require.NoError(t, auth.SoftDeleteUser(ctx, u.ID))
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_SoftDeleteUser -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// SoftDeleteUser sets deleted_at on the user and revokes all their active
+// keys in the same transaction. Idempotent on already-deleted users (the
+// user UPDATE matches zero rows, the keys UPDATE matches zero rows; both
+// silently succeed).
+func (s *AuthStore) SoftDeleteUser(ctx context.Context, userID string) error {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	now := s.now()
+
+	_, err = tx.Exec(ctx, `
+		UPDATE users SET deleted_at = $1
+		WHERE id = $2::uuid AND deleted_at IS NULL`, now, userID)
+	if err != nil {
+		return fmt.Errorf("soft-delete user: %w", err)
+	}
+
+	_, err = tx.Exec(ctx, `
+		UPDATE api_keys SET revoked_at = $1
+		WHERE user_id = $2::uuid AND revoked_at IS NULL`, now, userID)
+	if err != nil {
+		return fmt.Errorf("revoke keys: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_SoftDeleteUser -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement SoftDeleteUser with key revocation cascade"
+```
+
+---
+
+## Task 17: Implement `PurgeUser` (hard delete)
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (user row gone) + Invariant (CASCADE deletes bindings AND keys; complement to Task 16's "bindings persist on soft-delete") + Boundary (idempotent on already-purged).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestAuthStore_PurgeUser(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, err := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "reader",
+	}, &storage.OIDCBinding{Issuer: "iss1", Subject: "sub1"})
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO api_keys (user_id, prefix, phc_hash, label)
+		VALUES ($1::uuid, 'pre00003', 'phc3', 'k')`, u.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, auth.PurgeUser(ctx, u.ID))
+
+	// User gone.
+	_, err = auth.GetUserByID(ctx, u.ID)
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+
+	// Cascaded keys + bindings gone.
+	var n int
+	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM api_keys WHERE user_id = $1::uuid`, u.ID).Scan(&n))
+	require.Equal(t, 0, n)
+	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM oidc_bindings WHERE user_id = $1::uuid`, u.ID).Scan(&n))
+	require.Equal(t, 0, n)
+
+	// Idempotent.
+	require.NoError(t, auth.PurgeUser(ctx, u.ID))
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_PurgeUser -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// PurgeUser hard-deletes the user; CASCADE constraints handle bindings
+// and keys. Idempotent on already-purged users.
+func (s *AuthStore) PurgeUser(ctx context.Context, userID string) error {
+	_, err := s.pool.Exec(ctx, `DELETE FROM users WHERE id = $1::uuid`, userID)
+	if err != nil {
+		return fmt.Errorf("purge user: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_PurgeUser -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement PurgeUser"
+```
+
+---
+
+## Task 18: Implement `ListUsers` (filter + pagination)
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (unfiltered list of non-deleted) + Boundary (Kind / Role / IncludeDeleted filter combinations; default-limit pinning is verified in Task 31).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestAuthStore_ListUsers(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// Three humans, one service account.
+	owner, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "h1", Role: "admin"}, nil)
+	_, _ = auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "h2", Role: "reader"}, nil)
+	deleted, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "h3", Role: "writer"}, nil)
+	require.NoError(t, auth.SoftDeleteUser(ctx, deleted.ID))
+	_, _ = auth.CreateServiceAccount(ctx, &storage.User{Kind: storage.KindServiceAccount, DisplayName: "sa1", Role: "writer", OwnerUserID: owner.ID})
+
+	all, err := auth.ListUsers(ctx, storage.ListUsersFilter{})
+	require.NoError(t, err)
+	require.Len(t, all, 3) // excludes deleted by default
+
+	withDeleted, err := auth.ListUsers(ctx, storage.ListUsersFilter{IncludeDeleted: true})
+	require.NoError(t, err)
+	require.Len(t, withDeleted, 4)
+
+	humansOnly, err := auth.ListUsers(ctx, storage.ListUsersFilter{Kind: storage.KindHuman})
+	require.NoError(t, err)
+	require.Len(t, humansOnly, 2) // h3 deleted, sa1 excluded
+
+	readers, err := auth.ListUsers(ctx, storage.ListUsersFilter{Role: "reader"})
+	require.NoError(t, err)
+	require.Len(t, readers, 1)
+	require.Equal(t, "h2", readers[0].DisplayName)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_ListUsers -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// ListUsers returns users matching the filter. Default limit is 100.
+func (s *AuthStore) ListUsers(ctx context.Context, f storage.ListUsersFilter) ([]*storage.User, error) {
+	q := `
+		SELECT id, kind, display_name, email, role,
+		       coalesce(owner_user_id::text, ''), bootstrap,
+		       created_at, deleted_at
+		FROM users WHERE 1=1`
+	args := []any{}
+	if !f.IncludeDeleted {
+		q += ` AND deleted_at IS NULL`
+	}
+	if f.Kind != "" {
+		args = append(args, string(f.Kind))
+		q += fmt.Sprintf(` AND kind = $%d`, len(args))
+	}
+	if f.Role != "" {
+		args = append(args, f.Role)
+		q += fmt.Sprintf(` AND role = $%d`, len(args))
+	}
+	if f.CreatedAfter != nil {
+		args = append(args, *f.CreatedAfter)
+		q += fmt.Sprintf(` AND created_at > $%d`, len(args))
+	}
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	args = append(args, limit, f.Offset)
+	q += fmt.Sprintf(` ORDER BY created_at DESC LIMIT $%d OFFSET $%d`, len(args)-1, len(args))
+
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list users: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*storage.User
+	for rows.Next() {
+		var u storage.User
+		var kindStr string
+		err := rows.Scan(&u.ID, &kindStr, &u.DisplayName, &u.Email, &u.Role,
+			&u.OwnerUserID, &u.Bootstrap, &u.CreatedAt, &u.DeletedAt)
+		if err != nil {
+			return nil, err
+		}
+		u.Kind = storage.Kind(kindStr)
+		out = append(out, &u)
+	}
+	return out, rows.Err()
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_ListUsers -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement ListUsers with filter and pagination"
+```
+
+---
+
+## Task 19: Implement `CreateAPIKey` with prefix-collision retry
+
+**Decision pinned (called out in design):** the impl owns prefix generation. Callers pass an APIKey without `Prefix` set; the impl generates 8 random base32 chars and retries up to 3 times on collision.
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (key inserted; prefix populated; metadata round-trips) + Invariant (FK to users enforced — though this is tested implicitly via the schema; the collision retry is a Boundary covered in Task 19b).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestAuthStore_CreateAPIKey(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, _ := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "writer",
+	}, nil)
+
+	k, err := auth.CreateAPIKey(ctx, &storage.APIKey{
+		UserID: u.ID, PHCHash: "phc-stub", Label: "first key",
+	})
+	require.NoError(t, err)
+	require.Len(t, k.Prefix, 8)
+	require.NotEmpty(t, k.ID)
+	require.Equal(t, "first key", k.Label)
+}
+```
+
+> A separate test forces a collision via a stubbed prefix generator; that test lands in Task 19b below as a sub-step.
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_CreateAPIKey -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+The prefix generator and `genPrefix` field are already declared in `auth.go` from Task 7. Add the `CreateAPIKey` method to `users.go` consuming the per-instance generator:
+
+```go
+// CreateAPIKey inserts a new API key with a generated prefix. Retries up to
+// 3 times on prefix-uniqueness violation; returns ErrAPIKeyPrefixExists if
+// all retries collide (essentially impossible at 40 bits of entropy).
+//
+// The plaintext prefix and secret are NOT taken from the caller; the
+// caller passes only metadata (UserID, PHCHash, RoleDowngrade, Label,
+// ExpiresAt). Prefix is generated via s.genPrefix (overridable per-
+// instance via WithAuthKeyPrefixGenerator for tests; never package-global).
+func (s *AuthStore) CreateAPIKey(ctx context.Context, k *storage.APIKey) (*storage.APIKey, error) {
+	if k.UserID == "" {
+		return nil, errors.New("CreateAPIKey: UserID required")
+	}
+	if k.PHCHash == "" {
+		return nil, errors.New("CreateAPIKey: PHCHash required")
+	}
+	for attempt := 0; attempt < 3; attempt++ {
+		prefix, err := s.genPrefix()
+		if err != nil {
+			return nil, fmt.Errorf("generate prefix: %w", err)
+		}
+		const q = `
+			INSERT INTO api_keys (user_id, prefix, phc_hash, role_downgrade, label, expires_at)
+			VALUES ($1::uuid, $2, $3, $4, $5, $6)
+			RETURNING id, created_at`
+		var id string
+		var createdAt time.Time
+		err = s.pool.QueryRow(ctx, q, k.UserID, prefix, k.PHCHash, k.RoleDowngrade, k.Label, k.ExpiresAt).
+			Scan(&id, &createdAt)
+		if err == nil {
+			k.ID = id
+			k.Prefix = prefix
+			k.CreatedAt = createdAt
+			return k, nil
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "api_keys_prefix_key" {
+			continue // retry with new prefix
+		}
+		return nil, fmt.Errorf("insert api key: %w", err)
+	}
+	return nil, storage.ErrAPIKeyPrefixExists
+}
+```
+
+No new imports beyond what `users.go` already has (`context`, `errors`, `fmt`, `time`, `pgx`, `pgconn`, `storage`).
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_CreateAPIKey -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement CreateAPIKey with prefix-collision retry"
+```
+
+---
+
+## Task 19b: Prefix-collision retry test
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Boundary (collision retry succeeds within attempts; retry exhaustion returns `ErrAPIKeyPrefixExists`).
+
+- [ ] **Step 1: Write the collision test**
+
+The test uses `WithAuthKeyPrefixGenerator` (declared in Task 7) to inject a deterministic generator into a per-test AuthStore. This keeps test isolation: no package-global mutation, safe under `t.Parallel()`.
+
+```go
+func TestAuthStore_CreateAPIKey_CollisionRetry(t *testing.T) {
+	ctx := context.Background()
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// Build a dedicated AuthStore with a stubbed prefix generator.
+	calls := 0
+	gen := func() (string, error) {
+		calls++
+		if calls <= 2 {
+			return "collide1", nil
+		}
+		return "newpre23", nil
+	}
+	auth, err := postgres.NewAuth(ctx, pool, postgres.WithAuthKeyPrefixGenerator(gen))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = auth.Close(ctx) })
+
+	u, _ := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "writer",
+	}, nil)
+
+	// Seed a key with the prefix the generator will collide against.
+	_, err = pool.Exec(ctx, `INSERT INTO api_keys (user_id, prefix, phc_hash)
+	                         VALUES ($1::uuid, 'collide1', 'phc-seed-string-padding-to-meet-length-check')`, u.ID)
+	require.NoError(t, err)
+
+	k, err := auth.CreateAPIKey(ctx, &storage.APIKey{UserID: u.ID, PHCHash: "phc-stub-string-padding-to-meet-length-check"})
+	require.NoError(t, err)
+	require.Equal(t, "newpre23", k.Prefix)
+	require.GreaterOrEqual(t, calls, 3)
+
+	// Exhaustion: a generator that always returns the same colliding prefix.
+	authExhaust, err := postgres.NewAuth(ctx, pool, postgres.WithAuthKeyPrefixGenerator(
+		func() (string, error) { return "collide1", nil }))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = authExhaust.Close(ctx) })
+	_, err = authExhaust.CreateAPIKey(ctx, &storage.APIKey{UserID: u.ID, PHCHash: "phc-stub-string-padding-to-meet-length-check"})
+	require.ErrorIs(t, err, storage.ErrAPIKeyPrefixExists)
+}
+```
+
+> Note: PHC strings are padded to meet the schema's `length(phc_hash) >= 32` CHECK from Task 6. In real use, argon2id PHC strings are ~95+ chars and trivially satisfy this.
+
+- [ ] **Step 2: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_CreateAPIKey_CollisionRetry -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/storage/postgres/users_test.go
+git commit -s -m "test(postgres): exercise CreateAPIKey prefix-collision retry path"
+```
+
+---
+
+## Task 20: Implement `RevokeAPIKey`
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (revoked_at set) + Boundary (idempotent on already-revoked; silent on nonexistent ID).
+
+> **Deliberate asymmetry with `RotateAPIKey`:** Revoke is fire-and-forget on a nonexistent ID — no error. Rotate (Task 21) returns `ErrAPIKeyNotFound` on the same condition because rotation has a load-bearing existence requirement: you can't "rotate" a key that doesn't exist into a new one that does. The two methods are intentionally inconsistent in this one respect.
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestAuthStore_RevokeAPIKey(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, _ := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "writer",
+	}, nil)
+	k, _ := auth.CreateAPIKey(ctx, &storage.APIKey{UserID: u.ID, PHCHash: "phc"})
+
+	require.NoError(t, auth.RevokeAPIKey(ctx, k.ID))
+
+	reloaded, err := auth.LookupAPIKeyByPrefix(ctx, k.Prefix)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded.RevokedAt)
+	require.False(t, reloaded.IsActive(time.Now()))
+
+	// Idempotent on already-revoked.
+	require.NoError(t, auth.RevokeAPIKey(ctx, k.ID))
+
+	// Nonexistent ID is also a no-op (no error).
+	require.NoError(t, auth.RevokeAPIKey(ctx, "00000000-0000-0000-0000-aaaaaaaaaaaa"))
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_RevokeAPIKey -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// RevokeAPIKey marks the key revoked. Idempotent on already-revoked or
+// nonexistent IDs (does not error).
+func (s *AuthStore) RevokeAPIKey(ctx context.Context, keyID string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE api_keys SET revoked_at = $1
+		WHERE id = $2::uuid AND revoked_at IS NULL`, s.now(), keyID)
+	if err != nil {
+		return fmt.Errorf("revoke key: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_RevokeAPIKey -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement RevokeAPIKey"
+```
+
+---
+
+## Task 21: Implement `RotateAPIKey` (atomic revoke + create)
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (old revoked AND new active after rotate) + Invariant (atomic single-tx; rollback path leaves old key live with no new row — verified by injecting a forced rollback case, not just happy-path commits).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestAuthStore_RotateAPIKey(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, _ := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "writer",
+	}, nil)
+	old, _ := auth.CreateAPIKey(ctx, &storage.APIKey{
+		UserID: u.ID, PHCHash: "phc-old", Label: "ci-bot",
+	})
+
+	newKey, err := auth.RotateAPIKey(ctx, old.ID, &storage.APIKey{
+		UserID: u.ID, PHCHash: "phc-new", Label: "ci-bot",
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, old.Prefix, newKey.Prefix)
+	require.Equal(t, "ci-bot", newKey.Label)
+
+	// Old key is revoked, new key is active.
+	oldReload, _ := auth.LookupAPIKeyByPrefix(ctx, old.Prefix)
+	require.NotNil(t, oldReload.RevokedAt)
+	newReload, _ := auth.LookupAPIKeyByPrefix(ctx, newKey.Prefix)
+	require.Nil(t, newReload.RevokedAt)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_RotateAPIKey -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// RotateAPIKey revokes the old key and inserts a new one with the supplied
+// metadata in one transaction. Returns the new key with generated prefix
+// and ID populated.
+func (s *AuthStore) RotateAPIKey(ctx context.Context, oldKeyID string, newKey *storage.APIKey) (*storage.APIKey, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	tag, err := tx.Exec(ctx, `
+		UPDATE api_keys SET revoked_at = $1
+		WHERE id = $2::uuid AND revoked_at IS NULL`, s.now(), oldKeyID)
+	if err != nil {
+		return nil, fmt.Errorf("revoke old key: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return nil, storage.ErrAPIKeyNotFound
+	}
+
+	// Insert new key inside the same tx with collision retry.
+	for attempt := 0; attempt < 3; attempt++ {
+		prefix, err := s.genPrefix()
+		if err != nil {
+			return nil, fmt.Errorf("generate prefix: %w", err)
+		}
+		var id string
+		var createdAt time.Time
+		err = tx.QueryRow(ctx, `
+			INSERT INTO api_keys (user_id, prefix, phc_hash, role_downgrade, label, expires_at)
+			VALUES ($1::uuid, $2, $3, $4, $5, $6)
+			RETURNING id, created_at`,
+			newKey.UserID, prefix, newKey.PHCHash, newKey.RoleDowngrade,
+			newKey.Label, newKey.ExpiresAt).Scan(&id, &createdAt)
+		if err == nil {
+			newKey.ID = id
+			newKey.Prefix = prefix
+			newKey.CreatedAt = createdAt
+			if err := tx.Commit(ctx); err != nil {
+				return nil, err
+			}
+			return newKey, nil
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "api_keys_prefix_key" {
+			continue
+		}
+		return nil, fmt.Errorf("insert new key: %w", err)
+	}
+	return nil, storage.ErrAPIKeyPrefixExists
+}
+```
+
+- [ ] **Step 4: Add a forced-rollback test**
+
+The Invariant tag says "rollback path leaves old key live with no new row." Verify it concretely by forcing the new-insert to fail. The forcing mechanism is a `WithAuthKeyPrefixGenerator` that returns an empty string, which violates the schema's `CHECK (length(prefix) >= 8)` from Task 6 — that failure rolls back the entire tx including the old-key revoke.
+
+**Note for readers:** this test exercises the `23514 check_violation` branch (the CHECK constraint failure), NOT the `23505 unique_violation` retry loop. The impl falls through to `return nil, fmt.Errorf("insert new key: %w", err)` on the first attempt because the error isn't a unique-violation. A separate test (Step 5) exercises the unique-violation retry path.
+
+```go
+func TestAuthStore_RotateAPIKey_RollbackOnInsertFailure(t *testing.T) {
+	ctx := context.Background()
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	auth := authTestSetup(t)
+	u, _ := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "writer",
+	}, nil)
+	old, _ := auth.CreateAPIKey(ctx, &storage.APIKey{
+		UserID: u.ID, PHCHash: "phc-old-padding-to-meet-min-length-check",
+	})
+
+	// Build a SECOND store with a bad generator — returns empty string
+	// which violates the prefix length CHECK constraint (23514), forcing
+	// the INSERT to fail on the FIRST attempt (not via the 23505 retry
+	// loop) and rolling back the entire tx including the revoke of `old`.
+	badAuth, err := postgres.NewAuth(ctx, pool, postgres.WithAuthKeyPrefixGenerator(
+		func() (string, error) { return "", nil }))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = badAuth.Close(ctx) })
+
+	_, err = badAuth.RotateAPIKey(ctx, old.ID, &storage.APIKey{
+		UserID: u.ID, PHCHash: "phc-new-padding-to-meet-min-length-check",
+	})
+	require.Error(t, err)
+
+	// Old key MUST still be live (rollback worked) and no new row exists.
+	oldReload, _ := auth.LookupAPIKeyByPrefix(ctx, old.Prefix)
+	require.Nil(t, oldReload.RevokedAt, "old key must still be live after rollback")
+	var keyCount int
+	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM api_keys WHERE user_id = $1::uuid`, u.ID).Scan(&keyCount))
+	require.Equal(t, 1, keyCount, "only old key exists; no orphan from failed insert")
+}
+```
+
+- [ ] **Step 5: Add a unique-violation retry-loop test**
+
+The previous test (Step 4) hits a CHECK violation, which bypasses the retry loop. This test exercises the retry path directly: the generator returns a colliding prefix twice (each insert fails with `23505 unique_violation` and is retried), then a fresh prefix that succeeds.
+
+```go
+func TestAuthStore_RotateAPIKey_PrefixCollisionRetry(t *testing.T) {
+	ctx := context.Background()
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	auth := authTestSetup(t)
+	u, _ := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "writer",
+	}, nil)
+	old, _ := auth.CreateAPIKey(ctx, &storage.APIKey{
+		UserID: u.ID, PHCHash: "phc-old-padding-to-meet-min-length-check",
+	})
+
+	// Seed a separate user with a key whose prefix the rotate generator
+	// will collide against. Using a different user keeps the test focused
+	// on the rotate path (not on the user's own key inventory).
+	other, _ := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "bob", Role: "writer",
+	}, nil)
+	_, err := pool.Exec(ctx, `
+		INSERT INTO api_keys (user_id, prefix, phc_hash)
+		VALUES ($1::uuid, 'collidex', 'phc-bob-padding-to-meet-min-length-check')`, other.ID)
+	require.NoError(t, err)
+
+	// Generator returns the colliding prefix twice (triggers 23505 +
+	// retry both times), then a fresh prefix on attempt 3.
+	calls := 0
+	gen := func() (string, error) {
+		calls++
+		if calls <= 2 {
+			return "collidex", nil
+		}
+		return "rotated2", nil
+	}
+	rotateAuth, err := postgres.NewAuth(ctx, pool, postgres.WithAuthKeyPrefixGenerator(gen))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rotateAuth.Close(ctx) })
+
+	newKey, err := rotateAuth.RotateAPIKey(ctx, old.ID, &storage.APIKey{
+		UserID: u.ID, PHCHash: "phc-rot-padding-to-meet-min-length-check",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "rotated2", newKey.Prefix)
+	require.GreaterOrEqual(t, calls, 3, "retry loop should have invoked the generator at least 3 times")
+
+	// Old key is revoked, new key is active — same invariant as the happy
+	// path, but the path through the retry loop is now exercised.
+	oldReload, _ := auth.LookupAPIKeyByPrefix(ctx, old.Prefix)
+	require.NotNil(t, oldReload.RevokedAt)
+	newReload, _ := auth.LookupAPIKeyByPrefix(ctx, newKey.Prefix)
+	require.Nil(t, newReload.RevokedAt)
+}
+```
+
+- [ ] **Step 6: Run all rotate tests**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_RotateAPIKey -v`
+Expected: PASS for all three tests (happy path, rollback on CHECK violation, retry on prefix collision).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement RotateAPIKey atomically with rollback + retry tests"
+```
+
+---
+
+## Task 22: Implement `ListAPIKeys`
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (per-user list; admin all-user list) + Boundary (IncludeRevoked toggle; revoked keys excluded by default).
+
+> **Footgun acknowledged:** `ListAPIKeysFilter{UserID: ""}` lists across all users. A caller who forgets to set `UserID` accidentally reads every user's keys. This is admin functionality — callers reaching the storage layer with an empty `UserID` are deliberately doing an admin op, and authz gating is the handler/Cedar plan's responsibility. Document in the interface comment (Task 4 already states "empty = all users (admin)"); if a future story wants stricter type safety, introduce a sentinel like `AllUsers = "*"`. Out of scope for this story.
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestAuthStore_ListAPIKeys(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u1, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "alice", Role: "writer"}, nil)
+	u2, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "bob", Role: "writer"}, nil)
+
+	k1, _ := auth.CreateAPIKey(ctx, &storage.APIKey{UserID: u1.ID, PHCHash: "phc1", Label: "k1"})
+	_, _ = auth.CreateAPIKey(ctx, &storage.APIKey{UserID: u1.ID, PHCHash: "phc2", Label: "k2"})
+	_, _ = auth.CreateAPIKey(ctx, &storage.APIKey{UserID: u2.ID, PHCHash: "phc3", Label: "k3"})
+	require.NoError(t, auth.RevokeAPIKey(ctx, k1.ID))
+
+	// Per-user, excluding revoked by default.
+	keys, err := auth.ListAPIKeys(ctx, storage.ListAPIKeysFilter{UserID: u1.ID})
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Equal(t, "k2", keys[0].Label)
+
+	// IncludeRevoked.
+	keys, err = auth.ListAPIKeys(ctx, storage.ListAPIKeysFilter{UserID: u1.ID, IncludeRevoked: true})
+	require.NoError(t, err)
+	require.Len(t, keys, 2)
+
+	// All users (admin).
+	all, err := auth.ListAPIKeys(ctx, storage.ListAPIKeysFilter{})
+	require.NoError(t, err)
+	require.Len(t, all, 2) // k1 revoked excluded, k2 and k3 remain
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_ListAPIKeys -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// ListAPIKeys returns keys matching the filter.
+func (s *AuthStore) ListAPIKeys(ctx context.Context, f storage.ListAPIKeysFilter) ([]*storage.APIKey, error) {
+	q := `
+		SELECT id, user_id, prefix, phc_hash, role_downgrade, label,
+		       expires_at, last_used_at, revoked_at, created_at
+		FROM api_keys WHERE 1=1`
+	args := []any{}
+	if f.UserID != "" {
+		args = append(args, f.UserID)
+		q += fmt.Sprintf(` AND user_id = $%d::uuid`, len(args))
+	}
+	if !f.IncludeRevoked {
+		q += ` AND revoked_at IS NULL`
+	}
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	args = append(args, limit, f.Offset)
+	q += fmt.Sprintf(` ORDER BY created_at DESC LIMIT $%d OFFSET $%d`, len(args)-1, len(args))
+
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list api keys: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*storage.APIKey
+	for rows.Next() {
+		var k storage.APIKey
+		if err := rows.Scan(&k.ID, &k.UserID, &k.Prefix, &k.PHCHash, &k.RoleDowngrade,
+			&k.Label, &k.ExpiresAt, &k.LastUsedAt, &k.RevokedAt, &k.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, &k)
+	}
+	return out, rows.Err()
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_ListAPIKeys -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement ListAPIKeys with filter and pagination"
+```
+
+---
+
+## Task 23: Implement `TouchLastUsed`
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (last_used_at populated) + Boundary (silent on nonexistent key — fire-and-forget contract).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestAuthStore_TouchLastUsed(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "alice", Role: "writer"}, nil)
+	k, _ := auth.CreateAPIKey(ctx, &storage.APIKey{UserID: u.ID, PHCHash: "phc"})
+
+	require.Nil(t, k.LastUsedAt)
+	require.NoError(t, auth.TouchLastUsed(ctx, k.ID))
+
+	reloaded, _ := auth.LookupAPIKeyByPrefix(ctx, k.Prefix)
+	require.NotNil(t, reloaded.LastUsedAt)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_TouchLastUsed -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// TouchLastUsed sets last_used_at = now() for the key. Nonexistent or
+// already-revoked IDs are silent no-ops (fire-and-forget semantics).
+// Excluding revoked keys prevents audit-log confusion when a key is
+// revoked between a successful verify and the async last-used update.
+func (s *AuthStore) TouchLastUsed(ctx context.Context, keyID string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE api_keys SET last_used_at = $1
+		WHERE id = $2::uuid AND revoked_at IS NULL`, s.now(), keyID)
+	if err != nil {
+		return fmt.Errorf("touch last_used_at: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_TouchLastUsed -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement TouchLastUsed"
+```
+
+---
+
+## Task 24: Implement `JITCreateHuman` (race-safe)
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (atomic user + binding creation) + Invariant (single-tx atomicity; second JIT with same (issuer, subject) returns the existing user via race recovery, doesn't create a duplicate; concurrent verification in Task 28).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestAuthStore_JITCreateHuman(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u := &storage.User{Kind: storage.KindHuman, DisplayName: "alice", Email: "alice@x.com", Role: "reader"}
+	b := &storage.OIDCBinding{Issuer: "iss1", Subject: "alice-sub", EmailAtBind: "alice@x.com"}
+
+	user, binding, err := auth.JITCreateHuman(ctx, u, b)
+	require.NoError(t, err)
+	require.NotEmpty(t, user.ID)
+	require.NotEmpty(t, binding.ID)
+	require.Equal(t, user.ID, binding.UserID)
+
+	// Second JIT for same (issuer, subject) returns the existing user.
+	user2, binding2, err := auth.JITCreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "alice-dup", Role: "reader"}, b)
+	require.NoError(t, err)
+	require.Equal(t, user.ID, user2.ID)
+	require.Equal(t, binding.ID, binding2.ID)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_JITCreateHuman -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// JITCreateHuman creates a Human + OIDC binding atomically. If the (issuer,
+// subject) already exists (race with another JIT), re-reads and returns the
+// winning binding's user.
+//
+// Race recovery semantics: when a concurrent JIT wins the (issuer, subject)
+// uniqueness contest, this caller's INSERT receives a 23505. Postgres
+// guarantees the winner has already COMMITTED before the loser's INSERT can
+// observe the constraint violation (the winner's tx held a row lock until
+// commit, after which the loser's insert attempt resolves to "duplicate
+// key"). At READ COMMITTED isolation, the loser's subsequent SELECT for
+// the binding will see the committed row. No retry loop is needed.
+func (s *AuthStore) JITCreateHuman(ctx context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	var userID string
+	var createdAt time.Time
+	err = tx.QueryRow(ctx, `
+		INSERT INTO users (kind, display_name, email, role)
+		VALUES ('human', $1, $2, $3)
+		RETURNING id, created_at`,
+		u.DisplayName, u.Email, u.Role).Scan(&userID, &createdAt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("insert user (jit): %w", err)
+	}
+
+	var bindingID string
+	var bindingCreatedAt time.Time
+	err = tx.QueryRow(ctx, `
+		INSERT INTO oidc_bindings (user_id, issuer, subject, email_at_bind)
+		VALUES ($1::uuid, $2, $3, $4)
+		RETURNING id, created_at`,
+		userID, b.Issuer, b.Subject, b.EmailAtBind).Scan(&bindingID, &bindingCreatedAt)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" &&
+			pgErr.ConstraintName == "oidc_bindings_issuer_subject_key" {
+			// Race: another JIT won. Rollback, re-read.
+			_ = tx.Rollback(ctx)
+			existing, lookupErr := s.LookupOIDCBinding(ctx, b.Issuer, b.Subject)
+			if lookupErr != nil {
+				return nil, nil, fmt.Errorf("race recovery: %w", lookupErr)
+			}
+			existingUser, lookupErr := s.GetUserByID(ctx, existing.UserID)
+			if lookupErr != nil {
+				return nil, nil, fmt.Errorf("race recovery user: %w", lookupErr)
+			}
+			return existingUser, existing, nil
+		}
+		return nil, nil, fmt.Errorf("insert binding (jit): %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, nil, err
+	}
+
+	u.ID = userID
+	u.Kind = storage.KindHuman
+	u.CreatedAt = createdAt
+	b.ID = bindingID
+	b.UserID = userID
+	b.CreatedAt = bindingCreatedAt
+	return u, b, nil
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_JITCreateHuman -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement JITCreateHuman race-safely"
+```
+
+---
+
+## Task 25: Implement `ListOIDCBindings`
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (per-user bindings; multiple-provider case) + Boundary (empty slice for unbound user, not nil; an empty result is not an error).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestAuthStore_ListOIDCBindings(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "alice", Role: "reader"},
+		&storage.OIDCBinding{Issuer: "entra", Subject: "alice-entra"})
+	// Add a second binding (different provider).
+	_, _ = pool.Exec(ctx, `INSERT INTO oidc_bindings (user_id, issuer, subject)
+	                      VALUES ($1::uuid, 'github', 'alice-gh')`, u.ID)
+
+	bindings, err := auth.ListOIDCBindings(ctx, u.ID)
+	require.NoError(t, err)
+	require.Len(t, bindings, 2)
+
+	// Empty list for unbound user.
+	other, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "bob", Role: "reader"}, nil)
+	bindings, err = auth.ListOIDCBindings(ctx, other.ID)
+	require.NoError(t, err)
+	require.Empty(t, bindings)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_ListOIDCBindings -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// ListOIDCBindings returns bindings for the given user.
+func (s *AuthStore) ListOIDCBindings(ctx context.Context, userID string) ([]*storage.OIDCBinding, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, user_id, issuer, subject, email_at_bind, created_at
+		FROM oidc_bindings
+		WHERE user_id = $1::uuid
+		ORDER BY created_at`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list bindings: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*storage.OIDCBinding
+	for rows.Next() {
+		var b storage.OIDCBinding
+		if err := rows.Scan(&b.ID, &b.UserID, &b.Issuer, &b.Subject, &b.EmailAtBind, &b.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, &b)
+	}
+	return out, rows.Err()
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_ListOIDCBindings -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement ListOIDCBindings"
+```
+
+---
+
+## Task 26: Implement `UnbindOIDC`
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Happy (binding deleted) + Boundary (idempotent on already-deleted ID). Note: last-credential protection (refuse if user has no other creds) lives at the handler layer per the design; storage layer doesn't enforce.
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestAuthStore_UnbindOIDC(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "alice", Role: "reader"},
+		&storage.OIDCBinding{Issuer: "entra", Subject: "alice-entra"})
+	bindings, _ := auth.ListOIDCBindings(ctx, u.ID)
+	require.Len(t, bindings, 1)
+
+	require.NoError(t, auth.UnbindOIDC(ctx, bindings[0].ID))
+
+	after, _ := auth.ListOIDCBindings(ctx, u.ID)
+	require.Empty(t, after)
+
+	// Idempotent.
+	require.NoError(t, auth.UnbindOIDC(ctx, bindings[0].ID))
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_UnbindOIDC -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// UnbindOIDC deletes the binding. Idempotent on already-deleted.
+func (s *AuthStore) UnbindOIDC(ctx context.Context, bindingID string) error {
+	_, err := s.pool.Exec(ctx, `DELETE FROM oidc_bindings WHERE id = $1::uuid`, bindingID)
+	if err != nil {
+		return fmt.Errorf("unbind oidc: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_UnbindOIDC -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/storage/postgres/auth.go
+git commit -s -m "feat(postgres): implement UnbindOIDC"
+```
+
+---
+
+## Task 27: Concurrent bootstrap-uniqueness race test
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Invariant (at most one active bootstrap regardless of concurrent CreateHuman calls — the partial unique index from Task 6 is the schema-level enforcement; this test verifies the runtime error mapping in Task 13 correctly surfaces it).
+
+- [ ] **Step 1: Write the race test**
+
+```go
+func TestAuthStore_BootstrapRace(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	const concurrent = 5
+	var g errgroup.Group
+	results := make(chan error, concurrent)
+	for i := 0; i < concurrent; i++ {
+		g.Go(func() error {
+			_, err := auth.CreateHuman(ctx, &storage.User{
+				Kind: storage.KindHuman, DisplayName: "admin",
+				Role: "admin", Bootstrap: true,
+			}, nil)
+			results <- err
+			return nil
+		})
+	}
+	require.NoError(t, g.Wait())
+	close(results)
+
+	var successes, expectsBootstrapExists int
+	for err := range results {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, storage.ErrBootstrapExists):
+			expectsBootstrapExists++
+		default:
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	require.Equal(t, 1, successes, "exactly one bootstrap insert should succeed")
+	require.Equal(t, concurrent-1, expectsBootstrapExists)
+}
+```
+
+Imports: `"golang.org/x/sync/errgroup"`.
+
+- [ ] **Step 2: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_BootstrapRace -v`
+Expected: PASS (the partial unique index from Task 6 + the error mapping in Task 13 do the work).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/storage/postgres/users_test.go
+git commit -s -m "test(postgres): cover concurrent bootstrap-uniqueness race"
+```
+
+---
+
+## Task 28: Concurrent JIT race test
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Invariant ((issuer, subject) globally unique — concurrent JITs converge to the same user and binding row, never duplicate rows).
+
+- [ ] **Step 1: Write the JIT race test**
+
+```go
+func TestAuthStore_JITRace(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	const concurrent = 5
+	type result struct {
+		userID    string
+		bindingID string
+	}
+	results := make(chan result, concurrent)
+
+	var g errgroup.Group
+	for i := 0; i < concurrent; i++ {
+		g.Go(func() error {
+			u, b, err := auth.JITCreateHuman(ctx,
+				&storage.User{Kind: storage.KindHuman, DisplayName: "alice", Role: "reader"},
+				&storage.OIDCBinding{Issuer: "iss1", Subject: "alice-sub"})
+			if err != nil {
+				return err
+			}
+			results <- result{userID: u.ID, bindingID: b.ID}
+			return nil
+		})
+	}
+	require.NoError(t, g.Wait())
+	close(results)
+
+	userIDs := map[string]struct{}{}
+	bindingIDs := map[string]struct{}{}
+	for r := range results {
+		userIDs[r.userID] = struct{}{}
+		bindingIDs[r.bindingID] = struct{}{}
+	}
+	require.Len(t, userIDs, 1, "all callers should resolve to the same user")
+	require.Len(t, bindingIDs, 1, "all callers should resolve to the same binding")
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_JITRace -v`
+Expected: PASS (race-recovery code in Task 24 handles all but one caller).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/storage/postgres/users_test.go
+git commit -s -m "test(postgres): cover concurrent JIT race-recovery path"
+```
+
+---
+
+## Task 29: Final integration — full lifecycle smoke test
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** E2E / integration (multi-method flow through bootstrap → JIT → key → rotate → promote → soft-delete-bootstrap; asserts final state is coherent across all entities).
+
+- [ ] **Step 1: Write the lifecycle test**
+
+```go
+func TestAuthStore_FullLifecycle(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// Bootstrap admin.
+	admin, err := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "admin", Role: "admin", Bootstrap: true,
+	}, nil)
+	require.NoError(t, err)
+
+	got, err := auth.GetBootstrap(ctx)
+	require.NoError(t, err)
+	require.Equal(t, admin.ID, got.ID)
+
+	// JIT a real person via OIDC.
+	person, binding, err := auth.JITCreateHuman(ctx,
+		&storage.User{Kind: storage.KindHuman, DisplayName: "alice", Email: "alice@x.com", Role: "reader"},
+		&storage.OIDCBinding{Issuer: "entra", Subject: "alice-sub", EmailAtBind: "alice@x.com"})
+	require.NoError(t, err)
+
+	// Mint an API key.
+	key, err := auth.CreateAPIKey(ctx, &storage.APIKey{UserID: person.ID, PHCHash: "phc", Label: "personal"})
+	require.NoError(t, err)
+
+	// Rotate it.
+	newKey, err := auth.RotateAPIKey(ctx, key.ID, &storage.APIKey{UserID: person.ID, PHCHash: "phc-rot", Label: "personal"})
+	require.NoError(t, err)
+	require.NotEqual(t, key.Prefix, newKey.Prefix)
+
+	// Promote alice via UpdateUserRole.
+	require.NoError(t, auth.UpdateUserRole(ctx, person.ID, "admin"))
+
+	// Soft-delete bootstrap admin (force-flag policy enforced at handler layer, not here).
+	require.NoError(t, auth.SoftDeleteUser(ctx, admin.ID))
+
+	// GetBootstrap now empty.
+	_, err = auth.GetBootstrap(ctx)
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+
+	// Final state: alice is admin with one active key, one binding.
+	reloaded, _ := auth.GetUserByID(ctx, person.ID)
+	require.Equal(t, "admin", reloaded.Role)
+	keys, _ := auth.ListAPIKeys(ctx, storage.ListAPIKeysFilter{UserID: person.ID})
+	require.Len(t, keys, 1)
+	bindings, _ := auth.ListOIDCBindings(ctx, person.ID)
+	require.Len(t, bindings, 1)
+	require.Equal(t, binding.ID, bindings[0].ID)
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_FullLifecycle -v`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `cd internal/storage/postgres && go test -tags integration -v ./...`
+Expected: all auth tests PASS; existing project-storage tests unaffected.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/storage/postgres/users_test.go
+git commit -s -m "test(postgres): full identity lifecycle smoke test"
+```
+
+---
+
+## Task 30: Invariant sweep — ServiceAccount has no OIDC bindings
+
+The design says "ServiceAccounts MUST NOT have rows in `oidc_bindings`. Enforced at the store layer." `CreateHuman` (Task 13) already rejects `Kind=ServiceAccount` callers via the existing `if u.Kind != "" && u.Kind != storage.KindHuman` check. `JITCreateHuman` (Task 24) does NOT — it silently coerces the kind to `'human'` via the SQL literal. This task closes that gap.
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Invariant (Service Accounts cannot have OIDC bindings; both Human creation paths actively refuse a ServiceAccount kind rather than silently coerce).
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestAuthStore_ServiceAccountNoBindingInvariant(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// CreateHuman already rejects Kind=ServiceAccount (per Task 13's
+	// existing check). Verify that property survived.
+	_, err := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindServiceAccount, DisplayName: "wrong", Role: "writer",
+	}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "KindHuman")
+
+	// JITCreateHuman with Kind=ServiceAccount currently silently coerces
+	// to 'human' via the SQL literal — must instead refuse explicitly.
+	_, _, err = auth.JITCreateHuman(ctx,
+		&storage.User{Kind: storage.KindServiceAccount, DisplayName: "wrong", Role: "reader"},
+		&storage.OIDCBinding{Issuer: "iss", Subject: "sub"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "KindHuman")
+
+	// Defense in depth: no rows created by either failed call.
+	var n int
+	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM users WHERE kind='service_account'`).Scan(&n))
+	require.Equal(t, 0, n)
+	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM oidc_bindings`).Scan(&n))
+	require.Equal(t, 0, n)
+}
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_ServiceAccountNoBindingInvariant -v`
+Expected: FAIL on the JITCreateHuman assertion (no `KindHuman` error returned — instead a user is silently created as `kind='human'`). The CreateHuman half should already PASS thanks to the check landed in Task 13.
+
+- [ ] **Step 3: Add the JIT defensive check**
+
+In `JITCreateHuman` (in `internal/storage/postgres/users.go`), add this check at the top of the function:
+
+```go
+if u.Kind != "" && u.Kind != storage.KindHuman {
+	return nil, nil, fmt.Errorf("JITCreateHuman: u.Kind must be KindHuman or empty, got %q", u.Kind)
+}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run TestAuthStore_ServiceAccountNoBindingInvariant -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go
+git commit -s -m "feat(postgres): refuse Kind=ServiceAccount on JITCreateHuman explicitly"
+```
+
+---
+
+## Task 31: Boundary sweep — pagination, empty/null, missing-required
+
+A consolidated sweep of edge cases that don't naturally fit any single method's task: pagination defaults, empty-vs-nil distinctions, and required-field validation.
+
+**Files:**
+
+- Modify: `internal/storage/postgres/users.go`
+- Modify: `internal/storage/postgres/users_test.go`
+
+**Covers:** Boundary (pagination default-limit behavior; empty result returns empty slice not nil; missing required fields return clear errors).
+
+- [ ] **Step 1: Pagination boundary tests**
+
+Append to `users_test.go`:
+
+```go
+func TestAuthStore_Pagination_DefaultLimit(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// Insert 5 users; default limit is 100 so all are returned.
+	for i := 0; i < 5; i++ {
+		_, err := auth.CreateHuman(ctx, &storage.User{
+			Kind: storage.KindHuman, DisplayName: fmt.Sprintf("u%d", i), Role: "reader",
+		}, nil)
+		require.NoError(t, err)
+	}
+
+	// Limit=0 means "use default" (100), not "return zero".
+	users, err := auth.ListUsers(ctx, storage.ListUsersFilter{Limit: 0})
+	require.NoError(t, err)
+	require.Len(t, users, 5)
+
+	// Offset beyond rows returns empty slice (not nil, not error).
+	users, err = auth.ListUsers(ctx, storage.ListUsersFilter{Offset: 100})
+	require.NoError(t, err)
+	require.Empty(t, users)
+	require.NotNil(t, users, "empty result must be []*User{}, never nil")
+}
+```
+
+> Note: the `NotNil` assertion against an empty slice may need adjustment if Go's `require.Empty` treats nil and empty as equivalent. If so, replace with: `require.True(t, users != nil)` and ensure the implementation initializes the slice (`out := []*storage.User{}` instead of `var out []*storage.User`).
+
+- [ ] **Step 2: Empty/nil distinction tests**
+
+```go
+func TestAuthStore_EmptyResults_NotNil(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "alice", Role: "reader"}, nil)
+
+	// User with no bindings returns empty slice, not nil.
+	bindings, err := auth.ListOIDCBindings(ctx, u.ID)
+	require.NoError(t, err)
+	require.Empty(t, bindings)
+
+	// User with no keys returns empty slice, not nil.
+	keys, err := auth.ListAPIKeys(ctx, storage.ListAPIKeysFilter{UserID: u.ID})
+	require.NoError(t, err)
+	require.Empty(t, keys)
+}
+```
+
+- [ ] **Step 3: Missing-required-field tests**
+
+```go
+func TestAuthStore_RequiredFields(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// CreateAPIKey requires UserID.
+	_, err := auth.CreateAPIKey(ctx, &storage.APIKey{PHCHash: "phc"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "UserID required")
+
+	// CreateAPIKey requires PHCHash.
+	u, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "alice", Role: "writer"}, nil)
+	_, err = auth.CreateAPIKey(ctx, &storage.APIKey{UserID: u.ID})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "PHCHash required")
+
+	// CreateServiceAccount requires OwnerUserID (already covered in Task 14, asserted here for completeness).
+	_, err = auth.CreateServiceAccount(ctx, &storage.User{
+		Kind: storage.KindServiceAccount, DisplayName: "no-owner", Role: "writer",
+	})
+	require.Error(t, err)
+}
+```
+
+- [ ] **Step 4: Run all three sweep tests**
+
+Run: `cd internal/storage/postgres && go test -tags integration -run 'TestAuthStore_(Pagination_DefaultLimit|EmptyResults_NotNil|RequiredFields)' -v`
+Expected: PASS for all three. If `EmptyResults_NotNil` fails because the impl returns nil for empty slices, adjust the list implementations to initialize `out := []*X{}` rather than `var out []*X`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/postgres/users.go internal/storage/postgres/users_test.go
+git commit -s -m "test(postgres): boundary sweep — pagination, empty/null, required fields"
+```
+
+---
+
+## Task 32: Export an importable test-pool helper for cross-package integration tests
+
+**Why this task exists:** the `sharedTestPool` helper from Task 8 lives in `package postgres_test` and is backed by the `connString` set in `postgres_test.go`'s `TestMain`. That makes it usable **only** from `internal/storage/postgres`'s own test files. The downstream identity plans (Authn integration tests, Bootstrap-UX 4a `buildIdentityTestServer`, Bootstrap-UX 4b `bootstrap` integration test) need a Postgres pool from THEIR packages (`auth_test`, `server_test`, `bootstrap_test`) — separate test binaries that cannot reach `postgres_test`'s `TestMain`. An unexported helper cannot cross that boundary. This task creates an **importable** harness so every package's integration tests share one bootstrap mechanism.
+
+**Files:**
+
+- Create: `internal/storage/postgres/postgrestest/pool.go`
+- Modify: `internal/storage/postgres/postgres_test.go` (delegate the container bootstrap to the new package)
+- Modify: `internal/storage/postgres/auth_helpers_test.go` (Task 8's `sharedTestPool` delegates to `postgrestest.SharedPool`)
+
+**Covers:** N/A (test infrastructure) — validated by the existing integration suites continuing to pass under it.
+
+- [ ] **Step 1: Create the importable harness**
+
+`postgrestest` is a normal (importable) package, build-tagged `integration` so it is excluded from production builds and only compiles for tagged test runs. It owns the container via `sync.Once`, so each test binary that imports it starts exactly one pgvector container and applies the full migration set.
+
+```go
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+// Package postgrestest provides an importable testcontainers Postgres pool
+// shared across the identity integration suites (storage, auth, server,
+// bootstrap). It exists because the per-package external test packages cannot
+// reach one another's TestMain; this package centralizes the container +
+// migration bootstrap behind an exported SharedPool.
+package postgrestest
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	once    sync.Once
+	connStr string
+	startErr error
+)
+
+// SharedPool starts the shared testcontainer Postgres on first call (per test
+// binary), applies migrations, and returns a fresh pool against it. The pool
+// is closed via t.Cleanup; the container lives for the process lifetime.
+func SharedPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+	once.Do(func() {
+		connStr, startErr = startContainerAndMigrate(ctx)
+	})
+	require.NoError(t, startErr, "start shared test container")
+
+	pool, err := pgxpool.New(ctx, connStr)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// startContainerAndMigrate starts the pgvector container and applies the full
+// goose migration set, returning the connection string.
+//
+// IMPLEMENTATION: move the container-start + migration logic VERBATIM out of
+// the existing postgres_test.go TestMain (pgvector/pgvector:pg18, wait
+// strategy ForLog("database system is ready").WithOccurrence(2), then the
+// goose migrate call the harness already uses). This is a relocation, not new
+// behavior — keep the image, wait strategy, and migration runner identical so
+// the existing suites behave exactly as before.
+func startContainerAndMigrate(ctx context.Context) (string, error) {
+	// ... relocated from postgres_test.go TestMain ...
+	panic("relocate the existing TestMain container+migrate body here")
+}
+```
+
+> The `panic` placeholder marks the one block the executor fills by MOVING the existing `TestMain` body — it is not left as a stub. After relocation, no `panic` remains.
+
+- [ ] **Step 2: Delegate the existing harness to the new package**
+
+In `postgres_test.go`, replace the in-`TestMain` container bootstrap with a call into `postgrestest` (so there is ONE container-start implementation):
+
+- `postgres_test.go`'s `TestMain` / `connString` setup now obtains its connection string from `postgrestest` (e.g. `TestMain` calls a `postgrestest.EnsureStarted(ctx)` that returns the conn string, or `connString` is sourced from `postgrestest`). Keep `connString` available to the existing in-package tests.
+- In `auth_helpers_test.go` (Task 8), make `sharedTestPool` delegate: `func sharedTestPool(t *testing.T, ctx context.Context) *pgxpool.Pool { return postgrestest.SharedPool(t, ctx) }`. The ~15 existing `sharedTestPool(t, ctx)` call sites in this package are unchanged.
+
+> Keep the public behavior identical; this is a refactor to a single shared source. If splitting `TestMain` cleanly is awkward, the acceptable fallback is: `postgrestest` owns the container (Step 1), and `postgres_test.go`'s in-package tests ALSO route through `postgrestest.SharedPool` (drop the local `TestMain` container start). Either way, end state: one container-start implementation, importable cross-package.
+
+- [ ] **Step 3: Verify the storage integration suite still passes**
+
+Run: `cd internal/storage/postgres && go test -tags integration ./...`
+
+Expected: PASS (the relocation is behavior-preserving; all Task 8–31 integration tests run against the relocated harness).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/storage/postgres/postgrestest/pool.go internal/storage/postgres/postgres_test.go internal/storage/postgres/auth_helpers_test.go
+git commit -s -m "test(postgres): export importable SharedPool for cross-package integration tests"
+```
+
+> **Downstream consumers** (in later plans) import `postgrestest` and call `postgrestest.SharedPool(t, ctx)`: Authn integration tests (Tasks 33–34), Bootstrap-UX 4a (`buildIdentityTestServer`, Task 19), Bootstrap-UX 4b (`bootstrap` integration, Task 4). Those plans reference this helper directly.
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+- [x] User taxonomy (Human + ServiceAccount, single table + Kind discriminator): Tasks 1, 13, 14.
+- [x] OIDC binding global uniqueness (issuer, subject): Migration in Task 6; race-safety verified by Task 28.
+- [x] Soft-delete cascades to key revocation in one tx: Task 16 (impl + assertion); reinforced by Task 29.
+- [x] OIDC bindings remain after soft-delete, removed on purge: Tasks 16 and 17 verify both halves.
+- [x] Bootstrap uniqueness invariant (at most one active): Migration in Task 6 + Task 13 error mapping + Task 27 race verification.
+- [x] Argon2id PHC storage as text: Migration in Task 6 (`phc_hash text`); verification at hash-time happens in Authn (separate plan).
+- [x] `UsersBackend` interface as cross-domain seam: Task 4.
+- [x] Separate goose version table: Task 7 (`goose.SetTableName("goose_db_version_auth")`).
+- [x] Shared pool / NewAuth borrows: Tasks 5 (`Pool()` accessor) + 7 (`NewAuth(pool)` takes ownership-borrowed pool).
+- [x] API key prefix-collision retry: Task 19 + Task 19b verifies.
+- [x] RotateAPIKey atomicity: Task 21 (single tx wrapping revoke + create).
+- [x] JIT race-safety: Task 24 (impl) + Task 28 (concurrent race verification).
+- [x] TouchLastUsed is silent for nonexistent keys: Task 23.
+- [x] Full lifecycle smoke (bootstrap → JIT → key → rotate → promote → soft-delete bootstrap): Task 29.
+
+**Placeholder scan:** No "TBD" / "TODO" remain. Three documented decision points flagged inline:
+
+- Task 13 / Task 15 / Task 18: tests have an ordering dependency on Tasks 25 (`ListOIDCBindings`) and 16 (`SoftDeleteUser`). The executor either implements the dependent task first or substitutes direct SQL in the early test. Both options spelled out.
+- Task 19: the prefix-generation responsibility is pinned to the impl (not the caller). Documented in the method comment.
+
+These are not placeholders; they are explicit execution-order choices the implementer must make.
+
+**Type consistency:** `User`, `Kind`, `OIDCBinding`, `APIKey`, `UsersBackend`, `ListUsersFilter`, `ListAPIKeysFilter` referenced consistently. Method signatures across the interface (Task 4) and implementation (Tasks 9–26) match. The compile-time assertion in Task 7 (`var _ storage.UsersBackend = (*AuthStore)(nil)`) enforces this mechanically.
+
+**Migration ordering:** Tasks expose three soft dependencies that mean the executor SHOULD use the order in this document rather than implementing tasks in parallel: Task 5 (`Pool()` accessor) must precede Task 7 (`NewAuth(pool)`); Task 6 (migrations) must precede Task 8 (test harness); Tasks 13–14 must precede every test that needs to create a user. Otherwise tasks within Phase 3+ are mostly independent and could be batched.
+
+**Test category coverage:**
+
+- *Happy* — Task 8 (harness migration test) plus every method-introducing task (Tasks 9–26). Task 29 covers the multi-method happy lifecycle.
+- *Invariants* — bootstrap uniqueness (Tasks 13 + 27), (issuer, subject) global uniqueness (Tasks 24 + 28), soft-delete atomic cascade (Task 16), purge cascade complement (Task 17), atomic rotation incl. forced-rollback (Task 21), Service-Account-no-OIDC-binding (Task 30).
+- *Boundaries* — NotFound per resolve method (Tasks 9–12, 15), idempotent re-calls (Tasks 16, 17, 20, 26), prefix collision retry (Task 19b), pagination defaults + empty result + missing required fields (Task 31).
+- *E2E* — full storage lifecycle (Task 29). System-level E2E (CLI → RPC → storage) is out of scope for this plan.
+
+If during execution a category gap surfaces (e.g., a new invariant emerges from impl experience), add a new test to the appropriate sweep task (30 or 31) rather than retrofitting the existing per-method task. Keep test categorization legible.
+
+**Adversarial review applied (2026-05-26):** subagent review surfaced 3 Critical, 9 High, 8 Medium, 5 Low findings. All addressed in this revision. Notable structural fixes:
+
+- All test files carry `//go:build integration`; harness lives in a separate `auth_helpers_test.go`; `sharedTestPool` is concretely spec'd as a pool-per-test helper.
+- Task 7 inlines all 17 method stubs so the compile-time assertion is satisfied immediately.
+- `WithAuthKeyPrefixGenerator` replaces a package-global generator; tests are now parallel-safe.
+- Auth migrations live alongside the project migrations directory (sibling `auth_migrations/`) embedded by the `postgres` package itself, matching the existing `migrate.go` pattern; `goose.SetTableName` package-global concern is documented (sequential startup expected).
+- Schema CHECKs constrain prefix length (≥8 chars, the entropy floor the design depends on), email length, role length, etc.
+- `TouchLastUsed` excludes revoked keys.
+- Task 30 reframed to only address `JITCreateHuman` (CreateHuman's check landed in Task 13).
+- All `go test` commands carry `-tags integration`.
+
+---
+
+## Execution
+
+After this plan is approved:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, two-stage review between tasks.
+2. **Inline Execution** — execute tasks in the same session via the executing-plans skill, batch execution with checkpoints.
+
+The plan is bounded (~28 tasks, mostly TDD cycles); either execution mode fits.


### PR DESCRIPTION
## Summary

Adds the PLAN-phase implementation plans for the **Identity, RBAC & Audit** epic (`spgr-rjrt`). Each turns an approved design (merged in #964) into a subagent-ready, TDD, bite-sized task plan. Docs only — no code changes.

Five plans under `docs/plans/`:

| Plan | Scope |
|------|-------|
| `…-identity-storage-implementation-plan.md` | `UsersBackend` domain + postgres (users, api_keys, oidc_bindings); + **Task 32** exporting `postgrestest.SharedPool` for cross-package integration tests |
| `…-identity-authn-implementation-plan.md` | Single `Resolver`, JIT, `Authorizer` seam |
| `…-identity-policy-engine-implementation-plan.md` | **Cedar** (`cedar-go` v1.7.0) adoption — replaces `StaticTableAuthorizer`; zero interceptor diff |
| `…-identity-bootstrap-ux-4a-rpc-surface-…md` | `IdentityService` proto + handlers + `specgraph auth` CLI; admin-gating via Cedar `manage` verb |
| `…-identity-bootstrap-ux-4b-bootstrap-protections-…md` | Bootstrap flows (init local + serve hosted), multi-server credentials file, force/last-credential protections |

(Storage + Authn were drafted in a prior session; this PR adds Cedar, 4a, and 4b, plus the cross-plan `postgrestest` wiring.)

## Process

Each new plan went through the `superpowers:writing-plans` process plus an adversarial-review loop (opus reviewer) until a clean round:

- **Cedar** — 2 rounds, clean. cedar-go v1.7.0 API verified real (not fictional).
- **4a** — 2 rounds, clean. Caught a critical API-key prefix-ownership mismatch (storage owns the prefix) before it could ship dead tokens.
- **4b** — 2 rounds, clean. Caught a last-credential-guard ownership bypass and the cross-package test-pool reachability gap.

The test-pool gap is now an owned task (Storage **Task 32**: exported `postgrestest.SharedPool`), referenced by the Authn/4a/4b integration tests rather than left as a footnote.

## Notes

- Plans assume the prior plans' merged output; each has a "Dependency contract" section pinning consumed symbols.
- 4a and 4b should land together (4a's unguarded delete/purge/unbind are hardened by 4b).
- Release notes will need to call out the credentials-file schema change (old `api_keys:` → `specgraph auth api-key create` + multi-server `servers:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)