### PR TITLE
feat(storage): Identity Storage layer (UsersBackend + postgres) [spgr-rjrt.2]

### DIFF
--- a/docs/plans/2026-05-26-identity-bootstrap-ux-4a-rpc-surface-implementation-plan.md
+++ b/docs/plans/2026-05-26-identity-bootstrap-ux-4a-rpc-surface-implementation-plan.md
@@ -1881,7 +1881,7 @@ var knownVerbs = map[string]bool{"read": true, "write": true, "delete": true, "m
 
 Append to `internal/auth/policies/base.cedar`:
 
-```
+```text
 // Identity-management operations (IdentityService): admin-only. The "manage"
 // verb is reserved for sensitive operations that must NOT inherit the
 // read/write/delete role gates (e.g. ListUsers is a read but must be admin).

--- a/docs/plans/2026-05-26-identity-bootstrap-ux-4b-bootstrap-protections-implementation-plan.md
+++ b/docs/plans/2026-05-26-identity-bootstrap-ux-4b-bootstrap-protections-implementation-plan.md
@@ -1024,6 +1024,7 @@ Run: `cd internal/server && go build ./... && go test -run 'TestSoftDeleteUser|T
 Expected: PASS (new guard tests + the 4a tests, after the one stub fix below).
 
 > **Cross-task note (ripple into 4a tests):** The guard adds a `GetUserByID` call before the backend mutation. Auditing 4a's three delete/purge tests:
+>
 > - `TestSoftDeleteUser_Happy` — its stub sets only `softDeleteUser`; the default `getUserByID` returns `ErrUserNotFound`, so the guard now returns `CodeNotFound` and the test fails. **Fix:** add `getUserByID: func(_ context.Context, id string) (*storage.User, error) { return &storage.User{ID: id, Bootstrap: false}, nil }` to its stub.
 > - `TestSoftDeleteUser_RequiresID` — unaffected (the empty-id check runs before the guard).
 > - `TestPurgeUser_NotFound` — still passes unchanged: the guard's `GetUserByID` hits the default `ErrUserNotFound` and returns `CodeNotFound`, which is exactly what the test asserts (the `purgeUser` stub is simply never reached).

--- a/docs/plans/2026-05-26-identity-policy-engine-implementation-plan.md
+++ b/docs/plans/2026-05-26-identity-policy-engine-implementation-plan.md
@@ -89,7 +89,7 @@ Unit tests use an inline `stubSource` (Task 6) so the engine is exercised indepe
 
 ## Symbol-lifetime sweep (the bug class that bit the Authn plan three times)
 
-Go has one namespace per package and no overloading. Before finalizing, every NEW package-level identifier Cedar introduces was greppe�d against the post-Authn `internal/auth/*.go` surface. Results:
+Go has one namespace per package and no overloading. Before finalizing, every NEW package-level identifier Cedar introduces was grepped against the post-Authn `internal/auth/*.go` surface. Results:
 
 | New identifier | Collision? | Notes |
 |---|---|---|
@@ -315,7 +315,7 @@ The built-in policies, compiled into the binary. This is also where the `rpcPerm
 
 Create `internal/auth/policies/base.cedar` (no SPDX header — `.cedar` is not a license-checked extension):
 
-```
+```text
 // SpecGraph base authorization policies.
 //
 // Migrated from the static rpcPermissions table. Roles gate VERBS via action
@@ -897,7 +897,7 @@ func loadPolicySet(ctx context.Context, sources []PolicySource) (*cedar.PolicySe
 > // Temporary stubs — real impls land in Tasks 7 and 9.
 > func buildActionEntities(_ []string) (cedar.EntityMap, error) { return cedar.EntityMap{}, nil }
 > func (e *cedarEngine) Evaluate(_ context.Context, _ EvalRequest) (PolicyDecision, error) {
-> 	return PolicyDecision{}, fmt.Errorf("Evaluate not implemented")
+>     return PolicyDecision{}, fmt.Errorf("Evaluate not implemented")
 > }
 > ```
 
@@ -2099,16 +2099,20 @@ Expected: FAIL — `c.Auth.Roles` is still `map[string]RoleConfig`; `c.Auth.Poli
 In `internal/config/global.go`:
 
 1. Change the `Roles` field in `AuthConfig` from:
+
    ```go
    Roles map[string]RoleConfig `yaml:"roles"`
    ```
+
    to:
+
    ```go
    Roles    []string     `yaml:"roles"`
    Policies PolicyConfig `yaml:"policies"`
    ```
 
 2. Delete the `RoleConfig` type entirely:
+
    ```go
    // DELETE:
    // RoleConfig defines a custom role with explicit permissions.
@@ -2118,6 +2122,7 @@ In `internal/config/global.go`:
    ```
 
 3. Add the `PolicyConfig` type near the other auth config types:
+
    ```go
    // PolicyConfig configures the Cedar authorization engine's policy
    // sources. Built-in policies are always loaded; ExtraDirs adds operator
@@ -2495,7 +2500,7 @@ git commit -s -m "test(auth): integration test for discrete ownership policy lay
 
 **4. Build-discipline check:** Every task ends with `go build ./... && go test ./...` green at the package level; Tasks 6, 9, 14, 16, 17 additionally run the whole-project build+test (and Task 17 runs `task lint`). The one deliberate exception is Task 15 → 16: Task 15 leaves the whole project non-building (serve.go still references the old config shape) and is explicitly flagged as a coupled pair with Task 16 — they execute in one batch / before the next push. Phase A (1–14) is purely additive: `StaticTableAuthorizer` continues to serve authorization the entire time. Phase B (15–16) switches `serve.go` with a byte-identical interceptor line. Phase C (17) deletes the now-dead static authorizer and table together, after a pre-deletion survivor grep and a post-deletion clean grep plus `task lint` to catch any orphaned unexported symbol. Integration tests (18–19) are additive `//go:build integration` files.
 
-**5. Symbol-lifetime sweep:** Completed in the dedicated section above — every new identifier greppe�d against the post-Authn surface (no collisions; `PolicyDecision` and `PolicyDocument` chosen specifically to avoid `Decision`/`cedar.Policy` clashes), and every deleted symbol's consumers verified to be either switched (`serve.go`) or co-deleted (the four Task-17 files). The single survivor that the handoff's literal "delete permissions.go" would have broken — `IsExempt`/`exemptProcedures`, called by the interceptor — is relocated to `exempt.go` in Task 12 before `permissions.go` is deleted in Task 17.
+**5. Symbol-lifetime sweep:** Completed in the dedicated section above — every new identifier grepped against the post-Authn surface (no collisions; `PolicyDecision` and `PolicyDocument` chosen specifically to avoid `Decision`/`cedar.Policy` clashes), and every deleted symbol's consumers verified to be either switched (`serve.go`) or co-deleted (the four Task-17 files). The single survivor that the handoff's literal "delete permissions.go" would have broken — `IsExempt`/`exemptProcedures`, called by the interceptor — is relocated to `exempt.go` in Task 12 before `permissions.go` is deleted in Task 17.
 
 ---
 

--- a/docs/plans/2026-05-26-identity-storage-implementation-plan.md
+++ b/docs/plans/2026-05-26-identity-storage-implementation-plan.md
@@ -27,6 +27,7 @@ Example: "CreateHuman with a valid User struct returns the inserted row with a p
 Properties that must always hold regardless of input: structural rules enforced by the system. Invariants come from the design (e.g., "at most one bootstrap admin"); they're not method-specific — they're system-wide. Often invariants need their own dedicated tests rather than fitting inside a happy-path test.
 
 Examples:
+
 - *Bootstrap uniqueness* — at most one user has `bootstrap=true AND deleted_at IS NULL`. Tested via concurrent CreateHuman calls in Task 27.
 - *(issuer, subject) globally unique* — two providers with the same `sub` for different people can't collide. Tested via concurrent JIT calls in Task 28.
 - *Soft-delete cascades to key revocation in one tx* — never an intermediate state where the user is deleted but their keys still pass auth. Tested in Task 16.
@@ -39,6 +40,7 @@ When in doubt: if the property is "always true regardless of which method you ca
 Edges of the input space and behavior space: NotFound, idempotent re-calls, missing-required-fields, pagination edges (limit=0, very large offset, empty result), empty-vs-null distinctions, very-long strings. Boundary tests catch the "what if" cases that happy tests skip.
 
 Examples:
+
 - *NotFound* — every Lookup/Get method returns the appropriate sentinel error.
 - *Idempotent re-call* — calling Revoke / SoftDelete / Purge / Unbind twice is not an error.
 - *Empty filter* — ListUsers with no filter returns all (non-deleted) rows; an empty filter is not "no rows."

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -141,3 +141,20 @@ var ErrClaimRequiresAuthored = errors.New("claim requires provenance_type = AUTH
 
 // ErrCompletionRequiresAuthored is returned when report-completion is invoked on a non-AUTHORED spec.
 var ErrCompletionRequiresAuthored = errors.New("report-completion requires provenance_type = AUTHORED")
+
+// --- Identity errors ---
+
+// ErrUserNotFound is returned when a user does not exist.
+var ErrUserNotFound = errors.New("user not found")
+
+// ErrAPIKeyNotFound is returned when an API key does not exist.
+var ErrAPIKeyNotFound = errors.New("api key not found")
+
+// ErrOIDCBindingNotFound is returned when an OIDC binding does not exist.
+var ErrOIDCBindingNotFound = errors.New("oidc binding not found")
+
+// ErrBootstrapExists is returned when a bootstrap user already exists.
+var ErrBootstrapExists = errors.New("bootstrap user already exists")
+
+// ErrAPIKeyPrefixExists is returned when an API key prefix collides with an existing key.
+var ErrAPIKeyPrefixExists = errors.New("api key prefix collision")

--- a/internal/storage/postgres/auth.go
+++ b/internal/storage/postgres/auth.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package postgres
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"embed"
+	"encoding/base32"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/pressly/goose/v3"
+
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+//go:embed auth_migrations/*.sql
+var authMigrations embed.FS
+
+// Compile-time assertion that *AuthStore implements UsersBackend.
+// Mirrors the convention used by *Store for ConstitutionBackend etc.
+// Note: this assertion forces every UsersBackend method to exist on
+// *AuthStore. Stubs for every method are declared further down in this
+// file to satisfy the assertion; real implementations land in tasks 9–26
+// which replace the stubs one at a time.
+var _ storage.UsersBackend = (*AuthStore)(nil)
+
+// AuthStore is the Postgres implementation of UsersBackend. It is a sibling
+// to *Store: shares the database pool, holds no project scope, owns the
+// identity tables exclusively.
+//
+// Pool ownership: *Store owns the pool; *AuthStore borrows it. Callers
+// MUST close *AuthStore before *Store at shutdown. Today AuthStore.Close
+// is a no-op for the pool, but this ordering rule lets future flush-on-
+// shutdown work (usagetracker drain etc.) slot in cleanly.
+//
+// Migration safety: NewAuth runs auth migrations using a separate goose
+// version table (goose_db_version_auth) to avoid colliding with project
+// migrations. Goose mutates package-global state (BaseFS, TableName,
+// Dialect) so NewAuth and the existing postgres.New MUST NOT be called
+// concurrently. The expected pattern is sequential startup: New first,
+// then NewAuth, both single-threaded.
+type AuthStore struct {
+	pool      *pgxpool.Pool
+	nowFunc   func() time.Time
+	genPrefix func() (string, error)
+}
+
+// AuthOption configures an AuthStore.
+type AuthOption func(*AuthStore)
+
+// WithAuthClock overrides the wall clock used for explicit mutation
+// timestamps (deleted_at, revoked_at). Test-only. Does NOT affect insert
+// timestamps that come from SQL DEFAULT now().
+func WithAuthClock(fn func() time.Time) AuthOption {
+	return func(s *AuthStore) { s.nowFunc = fn }
+}
+
+// WithAuthKeyPrefixGenerator overrides the API-key prefix generator.
+// Test-only — used to force collision scenarios in CreateAPIKey tests.
+// Production code does not call WithAuthKeyPrefixGenerator.
+func WithAuthKeyPrefixGenerator(fn func() (string, error)) AuthOption {
+	return func(s *AuthStore) { s.genPrefix = fn }
+}
+
+// NewAuth constructs an AuthStore wrapping the given pool. The caller
+// retains ownership of the pool; AuthStore.Close is a no-op for the pool.
+// Auth migrations run inline using a dedicated goose version table.
+//
+// MUST be called after postgres.New and never concurrently with it
+// (goose uses package-global state). See type docstring.
+func NewAuth(ctx context.Context, pool *pgxpool.Pool, opts ...AuthOption) (*AuthStore, error) {
+	if pool == nil {
+		return nil, errors.New("postgres: NewAuth: pool must not be nil")
+	}
+	s := &AuthStore{
+		pool:      pool,
+		nowFunc:   time.Now,
+		genPrefix: defaultGenerateKeyPrefix,
+	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if err := s.runAuthMigrations(ctx); err != nil {
+		return nil, fmt.Errorf("postgres: auth migrations: %w", err)
+	}
+	return s, nil
+}
+
+// runAuthMigrations runs the embedded auth migrations using a dedicated
+// goose version table. Goose state is package-global; do not call
+// concurrently with the existing runMigrations from migrate.go.
+func (s *AuthStore) runAuthMigrations(ctx context.Context) error {
+	db := stdlib.OpenDBFromPool(s.pool)
+	// stdlib.OpenDBFromPool wraps the pool in a *sql.DB facade; closing
+	// the *sql.DB does NOT close the underlying pgxpool. Verified via pgx
+	// docs (jackc/pgx#1023) — pool ownership stays with the original
+	// caller.
+	defer func() { _ = db.Close() }()
+
+	goose.SetBaseFS(authMigrations)
+	if err := goose.SetDialect("postgres"); err != nil {
+		return fmt.Errorf("set dialect: %w", err)
+	}
+	goose.SetTableName("goose_db_version_auth")
+	defer goose.SetTableName("goose_db_version") // restore default for any subsequent caller
+	defer goose.SetBaseFS(nil)                   // restore goose's default (OS) filesystem; see concurrency note on the type
+
+	if err := goose.UpContext(ctx, db, "auth_migrations"); err != nil {
+		return fmt.Errorf("run auth migrations: %w", err)
+	}
+	return nil
+}
+
+// Close releases AuthStore resources. Today this is a no-op (the pool is
+// borrowed; no other resources held). Future flush-on-shutdown work
+// (usagetracker drain etc.) will hook here. Callers MUST call Close
+// before closing the underlying *Store.
+func (s *AuthStore) Close(_ context.Context) error {
+	return nil
+}
+
+// now returns the wall clock time used for explicit mutation timestamps.
+func (s *AuthStore) now() time.Time { return s.nowFunc() }
+
+// --- UsersBackend method stubs ---
+// These satisfy the compile-time assertion above; real implementations land
+// in tasks 9–26, which replace each stub with a SQL-backed method one at a
+// time. Stubs return errors.New("not implemented") so that accidental use
+// in tests fails loudly with a recognizable message rather than returning
+// a zero value.
+
+func (s *AuthStore) LookupAPIKeyByPrefix(ctx context.Context, prefix string) (*storage.APIKey, error) {
+	return nil, errors.New("LookupAPIKeyByPrefix not implemented")
+}
+
+func (s *AuthStore) LookupOIDCBinding(ctx context.Context, issuer, subject string) (*storage.OIDCBinding, error) {
+	return nil, errors.New("LookupOIDCBinding not implemented")
+}
+
+func (s *AuthStore) GetUserByID(ctx context.Context, id string) (*storage.User, error) {
+	return nil, errors.New("GetUserByID not implemented")
+}
+
+func (s *AuthStore) GetBootstrap(ctx context.Context) (*storage.User, error) {
+	return nil, errors.New("GetBootstrap not implemented")
+}
+
+func (s *AuthStore) CreateHuman(ctx context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, error) {
+	return nil, errors.New("CreateHuman not implemented")
+}
+
+func (s *AuthStore) CreateServiceAccount(ctx context.Context, u *storage.User) (*storage.User, error) {
+	return nil, errors.New("CreateServiceAccount not implemented")
+}
+
+func (s *AuthStore) UpdateUserRole(ctx context.Context, userID, role string) error {
+	return errors.New("UpdateUserRole not implemented")
+}
+
+func (s *AuthStore) SoftDeleteUser(ctx context.Context, userID string) error {
+	return errors.New("SoftDeleteUser not implemented")
+}
+
+func (s *AuthStore) PurgeUser(ctx context.Context, userID string) error {
+	return errors.New("PurgeUser not implemented")
+}
+
+func (s *AuthStore) ListUsers(ctx context.Context, f storage.ListUsersFilter) ([]*storage.User, error) {
+	return nil, errors.New("ListUsers not implemented")
+}
+
+func (s *AuthStore) CreateAPIKey(ctx context.Context, k *storage.APIKey) (*storage.APIKey, error) {
+	return nil, errors.New("CreateAPIKey not implemented")
+}
+
+func (s *AuthStore) RevokeAPIKey(ctx context.Context, keyID string) error {
+	return errors.New("RevokeAPIKey not implemented")
+}
+
+func (s *AuthStore) RotateAPIKey(ctx context.Context, oldKeyID string, newKey *storage.APIKey) (*storage.APIKey, error) {
+	return nil, errors.New("RotateAPIKey not implemented")
+}
+
+func (s *AuthStore) ListAPIKeys(ctx context.Context, f storage.ListAPIKeysFilter) ([]*storage.APIKey, error) {
+	return nil, errors.New("ListAPIKeys not implemented")
+}
+
+func (s *AuthStore) TouchLastUsed(ctx context.Context, keyID string) error {
+	return errors.New("TouchLastUsed not implemented")
+}
+
+func (s *AuthStore) JITCreateHuman(ctx context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error) {
+	return nil, nil, errors.New("JITCreateHuman not implemented")
+}
+
+func (s *AuthStore) ListOIDCBindings(ctx context.Context, userID string) ([]*storage.OIDCBinding, error) {
+	return nil, errors.New("ListOIDCBindings not implemented")
+}
+
+func (s *AuthStore) UnbindOIDC(ctx context.Context, bindingID string) error {
+	return errors.New("UnbindOIDC not implemented")
+}
+
+// defaultGenerateKeyPrefix produces 8 random URL-safe base32 characters.
+// Overridable via WithAuthKeyPrefixGenerator. Per-instance (not package-
+// global) so parallel tests do not race.
+func defaultGenerateKeyPrefix() (string, error) {
+	const prefixLen = 8
+	buf := make([]byte, 5) // 5 bytes -> 8 base32 chars
+	if _, err := cryptorand.Read(buf); err != nil {
+		return "", err
+	}
+	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(buf)[:prefixLen], nil
+}

--- a/internal/storage/postgres/auth.go
+++ b/internal/storage/postgres/auth.go
@@ -24,10 +24,6 @@ var authMigrations embed.FS
 
 // Compile-time assertion that *AuthStore implements UsersBackend.
 // Mirrors the convention used by *Store for ConstitutionBackend etc.
-// Note: this assertion forces every UsersBackend method to exist on
-// *AuthStore. Stubs for every method are declared further down in this
-// file to satisfy the assertion; real implementations land in tasks 9–26
-// which replace the stubs one at a time.
 var _ storage.UsersBackend = (*AuthStore)(nil)
 
 // AuthStore is the Postgres implementation of UsersBackend. It is a sibling
@@ -128,25 +124,6 @@ func (s *AuthStore) Close(_ context.Context) error {
 
 // now returns the wall clock time used for explicit mutation timestamps.
 func (s *AuthStore) now() time.Time { return s.nowFunc() }
-
-// --- UsersBackend method stubs ---
-// These satisfy the compile-time assertion above; real implementations land
-// in tasks 9–26, which replace each stub with a SQL-backed method one at a
-// time. Stubs return errors.New("not implemented") so that accidental use
-// in tests fails loudly with a recognizable message rather than returning
-// a zero value.
-
-func (s *AuthStore) JITCreateHuman(ctx context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error) {
-	return nil, nil, errors.New("JITCreateHuman not implemented")
-}
-
-func (s *AuthStore) ListOIDCBindings(ctx context.Context, userID string) ([]*storage.OIDCBinding, error) {
-	return nil, errors.New("ListOIDCBindings not implemented")
-}
-
-func (s *AuthStore) UnbindOIDC(ctx context.Context, bindingID string) error {
-	return errors.New("UnbindOIDC not implemented")
-}
 
 // defaultGenerateKeyPrefix produces 8 random URL-safe base32 characters.
 // Overridable via WithAuthKeyPrefixGenerator. Per-instance (not package-

--- a/internal/storage/postgres/auth.go
+++ b/internal/storage/postgres/auth.go
@@ -136,18 +136,6 @@ func (s *AuthStore) now() time.Time { return s.nowFunc() }
 // in tests fails loudly with a recognizable message rather than returning
 // a zero value.
 
-func (s *AuthStore) SoftDeleteUser(ctx context.Context, userID string) error {
-	return errors.New("SoftDeleteUser not implemented")
-}
-
-func (s *AuthStore) PurgeUser(ctx context.Context, userID string) error {
-	return errors.New("PurgeUser not implemented")
-}
-
-func (s *AuthStore) ListUsers(ctx context.Context, f storage.ListUsersFilter) ([]*storage.User, error) {
-	return nil, errors.New("ListUsers not implemented")
-}
-
 func (s *AuthStore) CreateAPIKey(ctx context.Context, k *storage.APIKey) (*storage.APIKey, error) {
 	return nil, errors.New("CreateAPIKey not implemented")
 }

--- a/internal/storage/postgres/auth.go
+++ b/internal/storage/postgres/auth.go
@@ -136,22 +136,6 @@ func (s *AuthStore) now() time.Time { return s.nowFunc() }
 // in tests fails loudly with a recognizable message rather than returning
 // a zero value.
 
-func (s *AuthStore) LookupAPIKeyByPrefix(ctx context.Context, prefix string) (*storage.APIKey, error) {
-	return nil, errors.New("LookupAPIKeyByPrefix not implemented")
-}
-
-func (s *AuthStore) LookupOIDCBinding(ctx context.Context, issuer, subject string) (*storage.OIDCBinding, error) {
-	return nil, errors.New("LookupOIDCBinding not implemented")
-}
-
-func (s *AuthStore) GetUserByID(ctx context.Context, id string) (*storage.User, error) {
-	return nil, errors.New("GetUserByID not implemented")
-}
-
-func (s *AuthStore) GetBootstrap(ctx context.Context) (*storage.User, error) {
-	return nil, errors.New("GetBootstrap not implemented")
-}
-
 func (s *AuthStore) CreateHuman(ctx context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, error) {
 	return nil, errors.New("CreateHuman not implemented")
 }

--- a/internal/storage/postgres/auth.go
+++ b/internal/storage/postgres/auth.go
@@ -136,18 +136,6 @@ func (s *AuthStore) now() time.Time { return s.nowFunc() }
 // in tests fails loudly with a recognizable message rather than returning
 // a zero value.
 
-func (s *AuthStore) CreateHuman(ctx context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, error) {
-	return nil, errors.New("CreateHuman not implemented")
-}
-
-func (s *AuthStore) CreateServiceAccount(ctx context.Context, u *storage.User) (*storage.User, error) {
-	return nil, errors.New("CreateServiceAccount not implemented")
-}
-
-func (s *AuthStore) UpdateUserRole(ctx context.Context, userID, role string) error {
-	return errors.New("UpdateUserRole not implemented")
-}
-
 func (s *AuthStore) SoftDeleteUser(ctx context.Context, userID string) error {
 	return errors.New("SoftDeleteUser not implemented")
 }

--- a/internal/storage/postgres/auth.go
+++ b/internal/storage/postgres/auth.go
@@ -136,26 +136,6 @@ func (s *AuthStore) now() time.Time { return s.nowFunc() }
 // in tests fails loudly with a recognizable message rather than returning
 // a zero value.
 
-func (s *AuthStore) CreateAPIKey(ctx context.Context, k *storage.APIKey) (*storage.APIKey, error) {
-	return nil, errors.New("CreateAPIKey not implemented")
-}
-
-func (s *AuthStore) RevokeAPIKey(ctx context.Context, keyID string) error {
-	return errors.New("RevokeAPIKey not implemented")
-}
-
-func (s *AuthStore) RotateAPIKey(ctx context.Context, oldKeyID string, newKey *storage.APIKey) (*storage.APIKey, error) {
-	return nil, errors.New("RotateAPIKey not implemented")
-}
-
-func (s *AuthStore) ListAPIKeys(ctx context.Context, f storage.ListAPIKeysFilter) ([]*storage.APIKey, error) {
-	return nil, errors.New("ListAPIKeys not implemented")
-}
-
-func (s *AuthStore) TouchLastUsed(ctx context.Context, keyID string) error {
-	return errors.New("TouchLastUsed not implemented")
-}
-
 func (s *AuthStore) JITCreateHuman(ctx context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error) {
 	return nil, nil, errors.New("JITCreateHuman not implemented")
 }

--- a/internal/storage/postgres/auth.go
+++ b/internal/storage/postgres/auth.go
@@ -90,9 +90,12 @@ func NewAuth(ctx context.Context, pool *pgxpool.Pool, opts ...AuthOption) (*Auth
 }
 
 // runAuthMigrations runs the embedded auth migrations using a dedicated
-// goose version table. Goose state is package-global; do not call
-// concurrently with the existing runMigrations from migrate.go.
+// goose version table. Goose state is package-global; the shared gooseMu
+// mutex (declared in migrate.go) prevents interleaving with runMigrations.
 func (s *AuthStore) runAuthMigrations(ctx context.Context) error {
+	gooseMu.Lock()
+	defer gooseMu.Unlock()
+
 	db := stdlib.OpenDBFromPool(s.pool)
 	// stdlib.OpenDBFromPool wraps the pool in a *sql.DB facade; closing
 	// the *sql.DB does NOT close the underlying pgxpool. Verified via pgx

--- a/internal/storage/postgres/auth.go
+++ b/internal/storage/postgres/auth.go
@@ -98,7 +98,7 @@ func (s *AuthStore) runAuthMigrations(ctx context.Context) error {
 	// the *sql.DB does NOT close the underlying pgxpool. Verified via pgx
 	// docs (jackc/pgx#1023) — pool ownership stays with the original
 	// caller.
-	defer func() { _ = db.Close() }()
+	defer func() { _ = db.Close() }() //nolint:errcheck // closing the sql.DB facade does not close the underlying pgxpool
 
 	goose.SetBaseFS(authMigrations)
 	if err := goose.SetDialect("postgres"); err != nil {
@@ -132,7 +132,7 @@ func defaultGenerateKeyPrefix() (string, error) {
 	const prefixLen = 8
 	buf := make([]byte, 5) // 5 bytes -> 8 base32 chars
 	if _, err := cryptorand.Read(buf); err != nil {
-		return "", err
+		return "", fmt.Errorf("rand read: %w", err)
 	}
 	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(buf)[:prefixLen], nil
 }

--- a/internal/storage/postgres/auth_helpers_test.go
+++ b/internal/storage/postgres/auth_helpers_test.go
@@ -1,7 +1,7 @@
-//go:build integration
-
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Sean Brandt
+
+//go:build integration
 
 package postgres_test
 
@@ -13,20 +13,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/specgraph/specgraph/internal/storage/postgres"
+	"github.com/specgraph/specgraph/internal/storage/postgres/postgrestest"
 )
 
 // sharedTestPool returns a fresh pgxpool against the testcontainers Postgres
-// started in postgres_test.go's TestMain. The pool is closed via t.Cleanup;
+// managed by postgrestest.SharedPool. The pool is closed via t.Cleanup;
 // callers do not need to manage lifecycle.
 //
-// Each call opens a new pool. This is the same pattern clearDatabase uses
-// (see postgres_test.go:108). The container is shared; the pools are not.
+// Delegates to postgrestest.SharedPool so there is ONE container-start
+// implementation, importable cross-package (Task 32).
 func sharedTestPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
 	t.Helper()
-	pool, err := pgxpool.New(ctx, connString)
-	require.NoError(t, err)
-	t.Cleanup(pool.Close)
-	return pool
+	return postgrestest.SharedPool(t, ctx)
 }
 
 // authTestSetup constructs an AuthStore against the test container's

--- a/internal/storage/postgres/auth_helpers_test.go
+++ b/internal/storage/postgres/auth_helpers_test.go
@@ -1,0 +1,54 @@
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/storage/postgres"
+)
+
+// sharedTestPool returns a fresh pgxpool against the testcontainers Postgres
+// started in postgres_test.go's TestMain. The pool is closed via t.Cleanup;
+// callers do not need to manage lifecycle.
+//
+// Each call opens a new pool. This is the same pattern clearDatabase uses
+// (see postgres_test.go:108). The container is shared; the pools are not.
+func sharedTestPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+	pool, err := pgxpool.New(ctx, connString)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// authTestSetup constructs an AuthStore against the test container's
+// Postgres. It uses sharedTestPool internally and registers AuthStore.Close
+// via t.Cleanup. The returned store has the auth migrations applied.
+func authTestSetup(t *testing.T) *postgres.AuthStore {
+	t.Helper()
+	ctx := context.Background()
+	pool := sharedTestPool(t, ctx)
+
+	auth, err := postgres.NewAuth(ctx, pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = auth.Close(ctx) })
+
+	return auth
+}
+
+// truncateAuthTables wipes identity tables between tests. FK CASCADE on
+// oidc_bindings.user_id and api_keys.user_id handles cleanup of child rows.
+func truncateAuthTables(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := pool.Exec(ctx, `TRUNCATE users CASCADE`)
+	require.NoError(t, err)
+}

--- a/internal/storage/postgres/auth_migrations/001_initial.sql
+++ b/internal/storage/postgres/auth_migrations/001_initial.sql
@@ -1,0 +1,58 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 Sean Brandt
+
+-- +goose Up
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE users (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    kind            text NOT NULL CHECK (kind IN ('human','service_account')),
+    display_name    text NOT NULL CHECK (length(display_name) <= 255),
+    email           text NOT NULL DEFAULT '' CHECK (length(email) <= 320),
+    role            text NOT NULL CHECK (length(role) <= 64),
+    owner_user_id   uuid REFERENCES users(id),
+    bootstrap       boolean NOT NULL DEFAULT false,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    deleted_at      timestamptz,
+
+    CHECK (kind = 'service_account' OR owner_user_id IS NULL),
+    CHECK (kind = 'human'           OR owner_user_id IS NOT NULL)
+);
+
+CREATE UNIQUE INDEX users_one_bootstrap ON users(bootstrap)
+    WHERE bootstrap = true AND deleted_at IS NULL;
+
+CREATE TABLE oidc_bindings (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    issuer          text NOT NULL CHECK (length(issuer) <= 512),
+    subject         text NOT NULL CHECK (length(subject) <= 255),
+    email_at_bind   text NOT NULL DEFAULT '' CHECK (length(email_at_bind) <= 320),
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (issuer, subject)
+);
+
+CREATE TABLE api_keys (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    prefix          text NOT NULL UNIQUE CHECK (length(prefix) >= 8 AND length(prefix) <= 16),
+    phc_hash        text NOT NULL CHECK (length(phc_hash) >= 32 AND length(phc_hash) <= 256),
+    role_downgrade  text NOT NULL DEFAULT '' CHECK (length(role_downgrade) <= 64),
+    label           text NOT NULL DEFAULT '' CHECK (length(label) <= 128),
+    expires_at      timestamptz,
+    last_used_at    timestamptz,
+    revoked_at      timestamptz,
+    created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX api_keys_active ON api_keys(user_id)
+    WHERE revoked_at IS NULL;
+
+-- +goose Down
+
+DROP INDEX IF EXISTS api_keys_active;
+DROP TABLE IF EXISTS api_keys;
+DROP TABLE IF EXISTS oidc_bindings;
+DROP INDEX IF EXISTS users_one_bootstrap;
+DROP TABLE IF EXISTS users;

--- a/internal/storage/postgres/migrate.go
+++ b/internal/storage/postgres/migrate.go
@@ -8,6 +8,7 @@ import (
 	"embed"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	_ "github.com/jackc/pgx/v5/stdlib" // registers "pgx" driver for database/sql
 	"github.com/pressly/goose/v3"
@@ -16,7 +17,15 @@ import (
 //go:embed migrations/*.sql
 var migrations embed.FS
 
+// gooseMu serializes access to goose's package-global state
+// (SetBaseFS / SetDialect / SetTableName). Both runMigrations and
+// runAuthMigrations mutate that state, so they must never interleave.
+var gooseMu sync.Mutex
+
 func runMigrations(connString string) error {
+	gooseMu.Lock()
+	defer gooseMu.Unlock()
+
 	db, err := sql.Open("pgx", connString)
 	if err != nil {
 		return fmt.Errorf("open migration connection: %w", err)

--- a/internal/storage/postgres/postgres.go
+++ b/internal/storage/postgres/postgres.go
@@ -99,6 +99,14 @@ func New(ctx context.Context, connString string, opts ...Option) (*Store, error)
 	return s, nil
 }
 
+// Pool returns the underlying pgxpool.Pool. Intended for the AuthStore
+// constructor to share the database connection without owning a second
+// pool. NOT a general-purpose escape hatch — code outside the auth and
+// project storage layers should never reach into the pool directly.
+func (s *Store) Pool() *pgxpool.Pool {
+	return s.pool
+}
+
 // Ping verifies Postgres connectivity through the connection pool. The
 // wrapping is load-bearing: callers surface the message verbatim, and
 // unwrapped pgxpool errors are too opaque to diagnose in isolation.

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -3,6 +3,7 @@
 
 //go:build integration
 
+// Package postgres_test exercises the postgres storage package via its public API using integration tests backed by a real Postgres container.
 package postgres_test
 
 import (

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -16,60 +16,27 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/specgraph/specgraph/internal/storage/postgres"
+	"github.com/specgraph/specgraph/internal/storage/postgres/postgrestest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 // connString is set once by TestMain and shared across all tests.
+// The container is started by postgrestest.ConnString (Task 32); there is now
+// ONE container-start implementation importable cross-package.
 var connString string
 
 func TestMain(m *testing.M) {
 	ctx := context.Background()
 
-	req := testcontainers.ContainerRequest{
-		Image:        "pgvector/pgvector:pg18",
-		ExposedPorts: []string{"5432/tcp"},
-		Env: map[string]string{
-			"POSTGRES_USER":     "test",
-			"POSTGRES_PASSWORD": "test",
-			"POSTGRES_DB":       "testdb",
-		},
-		WaitingFor: wait.ForLog("database system is ready to accept connections").
-			WithOccurrence(2).
-			WithStartupTimeout(60 * time.Second),
-	}
-
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+	var err error
+	connString, err = postgrestest.ConnString(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to start postgres container: %v\n", err)
 		os.Exit(1)
 	}
 
-	host, err := container.Host(ctx)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get container host: %v\n", err)
-		_ = container.Terminate(ctx)
-		os.Exit(1)
-	}
-
-	port, err := container.MappedPort(ctx, "5432")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get mapped port: %v\n", err)
-		_ = container.Terminate(ctx)
-		os.Exit(1)
-	}
-
-	connString = fmt.Sprintf("postgres://test:test@%s:%s/testdb", host, port.Port())
-
-	code := m.Run()
-
-	_ = container.Terminate(ctx)
-	os.Exit(code)
+	os.Exit(m.Run())
 }
 
 // newStore creates a postgres Store with retry logic and registers cleanup.

--- a/internal/storage/postgres/postgrestest/pool.go
+++ b/internal/storage/postgres/postgrestest/pool.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build integration
+
+// Package postgrestest provides an importable testcontainers Postgres pool
+// shared across the identity integration suites (storage, auth, server,
+// bootstrap). It exists because the per-package external test packages cannot
+// reach one another's TestMain; this package centralizes the container
+// bootstrap behind an exported SharedPool.
+package postgrestest
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+var (
+	once     sync.Once
+	sharedCS string
+	startErr error
+)
+
+// SharedPool starts the shared testcontainer Postgres on first call (per test
+// binary) and returns a fresh pool against it. The pool is closed via
+// t.Cleanup; the container lives for the process lifetime.
+//
+// Callers are responsible for running any schema migrations they need (e.g.
+// postgres.New runs spec migrations; postgres.NewAuth runs auth migrations).
+func SharedPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+	once.Do(func() {
+		sharedCS, startErr = startContainer(ctx)
+	})
+	require.NoError(t, startErr, "start shared test container")
+
+	pool, err := pgxpool.New(ctx, sharedCS)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// ConnString returns the connection string for the shared container, starting
+// it if not already running. Useful for in-package tests that open pools
+// directly (e.g. postgres_test.go's newStore).
+func ConnString(ctx context.Context) (string, error) {
+	once.Do(func() {
+		sharedCS, startErr = startContainer(ctx)
+	})
+	return sharedCS, startErr
+}
+
+// startContainer starts the pgvector/pgvector:pg18 testcontainer and returns
+// the connection string. This is a verbatim relocation of the container-start
+// body from postgres_test.go's TestMain: same image, same wait strategy, same
+// credentials.
+func startContainer(ctx context.Context) (string, error) {
+	req := testcontainers.ContainerRequest{
+		Image:        "pgvector/pgvector:pg18",
+		ExposedPorts: []string{"5432/tcp"},
+		Env: map[string]string{
+			"POSTGRES_USER":     "test",
+			"POSTGRES_PASSWORD": "test",
+			"POSTGRES_DB":       "testdb",
+		},
+		WaitingFor: wait.ForLog("database system is ready to accept connections").
+			WithOccurrence(2).
+			WithStartupTimeout(60 * time.Second),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("start postgres container: %w", err)
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return "", fmt.Errorf("get container host: %w", err)
+	}
+
+	port, err := container.MappedPort(ctx, "5432")
+	if err != nil {
+		_ = container.Terminate(ctx)
+		return "", fmt.Errorf("get mapped port: %w", err)
+	}
+
+	return fmt.Sprintf("postgres://test:test@%s:%s/testdb", host, port.Port()), nil
+}

--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -38,7 +38,7 @@ func (s *AuthStore) LookupAPIKeyByPrefix(ctx context.Context, prefix string) (*s
 		return nil, storage.ErrAPIKeyNotFound
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("scan api key: %w", err)
 	}
 	return &k, nil
 }
@@ -57,7 +57,7 @@ func (s *AuthStore) LookupOIDCBinding(ctx context.Context, issuer, subject strin
 		return nil, storage.ErrOIDCBindingNotFound
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("scan oidc binding: %w", err)
 	}
 	return &b, nil
 }
@@ -82,7 +82,7 @@ func (s *AuthStore) GetUserByID(ctx context.Context, id string) (*storage.User, 
 		return nil, storage.ErrUserNotFound
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("scan user: %w", err)
 	}
 	u.Kind = storage.Kind(kindStr)
 	return &u, nil
@@ -109,7 +109,7 @@ func (s *AuthStore) GetBootstrap(ctx context.Context) (*storage.User, error) {
 		return nil, storage.ErrUserNotFound
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("scan user: %w", err)
 	}
 	u.Kind = storage.Kind(kindStr)
 	return &u, nil
@@ -124,9 +124,9 @@ func (s *AuthStore) CreateHuman(ctx context.Context, u *storage.User, b *storage
 	}
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback(ctx) //nolint:errcheck
+	defer tx.Rollback(ctx) //nolint:errcheck // deferred rollback is a no-op after commit
 
 	const insertUser = `
 		INSERT INTO users (kind, display_name, email, role, bootstrap)
@@ -156,7 +156,7 @@ func (s *AuthStore) CreateHuman(ctx context.Context, u *storage.User, b *storage
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("commit tx: %w", err)
 	}
 
 	u.ID = id
@@ -215,9 +215,9 @@ func (s *AuthStore) UpdateUserRole(ctx context.Context, userID, role string) err
 func (s *AuthStore) SoftDeleteUser(ctx context.Context, userID string) error {
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback(ctx) //nolint:errcheck
+	defer tx.Rollback(ctx) //nolint:errcheck // deferred rollback is a no-op after commit
 
 	now := s.now()
 
@@ -235,7 +235,10 @@ func (s *AuthStore) SoftDeleteUser(ctx context.Context, userID string) error {
 		return fmt.Errorf("revoke keys: %w", err)
 	}
 
-	return tx.Commit(ctx)
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
+	}
+	return nil
 }
 
 // PurgeUser hard-deletes the user; CASCADE constraints handle bindings
@@ -293,12 +296,15 @@ func (s *AuthStore) ListUsers(ctx context.Context, f storage.ListUsersFilter) ([
 		err := rows.Scan(&u.ID, &kindStr, &u.DisplayName, &u.Email, &u.Role,
 			&u.OwnerUserID, &u.Bootstrap, &u.CreatedAt, &u.DeletedAt)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("scan user: %w", err)
 		}
 		u.Kind = storage.Kind(kindStr)
 		out = append(out, &u)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return out, nil
 }
 
 // CreateAPIKey inserts a new API key with a generated prefix. Retries up to
@@ -362,9 +368,9 @@ func (s *AuthStore) RevokeAPIKey(ctx context.Context, keyID string) error {
 func (s *AuthStore) RotateAPIKey(ctx context.Context, oldKeyID string, newKey *storage.APIKey) (*storage.APIKey, error) {
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback(ctx) //nolint:errcheck
+	defer tx.Rollback(ctx) //nolint:errcheck // deferred rollback is a no-op after commit
 
 	tag, err := tx.Exec(ctx, `
 		UPDATE api_keys SET revoked_at = $1
@@ -385,8 +391,8 @@ func (s *AuthStore) RotateAPIKey(ctx context.Context, oldKeyID string, newKey *s
 		if err != nil {
 			return nil, fmt.Errorf("generate prefix: %w", err)
 		}
-		if _, err := tx.Exec(ctx, `SAVEPOINT rotate_insert`); err != nil {
-			return nil, fmt.Errorf("savepoint: %w", err)
+		if _, spErr := tx.Exec(ctx, `SAVEPOINT rotate_insert`); spErr != nil {
+			return nil, fmt.Errorf("savepoint: %w", spErr)
 		}
 		var id string
 		var createdAt time.Time
@@ -406,8 +412,8 @@ func (s *AuthStore) RotateAPIKey(ctx context.Context, oldKeyID string, newKey *s
 			if _, relErr := tx.Exec(ctx, `RELEASE SAVEPOINT rotate_insert`); relErr != nil {
 				return nil, fmt.Errorf("release savepoint: %w", relErr)
 			}
-			if err := tx.Commit(ctx); err != nil {
-				return nil, err
+			if commitErr := tx.Commit(ctx); commitErr != nil {
+				return nil, fmt.Errorf("commit tx: %w", commitErr)
 			}
 			return newKey, nil
 		}
@@ -455,11 +461,14 @@ func (s *AuthStore) ListAPIKeys(ctx context.Context, f storage.ListAPIKeysFilter
 		var k storage.APIKey
 		if err := rows.Scan(&k.ID, &k.UserID, &k.Prefix, &k.PHCHash, &k.RoleDowngrade,
 			&k.Label, &k.ExpiresAt, &k.LastUsedAt, &k.RevokedAt, &k.CreatedAt); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("scan api key: %w", err)
 		}
 		out = append(out, &k)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return out, nil
 }
 
 // TouchLastUsed sets last_used_at = now() for the key. Nonexistent or
@@ -495,9 +504,9 @@ func (s *AuthStore) JITCreateHuman(ctx context.Context, u *storage.User, b *stor
 	}
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("begin tx: %w", err)
 	}
-	defer tx.Rollback(ctx) //nolint:errcheck
+	defer tx.Rollback(ctx) //nolint:errcheck // deferred rollback is a no-op after commit
 
 	var userID string
 	var createdAt time.Time
@@ -525,7 +534,7 @@ func (s *AuthStore) JITCreateHuman(ctx context.Context, u *storage.User, b *stor
 			// Explicit rollback discards the just-inserted (uncommitted) user
 			// row and frees the connection for the pool re-read below; the
 			// deferred Rollback then no-ops on the already-closed tx.
-			_ = tx.Rollback(ctx)
+			_ = tx.Rollback(ctx) //nolint:errcheck // best-effort rollback before read-back; tx is already aborted by the constraint violation
 			existing, lookupErr := s.LookupOIDCBinding(ctx, b.Issuer, b.Subject)
 			if lookupErr != nil {
 				return nil, nil, fmt.Errorf("race recovery: %w", lookupErr)
@@ -540,7 +549,7 @@ func (s *AuthStore) JITCreateHuman(ctx context.Context, u *storage.User, b *stor
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("commit tx: %w", err)
 	}
 
 	u.ID = userID
@@ -568,11 +577,14 @@ func (s *AuthStore) ListOIDCBindings(ctx context.Context, userID string) ([]*sto
 	for rows.Next() {
 		var b storage.OIDCBinding
 		if err := rows.Scan(&b.ID, &b.UserID, &b.Issuer, &b.Subject, &b.EmailAtBind, &b.CreatedAt); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("scan oidc binding: %w", err)
 		}
 		out = append(out, &b)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows: %w", err)
+	}
+	return out, nil
 }
 
 // UnbindOIDC deletes the binding. Idempotent on already-deleted.

--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -15,6 +15,11 @@ import (
 	"github.com/specgraph/specgraph/internal/storage"
 )
 
+// maxPrefixRetries bounds prefix-collision regeneration before returning
+// ErrAPIKeyPrefixExists. With ~40 bits of prefix entropy a collision is
+// astronomically unlikely, so 3 attempts is ample.
+const maxPrefixRetries = 3
+
 // LookupAPIKeyByPrefix returns the api_keys row whose prefix matches.
 func (s *AuthStore) LookupAPIKeyByPrefix(ctx context.Context, prefix string) (*storage.APIKey, error) {
 	const q = `
@@ -294,4 +299,179 @@ func (s *AuthStore) ListUsers(ctx context.Context, f storage.ListUsersFilter) ([
 		out = append(out, &u)
 	}
 	return out, rows.Err()
+}
+
+// CreateAPIKey inserts a new API key with a generated prefix. Retries up to
+// 3 times on prefix-uniqueness violation; returns ErrAPIKeyPrefixExists if
+// all retries collide (essentially impossible at 40 bits of entropy).
+//
+// The plaintext prefix and secret are NOT taken from the caller; the
+// caller passes only metadata (UserID, PHCHash, RoleDowngrade, Label,
+// ExpiresAt). Prefix is generated via s.genPrefix (overridable per-
+// instance via WithAuthKeyPrefixGenerator for tests; never package-global).
+func (s *AuthStore) CreateAPIKey(ctx context.Context, k *storage.APIKey) (*storage.APIKey, error) {
+	if k.UserID == "" {
+		return nil, errors.New("CreateAPIKey: UserID required")
+	}
+	if k.PHCHash == "" {
+		return nil, errors.New("CreateAPIKey: PHCHash required")
+	}
+	for attempt := 0; attempt < maxPrefixRetries; attempt++ {
+		prefix, err := s.genPrefix()
+		if err != nil {
+			return nil, fmt.Errorf("generate prefix: %w", err)
+		}
+		const q = `
+			INSERT INTO api_keys (user_id, prefix, phc_hash, role_downgrade, label, expires_at)
+			VALUES ($1::uuid, $2, $3, $4, $5, $6)
+			RETURNING id, created_at`
+		var id string
+		var createdAt time.Time
+		err = s.pool.QueryRow(ctx, q, k.UserID, prefix, k.PHCHash, k.RoleDowngrade, k.Label, k.ExpiresAt).
+			Scan(&id, &createdAt)
+		if err == nil {
+			k.ID = id
+			k.Prefix = prefix
+			k.CreatedAt = createdAt
+			return k, nil
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "api_keys_prefix_key" {
+			continue // retry with new prefix
+		}
+		return nil, fmt.Errorf("insert api key: %w", err)
+	}
+	return nil, storage.ErrAPIKeyPrefixExists
+}
+
+// RevokeAPIKey marks the key revoked. Idempotent on already-revoked or
+// nonexistent IDs (does not error).
+func (s *AuthStore) RevokeAPIKey(ctx context.Context, keyID string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE api_keys SET revoked_at = $1
+		WHERE id = $2::uuid AND revoked_at IS NULL`, s.now(), keyID)
+	if err != nil {
+		return fmt.Errorf("revoke key: %w", err)
+	}
+	return nil
+}
+
+// RotateAPIKey revokes the old key and inserts a new one with the supplied
+// metadata in one transaction. Returns the new key with generated prefix
+// and ID populated.
+func (s *AuthStore) RotateAPIKey(ctx context.Context, oldKeyID string, newKey *storage.APIKey) (*storage.APIKey, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	tag, err := tx.Exec(ctx, `
+		UPDATE api_keys SET revoked_at = $1
+		WHERE id = $2::uuid AND revoked_at IS NULL`, s.now(), oldKeyID)
+	if err != nil {
+		return nil, fmt.Errorf("revoke old key: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return nil, storage.ErrAPIKeyNotFound
+	}
+
+	// Insert new key inside the same tx with collision retry.
+	// Use savepoints to roll back only the failed INSERT on collision,
+	// keeping the revoke above intact. Postgres aborts the whole tx on
+	// any error without a savepoint, so we need one per attempt.
+	for attempt := 0; attempt < maxPrefixRetries; attempt++ {
+		prefix, err := s.genPrefix()
+		if err != nil {
+			return nil, fmt.Errorf("generate prefix: %w", err)
+		}
+		if _, err := tx.Exec(ctx, `SAVEPOINT rotate_insert`); err != nil {
+			return nil, fmt.Errorf("savepoint: %w", err)
+		}
+		var id string
+		var createdAt time.Time
+		err = tx.QueryRow(ctx, `
+			INSERT INTO api_keys (user_id, prefix, phc_hash, role_downgrade, label, expires_at)
+			VALUES ($1::uuid, $2, $3, $4, $5, $6)
+			RETURNING id, created_at`,
+			newKey.UserID, prefix, newKey.PHCHash, newKey.RoleDowngrade,
+			newKey.Label, newKey.ExpiresAt).Scan(&id, &createdAt)
+		if err == nil {
+			newKey.ID = id
+			newKey.Prefix = prefix
+			newKey.CreatedAt = createdAt
+			// Explicitly release the savepoint so its lifecycle is balanced
+			// (Commit would auto-release, but the explicit RELEASE keeps a
+			// future in-tx edit from leaving an orphaned savepoint).
+			if _, relErr := tx.Exec(ctx, `RELEASE SAVEPOINT rotate_insert`); relErr != nil {
+				return nil, fmt.Errorf("release savepoint: %w", relErr)
+			}
+			if err := tx.Commit(ctx); err != nil {
+				return nil, err
+			}
+			return newKey, nil
+		}
+		if _, rbErr := tx.Exec(ctx, `ROLLBACK TO SAVEPOINT rotate_insert`); rbErr != nil {
+			return nil, fmt.Errorf("rollback savepoint: %w", rbErr)
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "api_keys_prefix_key" {
+			continue
+		}
+		return nil, fmt.Errorf("insert new key: %w", err)
+	}
+	return nil, storage.ErrAPIKeyPrefixExists
+}
+
+// ListAPIKeys returns keys matching the filter.
+func (s *AuthStore) ListAPIKeys(ctx context.Context, f storage.ListAPIKeysFilter) ([]*storage.APIKey, error) {
+	q := `
+		SELECT id, user_id, prefix, phc_hash, role_downgrade, label,
+		       expires_at, last_used_at, revoked_at, created_at
+		FROM api_keys WHERE 1=1`
+	args := []any{}
+	if f.UserID != "" {
+		args = append(args, f.UserID)
+		q += fmt.Sprintf(` AND user_id = $%d::uuid`, len(args))
+	}
+	if !f.IncludeRevoked {
+		q += ` AND revoked_at IS NULL`
+	}
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	args = append(args, limit, f.Offset)
+	q += fmt.Sprintf(` ORDER BY created_at DESC LIMIT $%d OFFSET $%d`, len(args)-1, len(args))
+
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list api keys: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*storage.APIKey
+	for rows.Next() {
+		var k storage.APIKey
+		if err := rows.Scan(&k.ID, &k.UserID, &k.Prefix, &k.PHCHash, &k.RoleDowngrade,
+			&k.Label, &k.ExpiresAt, &k.LastUsedAt, &k.RevokedAt, &k.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, &k)
+	}
+	return out, rows.Err()
+}
+
+// TouchLastUsed sets last_used_at = now() for the key. Nonexistent or
+// already-revoked IDs are silent no-ops (fire-and-forget semantics).
+// Excluding revoked keys prevents audit-log confusion when a key is
+// revoked between a successful verify and the async last-used update.
+func (s *AuthStore) TouchLastUsed(ctx context.Context, keyID string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE api_keys SET last_used_at = $1
+		WHERE id = $2::uuid AND revoked_at IS NULL`, s.now(), keyID)
+	if err != nil {
+		return fmt.Errorf("touch last_used_at: %w", err)
+	}
+	return nil
 }

--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -475,3 +475,108 @@ func (s *AuthStore) TouchLastUsed(ctx context.Context, keyID string) error {
 	}
 	return nil
 }
+
+// JITCreateHuman creates a Human + OIDC binding atomically. If the (issuer,
+// subject) already exists (race with another JIT), re-reads and returns the
+// winning binding's user.
+//
+// Race recovery semantics: when a concurrent JIT wins the (issuer, subject)
+// uniqueness contest, this caller's INSERT receives a 23505. Postgres
+// guarantees the winner has already COMMITTED before the loser's INSERT can
+// observe the constraint violation (the winner's tx held a row lock until
+// commit, after which the loser's insert attempt resolves to "duplicate
+// key"). At READ COMMITTED isolation, the loser's subsequent SELECT for
+// the binding will see the committed row. No retry loop is needed. The user
+// row inserted before the failed binding INSERT is discarded by the
+// transaction rollback, so no orphan user accrues.
+func (s *AuthStore) JITCreateHuman(ctx context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	var userID string
+	var createdAt time.Time
+	err = tx.QueryRow(ctx, `
+		INSERT INTO users (kind, display_name, email, role)
+		VALUES ('human', $1, $2, $3)
+		RETURNING id, created_at`,
+		u.DisplayName, u.Email, u.Role).Scan(&userID, &createdAt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("insert user (jit): %w", err)
+	}
+
+	var bindingID string
+	var bindingCreatedAt time.Time
+	err = tx.QueryRow(ctx, `
+		INSERT INTO oidc_bindings (user_id, issuer, subject, email_at_bind)
+		VALUES ($1::uuid, $2, $3, $4)
+		RETURNING id, created_at`,
+		userID, b.Issuer, b.Subject, b.EmailAtBind).Scan(&bindingID, &bindingCreatedAt)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" &&
+			pgErr.ConstraintName == "oidc_bindings_issuer_subject_key" {
+			// Race: another JIT won. Rollback, re-read.
+			// Explicit rollback discards the just-inserted (uncommitted) user
+			// row and frees the connection for the pool re-read below; the
+			// deferred Rollback then no-ops on the already-closed tx.
+			_ = tx.Rollback(ctx)
+			existing, lookupErr := s.LookupOIDCBinding(ctx, b.Issuer, b.Subject)
+			if lookupErr != nil {
+				return nil, nil, fmt.Errorf("race recovery: %w", lookupErr)
+			}
+			existingUser, lookupErr := s.GetUserByID(ctx, existing.UserID)
+			if lookupErr != nil {
+				return nil, nil, fmt.Errorf("race recovery user: %w", lookupErr)
+			}
+			return existingUser, existing, nil
+		}
+		return nil, nil, fmt.Errorf("insert binding (jit): %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, nil, err
+	}
+
+	u.ID = userID
+	u.Kind = storage.KindHuman
+	u.CreatedAt = createdAt
+	b.ID = bindingID
+	b.UserID = userID
+	b.CreatedAt = bindingCreatedAt
+	return u, b, nil
+}
+
+// ListOIDCBindings returns bindings for the given user.
+func (s *AuthStore) ListOIDCBindings(ctx context.Context, userID string) ([]*storage.OIDCBinding, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, user_id, issuer, subject, email_at_bind, created_at
+		FROM oidc_bindings
+		WHERE user_id = $1::uuid
+		ORDER BY created_at`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list bindings: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]*storage.OIDCBinding, 0)
+	for rows.Next() {
+		var b storage.OIDCBinding
+		if err := rows.Scan(&b.ID, &b.UserID, &b.Issuer, &b.Subject, &b.EmailAtBind, &b.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, &b)
+	}
+	return out, rows.Err()
+}
+
+// UnbindOIDC deletes the binding. Idempotent on already-deleted.
+func (s *AuthStore) UnbindOIDC(ctx context.Context, bindingID string) error {
+	_, err := s.pool.Exec(ctx, `DELETE FROM oidc_bindings WHERE id = $1::uuid`, bindingID)
+	if err != nil {
+		return fmt.Errorf("unbind oidc: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -202,3 +202,96 @@ func (s *AuthStore) UpdateUserRole(ctx context.Context, userID, role string) err
 	}
 	return nil
 }
+
+// SoftDeleteUser sets deleted_at on the user and revokes all their active
+// keys in the same transaction. Idempotent on already-deleted users (the
+// user UPDATE matches zero rows, the keys UPDATE matches zero rows; both
+// silently succeed).
+func (s *AuthStore) SoftDeleteUser(ctx context.Context, userID string) error {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	now := s.now()
+
+	_, err = tx.Exec(ctx, `
+		UPDATE users SET deleted_at = $1
+		WHERE id = $2::uuid AND deleted_at IS NULL`, now, userID)
+	if err != nil {
+		return fmt.Errorf("soft-delete user: %w", err)
+	}
+
+	_, err = tx.Exec(ctx, `
+		UPDATE api_keys SET revoked_at = $1
+		WHERE user_id = $2::uuid AND revoked_at IS NULL`, now, userID)
+	if err != nil {
+		return fmt.Errorf("revoke keys: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}
+
+// PurgeUser hard-deletes the user; CASCADE constraints handle bindings
+// and keys. Idempotent on already-purged users.
+func (s *AuthStore) PurgeUser(ctx context.Context, userID string) error {
+	_, err := s.pool.Exec(ctx, `DELETE FROM users WHERE id = $1::uuid`, userID)
+	if err != nil {
+		return fmt.Errorf("purge user: %w", err)
+	}
+	return nil
+}
+
+// ListUsers returns users matching the filter. Default limit is 100.
+func (s *AuthStore) ListUsers(ctx context.Context, f storage.ListUsersFilter) ([]*storage.User, error) {
+	q := `
+		SELECT id, kind, display_name, email, role,
+		       coalesce(owner_user_id::text, ''), bootstrap,
+		       created_at, deleted_at
+		FROM users WHERE 1=1`
+	args := []any{}
+	if !f.IncludeDeleted {
+		q += ` AND deleted_at IS NULL`
+	}
+	if f.Kind != "" {
+		args = append(args, string(f.Kind))
+		q += fmt.Sprintf(` AND kind = $%d`, len(args))
+	}
+	if f.Role != "" {
+		args = append(args, f.Role)
+		q += fmt.Sprintf(` AND role = $%d`, len(args))
+	}
+	if f.CreatedAfter != nil {
+		args = append(args, *f.CreatedAfter)
+		q += fmt.Sprintf(` AND created_at > $%d`, len(args))
+	}
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	args = append(args, limit)
+	q += fmt.Sprintf(` ORDER BY created_at DESC LIMIT $%d`, len(args))
+	args = append(args, f.Offset)
+	q += fmt.Sprintf(` OFFSET $%d`, len(args))
+
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list users: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*storage.User
+	for rows.Next() {
+		var u storage.User
+		var kindStr string
+		err := rows.Scan(&u.ID, &kindStr, &u.DisplayName, &u.Email, &u.Role,
+			&u.OwnerUserID, &u.Bootstrap, &u.CreatedAt, &u.DeletedAt)
+		if err != nil {
+			return nil, err
+		}
+		u.Kind = storage.Kind(kindStr)
+		out = append(out, &u)
+	}
+	return out, rows.Err()
+}

--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -286,7 +286,7 @@ func (s *AuthStore) ListUsers(ctx context.Context, f storage.ListUsersFilter) ([
 	}
 	defer rows.Close()
 
-	var out []*storage.User
+	out := make([]*storage.User, 0)
 	for rows.Next() {
 		var u storage.User
 		var kindStr string
@@ -450,7 +450,7 @@ func (s *AuthStore) ListAPIKeys(ctx context.Context, f storage.ListAPIKeysFilter
 	}
 	defer rows.Close()
 
-	var out []*storage.APIKey
+	out := make([]*storage.APIKey, 0)
 	for rows.Next() {
 		var k storage.APIKey
 		if err := rows.Scan(&k.ID, &k.UserID, &k.Prefix, &k.PHCHash, &k.RoleDowngrade,
@@ -490,6 +490,9 @@ func (s *AuthStore) TouchLastUsed(ctx context.Context, keyID string) error {
 // row inserted before the failed binding INSERT is discarded by the
 // transaction rollback, so no orphan user accrues.
 func (s *AuthStore) JITCreateHuman(ctx context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error) {
+	if u.Kind != "" && u.Kind != storage.KindHuman {
+		return nil, nil, fmt.Errorf("JITCreateHuman: u.Kind must be KindHuman or empty, got %q", u.Kind)
+	}
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return nil, nil, err

--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package postgres
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// LookupAPIKeyByPrefix returns the api_keys row whose prefix matches.
+func (s *AuthStore) LookupAPIKeyByPrefix(ctx context.Context, prefix string) (*storage.APIKey, error) {
+	const q = `
+		SELECT id, user_id, prefix, phc_hash, role_downgrade, label,
+		       expires_at, last_used_at, revoked_at, created_at
+		FROM api_keys
+		WHERE prefix = $1`
+	row := s.pool.QueryRow(ctx, q, prefix)
+
+	var k storage.APIKey
+	err := row.Scan(
+		&k.ID, &k.UserID, &k.Prefix, &k.PHCHash, &k.RoleDowngrade, &k.Label,
+		&k.ExpiresAt, &k.LastUsedAt, &k.RevokedAt, &k.CreatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, storage.ErrAPIKeyNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &k, nil
+}
+
+// LookupOIDCBinding returns the binding for (issuer, subject).
+func (s *AuthStore) LookupOIDCBinding(ctx context.Context, issuer, subject string) (*storage.OIDCBinding, error) {
+	const q = `
+		SELECT id, user_id, issuer, subject, email_at_bind, created_at
+		FROM oidc_bindings
+		WHERE issuer = $1 AND subject = $2`
+	row := s.pool.QueryRow(ctx, q, issuer, subject)
+
+	var b storage.OIDCBinding
+	err := row.Scan(&b.ID, &b.UserID, &b.Issuer, &b.Subject, &b.EmailAtBind, &b.CreatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, storage.ErrOIDCBindingNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &b, nil
+}
+
+// GetUserByID returns the user row (including soft-deleted).
+func (s *AuthStore) GetUserByID(ctx context.Context, id string) (*storage.User, error) {
+	const q = `
+		SELECT id, kind, display_name, email, role,
+		       coalesce(owner_user_id::text, ''), bootstrap,
+		       created_at, deleted_at
+		FROM users
+		WHERE id = $1::uuid`
+	row := s.pool.QueryRow(ctx, q, id)
+
+	var u storage.User
+	var kindStr string
+	err := row.Scan(
+		&u.ID, &kindStr, &u.DisplayName, &u.Email, &u.Role,
+		&u.OwnerUserID, &u.Bootstrap, &u.CreatedAt, &u.DeletedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, storage.ErrUserNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	u.Kind = storage.Kind(kindStr)
+	return &u, nil
+}
+
+// GetBootstrap returns the active bootstrap admin, or ErrUserNotFound.
+func (s *AuthStore) GetBootstrap(ctx context.Context) (*storage.User, error) {
+	const q = `
+		SELECT id, kind, display_name, email, role,
+		       coalesce(owner_user_id::text, ''), bootstrap,
+		       created_at, deleted_at
+		FROM users
+		WHERE bootstrap = true AND deleted_at IS NULL
+		LIMIT 1`
+	row := s.pool.QueryRow(ctx, q)
+
+	var u storage.User
+	var kindStr string
+	err := row.Scan(
+		&u.ID, &kindStr, &u.DisplayName, &u.Email, &u.Role,
+		&u.OwnerUserID, &u.Bootstrap, &u.CreatedAt, &u.DeletedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, storage.ErrUserNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	u.Kind = storage.Kind(kindStr)
+	return &u, nil
+}

--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -6,8 +6,11 @@ package postgres
 import (
 	"context"
 	"errors"
+	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/specgraph/specgraph/internal/storage"
 )
@@ -105,4 +108,97 @@ func (s *AuthStore) GetBootstrap(ctx context.Context) (*storage.User, error) {
 	}
 	u.Kind = storage.Kind(kindStr)
 	return &u, nil
+}
+
+// CreateHuman inserts a Human row and (optionally) an OIDCBinding in one tx.
+// Returns ErrBootstrapExists if u.Bootstrap is true and another active
+// bootstrap user already exists (caught via the partial unique index).
+func (s *AuthStore) CreateHuman(ctx context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, error) {
+	if u.Kind != "" && u.Kind != storage.KindHuman {
+		return nil, errors.New("CreateHuman: u.Kind must be KindHuman or empty")
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	const insertUser = `
+		INSERT INTO users (kind, display_name, email, role, bootstrap)
+		VALUES ('human', $1, $2, $3, $4)
+		RETURNING id, created_at`
+	var id string
+	var createdAt time.Time
+	err = tx.QueryRow(ctx, insertUser, u.DisplayName, u.Email, u.Role, u.Bootstrap).
+		Scan(&id, &createdAt)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" /* unique_violation */ &&
+			pgErr.ConstraintName == "users_one_bootstrap" {
+			return nil, storage.ErrBootstrapExists
+		}
+		return nil, fmt.Errorf("insert user: %w", err)
+	}
+
+	if b != nil {
+		const insertBinding = `
+			INSERT INTO oidc_bindings (user_id, issuer, subject, email_at_bind)
+			VALUES ($1::uuid, $2, $3, $4)`
+		_, err = tx.Exec(ctx, insertBinding, id, b.Issuer, b.Subject, b.EmailAtBind)
+		if err != nil {
+			return nil, fmt.Errorf("insert binding: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	u.ID = id
+	u.Kind = storage.KindHuman
+	u.CreatedAt = createdAt
+	return u, nil
+}
+
+// CreateServiceAccount inserts a ServiceAccount row. OwnerUserID must
+// reference an existing user (FK enforced).
+func (s *AuthStore) CreateServiceAccount(ctx context.Context, u *storage.User) (*storage.User, error) {
+	if u.OwnerUserID == "" {
+		return nil, fmt.Errorf("CreateServiceAccount: OwnerUserID required: %w", storage.ErrUserNotFound)
+	}
+	const q = `
+		INSERT INTO users (kind, display_name, email, role, owner_user_id)
+		VALUES ('service_account', $1, $2, $3, $4::uuid)
+		RETURNING id, created_at`
+	var id string
+	var createdAt time.Time
+	err := s.pool.QueryRow(ctx, q, u.DisplayName, u.Email, u.Role, u.OwnerUserID).
+		Scan(&id, &createdAt)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
+			return nil, fmt.Errorf("insert service account: %w", storage.ErrUserNotFound)
+		}
+		return nil, fmt.Errorf("insert service account: %w", err)
+	}
+	u.ID = id
+	u.Kind = storage.KindServiceAccount
+	u.CreatedAt = createdAt
+	return u, nil
+}
+
+// UpdateUserRole sets the role on an active user. Returns ErrUserNotFound
+// if no active user has the given ID.
+func (s *AuthStore) UpdateUserRole(ctx context.Context, userID, role string) error {
+	const q = `
+		UPDATE users SET role = $1
+		WHERE id = $2::uuid AND deleted_at IS NULL`
+	tag, err := s.pool.Exec(ctx, q, role, userID)
+	if err != nil {
+		return fmt.Errorf("update role: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return storage.ErrUserNotFound
+	}
+	return nil
 }

--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -166,24 +166,31 @@ func (s *AuthStore) CreateHuman(ctx context.Context, u *storage.User, b *storage
 }
 
 // CreateServiceAccount inserts a ServiceAccount row. OwnerUserID must
-// reference an existing user (FK enforced).
+// reference an existing, active (not soft-deleted) Human user; the check
+// is enforced atomically by the INSERT … SELECT so there is no TOCTOU window.
 func (s *AuthStore) CreateServiceAccount(ctx context.Context, u *storage.User) (*storage.User, error) {
 	if u.OwnerUserID == "" {
 		return nil, fmt.Errorf("CreateServiceAccount: OwnerUserID required: %w", storage.ErrUserNotFound)
 	}
+	// The INSERT … SELECT enforces that the owner exists, is a human, and is
+	// not soft-deleted. If the WHERE EXISTS sub-select matches no row (owner
+	// missing, deleted, or not a human), QueryRow returns pgx.ErrNoRows.
 	const q = `
 		INSERT INTO users (kind, display_name, email, role, owner_user_id)
-		VALUES ('service_account', $1, $2, $3, $4::uuid)
+		SELECT 'service_account', $1, $2, $3, $4::uuid
+		WHERE EXISTS (
+			SELECT 1 FROM users
+			WHERE id = $4::uuid AND kind = 'human' AND deleted_at IS NULL
+		)
 		RETURNING id, created_at`
 	var id string
 	var createdAt time.Time
 	err := s.pool.QueryRow(ctx, q, u.DisplayName, u.Email, u.Role, u.OwnerUserID).
 		Scan(&id, &createdAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("insert service account: %w", storage.ErrUserNotFound)
+	}
 	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
-			return nil, fmt.Errorf("insert service account: %w", storage.ErrUserNotFound)
-		}
 		return nil, fmt.Errorf("insert service account: %w", err)
 	}
 	u.ID = id
@@ -327,9 +334,16 @@ func (s *AuthStore) CreateAPIKey(ctx context.Context, k *storage.APIKey) (*stora
 		if err != nil {
 			return nil, fmt.Errorf("generate prefix: %w", err)
 		}
+		// INSERT … SELECT guards that the user exists and is not soft-deleted.
+		// Both humans and service accounts may hold keys; only deleted_at IS NULL
+		// matters. If the WHERE EXISTS sub-select matches no row, QueryRow
+		// returns pgx.ErrNoRows — break out immediately (do NOT retry).
 		const q = `
 			INSERT INTO api_keys (user_id, prefix, phc_hash, role_downgrade, label, expires_at)
-			VALUES ($1::uuid, $2, $3, $4, $5, $6)
+			SELECT $1::uuid, $2, $3, $4, $5, $6
+			WHERE EXISTS (
+				SELECT 1 FROM users WHERE id = $1::uuid AND deleted_at IS NULL
+			)
 			RETURNING id, created_at`
 		var id string
 		var createdAt time.Time
@@ -340,6 +354,9 @@ func (s *AuthStore) CreateAPIKey(ctx context.Context, k *storage.APIKey) (*stora
 			k.Prefix = prefix
 			k.CreatedAt = createdAt
 			return k, nil
+		}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("insert api key: %w", storage.ErrUserNotFound)
 		}
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "api_keys_prefix_key" {
@@ -362,9 +379,10 @@ func (s *AuthStore) RevokeAPIKey(ctx context.Context, keyID string) error {
 	return nil
 }
 
-// RotateAPIKey revokes the old key and inserts a new one with the supplied
-// metadata in one transaction. Returns the new key with generated prefix
-// and ID populated.
+// RotateAPIKey revokes the old key and inserts a new one in one transaction.
+// Only newKey.PHCHash is consumed from the caller; owner (user_id),
+// role_downgrade, label, and expires_at are inherited from the old key.
+// Returns the new key with generated prefix and ID populated.
 func (s *AuthStore) RotateAPIKey(ctx context.Context, oldKeyID string, newKey *storage.APIKey) (*storage.APIKey, error) {
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
@@ -372,14 +390,28 @@ func (s *AuthStore) RotateAPIKey(ctx context.Context, oldKeyID string, newKey *s
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck // deferred rollback is a no-op after commit
 
-	tag, err := tx.Exec(ctx, `
+	// Read the old key's metadata first so the new key inherits owner +
+	// metadata, not the potentially bogus values from the caller.
+	var oldUserID, oldRoleDowngrade, oldLabel string
+	var oldExpiresAt *time.Time
+	err = tx.QueryRow(ctx, `
+		SELECT user_id, coalesce(role_downgrade, ''), coalesce(label, ''), expires_at
+		FROM api_keys
+		WHERE id = $1::uuid AND revoked_at IS NULL`, oldKeyID).
+		Scan(&oldUserID, &oldRoleDowngrade, &oldLabel, &oldExpiresAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, storage.ErrAPIKeyNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read old key: %w", err)
+	}
+
+	// Revoke the old key now that we know it exists and is active.
+	_, err = tx.Exec(ctx, `
 		UPDATE api_keys SET revoked_at = $1
 		WHERE id = $2::uuid AND revoked_at IS NULL`, s.now(), oldKeyID)
 	if err != nil {
 		return nil, fmt.Errorf("revoke old key: %w", err)
-	}
-	if tag.RowsAffected() == 0 {
-		return nil, storage.ErrAPIKeyNotFound
 	}
 
 	// Insert new key inside the same tx with collision retry.
@@ -400,12 +432,9 @@ func (s *AuthStore) RotateAPIKey(ctx context.Context, oldKeyID string, newKey *s
 			INSERT INTO api_keys (user_id, prefix, phc_hash, role_downgrade, label, expires_at)
 			VALUES ($1::uuid, $2, $3, $4, $5, $6)
 			RETURNING id, created_at`,
-			newKey.UserID, prefix, newKey.PHCHash, newKey.RoleDowngrade,
-			newKey.Label, newKey.ExpiresAt).Scan(&id, &createdAt)
+			oldUserID, prefix, newKey.PHCHash, oldRoleDowngrade,
+			oldLabel, oldExpiresAt).Scan(&id, &createdAt)
 		if err == nil {
-			newKey.ID = id
-			newKey.Prefix = prefix
-			newKey.CreatedAt = createdAt
 			// Explicitly release the savepoint so its lifecycle is balanced
 			// (Commit would auto-release, but the explicit RELEASE keeps a
 			// future in-tx edit from leaving an orphaned savepoint).
@@ -415,7 +444,17 @@ func (s *AuthStore) RotateAPIKey(ctx context.Context, oldKeyID string, newKey *s
 			if commitErr := tx.Commit(ctx); commitErr != nil {
 				return nil, fmt.Errorf("commit tx: %w", commitErr)
 			}
-			return newKey, nil
+			out := &storage.APIKey{
+				ID:            id,
+				UserID:        oldUserID,
+				Prefix:        prefix,
+				PHCHash:       newKey.PHCHash,
+				RoleDowngrade: oldRoleDowngrade,
+				Label:         oldLabel,
+				ExpiresAt:     oldExpiresAt,
+				CreatedAt:     createdAt,
+			}
+			return out, nil
 		}
 		if _, rbErr := tx.Exec(ctx, `ROLLBACK TO SAVEPOINT rotate_insert`); rbErr != nil {
 			return nil, fmt.Errorf("rollback savepoint: %w", rbErr)

--- a/internal/storage/postgres/users_test.go
+++ b/internal/storage/postgres/users_test.go
@@ -8,9 +8,11 @@ package postgres_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/specgraph/specgraph/internal/storage/postgres"
 )
 
@@ -30,4 +32,135 @@ func TestAuthStore_NewAuth_RunsMigrations(t *testing.T) {
 		WHERE table_name = 'users')`)
 	require.NoError(t, row.Scan(&exists))
 	require.True(t, exists, "users table should exist after migrations")
+}
+
+func TestAuthStore_LookupAPIKeyByPrefix(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// Seed: a Human + one APIKey via direct SQL (CRUD methods come later).
+	_, err := pool.Exec(ctx, `
+		INSERT INTO users (id, kind, display_name, role, bootstrap)
+		VALUES ('00000000-0000-0000-0000-000000000001'::uuid,
+		        'human', 'alice', 'reader', false)`)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO api_keys (id, user_id, prefix, phc_hash, label)
+		VALUES ('00000000-0000-0000-0000-000000000002'::uuid,
+		        '00000000-0000-0000-0000-000000000001'::uuid,
+		        'abc12345', '$argon2id$v=19$m=65536,t=1,p=4$stub-salt-padded-to-32chars', 'test-key')`)
+	require.NoError(t, err)
+
+	key, err := auth.LookupAPIKeyByPrefix(ctx, "abc12345")
+	require.NoError(t, err)
+	require.Equal(t, "abc12345", key.Prefix)
+	require.Equal(t, "00000000-0000-0000-0000-000000000001", key.UserID)
+	require.Equal(t, "test-key", key.Label)
+
+	// Miss returns ErrAPIKeyNotFound.
+	_, err = auth.LookupAPIKeyByPrefix(ctx, "no-such-prefix")
+	require.ErrorIs(t, err, storage.ErrAPIKeyNotFound)
+}
+
+func TestAuthStore_LookupOIDCBinding(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	_, err := pool.Exec(ctx, `
+		INSERT INTO users (id, kind, display_name, role)
+		VALUES ('00000000-0000-0000-0000-000000000001'::uuid,
+		        'human', 'alice', 'reader')`)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO oidc_bindings (id, user_id, issuer, subject)
+		VALUES ('00000000-0000-0000-0000-000000000003'::uuid,
+		        '00000000-0000-0000-0000-000000000001'::uuid,
+		        'https://login.microsoftonline.com/tenant/v2.0',
+		        'sub-12345')`)
+	require.NoError(t, err)
+
+	b, err := auth.LookupOIDCBinding(ctx, "https://login.microsoftonline.com/tenant/v2.0", "sub-12345")
+	require.NoError(t, err)
+	require.Equal(t, "00000000-0000-0000-0000-000000000001", b.UserID)
+	require.Equal(t, "https://login.microsoftonline.com/tenant/v2.0", b.Issuer)
+	require.Equal(t, "sub-12345", b.Subject)
+
+	_, err = auth.LookupOIDCBinding(ctx, "https://github.com", "sub-12345")
+	require.ErrorIs(t, err, storage.ErrOIDCBindingNotFound)
+}
+
+func TestAuthStore_GetUserByID(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	_, err := pool.Exec(ctx, `
+		INSERT INTO users (id, kind, display_name, email, role, bootstrap, created_at, deleted_at)
+		VALUES ('00000000-0000-0000-0000-000000000001'::uuid,
+		        'human', 'alice', 'alice@example.com', 'reader',
+		        false, $1, NULL),
+		       ('00000000-0000-0000-0000-000000000002'::uuid,
+		        'human', 'bob', '', 'writer', false, $1, $2)`,
+		now, now.Add(time.Hour))
+	require.NoError(t, err)
+
+	// Active user.
+	u, err := auth.GetUserByID(ctx, "00000000-0000-0000-0000-000000000001")
+	require.NoError(t, err)
+	require.Equal(t, "alice", u.DisplayName)
+	require.True(t, u.IsActive())
+
+	// Soft-deleted user — still returned (caller gates).
+	u, err = auth.GetUserByID(ctx, "00000000-0000-0000-0000-000000000002")
+	require.NoError(t, err)
+	require.False(t, u.IsActive())
+	require.NotNil(t, u.DeletedAt)
+
+	// Miss.
+	_, err = auth.GetUserByID(ctx, "00000000-0000-0000-0000-aaaaaaaaaaaa")
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+
+	// ServiceAccount round-trip: owner_user_id is populated, scan handles
+	// the nullable-FK column via coalesce. Seed via direct SQL (Task 14
+	// implements CreateServiceAccount; this test verifies the read path
+	// independently).
+	_, err = pool.Exec(ctx, `
+		INSERT INTO users (id, kind, display_name, role, owner_user_id)
+		VALUES ('00000000-0000-0000-0000-000000000003'::uuid,
+		        'service_account', 'ci-bot', 'writer',
+		        '00000000-0000-0000-0000-000000000001'::uuid)`)
+	require.NoError(t, err)
+	sa, err := auth.GetUserByID(ctx, "00000000-0000-0000-0000-000000000003")
+	require.NoError(t, err)
+	require.True(t, sa.IsServiceAccount())
+	require.Equal(t, "00000000-0000-0000-0000-000000000001", sa.OwnerUserID)
+}
+
+func TestAuthStore_GetBootstrap(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// No bootstrap yet.
+	_, err := auth.GetBootstrap(ctx)
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+
+	// Insert active bootstrap.
+	_, err = pool.Exec(ctx, `
+		INSERT INTO users (id, kind, display_name, role, bootstrap)
+		VALUES ('00000000-0000-0000-0000-000000000001'::uuid,
+		        'human', 'admin', 'admin', true)`)
+	require.NoError(t, err)
+
+	u, err := auth.GetBootstrap(ctx)
+	require.NoError(t, err)
+	require.True(t, u.Bootstrap)
+	require.Equal(t, "admin", u.DisplayName)
 }

--- a/internal/storage/postgres/users_test.go
+++ b/internal/storage/postgres/users_test.go
@@ -270,3 +270,113 @@ func TestAuthStore_UpdateUserRole(t *testing.T) {
 	err = auth.UpdateUserRole(ctx, "00000000-0000-0000-0000-aaaaaaaaaaaa", "reader")
 	require.ErrorIs(t, err, storage.ErrUserNotFound)
 }
+
+func TestAuthStore_SoftDeleteUser(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, err := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "reader",
+	}, &storage.OIDCBinding{Issuer: "iss1", Subject: "sub1"})
+	require.NoError(t, err)
+
+	// Seed two API keys directly (phc_hash >= 32 chars per schema CHECK).
+	_, err = pool.Exec(ctx, `
+		INSERT INTO api_keys (user_id, prefix, phc_hash, label)
+		VALUES ($1::uuid, 'pre00001', '$argon2id$v=19$m=65536,t=1,p=4$stub-salt-padded-to-32chars', 'k1'),
+		       ($1::uuid, 'pre00002', '$argon2id$v=19$m=65536,t=1,p=4$stub-salt-padded-to-32chars', 'k2')`, u.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, auth.SoftDeleteUser(ctx, u.ID))
+
+	// User deleted_at set.
+	reloaded, err := auth.GetUserByID(ctx, u.ID)
+	require.NoError(t, err)
+	require.False(t, reloaded.IsActive())
+
+	// Both keys revoked in the same tx (same revoked_at timestamp).
+	var count int
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM api_keys
+		WHERE user_id = $1::uuid AND revoked_at IS NOT NULL`, u.ID).Scan(&count))
+	require.Equal(t, 2, count)
+
+	// Bindings rows remain (they're history).
+	var bindingCount int
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM oidc_bindings WHERE user_id = $1::uuid`, u.ID).Scan(&bindingCount))
+	require.Equal(t, 1, bindingCount)
+
+	// Idempotent: re-deleting is a no-op.
+	require.NoError(t, auth.SoftDeleteUser(ctx, u.ID))
+
+	// Unknown/nonexistent userID is also a no-op (returns nil, NOT
+	// ErrUserNotFound) — intentional idempotent-delete semantics, distinct
+	// from UpdateUserRole.
+	require.NoError(t, auth.SoftDeleteUser(ctx, "00000000-0000-0000-0000-aaaaaaaaaaaa"))
+}
+
+func TestAuthStore_PurgeUser(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, err := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "reader",
+	}, &storage.OIDCBinding{Issuer: "iss1", Subject: "sub1"})
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO api_keys (user_id, prefix, phc_hash, label)
+		VALUES ($1::uuid, 'pre00003', '$argon2id$v=19$m=65536,t=1,p=4$stub-salt-padded-to-32chars', 'k')`, u.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, auth.PurgeUser(ctx, u.ID))
+
+	// User gone.
+	_, err = auth.GetUserByID(ctx, u.ID)
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+
+	// Cascaded keys + bindings gone.
+	var n int
+	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM api_keys WHERE user_id = $1::uuid`, u.ID).Scan(&n))
+	require.Equal(t, 0, n)
+	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM oidc_bindings WHERE user_id = $1::uuid`, u.ID).Scan(&n))
+	require.Equal(t, 0, n)
+
+	// Idempotent.
+	require.NoError(t, auth.PurgeUser(ctx, u.ID))
+}
+
+func TestAuthStore_ListUsers(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// Three humans, one service account.
+	owner, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "h1", Role: "admin"}, nil)
+	_, _ = auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "h2", Role: "reader"}, nil)
+	deleted, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "h3", Role: "writer"}, nil)
+	require.NoError(t, auth.SoftDeleteUser(ctx, deleted.ID))
+	_, _ = auth.CreateServiceAccount(ctx, &storage.User{Kind: storage.KindServiceAccount, DisplayName: "sa1", Role: "writer", OwnerUserID: owner.ID})
+
+	all, err := auth.ListUsers(ctx, storage.ListUsersFilter{})
+	require.NoError(t, err)
+	require.Len(t, all, 3) // excludes deleted by default
+
+	withDeleted, err := auth.ListUsers(ctx, storage.ListUsersFilter{IncludeDeleted: true})
+	require.NoError(t, err)
+	require.Len(t, withDeleted, 4)
+
+	humansOnly, err := auth.ListUsers(ctx, storage.ListUsersFilter{Kind: storage.KindHuman})
+	require.NoError(t, err)
+	require.Len(t, humansOnly, 2) // h3 deleted, sa1 excluded
+
+	readers, err := auth.ListUsers(ctx, storage.ListUsersFilter{Role: "reader"})
+	require.NoError(t, err)
+	require.Len(t, readers, 1)
+	require.Equal(t, "h2", readers[0].DisplayName)
+}

--- a/internal/storage/postgres/users_test.go
+++ b/internal/storage/postgres/users_test.go
@@ -1,13 +1,14 @@
-//go:build integration
-
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Sean Brandt
+
+//go:build integration
 
 package postgres_test
 
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -854,4 +855,129 @@ func TestAuthStore_FullLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, bindings, 1)
 	require.Equal(t, binding.ID, bindings[0].ID)
+}
+
+// ---- Task 30: Invariant sweep — ServiceAccount has no OIDC bindings ----
+
+// TestAuthStore_ServiceAccountNoBindingInvariant verifies that neither
+// CreateHuman nor JITCreateHuman will accept Kind=ServiceAccount, so a
+// ServiceAccount can never acquire an OIDC binding via these write surfaces.
+func TestAuthStore_ServiceAccountNoBindingInvariant(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// CreateHuman already rejects Kind=ServiceAccount (per Task 13's
+	// existing check). Verify that property survived.
+	_, err := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindServiceAccount, DisplayName: "wrong", Role: "writer",
+	}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "KindHuman")
+
+	// JITCreateHuman with Kind=ServiceAccount must refuse explicitly.
+	_, _, err = auth.JITCreateHuman(ctx,
+		&storage.User{Kind: storage.KindServiceAccount, DisplayName: "wrong", Role: "reader"},
+		&storage.OIDCBinding{Issuer: "iss", Subject: "sub"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "KindHuman")
+
+	// Defense in depth: no rows created by either failed call.
+	var n int
+	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM users WHERE kind='service_account'`).Scan(&n))
+	require.Equal(t, 0, n)
+	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM oidc_bindings`).Scan(&n))
+	require.Equal(t, 0, n)
+}
+
+// ---- Task 31: Boundary sweep — pagination, empty/null, missing-required ----
+
+// TestAuthStore_Pagination_DefaultLimit verifies that Limit=0 is treated as the
+// default (100), and that an offset beyond the result set returns a non-nil
+// empty slice.
+func TestAuthStore_Pagination_DefaultLimit(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// Insert 5 users; default limit is 100 so all are returned.
+	for i := 0; i < 5; i++ {
+		_, err := auth.CreateHuman(ctx, &storage.User{
+			Kind: storage.KindHuman, DisplayName: fmt.Sprintf("u%d", i), Role: "reader",
+		}, nil)
+		require.NoError(t, err)
+	}
+
+	// Limit=0 means "use default" (100), not "return zero".
+	users, err := auth.ListUsers(ctx, storage.ListUsersFilter{Limit: 0})
+	require.NoError(t, err)
+	require.Len(t, users, 5)
+
+	// Offset beyond rows returns empty slice (not nil, not error).
+	users, err = auth.ListUsers(ctx, storage.ListUsersFilter{Offset: 100})
+	require.NoError(t, err)
+	require.Empty(t, users)
+	require.True(t, users != nil, "empty result must be []*User{}, never nil")
+}
+
+// TestAuthStore_EmptyResults_NotNil verifies that ListOIDCBindings and
+// ListAPIKeys return non-nil empty slices (not nil) when no rows match,
+// and that ListUsers does the same.
+func TestAuthStore_EmptyResults_NotNil(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, err := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "alice", Role: "reader"}, nil)
+	require.NoError(t, err)
+
+	// User with no bindings returns empty slice, not nil.
+	bindingSlice, err := auth.ListOIDCBindings(ctx, u.ID)
+	require.NoError(t, err)
+	require.Empty(t, bindingSlice)
+	require.NotNil(t, bindingSlice, "ListOIDCBindings empty result must be non-nil slice")
+
+	// User with no keys returns empty slice, not nil.
+	keys, err := auth.ListAPIKeys(ctx, storage.ListAPIKeysFilter{UserID: u.ID})
+	require.NoError(t, err)
+	require.Empty(t, keys)
+	require.NotNil(t, keys, "ListAPIKeys empty result must be non-nil slice")
+
+	// ListUsers on an empty filter (after truncate) returns non-nil empty.
+	truncateAuthTables(t, pool)
+	allUsers, err := auth.ListUsers(ctx, storage.ListUsersFilter{})
+	require.NoError(t, err)
+	require.Empty(t, allUsers)
+	require.True(t, allUsers != nil, "ListUsers empty result must be non-nil slice")
+}
+
+// TestAuthStore_RequiredFields verifies that CreateAPIKey returns clear errors
+// for missing UserID and missing PHCHash, and that CreateServiceAccount
+// rejects a missing OwnerUserID.
+func TestAuthStore_RequiredFields(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// CreateAPIKey requires UserID.
+	_, err := auth.CreateAPIKey(ctx, &storage.APIKey{PHCHash: "phc-stub-padded-to-meet-min-length-ok"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "UserID required")
+
+	// CreateAPIKey requires PHCHash.
+	u, err := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "alice", Role: "writer"}, nil)
+	require.NoError(t, err)
+	_, err = auth.CreateAPIKey(ctx, &storage.APIKey{UserID: u.ID})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "PHCHash required")
+
+	// CreateServiceAccount requires OwnerUserID (also covered in Task 14).
+	_, err = auth.CreateServiceAccount(ctx, &storage.User{
+		Kind: storage.KindServiceAccount, DisplayName: "no-owner", Role: "writer",
+	})
+	require.Error(t, err)
 }

--- a/internal/storage/postgres/users_test.go
+++ b/internal/storage/postgres/users_test.go
@@ -380,3 +380,253 @@ func TestAuthStore_ListUsers(t *testing.T) {
 	require.Len(t, readers, 1)
 	require.Equal(t, "h2", readers[0].DisplayName)
 }
+
+func TestAuthStore_CreateAPIKey(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, _ := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "writer",
+	}, nil)
+
+	k, err := auth.CreateAPIKey(ctx, &storage.APIKey{
+		UserID: u.ID, PHCHash: "phc-stub-padded-to-meet-min-length-ok", Label: "first key",
+	})
+	require.NoError(t, err)
+	require.Len(t, k.Prefix, 8)
+	require.NotEmpty(t, k.ID)
+	require.Equal(t, "first key", k.Label)
+}
+
+func TestAuthStore_CreateAPIKey_CollisionRetry(t *testing.T) {
+	ctx := context.Background()
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// Build a dedicated AuthStore with a stubbed prefix generator.
+	calls := 0
+	gen := func() (string, error) {
+		calls++
+		if calls <= 2 {
+			return "collide1", nil
+		}
+		return "newpre23", nil
+	}
+	auth, err := postgres.NewAuth(ctx, pool, postgres.WithAuthKeyPrefixGenerator(gen))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = auth.Close(ctx) })
+
+	u, _ := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "writer",
+	}, nil)
+
+	// Seed a key with the prefix the generator will collide against.
+	_, err = pool.Exec(ctx, `INSERT INTO api_keys (user_id, prefix, phc_hash)
+	                         VALUES ($1::uuid, 'collide1', 'phc-seed-string-padding-to-meet-length-check')`, u.ID)
+	require.NoError(t, err)
+
+	k, err := auth.CreateAPIKey(ctx, &storage.APIKey{UserID: u.ID, PHCHash: "phc-stub-string-padding-to-meet-length-check"})
+	require.NoError(t, err)
+	require.Equal(t, "newpre23", k.Prefix)
+	require.GreaterOrEqual(t, calls, 3)
+
+	// Exhaustion: a generator that always returns the same colliding prefix.
+	authExhaust, err := postgres.NewAuth(ctx, pool, postgres.WithAuthKeyPrefixGenerator(
+		func() (string, error) { return "collide1", nil }))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = authExhaust.Close(ctx) })
+	_, err = authExhaust.CreateAPIKey(ctx, &storage.APIKey{UserID: u.ID, PHCHash: "phc-stub-string-padding-to-meet-length-check"})
+	require.ErrorIs(t, err, storage.ErrAPIKeyPrefixExists)
+}
+
+func TestAuthStore_RevokeAPIKey(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, _ := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "writer",
+	}, nil)
+	k, _ := auth.CreateAPIKey(ctx, &storage.APIKey{UserID: u.ID, PHCHash: "phc-stub-padded-to-meet-min-length-ok"})
+
+	require.NoError(t, auth.RevokeAPIKey(ctx, k.ID))
+
+	reloaded, err := auth.LookupAPIKeyByPrefix(ctx, k.Prefix)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded.RevokedAt)
+	require.False(t, reloaded.IsActive(time.Now()))
+
+	// Idempotent on already-revoked.
+	require.NoError(t, auth.RevokeAPIKey(ctx, k.ID))
+
+	// Nonexistent ID is also a no-op (no error).
+	require.NoError(t, auth.RevokeAPIKey(ctx, "00000000-0000-0000-0000-aaaaaaaaaaaa"))
+}
+
+func TestAuthStore_RotateAPIKey(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, _ := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "writer",
+	}, nil)
+	old, _ := auth.CreateAPIKey(ctx, &storage.APIKey{
+		UserID: u.ID, PHCHash: "phc-old-padded-to-meet-min-length-ok-00", Label: "ci-bot",
+	})
+
+	newKey, err := auth.RotateAPIKey(ctx, old.ID, &storage.APIKey{
+		UserID: u.ID, PHCHash: "phc-new-padded-to-meet-min-length-ok-00", Label: "ci-bot",
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, old.Prefix, newKey.Prefix)
+	require.Equal(t, "ci-bot", newKey.Label)
+
+	// Old key is revoked, new key is active.
+	oldReload, _ := auth.LookupAPIKeyByPrefix(ctx, old.Prefix)
+	require.NotNil(t, oldReload.RevokedAt)
+	newReload, _ := auth.LookupAPIKeyByPrefix(ctx, newKey.Prefix)
+	require.Nil(t, newReload.RevokedAt)
+}
+
+func TestAuthStore_RotateAPIKey_RollbackOnInsertFailure(t *testing.T) {
+	ctx := context.Background()
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	auth := authTestSetup(t)
+	u, _ := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "writer",
+	}, nil)
+	old, _ := auth.CreateAPIKey(ctx, &storage.APIKey{
+		UserID: u.ID, PHCHash: "phc-old-padding-to-meet-min-length-check",
+	})
+
+	// Build a SECOND store with a bad generator — returns empty string
+	// which violates the prefix length CHECK constraint (23514), forcing
+	// the INSERT to fail on the FIRST attempt (not via the 23505 retry
+	// loop) and rolling back the entire tx including the revoke of `old`.
+	badAuth, err := postgres.NewAuth(ctx, pool, postgres.WithAuthKeyPrefixGenerator(
+		func() (string, error) { return "", nil }))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = badAuth.Close(ctx) })
+
+	_, err = badAuth.RotateAPIKey(ctx, old.ID, &storage.APIKey{
+		UserID: u.ID, PHCHash: "phc-new-padding-to-meet-min-length-check",
+	})
+	require.Error(t, err)
+
+	// Old key MUST still be live (rollback worked) and no new row exists.
+	// `auth` and `badAuth` deliberately share the same pool/tables, so this
+	// read-back via `auth` verifies committed/rolled-back DB state — not any
+	// in-memory store state — of the rotate performed through `badAuth`.
+	oldReload, _ := auth.LookupAPIKeyByPrefix(ctx, old.Prefix)
+	require.Nil(t, oldReload.RevokedAt, "old key must still be live after rollback")
+	var keyCount int
+	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM api_keys WHERE user_id = $1::uuid`, u.ID).Scan(&keyCount))
+	require.Equal(t, 1, keyCount, "only old key exists; no orphan from failed insert")
+}
+
+func TestAuthStore_RotateAPIKey_PrefixCollisionRetry(t *testing.T) {
+	ctx := context.Background()
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	auth := authTestSetup(t)
+	u, _ := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "writer",
+	}, nil)
+	old, _ := auth.CreateAPIKey(ctx, &storage.APIKey{
+		UserID: u.ID, PHCHash: "phc-old-padding-to-meet-min-length-check",
+	})
+
+	// Seed a separate user with a key whose prefix the rotate generator
+	// will collide against. Using a different user keeps the test focused
+	// on the rotate path (not on the user's own key inventory).
+	other, _ := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "bob", Role: "writer",
+	}, nil)
+	_, err := pool.Exec(ctx, `
+		INSERT INTO api_keys (user_id, prefix, phc_hash)
+		VALUES ($1::uuid, 'collidex', 'phc-bob-padding-to-meet-min-length-check')`, other.ID)
+	require.NoError(t, err)
+
+	// Generator returns the colliding prefix twice (triggers 23505 +
+	// retry both times), then a fresh prefix on attempt 3.
+	calls := 0
+	gen := func() (string, error) {
+		calls++
+		if calls <= 2 {
+			return "collidex", nil
+		}
+		return "rotated2", nil
+	}
+	rotateAuth, err := postgres.NewAuth(ctx, pool, postgres.WithAuthKeyPrefixGenerator(gen))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rotateAuth.Close(ctx) })
+
+	newKey, err := rotateAuth.RotateAPIKey(ctx, old.ID, &storage.APIKey{
+		UserID: u.ID, PHCHash: "phc-rot-padding-to-meet-min-length-check",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "rotated2", newKey.Prefix)
+	require.GreaterOrEqual(t, calls, 3, "retry loop should have invoked the generator at least 3 times")
+
+	// Old key is revoked, new key is active — same invariant as the happy
+	// path, but the path through the retry loop is now exercised.
+	oldReload, _ := auth.LookupAPIKeyByPrefix(ctx, old.Prefix)
+	require.NotNil(t, oldReload.RevokedAt)
+	newReload, _ := auth.LookupAPIKeyByPrefix(ctx, newKey.Prefix)
+	require.Nil(t, newReload.RevokedAt)
+}
+
+func TestAuthStore_ListAPIKeys(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u1, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "alice", Role: "writer"}, nil)
+	u2, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "bob", Role: "writer"}, nil)
+
+	k1, _ := auth.CreateAPIKey(ctx, &storage.APIKey{UserID: u1.ID, PHCHash: "phc1-padded-to-meet-min-length-ok-xxx", Label: "k1"})
+	_, _ = auth.CreateAPIKey(ctx, &storage.APIKey{UserID: u1.ID, PHCHash: "phc2-padded-to-meet-min-length-ok-xxx", Label: "k2"})
+	_, _ = auth.CreateAPIKey(ctx, &storage.APIKey{UserID: u2.ID, PHCHash: "phc3-padded-to-meet-min-length-ok-xxx", Label: "k3"})
+	require.NoError(t, auth.RevokeAPIKey(ctx, k1.ID))
+
+	// Per-user, excluding revoked by default.
+	keys, err := auth.ListAPIKeys(ctx, storage.ListAPIKeysFilter{UserID: u1.ID})
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Equal(t, "k2", keys[0].Label)
+
+	// IncludeRevoked.
+	keys, err = auth.ListAPIKeys(ctx, storage.ListAPIKeysFilter{UserID: u1.ID, IncludeRevoked: true})
+	require.NoError(t, err)
+	require.Len(t, keys, 2)
+
+	// All users (admin).
+	all, err := auth.ListAPIKeys(ctx, storage.ListAPIKeysFilter{})
+	require.NoError(t, err)
+	require.Len(t, all, 2) // k1 revoked excluded, k2 and k3 remain
+}
+
+func TestAuthStore_TouchLastUsed(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "alice", Role: "writer"}, nil)
+	k, _ := auth.CreateAPIKey(ctx, &storage.APIKey{UserID: u.ID, PHCHash: "phc-stub-padded-to-meet-min-length-ok"})
+
+	require.Nil(t, k.LastUsedAt)
+	require.NoError(t, auth.TouchLastUsed(ctx, k.ID))
+
+	reloaded, _ := auth.LookupAPIKeyByPrefix(ctx, k.Prefix)
+	require.NotNil(t, reloaded.LastUsedAt)
+}

--- a/internal/storage/postgres/users_test.go
+++ b/internal/storage/postgres/users_test.go
@@ -164,3 +164,109 @@ func TestAuthStore_GetBootstrap(t *testing.T) {
 	require.True(t, u.Bootstrap)
 	require.Equal(t, "admin", u.DisplayName)
 }
+
+func TestAuthStore_CreateHuman(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u := &storage.User{
+		Kind:        storage.KindHuman,
+		DisplayName: "alice",
+		Email:       "alice@example.com",
+		Role:        "reader",
+	}
+	created, err := auth.CreateHuman(ctx, u, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, created.ID)
+	require.Equal(t, "alice", created.DisplayName)
+	require.True(t, created.IsHuman())
+	require.True(t, created.IsActive())
+
+	// With binding atomically.
+	u2 := &storage.User{Kind: storage.KindHuman, DisplayName: "bob", Role: "reader"}
+	b := &storage.OIDCBinding{
+		Issuer: "https://login.microsoftonline.com/t/v2.0", Subject: "sub-bob",
+		EmailAtBind: "bob@example.com",
+	}
+	created2, err := auth.CreateHuman(ctx, u2, b)
+	require.NoError(t, err)
+
+	// Verify the binding via direct SQL — ListOIDCBindings is implemented
+	// later in Task 25, so we don't depend on it here.
+	var bindingCount int
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM oidc_bindings
+		WHERE user_id = $1::uuid AND subject = 'sub-bob'`, created2.ID).
+		Scan(&bindingCount))
+	require.Equal(t, 1, bindingCount)
+
+	// Bootstrap dedup: first bootstrap insert succeeds.
+	boot := &storage.User{Kind: storage.KindHuman, DisplayName: "admin", Role: "admin", Bootstrap: true}
+	_, err = auth.CreateHuman(ctx, boot, nil)
+	require.NoError(t, err)
+	// Second bootstrap insert fails.
+	boot2 := &storage.User{Kind: storage.KindHuman, DisplayName: "admin", Role: "admin", Bootstrap: true}
+	_, err = auth.CreateHuman(ctx, boot2, nil)
+	require.ErrorIs(t, err, storage.ErrBootstrapExists)
+}
+
+func TestAuthStore_CreateServiceAccount(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// Owner first.
+	owner, err := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "owner", Role: "admin",
+	}, nil)
+	require.NoError(t, err)
+
+	sa, err := auth.CreateServiceAccount(ctx, &storage.User{
+		Kind: storage.KindServiceAccount, DisplayName: "ci-bot",
+		Role: "writer", OwnerUserID: owner.ID,
+	})
+	require.NoError(t, err)
+	require.True(t, sa.IsServiceAccount())
+	require.Equal(t, owner.ID, sa.OwnerUserID)
+
+	// Missing owner rejected.
+	_, err = auth.CreateServiceAccount(ctx, &storage.User{
+		Kind: storage.KindServiceAccount, DisplayName: "no-owner", Role: "writer",
+	})
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+}
+
+func TestAuthStore_UpdateUserRole(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, err := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "alice", Role: "reader",
+	}, nil)
+	require.NoError(t, err)
+
+	err = auth.UpdateUserRole(ctx, u.ID, "writer")
+	require.NoError(t, err)
+
+	reloaded, err := auth.GetUserByID(ctx, u.ID)
+	require.NoError(t, err)
+	require.Equal(t, "writer", reloaded.Role)
+
+	// Soft-deleted user is not updateable. Set deleted_at via direct SQL
+	// rather than calling SoftDeleteUser (Task 16) to avoid a forward
+	// reference; soft-delete cascade semantics are exercised in Task 16's
+	// own test.
+	_, err = pool.Exec(ctx, `UPDATE users SET deleted_at = now() WHERE id = $1::uuid`, u.ID)
+	require.NoError(t, err)
+	err = auth.UpdateUserRole(ctx, u.ID, "admin")
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+
+	// Nonexistent.
+	err = auth.UpdateUserRole(ctx, "00000000-0000-0000-0000-aaaaaaaaaaaa", "reader")
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+}

--- a/internal/storage/postgres/users_test.go
+++ b/internal/storage/postgres/users_test.go
@@ -7,6 +7,8 @@ package postgres_test
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -695,4 +697,161 @@ func TestAuthStore_UnbindOIDC(t *testing.T) {
 
 	// Idempotent.
 	require.NoError(t, auth.UnbindOIDC(ctx, bindings[0].ID))
+}
+
+// TestAuthStore_BootstrapRace verifies that N concurrent CreateHuman calls with
+// Bootstrap=true result in exactly one success and N-1 ErrBootstrapExists
+// errors, proving the partial unique index users_one_bootstrap is correctly
+// mapped at runtime.
+func TestAuthStore_BootstrapRace(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	const concurrent = 5
+	// Each goroutine writes its own result into a dedicated slot, so no
+	// synchronization beyond the WaitGroup is needed (race-free).
+	errs := make([]error, concurrent)
+	var wg sync.WaitGroup
+	wg.Add(concurrent)
+	for i := 0; i < concurrent; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			_, err := auth.CreateHuman(ctx, &storage.User{
+				Kind: storage.KindHuman, DisplayName: "admin",
+				Role: "admin", Bootstrap: true,
+			}, nil)
+			errs[idx] = err
+		}(i)
+	}
+	wg.Wait()
+
+	var successes, expectsBootstrapExists int
+	for _, err := range errs {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, storage.ErrBootstrapExists):
+			expectsBootstrapExists++
+		default:
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	require.Equal(t, 1, successes, "exactly one bootstrap insert should succeed")
+	require.Equal(t, concurrent-1, expectsBootstrapExists)
+}
+
+// TestAuthStore_JITRace verifies that N concurrent JITCreateHuman calls for
+// the same (issuer, subject) all resolve to the same user and binding, proving
+// the race-recovery relookup path maintains the (issuer,subject) uniqueness
+// invariant.
+func TestAuthStore_JITRace(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	const concurrent = 5
+	type result struct {
+		userID    string
+		bindingID string
+		err       error
+	}
+	// Each goroutine writes its own result into a dedicated slot, so no
+	// synchronization beyond the WaitGroup is needed (race-free).
+	results := make([]result, concurrent)
+	var wg sync.WaitGroup
+	wg.Add(concurrent)
+	for i := 0; i < concurrent; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			u, b, err := auth.JITCreateHuman(ctx,
+				&storage.User{Kind: storage.KindHuman, DisplayName: "alice", Role: "reader"},
+				&storage.OIDCBinding{Issuer: "iss1", Subject: "alice-sub"})
+			if err != nil {
+				results[idx] = result{err: err}
+				return
+			}
+			results[idx] = result{userID: u.ID, bindingID: b.ID}
+		}(i)
+	}
+	wg.Wait()
+
+	userIDs := map[string]struct{}{}
+	bindingIDs := map[string]struct{}{}
+	for _, r := range results {
+		require.NoError(t, r.err)
+		userIDs[r.userID] = struct{}{}
+		bindingIDs[r.bindingID] = struct{}{}
+	}
+	require.Len(t, userIDs, 1, "all callers should resolve to the same user")
+	require.Len(t, bindingIDs, 1, "all callers should resolve to the same binding")
+}
+
+// TestAuthStore_FullLifecycle is an end-to-end smoke test walking the complete
+// identity lifecycle: bootstrap → JIT-create real user → mint key → rotate key
+// → promote role → soft-delete bootstrap, asserting final state is coherent.
+//
+// Plan note: the PHCHash values in the plan ("phc", "phc-rot") are shorter than
+// the schema CHECK constraint (length(phc_hash) >= 32). They are replaced here
+// with valid 32+ character strings.
+func TestAuthStore_FullLifecycle(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	// Bootstrap admin.
+	admin, err := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "admin", Role: "admin", Bootstrap: true,
+	}, nil)
+	require.NoError(t, err)
+
+	got, err := auth.GetBootstrap(ctx)
+	require.NoError(t, err)
+	require.Equal(t, admin.ID, got.ID)
+
+	// JIT a real person via OIDC.
+	person, binding, err := auth.JITCreateHuman(ctx,
+		&storage.User{Kind: storage.KindHuman, DisplayName: "alice", Email: "alice@x.com", Role: "reader"},
+		&storage.OIDCBinding{Issuer: "entra", Subject: "alice-sub", EmailAtBind: "alice@x.com"})
+	require.NoError(t, err)
+
+	// Mint an API key. PHCHash must be >= 32 chars (schema CHECK constraint).
+	key, err := auth.CreateAPIKey(ctx, &storage.APIKey{
+		UserID: person.ID, PHCHash: "phc-stub-padded-to-meet-min-length-ok", Label: "personal",
+	})
+	require.NoError(t, err)
+
+	// Rotate it. PHCHash must be >= 32 chars (schema CHECK constraint).
+	newKey, err := auth.RotateAPIKey(ctx, key.ID, &storage.APIKey{
+		UserID: person.ID, PHCHash: "phc-rot-stub-padded-to-meet-min-length", Label: "personal",
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, key.Prefix, newKey.Prefix)
+
+	// Promote alice via UpdateUserRole.
+	require.NoError(t, auth.UpdateUserRole(ctx, person.ID, "admin"))
+
+	// Soft-delete bootstrap admin (force-flag policy enforced at handler layer, not here).
+	require.NoError(t, auth.SoftDeleteUser(ctx, admin.ID))
+
+	// GetBootstrap now empty.
+	_, err = auth.GetBootstrap(ctx)
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+
+	// Final state: alice is admin with one active key, one binding.
+	reloaded, err := auth.GetUserByID(ctx, person.ID)
+	require.NoError(t, err)
+	require.Equal(t, "admin", reloaded.Role)
+
+	keys, err := auth.ListAPIKeys(ctx, storage.ListAPIKeysFilter{UserID: person.ID})
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+
+	bindings, err := auth.ListOIDCBindings(ctx, person.ID)
+	require.NoError(t, err)
+	require.Len(t, bindings, 1)
+	require.Equal(t, binding.ID, bindings[0].ID)
 }

--- a/internal/storage/postgres/users_test.go
+++ b/internal/storage/postgres/users_test.go
@@ -1,0 +1,33 @@
+//go:build integration
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/storage/postgres"
+)
+
+// TestAuthStore_NewAuth_RunsMigrations asserts the constructor brings the
+// schema up.
+func TestAuthStore_NewAuth_RunsMigrations(t *testing.T) {
+	ctx := context.Background()
+	pool := sharedTestPool(t, ctx)
+	auth, err := postgres.NewAuth(ctx, pool)
+	require.NoError(t, err)
+	defer auth.Close(ctx)
+
+	// Tables exist?
+	var exists bool
+	row := pool.QueryRow(ctx, `SELECT EXISTS (
+		SELECT 1 FROM information_schema.tables
+		WHERE table_name = 'users')`)
+	require.NoError(t, row.Scan(&exists))
+	require.True(t, exists, "users table should exist after migrations")
+}

--- a/internal/storage/postgres/users_test.go
+++ b/internal/storage/postgres/users_test.go
@@ -240,6 +240,30 @@ func TestAuthStore_CreateServiceAccount(t *testing.T) {
 		Kind: storage.KindServiceAccount, DisplayName: "no-owner", Role: "writer",
 	})
 	require.ErrorIs(t, err, storage.ErrUserNotFound)
+
+	// Soft-deleted human owner must be rejected with ErrUserNotFound.
+	deletedOwner, err := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "deleted-owner", Role: "admin",
+	}, nil)
+	require.NoError(t, err)
+	require.NoError(t, auth.SoftDeleteUser(ctx, deletedOwner.ID))
+	_, err = auth.CreateServiceAccount(ctx, &storage.User{
+		Kind: storage.KindServiceAccount, DisplayName: "sa-for-deleted", Role: "writer",
+		OwnerUserID: deletedOwner.ID,
+	})
+	require.ErrorIs(t, err, storage.ErrUserNotFound, "soft-deleted human owner must be rejected")
+
+	// Service-account owner must be rejected with ErrUserNotFound (only humans may own).
+	saOwner, err := auth.CreateServiceAccount(ctx, &storage.User{
+		Kind: storage.KindServiceAccount, DisplayName: "sa-owner-attempt", Role: "writer",
+		OwnerUserID: owner.ID,
+	})
+	require.NoError(t, err)
+	_, err = auth.CreateServiceAccount(ctx, &storage.User{
+		Kind: storage.KindServiceAccount, DisplayName: "sa-of-sa", Role: "writer",
+		OwnerUserID: saOwner.ID,
+	})
+	require.ErrorIs(t, err, storage.ErrUserNotFound, "service-account owner must be rejected — only active humans may own")
 }
 
 func TestAuthStore_UpdateUserRole(t *testing.T) {
@@ -401,6 +425,18 @@ func TestAuthStore_CreateAPIKey(t *testing.T) {
 	require.Len(t, k.Prefix, 8)
 	require.NotEmpty(t, k.ID)
 	require.Equal(t, "first key", k.Label)
+
+	// Soft-deleted user must be rejected with ErrUserNotFound.
+	deleted, err := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "gone", Role: "reader",
+	}, nil)
+	require.NoError(t, err)
+	require.NoError(t, auth.SoftDeleteUser(ctx, deleted.ID))
+	_, err = auth.CreateAPIKey(ctx, &storage.APIKey{
+		UserID:  deleted.ID,
+		PHCHash: "phc-stub-padded-to-meet-min-length-ok",
+	})
+	require.ErrorIs(t, err, storage.ErrUserNotFound, "CreateAPIKey for soft-deleted user must return ErrUserNotFound")
 }
 
 func TestAuthStore_CreateAPIKey_CollisionRetry(t *testing.T) {
@@ -478,22 +514,45 @@ func TestAuthStore_RotateAPIKey(t *testing.T) {
 	u, _ := auth.CreateHuman(ctx, &storage.User{
 		Kind: storage.KindHuman, DisplayName: "alice", Role: "writer",
 	}, nil)
+	// Create a second user to supply as a "bogus" caller-side owner — the
+	// rotate must NOT use this; it must inherit the old key's owner.
+	other, _ := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "impostor", Role: "reader",
+	}, nil)
 	old, _ := auth.CreateAPIKey(ctx, &storage.APIKey{
-		UserID: u.ID, PHCHash: "phc-old-padded-to-meet-min-length-ok-00", Label: "ci-bot",
+		UserID:        u.ID,
+		PHCHash:       "phc-old-padded-to-meet-min-length-ok-00",
+		Label:         "ci-bot",
+		RoleDowngrade: "reader",
 	})
 
+	// Pass a newKey with completely different metadata to prove the impl
+	// ignores everything except PHCHash.
 	newKey, err := auth.RotateAPIKey(ctx, old.ID, &storage.APIKey{
-		UserID: u.ID, PHCHash: "phc-new-padded-to-meet-min-length-ok-00", Label: "ci-bot",
+		UserID:        other.ID, // bogus — must be overridden
+		PHCHash:       "phc-new-padded-to-meet-min-length-ok-00",
+		Label:         "WRONG-LABEL", // bogus — must be overridden
+		RoleDowngrade: "admin",       // bogus — must be overridden
 	})
 	require.NoError(t, err)
 	require.NotEqual(t, old.Prefix, newKey.Prefix)
-	require.Equal(t, "ci-bot", newKey.Label)
 
-	// Old key is revoked, new key is active.
+	// Owner, label, and role_downgrade must be inherited from the OLD key.
+	require.Equal(t, u.ID, newKey.UserID, "UserID must be inherited from old key, not caller's newKey.UserID")
+	require.Equal(t, "ci-bot", newKey.Label, "Label must be inherited from old key")
+	require.Equal(t, "reader", newKey.RoleDowngrade, "RoleDowngrade must be inherited from old key")
+
+	// Verify the persisted row also has the correct owner and metadata.
+	newReload, err := auth.LookupAPIKeyByPrefix(ctx, newKey.Prefix)
+	require.NoError(t, err)
+	require.Equal(t, u.ID, newReload.UserID)
+	require.Equal(t, "ci-bot", newReload.Label)
+	require.Equal(t, "reader", newReload.RoleDowngrade)
+	require.Nil(t, newReload.RevokedAt)
+
+	// Old key is revoked.
 	oldReload, _ := auth.LookupAPIKeyByPrefix(ctx, old.Prefix)
 	require.NotNil(t, oldReload.RevokedAt)
-	newReload, _ := auth.LookupAPIKeyByPrefix(ctx, newKey.Prefix)
-	require.Nil(t, newReload.RevokedAt)
 }
 
 func TestAuthStore_RotateAPIKey_RollbackOnInsertFailure(t *testing.T) {

--- a/internal/storage/postgres/users_test.go
+++ b/internal/storage/postgres/users_test.go
@@ -630,3 +630,69 @@ func TestAuthStore_TouchLastUsed(t *testing.T) {
 	reloaded, _ := auth.LookupAPIKeyByPrefix(ctx, k.Prefix)
 	require.NotNil(t, reloaded.LastUsedAt)
 }
+
+func TestAuthStore_JITCreateHuman(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u := &storage.User{Kind: storage.KindHuman, DisplayName: "alice", Email: "alice@x.com", Role: "reader"}
+	b := &storage.OIDCBinding{Issuer: "iss1", Subject: "alice-sub", EmailAtBind: "alice@x.com"}
+
+	user, binding, err := auth.JITCreateHuman(ctx, u, b)
+	require.NoError(t, err)
+	require.NotEmpty(t, user.ID)
+	require.NotEmpty(t, binding.ID)
+	require.Equal(t, user.ID, binding.UserID)
+
+	// Second JIT for same (issuer, subject) returns the existing user.
+	user2, binding2, err := auth.JITCreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "alice-dup", Role: "reader"}, b)
+	require.NoError(t, err)
+	require.Equal(t, user.ID, user2.ID)
+	require.Equal(t, binding.ID, binding2.ID)
+}
+
+func TestAuthStore_ListOIDCBindings(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "alice", Role: "reader"},
+		&storage.OIDCBinding{Issuer: "entra", Subject: "alice-entra"})
+	// Add a second binding (different provider).
+	_, _ = pool.Exec(ctx, `INSERT INTO oidc_bindings (user_id, issuer, subject)
+	                      VALUES ($1::uuid, 'github', 'alice-gh')`, u.ID)
+
+	bindings, err := auth.ListOIDCBindings(ctx, u.ID)
+	require.NoError(t, err)
+	require.Len(t, bindings, 2)
+
+	// Empty list for unbound user.
+	other, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "bob", Role: "reader"}, nil)
+	bindings, err = auth.ListOIDCBindings(ctx, other.ID)
+	require.NoError(t, err)
+	require.NotNil(t, bindings)
+	require.Empty(t, bindings)
+}
+
+func TestAuthStore_UnbindOIDC(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, _ := auth.CreateHuman(ctx, &storage.User{Kind: storage.KindHuman, DisplayName: "alice", Role: "reader"},
+		&storage.OIDCBinding{Issuer: "entra", Subject: "alice-entra"})
+	bindings, _ := auth.ListOIDCBindings(ctx, u.ID)
+	require.Len(t, bindings, 1)
+
+	require.NoError(t, auth.UnbindOIDC(ctx, bindings[0].ID))
+
+	after, _ := auth.ListOIDCBindings(ctx, u.ID)
+	require.Empty(t, after)
+
+	// Idempotent.
+	require.NoError(t, auth.UnbindOIDC(ctx, bindings[0].ID))
+}

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -77,9 +77,10 @@ type UsersBackend interface {
 	// RevokeAPIKey marks the key revoked. Idempotent on already-revoked keys.
 	RevokeAPIKey(ctx context.Context, keyID string) error
 
-	// RotateAPIKey revokes the old key and creates a new one with the same
-	// metadata (label, role_downgrade, expires_at) in one transaction.
-	// Returns the new key.
+	// RotateAPIKey revokes the old key and creates a new one in one transaction.
+	// Only newKey.PHCHash is consumed from the caller; owner (user_id),
+	// role_downgrade, label, and expires_at are inherited from the old key.
+	// Returns the new key with a freshly generated prefix and new ID.
 	RotateAPIKey(ctx context.Context, oldKeyID string, newKey *APIKey) (*APIKey, error)
 
 	// ListAPIKeys returns keys for the given user; pass userID="" to list

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -51,7 +51,13 @@ type UsersBackend interface {
 	UpdateUserRole(ctx context.Context, userID, role string) error
 
 	// SoftDeleteUser sets deleted_at and revokes all active keys in one tx.
-	// Idempotent (re-deleting already-deleted user is a no-op).
+	// Idempotent (re-deleting already-deleted user is a no-op). An
+	// unknown/nonexistent userID is also treated as a no-op: it returns nil,
+	// NOT ErrUserNotFound. This intentional idempotent-delete behavior is
+	// distinct from UpdateUserRole, which returns ErrUserNotFound for a
+	// missing target. (The deleted_at IS NULL guard means an already-deleted
+	// user matches zero rows too, so erroring on zero rows would break the
+	// documented re-delete idempotency.)
 	SoftDeleteUser(ctx context.Context, userID string) error
 
 	// PurgeUser hard-deletes the user; cascades through bindings and keys.

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package storage
+
+import (
+	"context"
+	"time"
+)
+
+// UsersBackend defines storage operations for the identity domain (users,
+// API keys, OIDC bindings). It is the canonical cross-domain seam for any
+// other domain that needs to ask identity questions (story #3, #4).
+//
+// Implementations MUST honor the invariants stated on User and the design
+// document (docs/plans/2026-05-22-identity-storage-design.md).
+type UsersBackend interface {
+	// --- resolve-path queries (hot) ---
+
+	// LookupAPIKeyByPrefix returns the key with the given prefix. Returns
+	// ErrAPIKeyNotFound on miss. Does not verify the secret; callers must.
+	LookupAPIKeyByPrefix(ctx context.Context, prefix string) (*APIKey, error)
+
+	// LookupOIDCBinding returns the binding for the (issuer, subject) pair.
+	// Returns ErrOIDCBindingNotFound on miss.
+	LookupOIDCBinding(ctx context.Context, issuer, subject string) (*OIDCBinding, error)
+
+	// GetUserByID returns the user with the given ID, including soft-deleted.
+	// Callers gate on User.IsActive() per their semantics. Returns
+	// ErrUserNotFound on miss.
+	GetUserByID(ctx context.Context, id string) (*User, error)
+
+	// GetBootstrap returns the active bootstrap user, or ErrUserNotFound if
+	// none exists. Used by bootstrap path to detect idempotency.
+	GetBootstrap(ctx context.Context) (*User, error)
+
+	// --- user CRUD ---
+
+	// CreateHuman inserts a Human row. The OIDCBinding is created in the
+	// same transaction; pass binding=nil for admin-created Humans (rare).
+	// Returns ErrBootstrapExists if u.Bootstrap is true AND a bootstrap
+	// already exists.
+	CreateHuman(ctx context.Context, u *User, binding *OIDCBinding) (*User, error)
+
+	// CreateServiceAccount inserts a ServiceAccount row. u.OwnerUserID
+	// must reference an existing active Human.
+	CreateServiceAccount(ctx context.Context, u *User) (*User, error)
+
+	// UpdateUserRole sets the role on an active user. Role validation
+	// against the YAML config is the caller's responsibility.
+	UpdateUserRole(ctx context.Context, userID, role string) error
+
+	// SoftDeleteUser sets deleted_at and revokes all active keys in one tx.
+	// Idempotent (re-deleting already-deleted user is a no-op).
+	SoftDeleteUser(ctx context.Context, userID string) error
+
+	// PurgeUser hard-deletes the user; cascades through bindings and keys.
+	PurgeUser(ctx context.Context, userID string) error
+
+	// ListUsers returns users matching the filter, optionally including
+	// soft-deleted rows. Pagination is offset/limit; impl may add cursor
+	// later.
+	ListUsers(ctx context.Context, filter ListUsersFilter) ([]*User, error)
+
+	// --- API key CRUD ---
+
+	// CreateAPIKey inserts a new key. Retries on prefix-uniqueness violation
+	// up to 3 times before returning ErrAPIKeyPrefixExists.
+	CreateAPIKey(ctx context.Context, k *APIKey) (*APIKey, error)
+
+	// RevokeAPIKey marks the key revoked. Idempotent on already-revoked keys.
+	RevokeAPIKey(ctx context.Context, keyID string) error
+
+	// RotateAPIKey revokes the old key and creates a new one with the same
+	// metadata (label, role_downgrade, expires_at) in one transaction.
+	// Returns the new key.
+	RotateAPIKey(ctx context.Context, oldKeyID string, newKey *APIKey) (*APIKey, error)
+
+	// ListAPIKeys returns keys for the given user; pass userID="" to list
+	// across all users (admin operation). Excludes revoked keys unless
+	// IncludeRevoked is set.
+	ListAPIKeys(ctx context.Context, filter ListAPIKeysFilter) ([]*APIKey, error)
+
+	// TouchLastUsed sets last_used_at = now() for the key. Fire-and-forget
+	// from caller's perspective; impl is fast and ignores errors silently
+	// (but returns them for tests).
+	TouchLastUsed(ctx context.Context, keyID string) error
+
+	// --- OIDC binding CRUD ---
+
+	// JITCreateHuman creates a Human + its OIDCBinding atomically. Used by
+	// the OIDC resolver when a binding lookup misses. On (issuer, subject)
+	// uniqueness violation, returns the existing user via a re-lookup
+	// (race-safe).
+	JITCreateHuman(ctx context.Context, u *User, binding *OIDCBinding) (*User, *OIDCBinding, error)
+
+	// ListOIDCBindings returns bindings for the given user.
+	ListOIDCBindings(ctx context.Context, userID string) ([]*OIDCBinding, error)
+
+	// UnbindOIDC removes the given binding. Last-credential protection is
+	// the caller's responsibility (handler-level policy, not storage).
+	UnbindOIDC(ctx context.Context, bindingID string) error
+}
+
+// ListUsersFilter narrows ListUsers results.
+type ListUsersFilter struct {
+	Kind           Kind   // empty = all kinds
+	Role           string // empty = all roles
+	IncludeDeleted bool
+	CreatedAfter   *time.Time
+	Limit          int // 0 = default 100
+	Offset         int
+}
+
+// ListAPIKeysFilter narrows ListAPIKeys results.
+type ListAPIKeysFilter struct {
+	UserID         string // empty = all users (admin)
+	IncludeRevoked bool
+	Limit          int
+	Offset         int
+}

--- a/internal/storage/users_domain.go
+++ b/internal/storage/users_domain.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package storage
+
+import (
+	"time"
+)
+
+// Kind discriminates a User row as a Human (OIDC-backed person) or a
+// ServiceAccount (machine identity owned by a Human). The kind constrains
+// which credentials and ownership relationships are valid (see UsersBackend
+// invariants); it does NOT change lifecycle semantics — soft-delete behaves
+// identically for both kinds.
+type Kind string
+
+const (
+	KindHuman          Kind = "human"
+	KindServiceAccount Kind = "service_account"
+)
+
+// User is the identity row for a Human or ServiceAccount. Single table with
+// a Kind discriminator; lifecycle is uniform across kinds.
+//
+// Invariants enforced at the schema or store layer (see UsersBackend):
+//   - ServiceAccounts MUST have OwnerUserID set; Humans MUST NOT.
+//   - At most one User has Bootstrap=true AND DeletedAt=nil.
+//   - ServiceAccounts MUST NOT have rows in oidc_bindings (store-layer).
+type User struct {
+	ID          string // uuid
+	Kind        Kind
+	DisplayName string
+	Email       string // nullable; empty when not set
+	Role        string // role assignment; built-in or custom (validated against config)
+	OwnerUserID string // ServiceAccount owner; empty for Humans
+	Bootstrap   bool   // true for the system bootstrap admin
+	CreatedAt   time.Time
+	DeletedAt   *time.Time // nil = active
+}
+
+// IsHuman reports whether the user is a Human kind.
+func (u *User) IsHuman() bool { return u.Kind == KindHuman }
+
+// IsServiceAccount reports whether the user is a ServiceAccount kind.
+func (u *User) IsServiceAccount() bool { return u.Kind == KindServiceAccount }
+
+// IsActive reports whether the user has not been soft-deleted.
+func (u *User) IsActive() bool { return u.DeletedAt == nil }
+
+// OIDCBinding links a User to an external OIDC subject. The (Issuer, Subject)
+// pair is globally unique across providers to prevent same-sub collisions
+// between IdPs.
+type OIDCBinding struct {
+	ID          string
+	UserID      string
+	Issuer      string
+	Subject     string
+	EmailAtBind string // captured at JIT bind; nullable
+	CreatedAt   time.Time
+}
+
+// APIKey is an issued credential owned by a single User (Human or
+// ServiceAccount). Plaintext is never persisted; only the argon2id PHC
+// hash. The prefix is queryable for O(log N) lookup; the secret is
+// constant-time-verified against PHCHash.
+//
+// RoleDowngrade, when set, caps the EffectiveRole at request time to at most
+// the named role (subject to the partial-ordering rules in the design).
+type APIKey struct {
+	ID            string
+	UserID        string
+	Prefix        string
+	PHCHash       string // argon2id PHC-format string
+	RoleDowngrade string // empty = no downgrade
+	Label         string
+	ExpiresAt     *time.Time // nil = no expiry; expired when now >= ExpiresAt
+	LastUsedAt    *time.Time // nil = never used
+	RevokedAt     *time.Time // nil = active
+	CreatedAt     time.Time
+}
+
+// IsActive reports whether the key is neither revoked nor expired (as of now).
+// The expiry boundary is exclusive: a key is expired once now reaches or
+// passes ExpiresAt, so an active key requires now < ExpiresAt.
+func (k *APIKey) IsActive(now time.Time) bool {
+	if k.RevokedAt != nil {
+		return false
+	}
+	if k.ExpiresAt != nil && !k.ExpiresAt.After(now) {
+		return false
+	}
+	return true
+}

--- a/internal/storage/users_domain.go
+++ b/internal/storage/users_domain.go
@@ -14,6 +14,7 @@ import (
 // identically for both kinds.
 type Kind string
 
+// Kind constants for the two supported user discriminators.
 const (
 	KindHuman          Kind = "human"
 	KindServiceAccount Kind = "service_account"


### PR DESCRIPTION
Implements identity storage (epic spgr-rjrt, bead spgr-rjrt.2): all 32 tasks of docs/plans/2026-05-26-identity-storage-implementation-plan.md (design spgr-e82m). Postgres-backed UsersBackend (AuthStore) with all 18 methods, migrations, integration+race+lifecycle tests, and the importable postgrestest.SharedPool harness (Task 32) that unblocks downstream Authn/Cedar/Bootstrap-UX suites. Fixed a latent RotateAPIKey in-tx-retry bug (SAVEPOINT). task check green; integration passes under -race; e2e api/cli/docker pass (e2e:ui blocked only by a corporate-proxy TLS cert in the Docker build, unrelated). Filed spgr-rjrt.7 for a List max-limit guard. Developed via subagent-driven-development with two-stage review per task group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)