### PR TITLE
fix(bootstrap): recover a keyless bootstrap admin by minting a key on Ensure (spgr-rjrt.12)

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -56,23 +56,11 @@ func Ensure(ctx context.Context, b Backend, opts Options) (Result, error) {
 		role = "admin"
 	}
 
-	// Idempotency check. A pre-existing bootstrap user is normally a no-op —
-	// EXCEPT when it has no active key, which happens if an earlier Ensure died
-	// between CreateHuman and CreateAPIKey. Such an admin is otherwise
-	// unrecoverable (every later Ensure short-circuits here), so mint a key.
+	// Idempotency check. A pre-existing bootstrap user is normally a no-op, but
+	// recoverIfKeyless re-mints a key if the user persisted without one (an
+	// earlier Ensure died between CreateHuman and CreateAPIKey).
 	if existing, err := b.GetBootstrap(ctx); err == nil {
-		keys, listErr := b.ListAPIKeys(ctx, storage.ListAPIKeysFilter{UserID: existing.ID})
-		if listErr != nil {
-			return Result{}, fmt.Errorf("list bootstrap keys: %w", listErr)
-		}
-		if len(keys) > 0 {
-			return Result{Created: false, UserID: existing.ID}, nil
-		}
-		token, mintErr := mintBootstrapKey(ctx, b, existing.ID)
-		if mintErr != nil {
-			return Result{}, mintErr
-		}
-		return Result{Created: true, Token: token, UserID: existing.ID}, nil
+		return recoverIfKeyless(ctx, b, existing)
 	} else if !errors.Is(err, storage.ErrUserNotFound) {
 		return Result{}, fmt.Errorf("check bootstrap: %w", err)
 	}
@@ -85,13 +73,16 @@ func Ensure(ctx context.Context, b Backend, opts Options) (Result, error) {
 		Bootstrap:   true,
 	}, nil)
 	if err != nil {
-		// Lost a race: another caller created the bootstrap first.
+		// Lost a race: another caller created the bootstrap first. Re-read it and
+		// run the same keyless-recovery check — if the race WINNER died between
+		// CreateHuman and CreateAPIKey, the user is keyless and we must mint here
+		// rather than no-op and defer recovery to a later Ensure.
 		if errors.Is(err, storage.ErrBootstrapExists) {
 			existing, getErr := b.GetBootstrap(ctx)
 			if getErr != nil {
 				return Result{}, fmt.Errorf("re-read bootstrap after race: %w", getErr)
 			}
-			return Result{Created: false, UserID: existing.ID}, nil
+			return recoverIfKeyless(ctx, b, existing)
 		}
 		return Result{}, fmt.Errorf("create bootstrap user: %w", err)
 	}
@@ -104,6 +95,27 @@ func Ensure(ctx context.Context, b Backend, opts Options) (Result, error) {
 		return Result{}, err
 	}
 	return Result{Created: true, Token: token, UserID: user.ID}, nil
+}
+
+// recoverIfKeyless returns a no-op Result for an existing bootstrap user that
+// still has an active key, or mints a recovery key (Created + Token) if it has
+// none. It closes the mint-failure-after-create window: a bootstrap user that
+// persisted without a key would otherwise be unrecoverable, since every later
+// Ensure short-circuits on the idempotency check or the race re-read. Shared by
+// both of those paths so they recover identically.
+func recoverIfKeyless(ctx context.Context, b Backend, existing *storage.User) (Result, error) {
+	keys, err := b.ListAPIKeys(ctx, storage.ListAPIKeysFilter{UserID: existing.ID})
+	if err != nil {
+		return Result{}, fmt.Errorf("list bootstrap keys: %w", err)
+	}
+	if len(keys) > 0 {
+		return Result{Created: false, UserID: existing.ID}, nil
+	}
+	token, err := mintBootstrapKey(ctx, b, existing.ID)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{Created: true, Token: token, UserID: existing.ID}, nil
 }
 
 // mintBootstrapKey generates a secret and persists an admin API key for userID,

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -23,6 +23,10 @@ type Backend interface {
 	GetBootstrap(ctx context.Context) (*storage.User, error)
 	CreateHuman(ctx context.Context, u *storage.User, binding *storage.OIDCBinding) (*storage.User, error)
 	CreateAPIKey(ctx context.Context, k *storage.APIKey) (*storage.APIKey, error)
+	// ListAPIKeys is used to detect a keyless bootstrap admin (a user that
+	// persisted after CreateHuman but before CreateAPIKey) so Ensure can mint a
+	// recovery key. A zero-Limit filter relies on the storage default page size.
+	ListAPIKeys(ctx context.Context, f storage.ListAPIKeysFilter) ([]*storage.APIKey, error)
 }
 
 // Options parametrizes Ensure.
@@ -33,7 +37,11 @@ type Options struct {
 
 // Result reports what Ensure did.
 type Result struct {
-	Created bool   // true if this call created the bootstrap user + key
+	// Created is true when this call produced a fresh plaintext token the
+	// operator must save — either because it created the bootstrap user + key,
+	// or because it recovered a pre-existing keyless bootstrap admin by minting
+	// a new key. False on a true no-op (bootstrap user already has a key).
+	Created bool
 	Token   string // plaintext token (only set when Created; show once)
 	UserID  string // bootstrap user id (set whether created or pre-existing)
 }
@@ -48,9 +56,23 @@ func Ensure(ctx context.Context, b Backend, opts Options) (Result, error) {
 		role = "admin"
 	}
 
-	// Idempotency check.
+	// Idempotency check. A pre-existing bootstrap user is normally a no-op —
+	// EXCEPT when it has no active key, which happens if an earlier Ensure died
+	// between CreateHuman and CreateAPIKey. Such an admin is otherwise
+	// unrecoverable (every later Ensure short-circuits here), so mint a key.
 	if existing, err := b.GetBootstrap(ctx); err == nil {
-		return Result{Created: false, UserID: existing.ID}, nil
+		keys, listErr := b.ListAPIKeys(ctx, storage.ListAPIKeysFilter{UserID: existing.ID})
+		if listErr != nil {
+			return Result{}, fmt.Errorf("list bootstrap keys: %w", listErr)
+		}
+		if len(keys) > 0 {
+			return Result{Created: false, UserID: existing.ID}, nil
+		}
+		token, mintErr := mintBootstrapKey(ctx, b, existing.ID)
+		if mintErr != nil {
+			return Result{}, mintErr
+		}
+		return Result{Created: true, Token: token, UserID: existing.ID}, nil
 	} else if !errors.Is(err, storage.ErrUserNotFound) {
 		return Result{}, fmt.Errorf("check bootstrap: %w", err)
 	}
@@ -74,29 +96,31 @@ func Ensure(ctx context.Context, b Backend, opts Options) (Result, error) {
 		return Result{}, fmt.Errorf("create bootstrap user: %w", err)
 	}
 
-	// Mint an admin key. Storage owns the prefix (see 4a Task 7); build the
-	// token from the storage-assigned prefix.
-	//
-	// NOTE: if key minting fails after the bootstrap user was created, the user
-	// persists with no key and a later Ensure short-circuits on idempotency
-	// (GetBootstrap finds the user) — it will NOT retry the key. Recovering a
-	// keyless bootstrap admin is tracked as a follow-up (spgr-rjrt orphaned-
-	// bootstrap recovery); for now a mint failure here requires operator action.
+	// Mint the admin key. If this fails after CreateHuman committed, the user
+	// persists keyless — but a later Ensure now recovers it via the idempotency
+	// branch above (it re-mints when ListAPIKeys finds no active key).
+	token, err := mintBootstrapKey(ctx, b, user.ID)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{Created: true, Token: token, UserID: user.ID}, nil
+}
+
+// mintBootstrapKey generates a secret and persists an admin API key for userID,
+// returning the one-time plaintext token. Storage owns the prefix (see 4a Task
+// 7); the token is assembled from the storage-assigned prefix.
+func mintBootstrapKey(ctx context.Context, b Backend, userID string) (string, error) {
 	secret, phc, err := auth.GenerateAPIKeySecret()
 	if err != nil {
-		return Result{}, fmt.Errorf("generate bootstrap key: %w", err)
+		return "", fmt.Errorf("generate bootstrap key: %w", err)
 	}
 	key, err := b.CreateAPIKey(ctx, &storage.APIKey{
-		UserID:  user.ID,
+		UserID:  userID,
 		PHCHash: phc,
 		Label:   "bootstrap admin key",
 	})
 	if err != nil {
-		return Result{}, fmt.Errorf("create bootstrap key: %w", err)
+		return "", fmt.Errorf("create bootstrap key: %w", err)
 	}
-	return Result{
-		Created: true,
-		Token:   auth.FormatAPIKeyToken(key.Prefix, secret),
-		UserID:  user.ID,
-	}, nil
+	return auth.FormatAPIKeyToken(key.Prefix, secret), nil
 }

--- a/internal/bootstrap/bootstrap_integration_test.go
+++ b/internal/bootstrap/bootstrap_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/specgraph/specgraph/internal/auth"
 	"github.com/specgraph/specgraph/internal/auth/usagetracker"
 	"github.com/specgraph/specgraph/internal/bootstrap"
+	"github.com/specgraph/specgraph/internal/storage"
 	"github.com/specgraph/specgraph/internal/storage/postgres"
 	"github.com/specgraph/specgraph/internal/storage/postgres/postgrestest"
 )
@@ -49,4 +50,56 @@ func TestIntegration_EnsureIdempotentAndResolvable(t *testing.T) {
 	require.False(t, res2.Created)
 	require.Empty(t, res2.Token)
 	require.Equal(t, res.UserID, res2.UserID)
+}
+
+// TestIntegration_EnsureRecoversKeylessBootstrap drives the mint-failure-
+// after-create window end-to-end: a bootstrap admin whose only key has been
+// revoked is otherwise locked out, since every later Ensure short-circuits on
+// idempotency. Ensure must instead mint a fresh, resolvable recovery key.
+func TestIntegration_EnsureRecoversKeylessBootstrap(t *testing.T) {
+	ctx := context.Background()
+	pool := postgrestest.SharedPool(t, ctx)
+	authStore, err := postgres.NewAuth(ctx, pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = authStore.Close(ctx) })
+
+	_, err = pool.Exec(ctx, `TRUNCATE users CASCADE`)
+	require.NoError(t, err)
+
+	// Create the bootstrap admin + its initial key.
+	res, err := bootstrap.Ensure(ctx, authStore, bootstrap.Options{})
+	require.NoError(t, err)
+	require.True(t, res.Created)
+
+	// Simulate the keyless state: revoke every active key for the admin.
+	keys, err := authStore.ListAPIKeys(ctx, storage.ListAPIKeysFilter{UserID: res.UserID})
+	require.NoError(t, err)
+	require.NotEmpty(t, keys)
+	for _, k := range keys {
+		require.NoError(t, authStore.RevokeAPIKey(ctx, k.ID))
+	}
+
+	// Ensure now recovers: same user, a freshly minted token.
+	rec, err := bootstrap.Ensure(ctx, authStore, bootstrap.Options{})
+	require.NoError(t, err)
+	require.True(t, rec.Created, "a keyless bootstrap admin must be recovered with a new key")
+	require.NotEmpty(t, rec.Token)
+	require.Equal(t, res.UserID, rec.UserID, "recovery reuses the existing bootstrap user")
+	require.NotEqual(t, res.Token, rec.Token, "a brand-new secret is minted")
+
+	// The recovery token resolves to the same admin.
+	tracker := usagetracker.NewManager(authStore, usagetracker.Config{})
+	t.Cleanup(func() { _ = tracker.Close(ctx) })
+	resolver, err := auth.NewIdentityStore(auth.IdentityStoreConfig{Users: authStore, Tracker: tracker})
+	require.NoError(t, err)
+	id, err := resolver.Resolve(ctx, rec.Token)
+	require.NoError(t, err)
+	require.Equal(t, res.UserID, id.UserID)
+	require.Equal(t, auth.Role("admin"), id.Role)
+
+	// Now that an active key exists again, Ensure is a no-op.
+	noop, err := bootstrap.Ensure(ctx, authStore, bootstrap.Options{})
+	require.NoError(t, err)
+	require.False(t, noop.Created)
+	require.Empty(t, noop.Token)
 }

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -22,6 +22,7 @@ type stub struct {
 	bootstrapUser *storage.User
 	createHuman   func(*storage.User) (*storage.User, error)
 	createdKey    *storage.APIKey
+	keys          []*storage.APIKey // active keys returned by ListAPIKeys
 }
 
 func (s *stub) GetBootstrap(context.Context) (*storage.User, error) {
@@ -38,6 +39,9 @@ func (s *stub) CreateAPIKey(_ context.Context, k *storage.APIKey) (*storage.APIK
 	k.Prefix = "boot1234" // simulate storage-assigned prefix
 	s.createdKey = k
 	return k, nil
+}
+func (s *stub) ListAPIKeys(_ context.Context, _ storage.ListAPIKeysFilter) ([]*storage.APIKey, error) {
+	return s.keys, nil
 }
 
 // stub satisfies bootstrap.Backend with exactly these three methods — no
@@ -64,11 +68,39 @@ func TestEnsure_CreatesBootstrapAdmin(t *testing.T) {
 }
 
 func TestEnsure_IdempotentWhenExists(t *testing.T) {
-	s := &stub{bootstrapUser: &storage.User{ID: "boot-user", DisplayName: "admin", Bootstrap: true, Role: "admin"}}
+	// Existing bootstrap user that ALREADY has an active key → true no-op.
+	s := &stub{
+		bootstrapUser: &storage.User{ID: "boot-user", DisplayName: "admin", Bootstrap: true, Role: "admin"},
+		keys:          []*storage.APIKey{{ID: "existing-key", UserID: "boot-user"}},
+	}
 	res, err := bootstrap.Ensure(context.Background(), s, bootstrap.Options{})
 	require.NoError(t, err)
-	require.False(t, res.Created, "existing bootstrap is a no-op")
-	require.Empty(t, res.Token, "no token minted when bootstrap already exists")
+	require.False(t, res.Created, "existing bootstrap with a key is a no-op")
+	require.Empty(t, res.Token, "no token minted when the bootstrap admin already has a key")
+	require.Nil(t, s.createdKey, "no key minted when one already exists")
+}
+
+// TestEnsure_RecoversKeylessBootstrap covers the mint-failure-after-create
+// window: a bootstrap user persisted with NO active key (an earlier Ensure
+// crashed between CreateHuman and CreateAPIKey). A later Ensure must mint a key
+// and return it, rather than no-op'ing forever on idempotency.
+func TestEnsure_RecoversKeylessBootstrap(t *testing.T) {
+	s := &stub{
+		bootstrapUser: &storage.User{ID: "boot-user", DisplayName: "admin", Bootstrap: true, Role: "admin"},
+		keys:          nil, // no active keys → unrecoverable without this fix
+		createHuman: func(*storage.User) (*storage.User, error) {
+			panic("CreateHuman must not be called when the bootstrap user already exists")
+		},
+	}
+	res, err := bootstrap.Ensure(context.Background(), s, bootstrap.Options{})
+	require.NoError(t, err)
+	require.True(t, res.Created, "a keyless bootstrap must mint a recovery key")
+	require.NotEmpty(t, res.Token, "the recovery token must be returned for the operator to save")
+	require.True(t, strings.HasPrefix(res.Token, auth.APIKeyTokenPrefix()))
+	require.Contains(t, res.Token, "boot1234", "token embeds the storage-assigned prefix")
+	require.Equal(t, "boot-user", res.UserID)
+	require.NotNil(t, s.createdKey, "a key must have been minted")
+	require.Equal(t, "boot-user", s.createdKey.UserID, "the recovery key belongs to the existing bootstrap user")
 }
 
 // raceStub models losing the create race: GetBootstrap misses first (so
@@ -93,6 +125,9 @@ func (r *raceStub) CreateHuman(context.Context, *storage.User, *storage.OIDCBind
 func (r *raceStub) CreateAPIKey(context.Context, *storage.APIKey) (*storage.APIKey, error) {
 	panic("CreateAPIKey must not be called when the create race is lost")
 }
+func (r *raceStub) ListAPIKeys(context.Context, storage.ListAPIKeysFilter) ([]*storage.APIKey, error) {
+	panic("ListAPIKeys must not be called on the create-race path")
+}
 
 func TestEnsure_RaceLosesGracefully(t *testing.T) {
 	r := &raceStub{winner: &storage.User{ID: "winner", DisplayName: "admin", Bootstrap: true}}
@@ -113,6 +148,9 @@ func (e *errStub) CreateHuman(context.Context, *storage.User, *storage.OIDCBindi
 }
 func (e *errStub) CreateAPIKey(context.Context, *storage.APIKey) (*storage.APIKey, error) {
 	panic("CreateAPIKey must not be called when GetBootstrap errors")
+}
+func (e *errStub) ListAPIKeys(context.Context, storage.ListAPIKeysFilter) ([]*storage.APIKey, error) {
+	panic("ListAPIKeys must not be called when GetBootstrap errors")
 }
 
 func TestEnsure_GetBootstrapErrorSurfaced(t *testing.T) {

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -108,8 +108,10 @@ func TestEnsure_RecoversKeylessBootstrap(t *testing.T) {
 // (the winner created it concurrently), and the re-fetch GetBootstrap returns
 // the winner.
 type raceStub struct {
-	winner   *storage.User
-	getCalls int
+	winner     *storage.User
+	getCalls   int
+	keys       []*storage.APIKey // active keys the winner already has
+	createdKey *storage.APIKey
 }
 
 func (r *raceStub) GetBootstrap(context.Context) (*storage.User, error) {
@@ -122,20 +124,46 @@ func (r *raceStub) GetBootstrap(context.Context) (*storage.User, error) {
 func (r *raceStub) CreateHuman(context.Context, *storage.User, *storage.OIDCBinding) (*storage.User, error) {
 	return nil, storage.ErrBootstrapExists
 }
-func (r *raceStub) CreateAPIKey(context.Context, *storage.APIKey) (*storage.APIKey, error) {
-	panic("CreateAPIKey must not be called when the create race is lost")
+func (r *raceStub) CreateAPIKey(_ context.Context, k *storage.APIKey) (*storage.APIKey, error) {
+	k.ID = "race-key"
+	k.Prefix = "race5678"
+	r.createdKey = k
+	return k, nil
 }
 func (r *raceStub) ListAPIKeys(context.Context, storage.ListAPIKeysFilter) ([]*storage.APIKey, error) {
-	panic("ListAPIKeys must not be called on the create-race path")
+	return r.keys, nil
 }
 
 func TestEnsure_RaceLosesGracefully(t *testing.T) {
-	r := &raceStub{winner: &storage.User{ID: "winner", DisplayName: "admin", Bootstrap: true}}
+	// Winner already minted its key → loser observes a complete bootstrap.
+	r := &raceStub{
+		winner: &storage.User{ID: "winner", DisplayName: "admin", Bootstrap: true},
+		keys:   []*storage.APIKey{{ID: "winner-key", UserID: "winner"}},
+	}
 	res, err := bootstrap.Ensure(context.Background(), r, bootstrap.Options{})
 	require.NoError(t, err)
-	require.False(t, res.Created, "race loser observes the winner's bootstrap")
+	require.False(t, res.Created, "race loser observes the winner's complete bootstrap")
 	require.Equal(t, "winner", res.UserID)
-	require.Empty(t, res.Token, "loser mints no key")
+	require.Empty(t, res.Token, "loser mints no key when the winner already has one")
+	require.Nil(t, r.createdKey)
+}
+
+// TestEnsure_RaceRecoversKeylessWinner covers the worst-case race: the loser
+// re-reads the winner's user, but the winner died between CreateHuman and
+// CreateAPIKey, so the winner is keyless. The loser must recover it in-call
+// rather than no-op'ing and deferring recovery to a hypothetical next Ensure.
+func TestEnsure_RaceRecoversKeylessWinner(t *testing.T) {
+	r := &raceStub{
+		winner: &storage.User{ID: "winner", DisplayName: "admin", Bootstrap: true},
+		keys:   nil, // winner crashed before minting → keyless
+	}
+	res, err := bootstrap.Ensure(context.Background(), r, bootstrap.Options{})
+	require.NoError(t, err)
+	require.True(t, res.Created, "the race loser must recover a keyless winner")
+	require.NotEmpty(t, res.Token)
+	require.Equal(t, "winner", res.UserID)
+	require.NotNil(t, r.createdKey, "a recovery key was minted for the winner")
+	require.Equal(t, "winner", r.createdKey.UserID)
 }
 
 // errStub returns a non-sentinel error from GetBootstrap; Ensure must surface


### PR DESCRIPTION
## Summary

PR-C of the Identity epic (spgr-rjrt) follow-ups — closes the keyless-bootstrap recovery gap (P3).

### The bug
If `bootstrap.Ensure` died between `CreateHuman` and `CreateAPIKey` (a crash, transient DB error, etc.), the bootstrap admin persisted **with no API key**. Every later `Ensure` then short-circuited on idempotency (`GetBootstrap` finds the user) and never retried the key — leaving the admin **permanently unrecoverable** without manual DB surgery.

### The fix
On finding an existing bootstrap user, `Ensure` now checks whether it has an **active** API key (`ListAPIKeys` added to the narrow `bootstrap.Backend` interface — `*postgres.AuthStore` already implements it). If none exist, it mints a fresh key and returns it as `Created`/`Token`, so `init` and `serve` surface the recovered credential exactly as they do a first-time bootstrap. Key minting is factored into a shared `mintBootstrapKey` helper.

`Result.Created` is documented to cover the recovery case ("this call produced a token you must save"), and the stale NOTE comment describing the unrecoverable window is removed.

### Semantics
- existing admin **with** an active key → true no-op (unchanged)
- existing admin **with no** active key → mint + return token (new)
- Uses active keys only (`IncludeRevoked: false`), so an admin whose only key was revoked is also recovered.

## Testing

- Unit: existing-user-with-key → no-op; existing-user-no-key → mints (and never calls `CreateHuman`).
- Integration: create bootstrap → revoke its key → `Ensure` recovers a **resolvable** new key (same user, new secret) → a subsequent `Ensure` is a no-op.
- `go build ./...`, `lint:go`, `-race` unit suite, and `internal/bootstrap` integration all green.

Note: `task check` flags a pre-existing `MD077` rumdl issue in an unrelated plan doc (local rumdl version drift) — untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)