### PR TITLE
fix(auth): fail-closed role-downgrade clamp for custom/unranked roles (spgr-rjrt.9)

### DIFF
--- a/docs/superpowers/specs/2026-06-04-spgr-rjrt-9-role-downgrade-failclosed-design.md
+++ b/docs/superpowers/specs/2026-06-04-spgr-rjrt-9-role-downgrade-failclosed-design.md
@@ -1,0 +1,101 @@
+# Custom-role downgrade: fail-closed clamp (spgr-rjrt.9)
+
+## Problem
+
+An API key carries an optional `RoleDowngrade` — a cap that should make the key
+*less* privileged than its owning user. The resolver computes the key's
+`EffectiveRole` as `clampedRole(user.Role, key.RoleDowngrade)` and hands it to
+the Cedar policy engine.
+
+`clampedRole` orders only the built-in roles (`reader < writer < admin`) via the
+`roleRank` map; `roleLessThan` returns `false` for any role not in that map.
+The current implementation returns `userRole` whenever the downgrade is not
+provably lower:
+
+```go
+func clampedRole(userRole, downgrade Role) Role {
+    if downgrade == "" {
+        return userRole
+    }
+    if roleLessThan(downgrade, userRole) {
+        return downgrade
+    }
+    return userRole
+}
+```
+
+So when **either** operand is a custom (unranked) role, the comparison is
+`false` and the function returns the user's *fuller* role. A key whose
+`RoleDowngrade` is a custom role — or any key on a user whose role is custom —
+silently keeps the broader role instead of being restricted. This is a
+fail-**open** privilege relaxation: a cap intended to restrict is a no-op.
+
+Cedar (the policy engine) is default-deny on the role attribute and faithfully
+enforces whatever `EffectiveRole` it is given; the downgrade is computed
+upstream of Cedar, so this is not fixed by the policy layer. It must be fixed
+where `EffectiveRole` is derived.
+
+## Decisions
+
+- **`RoleDowngrade` targets built-in roles only.** A downgrade is a cap and is
+  only meaningful where a privilege order exists. Scoping a key to a custom role
+  is a separate concern (see Non-goals).
+- **The resolver fails closed.** When a downgrade is set but the two roles
+  cannot be ordered (a custom role on either side), the effective role becomes
+  the most-restrictive built-in, `reader`. Never the user's fuller role.
+
+## Design
+
+Two layers: enforce on read (the security guarantee) and validate on write
+(prevention plus a clear error).
+
+### 1. Resolver — fail-closed `clampedRole`
+
+```text
+clampedRole(userRole, downgrade):
+  downgrade == ""                        -> userRole                 # no cap; key == owner
+  userRole and downgrade both ranked     -> min(userRole, downgrade) # correct clamp; never elevates
+  otherwise (a custom role either side)  -> RoleReader               # cap set but unorderable -> floor
+```
+
+"Ranked" means present in `roleRank`. The `min` branch preserves today's
+correct behavior, including the anti-escalation case (a downgrade higher than
+the user's role yields the user's role). The floor branch is the fix: an
+unorderable-but-present downgrade resolves to `reader` rather than to the user's
+role.
+
+This holds at the enforcement point for every key — including legacy keys that
+were created with a custom downgrade before write-side validation existed, and
+keys on users whose role is custom.
+
+The empty-downgrade path is unchanged: a key with no cap is exactly its owner's
+role, custom or not.
+
+### 2. Handler — validate `RoleDowngrade` at key creation
+
+In the `CreateAPIKey` handler: if `role_downgrade` is non-empty and not one of
+`reader`, `writer`, `admin`, return `InvalidArgument` with a message naming the
+allowed values. This fails fast with a clear error instead of silently flooring
+the key, and prevents new custom-downgrade keys from being created.
+
+`RotateAPIKey` does not accept `role_downgrade` (the field was reserved when
+rotation was made identity-preserving); rotation inherits the old key's
+downgrade, so no validation is added there. Any legacy custom downgrade carried
+forward by rotation is still contained by the resolver floor.
+
+## Non-goals (YAGNI)
+
+- Custom-role downgrade targets.
+- A configurable privilege rank for custom roles.
+- Changing an existing key's `role_downgrade` (tracked separately).
+- Expressing role ordering inside Cedar.
+
+## Testing
+
+- `clampedRole` table (direct): empty -> user; `writer`+`reader` -> reader;
+  `reader`+`writer` -> reader (no escalation); `admin`+`reader` -> reader;
+  custom-user + `reader` -> reader (floor); built-in-user + custom downgrade ->
+  reader (floor); custom-user + empty -> custom (unchanged).
+- Resolver (end-to-end): a key with a custom downgrade floors to `reader`.
+- `CreateAPIKey` handler: custom `role_downgrade` -> `InvalidArgument`;
+  built-in -> ok; empty -> ok.

--- a/internal/auth/clampedrole_internal_test.go
+++ b/internal/auth/clampedrole_internal_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import "testing"
+
+// TestClampedRole_FailClosed exercises clampedRole directly (it is unexported).
+// The contract: a set downgrade must never leave the key with the owner's
+// fuller role. Comparable built-in pairs clamp to the minimum; any pair that
+// cannot be ordered (a custom role on either side) floors to reader.
+func TestClampedRole_FailClosed(t *testing.T) {
+	const (
+		ops = Role("ops") // custom, unranked
+		dev = Role("dev") // custom, unranked
+	)
+	cases := []struct {
+		name     string
+		userRole Role
+		downgrade Role
+		want     Role
+	}{
+		{"no cap keeps built-in owner role", RoleAdmin, "", RoleAdmin},
+		{"no cap keeps reader", RoleReader, "", RoleReader},
+		{"no cap keeps custom owner role", ops, "", ops},
+		{"writer capped to reader", RoleWriter, RoleReader, RoleReader},
+		{"admin capped to reader", RoleAdmin, RoleReader, RoleReader},
+		{"admin capped to writer", RoleAdmin, RoleWriter, RoleWriter},
+		{"downgrade above owner does not escalate", RoleReader, RoleWriter, RoleReader},
+		{"admin downgrade on reader does not escalate", RoleReader, RoleAdmin, RoleReader},
+		{"custom owner + builtin cap floors to reader", ops, RoleReader, RoleReader},
+		{"builtin owner + custom cap floors to reader", RoleAdmin, ops, RoleReader},
+		{"custom owner + custom cap floors to reader", ops, dev, RoleReader},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := clampedRole(c.userRole, c.downgrade); got != c.want {
+				t.Errorf("clampedRole(%q, %q) = %q, want %q", c.userRole, c.downgrade, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/auth/identitystore.go
+++ b/internal/auth/identitystore.go
@@ -230,6 +230,15 @@ func argon2idVerify(phc, secret string) bool {
 // reader < writer < admin. Custom/unranked roles are absent from the map.
 var roleRank = map[Role]int{RoleReader: 1, RoleWriter: 2, RoleAdmin: 3}
 
+// IsBuiltinRole reports whether r is one of the ranked built-in roles
+// (reader, writer, admin). It is the single source of truth for "ranked" —
+// callers validating a RoleDowngrade target (a cap, which must be orderable)
+// use it rather than duplicating the role list.
+func IsBuiltinRole(r Role) bool {
+	_, ok := roleRank[r]
+	return ok
+}
+
 // roleLessThan reports whether a is strictly less privileged than b.
 // Built-in roles are linearly ordered: reader < writer < admin. Custom
 // roles return false in either direction (see Storage design's roleLessThan).
@@ -242,12 +251,24 @@ func roleLessThan(a, b Role) bool {
 	return ra < rb
 }
 
-// clampedRole returns the lesser of userRole and downgrade, but only for
-// built-in roles. A downgrade on a custom/unranked role has no defined
-// ordering, so it is silently a no-op: EffectiveRole equals userRole.
+// clampedRole computes a key's EffectiveRole from its owner's role and the
+// key's RoleDowngrade cap. An empty downgrade is no cap (the key is its owner's
+// role). When both roles are ranked built-ins it returns the lesser, so a cap
+// never escalates. Otherwise — a cap is set but a custom/unranked role on
+// either side makes the pair incomparable — it fails CLOSED to the
+// most-restrictive built-in (reader) rather than silently keeping the owner's
+// fuller role (the spgr-rjrt.9 fail-open bug). RoleDowngrade is validated to a
+// built-in at key creation; the floor still contains legacy keys and
+// custom-role owners. See
+// docs/superpowers/specs/2026-06-04-spgr-rjrt-9-role-downgrade-failclosed-design.md.
 func clampedRole(userRole, downgrade Role) Role {
 	if downgrade == "" {
 		return userRole
+	}
+	_, ownerRanked := roleRank[userRole]
+	_, downgradeRanked := roleRank[downgrade]
+	if !ownerRanked || !downgradeRanked {
+		return RoleReader
 	}
 	if roleLessThan(downgrade, userRole) {
 		return downgrade

--- a/internal/server/identity_handler.go
+++ b/internal/server/identity_handler.go
@@ -225,6 +225,13 @@ func (h *IdentityHandler) CreateAPIKey(ctx context.Context, req *connect.Request
 	if msg.GetUserId() == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("user_id is required"))
 	}
+	// RoleDowngrade is a privilege cap and is only meaningful among the ranked
+	// built-in roles; a custom target would fail closed to reader at resolve
+	// time, so reject it here with a clear error (spgr-rjrt.9).
+	if d := msg.GetRoleDowngrade(); d != "" && !auth.IsBuiltinRole(auth.Role(d)) {
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			errors.New("role_downgrade must be one of: reader, writer, admin"))
+	}
 
 	secret, phc, err := auth.GenerateAPIKeySecret()
 	if err != nil {

--- a/internal/server/identity_handler_test.go
+++ b/internal/server/identity_handler_test.go
@@ -386,6 +386,41 @@ func TestCreateAPIKey_RequiresUserID(t *testing.T) {
 	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }
 
+// TestCreateAPIKey_RejectsCustomRoleDowngrade asserts a non-built-in
+// role_downgrade is rejected before touching the backend — RoleDowngrade is a
+// cap and is only meaningful among the ranked built-in roles (spgr-rjrt.9).
+func TestCreateAPIKey_RejectsCustomRoleDowngrade(t *testing.T) {
+	stub := &usersBackendStub{
+		createAPIKey: func(context.Context, *storage.APIKey) (*storage.APIKey, error) {
+			t.Fatal("backend CreateAPIKey must not be called for an invalid role_downgrade")
+			return nil, nil
+		},
+	}
+	client := newTestIdentityHandler(t, stub)
+	_, err := client.CreateAPIKey(context.Background(), connect.NewRequest(&specv1.CreateAPIKeyRequest{
+		UserId: "u1", RoleDowngrade: "ops", // custom, unranked
+	}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+// TestCreateAPIKey_AcceptsBuiltinRoleDowngrade asserts a built-in role_downgrade
+// is threaded through to the backend unchanged.
+func TestCreateAPIKey_AcceptsBuiltinRoleDowngrade(t *testing.T) {
+	stub := &usersBackendStub{
+		createAPIKey: func(_ context.Context, k *storage.APIKey) (*storage.APIKey, error) {
+			require.Equal(t, "reader", k.RoleDowngrade)
+			out := *k
+			out.ID, out.Prefix, out.CreatedAt = "k1", "abcd1234", time.Now()
+			return &out, nil
+		},
+	}
+	client := newTestIdentityHandler(t, stub)
+	_, err := client.CreateAPIKey(context.Background(), connect.NewRequest(&specv1.CreateAPIKeyRequest{
+		UserId: "u1", RoleDowngrade: "reader",
+	}))
+	require.NoError(t, err)
+}
+
 func TestRotateAPIKey_ReturnsNewPlaintext(t *testing.T) {
 	const oldKeyID = "old-key-id"
 	stub := &usersBackendStub{


### PR DESCRIPTION
## Summary

Final follow-up of the Identity epic (spgr-rjrt) — fixes a fail-**open** privilege relaxation in role-downgrade handling (P3, flagged by CodeRabbit on #967).

### The bug
`clampedRole(user.Role, key.RoleDowngrade)` ordered only the built-in roles (`reader<writer<admin`) and returned the **owner's** role whenever the downgrade couldn't be proven lower. So a key whose `RoleDowngrade` was a custom role — or any key on a user whose role is custom — silently kept the fuller role. A cap meant to *restrict* was a no-op. Cedar enforces whatever `EffectiveRole` it's handed (default-deny on the role), so the fix belongs where `EffectiveRole` is derived.

### The fix — two layers
**Enforce on read** (`internal/auth/identitystore.go`): `clampedRole` now fails **closed**.
- empty downgrade → owner role (unchanged)
- both roles ranked built-ins → `min` (unchanged — still prevents escalation)
- a custom role on either side with a cap set → **`RoleReader`** floor (never the owner's fuller role)

**Validate on write** (`CreateAPIKey` handler): a non-built-in `role_downgrade` → `InvalidArgument` ("must be one of: reader, writer, admin"), via new `auth.IsBuiltinRole` (single source of truth over `roleRank`). Rotate inherits `role_downgrade` (reserved in #971) and is unchanged; the resolver floor still contains legacy keys and custom-role owners.

### Design decisions (brainstormed)
- `RoleDowngrade` targets **built-in roles only** — a cap is only meaningful where an order exists. Scoping a key to a custom role is out of scope (see **spgr-w20x**).
- Incomparable cases fail closed to **reader** (most-restrictive built-in) rather than denying — never escalates, stays available read-only.

Full rationale: `docs/superpowers/specs/2026-06-04-spgr-rjrt-9-role-downgrade-failclosed-design.md` (included in this PR).

## Testing
- Direct `clampedRole` table: min, anti-escalation, floor (custom owner / custom downgrade / both custom), empty→owner.
- Handler: custom `role_downgrade` → `InvalidArgument`; built-in → threaded through; empty → ok.
- Existing resolver clamp/escalation tests stay green.
- `lint:go` (0 issues), `-race` unit suite, and `internal/auth` + `internal/server` integration all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)