### PR TITLE
docs(plans): fix MD077 continuation-line indentation (managed-files design)

### DIFF
--- a/docs/plans/2026-05-11-spgr-rwrp-pr-b-port-managed-files-design.md
+++ b/docs/plans/2026-05-11-spgr-rwrp-pr-b-port-managed-files-design.md
@@ -462,9 +462,9 @@ from a freshly-written canonical file.
      - Else → `StateStale` / `ActionRefreshed` (overwrite, fresh
        sentinel).
 
-     If disk hash doesn't match recorded sentinel hash →
-     `StateDrifted`. Skip without `--force`; `--force` rewrites;
-     `--force --keep-edits` refreshes the sentinel to match disk.
+   If disk hash doesn't match recorded sentinel hash →
+   `StateDrifted`. Skip without `--force`; `--force` rewrites;
+   `--force --keep-edits` refreshes the sentinel to match disk.
 
    - **v=1 markers.** Defensive recompute: call private
      `renderV1MarkdownBlockBody(mf, params)` for the same file's prior


### PR DESCRIPTION
## What

`rumdl`'s `MD077` flags three over-indented continuation lines (expected 3, found 5) in `docs/plans/2026-05-11-spgr-rwrp-pr-b-port-managed-files-design.md`, which blocks `task lint` / `task check` locally.

This applies `rumdl fmt` to normalize the indentation of the continuation paragraph under the **v=2 markers** bullet. Content is unchanged; only leading whitespace (5→3 spaces) on three lines.

## Verification

- `rumdl check` on the file: **no issues**.
- Single commit, single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)