### PR TITLE
test(authn): OIDC coverage — full-stack interceptor, CLI oidc cmds, verifier branches

### DIFF
--- a/cmd/specgraph/auth_oidc_test.go
+++ b/cmd/specgraph/auth_oidc_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	specv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/gen/specgraph/v1/specgraphv1connect"
+)
+
+// --- Validation branches (execute before any RPC) ---
+
+// TestAuthOIDCList_RequiresUser verifies the --user guard returns an error
+// before any client is constructed.
+func TestAuthOIDCList_RequiresUser(t *testing.T) {
+	defer func(v string) { oidcListUser = v }(oidcListUser)
+	oidcListUser = ""
+	err := authOIDCListCmd.RunE(authOIDCListCmd, nil)
+	require.EqualError(t, err, "--user is required")
+}
+
+// TestAuthOIDCUnbind_RequiresUser verifies the --user guard on unbind (the
+// owner of the binding) returns an error before any client is constructed.
+func TestAuthOIDCUnbind_RequiresUser(t *testing.T) {
+	defer func(v string) { oidcUnbindUser = v }(oidcUnbindUser)
+	oidcUnbindUser = ""
+	err := authOIDCUnbindCmd.RunE(authOIDCUnbindCmd, []string{"binding-1"})
+	require.EqualError(t, err, "--user is required (owner of the binding)")
+}
+
+// --- Happy-path round-trips (via the injectable identityClient seam) ---
+
+// stubIdentityHandler serves canned ListOIDCBindings / UnbindOIDC responses so
+// CLI commands can be exercised end-to-end (RPC round-trip + render) without a
+// real backend. unbindReq captures the last UnbindOIDC request for assertions.
+type stubIdentityHandler struct {
+	specgraphv1connect.UnimplementedIdentityServiceHandler
+	bindings  []*specv1.OIDCBinding
+	unbindReq *specv1.UnbindOIDCRequest
+}
+
+func (h *stubIdentityHandler) ListOIDCBindings(_ context.Context, _ *connect.Request[specv1.ListOIDCBindingsRequest]) (*connect.Response[specv1.ListOIDCBindingsResponse], error) {
+	return connect.NewResponse(&specv1.ListOIDCBindingsResponse{Bindings: h.bindings}), nil
+}
+
+func (h *stubIdentityHandler) UnbindOIDC(_ context.Context, req *connect.Request[specv1.UnbindOIDCRequest]) (*connect.Response[specv1.UnbindOIDCResponse], error) {
+	h.unbindReq = req.Msg
+	return connect.NewResponse(&specv1.UnbindOIDCResponse{}), nil
+}
+
+// withStubIdentityClient stands up an httptest server backed by handler and
+// points the package-level identityClient at it for the duration of the test.
+func withStubIdentityClient(t *testing.T, handler *stubIdentityHandler) {
+	t.Helper()
+	mux := http.NewServeMux()
+	path, h := specgraphv1connect.NewIdentityServiceHandler(handler)
+	mux.Handle(path, h)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client := specgraphv1connect.NewIdentityServiceClient(http.DefaultClient, srv.URL)
+	prev := identityClient
+	identityClient = func() (specgraphv1connect.IdentityServiceClient, error) { return client, nil }
+	t.Cleanup(func() { identityClient = prev })
+}
+
+// TestAuthOIDCList_RendersBindings drives `auth oidc list --user u1` against a
+// stub server and asserts the rendered table contains the returned binding.
+func TestAuthOIDCList_RendersBindings(t *testing.T) {
+	defer func(v string, j bool) { oidcListUser = v; authJSON = j }(oidcListUser, authJSON)
+	withStubIdentityClient(t, &stubIdentityHandler{
+		bindings: []*specv1.OIDCBinding{
+			{Id: "bind-1", Issuer: "https://idp.example.com", Subject: "sub-123"},
+		},
+	})
+	oidcListUser = "u1"
+	authJSON = false
+
+	var buf bytes.Buffer
+	authOIDCListCmd.SetOut(&buf)
+	authOIDCListCmd.SetContext(context.Background())
+	t.Cleanup(func() { authOIDCListCmd.SetOut(nil) })
+
+	require.NoError(t, authOIDCListCmd.RunE(authOIDCListCmd, nil))
+	out := buf.String()
+	require.Contains(t, out, "bind-1")
+	require.Contains(t, out, "sub-123")
+	require.Contains(t, out, "ISSUER")
+}
+
+// TestAuthOIDCList_EmptyRendersPlaceholder asserts the no-bindings case renders
+// the placeholder line rather than an empty/garbled table.
+func TestAuthOIDCList_EmptyRendersPlaceholder(t *testing.T) {
+	defer func(v string, j bool) { oidcListUser = v; authJSON = j }(oidcListUser, authJSON)
+	withStubIdentityClient(t, &stubIdentityHandler{bindings: nil})
+	oidcListUser = "u1"
+	authJSON = false
+
+	var buf bytes.Buffer
+	authOIDCListCmd.SetOut(&buf)
+	authOIDCListCmd.SetContext(context.Background())
+	t.Cleanup(func() { authOIDCListCmd.SetOut(nil) })
+
+	require.NoError(t, authOIDCListCmd.RunE(authOIDCListCmd, nil))
+	require.Contains(t, buf.String(), "No OIDC bindings found.")
+}
+
+// TestAuthOIDCUnbind_PassesForceAndIDs verifies the unbind command forwards the
+// binding ID (positional arg), owner --user, and --force flag into the request.
+func TestAuthOIDCUnbind_PassesForceAndIDs(t *testing.T) {
+	defer func(u string, f bool) { oidcUnbindUser = u; oidcUnbindForce = f }(oidcUnbindUser, oidcUnbindForce)
+	h := &stubIdentityHandler{}
+	withStubIdentityClient(t, h)
+	oidcUnbindUser = "owner-9"
+	oidcUnbindForce = true
+
+	var buf bytes.Buffer
+	authOIDCUnbindCmd.SetOut(&buf)
+	authOIDCUnbindCmd.SetContext(context.Background())
+	t.Cleanup(func() { authOIDCUnbindCmd.SetOut(nil) })
+
+	require.NoError(t, authOIDCUnbindCmd.RunE(authOIDCUnbindCmd, []string{"bind-7"}))
+	require.NotNil(t, h.unbindReq, "handler must have received the unbind request")
+	require.Equal(t, "bind-7", h.unbindReq.GetBindingId())
+	require.Equal(t, "owner-9", h.unbindReq.GetUserId())
+	require.True(t, h.unbindReq.GetForce(), "--force must propagate into the request")
+	require.Contains(t, buf.String(), "Unbound bind-7")
+}
+
+// TestAuthOIDCUnbind_SurfacesServerError confirms an RPC error is wrapped and
+// returned rather than swallowed.
+func TestAuthOIDCUnbind_SurfacesServerError(t *testing.T) {
+	defer func(u string) { oidcUnbindUser = u }(oidcUnbindUser)
+	prev := identityClient
+	identityClient = func() (specgraphv1connect.IdentityServiceClient, error) {
+		return nil, errors.New("dial failed")
+	}
+	t.Cleanup(func() { identityClient = prev })
+	oidcUnbindUser = "owner-9"
+
+	err := authOIDCUnbindCmd.RunE(authOIDCUnbindCmd, []string{"bind-7"})
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "dial failed"))
+}

--- a/cmd/specgraph/identity_client.go
+++ b/cmd/specgraph/identity_client.go
@@ -9,6 +9,9 @@ import (
 
 // identityClient builds an authenticated IdentityService client using the
 // shared credential/base-URL resolution (newClient).
-func identityClient() (specgraphv1connect.IdentityServiceClient, error) {
+//
+// It is a package-level var (not a plain func) so tests can substitute a client
+// pointed at an in-process stub server; production callers invoke it unchanged.
+var identityClient = func() (specgraphv1connect.IdentityServiceClient, error) {
 	return newClient(specgraphv1connect.NewIdentityServiceClient)
 }

--- a/internal/auth/identitystore_jit_test.go
+++ b/internal/auth/identitystore_jit_test.go
@@ -340,3 +340,49 @@ func TestJIT_ClaimsMapping_NoMatchFallsBackToDefault(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "writer", capturedRole, "no claims-mapping match should fall back to default role")
 }
+
+// TestJIT_ClaimsMapping_ScalarStringClaim covers matchClaimValue's scalar-string
+// branch: a claim carrying a single JSON string (not a []string array) must
+// still match a mapping rule. The existing mapping tests only use array claims,
+// leaving the string path — common for single-valued claims like "role" — uncovered.
+func TestJIT_ClaimsMapping_ScalarStringClaim(t *testing.T) {
+	p := newOIDCTestIssuer(t)
+	v, err := auth.NewOIDCVerifier(context.Background(), config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "aud-1",
+	})
+	require.NoError(t, err)
+	var capturedRole string
+	stub := &usersBackendStub{
+		lookupOIDCBinding: func(_ context.Context, _, _ string) (*storage.OIDCBinding, error) {
+			return nil, storage.ErrOIDCBindingNotFound
+		},
+		jitCreateHuman: func(_ context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error) {
+			capturedRole = u.Role
+			u.ID = "u"
+			b.ID = "b"
+			b.UserID = "u"
+			return u, b, nil
+		},
+	}
+	store, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Verifiers: []*auth.OIDCVerifier{v}, Tracker: &noopTracker{},
+		JITEnabled:     true,
+		JITDefaultRole: auth.RoleReader,
+		JITClaimsMapping: map[string][]config.ClaimMapping{
+			p.server.URL: {
+				{Claim: "role", Value: "platform-admin", Role: "admin"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	tok := p.mintToken(t, map[string]any{
+		"iss": p.server.URL, "sub": "x", "aud": "aud-1",
+		"exp":   time.Now().Add(time.Hour).Unix(),
+		"iat":   time.Now().Unix(),
+		"email": "a@example.com",
+		"role":  "platform-admin", // scalar string, not an array
+	})
+	_, err = store.Resolve(context.Background(), tok)
+	require.NoError(t, err)
+	require.Equal(t, "admin", capturedRole, "a scalar-string claim must match a mapping rule")
+}

--- a/internal/auth/interceptor_oidc_integration_test.go
+++ b/internal/auth/interceptor_oidc_integration_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build integration
+
+package auth_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	specgraphv1 "github.com/specgraph/specgraph/gen/specgraph/v1"
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// capturingAuthorizer allows every request and records the Identity it was
+// handed. It lets the full-stack tests assert that the Identity the resolver
+// produced from a real JWT actually propagated through the interceptor to the
+// authorization boundary (and thus to the handler).
+type capturingAuthorizer struct {
+	mu   sync.Mutex
+	last *auth.Identity
+}
+
+func (c *capturingAuthorizer) Authorize(_ context.Context, id *auth.Identity, _ string, _ any) (auth.Decision, error) {
+	c.mu.Lock()
+	c.last = id
+	c.mu.Unlock()
+	return auth.Decision{Allowed: true, Reason: "test-allow"}, nil
+}
+
+func (c *capturingAuthorizer) lastIdentity() *auth.Identity {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.last
+}
+
+// TestFullStack_JWT_JITProvisionsAndReachesHandler drives a real signed JWT for
+// an unknown subject through NewAuthInterceptor backed by the real Postgres
+// resolver + verifier. This closes the seam the unit/integration suites left
+// open: header parsing → interceptor → real JIT resolve → identity at the
+// authorization boundary. The existing full-stack identity tests only ever used
+// API-key tokens, so the JWT branch never traversed the interceptor before.
+func TestFullStack_JWT_JITProvisionsAndReachesHandler(t *testing.T) {
+	ctx := context.Background()
+	issuer := newOIDCTestIssuer(t)
+	_, resolver := authnTestStore(t, issuer, "aud-1")
+
+	authorizer := &capturingAuthorizer{}
+	srv, _, _ := newTestServer(t, resolver, authorizer)
+
+	const subject = "fullstack-jit-subject"
+	token := issuer.mintToken(t, map[string]any{
+		"iss": issuer.server.URL, "sub": subject, "aud": "aud-1",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"email": "carol@example.com",
+	})
+
+	client := newSpecClientWithAuth(srv.URL, token)
+	_, err := client.GetSpec(ctx, connect.NewRequest(&specgraphv1.GetSpecRequest{}))
+	require.NoError(t, err, "a valid JWT must authenticate through the full interceptor stack")
+
+	id := authorizer.lastIdentity()
+	require.NotNil(t, id, "the resolved identity must reach the authorizer")
+	require.Equal(t, "oidc", id.Source)
+	require.Equal(t, "oidc:"+subject, id.Subject)
+	require.Equal(t, auth.RoleReader, id.EffectiveRole, "JIT provisions at the configured default role")
+	require.Equal(t, "carol@example.com", id.Email)
+}
+
+// TestFullStack_JWT_ExistingBindingRoleReachesHandler verifies that a JWT whose
+// (issuer, subject) is already bound resolves to the persisted user — including
+// the user's role — through the interceptor to the authorization boundary.
+func TestFullStack_JWT_ExistingBindingRoleReachesHandler(t *testing.T) {
+	ctx := context.Background()
+	issuer := newOIDCTestIssuer(t)
+	store, resolver := authnTestStore(t, issuer, "aud-1")
+
+	const subject = "fullstack-bound-subject"
+	_, err := store.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "Dave", Email: "dave@example.com", Role: "writer",
+	}, &storage.OIDCBinding{
+		Issuer: issuer.server.URL, Subject: subject, EmailAtBind: "dave@example.com",
+	})
+	require.NoError(t, err)
+
+	authorizer := &capturingAuthorizer{}
+	srv, _, _ := newTestServer(t, resolver, authorizer)
+
+	token := issuer.mintToken(t, map[string]any{
+		"iss": issuer.server.URL, "sub": subject, "aud": "aud-1",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"email": "dave@example.com",
+	})
+	client := newSpecClientWithAuth(srv.URL, token)
+	_, err = client.GetSpec(ctx, connect.NewRequest(&specgraphv1.GetSpecRequest{}))
+	require.NoError(t, err)
+
+	id := authorizer.lastIdentity()
+	require.NotNil(t, id)
+	require.Equal(t, auth.Role("writer"), id.EffectiveRole, "the bound user's role must reach the authorizer")
+}
+
+// TestFullStack_JWT_BadAudienceRejected asserts a JWT with a wrong audience is
+// rejected at the interceptor with CodeUnauthenticated and never reaches the
+// authorizer.
+func TestFullStack_JWT_BadAudienceRejected(t *testing.T) {
+	ctx := context.Background()
+	issuer := newOIDCTestIssuer(t)
+	_, resolver := authnTestStore(t, issuer, "aud-1")
+
+	authorizer := &capturingAuthorizer{}
+	srv, _, _ := newTestServer(t, resolver, authorizer)
+
+	token := issuer.mintToken(t, map[string]any{
+		"iss": issuer.server.URL, "sub": "x", "aud": "wrong-audience",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+	})
+	client := newSpecClientWithAuth(srv.URL, token)
+	_, err := client.GetSpec(ctx, connect.NewRequest(&specgraphv1.GetSpecRequest{}))
+	require.Error(t, err)
+	require.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+	require.Nil(t, authorizer.lastIdentity(), "a rejected token must never reach the authorizer")
+}
+
+// TestFullStack_JWT_UnknownIssuerRejected asserts a validly-structured JWT from
+// an issuer with no configured verifier is rejected at the interceptor and
+// never reaches the authorizer.
+func TestFullStack_JWT_UnknownIssuerRejected(t *testing.T) {
+	ctx := context.Background()
+	issuer := newOIDCTestIssuer(t)
+	other := newOIDCTestIssuer(t) // a second issuer the resolver has no verifier for
+	_, resolver := authnTestStore(t, issuer, "aud-1")
+
+	authorizer := &capturingAuthorizer{}
+	srv, _, _ := newTestServer(t, resolver, authorizer)
+
+	// Token signed by `other` and claiming `other`'s issuer — the resolver has
+	// no verifier registered for that issuer, so routing fails closed.
+	token := other.mintToken(t, map[string]any{
+		"iss": other.server.URL, "sub": "x", "aud": "aud-1",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+	})
+	client := newSpecClientWithAuth(srv.URL, token)
+	_, err := client.GetSpec(ctx, connect.NewRequest(&specgraphv1.GetSpecRequest{}))
+	require.Error(t, err)
+	require.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+	require.Nil(t, authorizer.lastIdentity())
+}

--- a/internal/auth/oidc_verifier_test.go
+++ b/internal/auth/oidc_verifier_test.go
@@ -126,3 +126,52 @@ func TestOIDCVerifier_RejectsMalformed(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "oidc verify: oidc: malformed jwt")
 }
+
+// TestOIDCVerifier_ExplicitAudienceOverridesClientID proves the audience
+// precedence in NewOIDCVerifier: when cfg.Audience is set it is the expected
+// audience, NOT cfg.ClientID. A token whose aud matches Audience verifies;
+// one matching only ClientID is rejected. Guards against an aud/client_id swap.
+func TestOIDCVerifier_ExplicitAudienceOverridesClientID(t *testing.T) {
+	ctx := context.Background()
+	p := newOIDCTestIssuer(t)
+	v, err := auth.NewOIDCVerifier(ctx, config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "the-client", Audience: "explicit-aud",
+	})
+	require.NoError(t, err)
+
+	// aud == Audience → verifies.
+	okToken := p.mintToken(t, map[string]any{
+		"iss": p.server.URL, "sub": "u", "aud": "explicit-aud",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+	})
+	_, err = v.Verify(ctx, okToken)
+	require.NoError(t, err, "token whose aud matches the explicit Audience must verify")
+
+	// aud == ClientID (but != Audience) → rejected, proving Audience wins.
+	clientIDToken := p.mintToken(t, map[string]any{
+		"iss": p.server.URL, "sub": "u", "aud": "the-client",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+	})
+	_, err = v.Verify(ctx, clientIDToken)
+	require.Error(t, err, "ClientID must not be accepted when an explicit Audience is configured")
+	require.ErrorContains(t, err, "expected audience")
+}
+
+// TestOIDCVerifier_DiscoveryFailure asserts NewOIDCVerifier surfaces a wrapped
+// error (rather than a nil verifier) when the issuer's discovery endpoint is
+// unreachable/absent. The error is wrapped with the provider ID for operator
+// diagnosis at startup.
+func TestOIDCVerifier_DiscoveryFailure(t *testing.T) {
+	ctx := context.Background()
+	// A bare server with no discovery handler returns 404 for
+	// /.well-known/openid-configuration, so provider discovery fails.
+	srv := httptest.NewServer(http.NewServeMux())
+	t.Cleanup(srv.Close)
+
+	v, err := auth.NewOIDCVerifier(ctx, config.OIDCProviderConfig{
+		ID: "broken-idp", Issuer: srv.URL, ClientID: "aud-1",
+	})
+	require.Error(t, err)
+	require.Nil(t, v, "no verifier should be returned on discovery failure")
+	require.ErrorContains(t, err, "discover OIDC provider broken-idp")
+}


### PR DESCRIPTION
## What

Adds test coverage for the OIDC authn surface landed in the identity epic, closing the gaps found in a coverage audit.

### Full-stack integration (`internal/auth`, `//go:build integration`)
A real signed JWT through `NewAuthInterceptor` → real Postgres resolver (JIT + existing-binding) → authorizer, asserting the resolved OIDC identity reaches the authorization boundary. The existing full-stack identity tests only ever drove **API-key** tokens, so the JWT branch never traversed the interceptor before. Covers JIT-provision, existing-binding role propagation, bad-audience rejection, and unknown-issuer rejection (via a capturing authorizer).

### CLI (`cmd/specgraph/auth_oidc_test.go`)
`specgraph auth oidc list/unbind` — `--user` guards, table render, empty placeholder, `--force` passthrough, and RPC-error surfacing.

### Verifier + JIT branch gaps
- `OIDCVerifier`: explicit `Audience` precedence over `ClientID`, and discovery-failure error path.
- JIT claims-mapping: scalar-string claim (only array claims were tested before).

## Notable change

`identityClient` becomes an injectable package var (func→var) so CLI commands can run against an in-process stub server. Production callers are unchanged.

## Verification

- `task check`: ✅ (fmt, license, lint — 0 Go issues, build, unit)
- `test:integration`: ✅
- `test:e2e:api`: ✅ 195/195 · `test:e2e:cli`: ✅ 19/19
- Each test's assertions were validated by perturbing the production code to confirm a true RED before reverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)