### PR TITLE
feat(logging): structured log config, slog.LogAttrs migration, sloglint enforcement

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,6 +24,8 @@ linters:
     - unparam
     - gocritic
     - nolintlint
+    # Logging
+    - sloglint
   exclusions:
     # Default exclusion presets
     presets:
@@ -39,6 +41,7 @@ linters:
           - gocritic
           - wrapcheck
           - errcheck
+          - sloglint
       # Main package doesn't need to wrap errors
       - path: cmd/
         linters:
@@ -104,6 +107,11 @@ linters:
     nolintlint:
       require-explanation: true
       require-specific: true
+    sloglint:
+      no-mixed-args: true
+      attr-only: true
+      context: scope
+      static-msg: true
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -56,18 +56,38 @@ func init() {
 	serveCmd.Flags().String("cors-origin", "", "Enable CORS for this origin (dev mode only)")
 	serveCmd.Flags().String("pg-url", "", "PostgreSQL connection URL (overrides config; env: SPECGRAPH_SERVER_POSTGRES_URL)")
 	serveCmd.Flags().String("listen", "", "Address to listen on (overrides config; env: SPECGRAPH_SERVER_LISTEN)")
+	serveCmd.Flags().String("log-level", "", "Log level: debug, info, warn, error (overrides config; env: SPECGRAPH_LOG_LEVEL)")
+	serveCmd.Flags().String("log-format", "", "Log format: json, text (overrides config; env: SPECGRAPH_LOG_FORMAT)")
+	serveCmd.Flags().String("log-output", "", "Log output stream: stdout, stderr (overrides config; env: SPECGRAPH_LOG_OUTPUT)")
 	rootCmd.AddCommand(serveCmd)
 }
 
 func runServe(cmd *cobra.Command, _ []string) error {
 	if os.Getenv("SPECGRAPH_PG_URL") != "" {
-		slog.Warn("SPECGRAPH_PG_URL is no longer read; use SPECGRAPH_SERVER_POSTGRES_URL")
+		slog.LogAttrs(context.Background(), slog.LevelWarn, "SPECGRAPH_PG_URL is no longer read; use SPECGRAPH_SERVER_POSTGRES_URL")
 	}
 
 	cfg, err := loadGlobalCfg(config.WithFlags(cmd.Flags()))
 	if err != nil {
 		return fmt.Errorf("load global config: %w", err)
 	}
+
+	// Initialise structured logging as early as possible so every subsequent
+	// slog call in this process uses the configured handler. All handlers
+	// downstream capture slog.Default() at construction time, so this must
+	// happen before any service is registered.
+	logger, err := cfg.Log.Build()
+	if err != nil {
+		return fmt.Errorf("configure logger: %w", err)
+	}
+	slog.SetDefault(logger)
+	slog.LogAttrs(context.Background(), slog.LevelInfo, "specgraph server starting",
+		slog.String("version", buildVersion()),
+		slog.String("listen", cfg.Server.Listen),
+		slog.String("log_level", cfg.Log.Level),
+		slog.String("log_format", cfg.Log.Format),
+		slog.String("log_output", cfg.Log.Output),
+	)
 
 	ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -80,13 +100,13 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		if dockerErr != nil {
 			return dockerErr
 		}
-		fmt.Println("Starting Docker Compose stack...")
+		slog.LogAttrs(context.Background(), slog.LevelInfo, "starting Docker Compose stack")
 		if upErr := docker.ComposeUp(composeFile); upErr != nil {
 			return upErr
 		}
 		defer func() {
 			if stopErr := docker.ComposeStop(composeFile); stopErr != nil {
-				fmt.Fprintf(os.Stderr, "warning: compose stop: %v\n", stopErr)
+				slog.LogAttrs(context.Background(), slog.LevelWarn, "compose stop", slog.Any("error", stopErr))
 			}
 		}()
 	}
@@ -114,7 +134,7 @@ func runServe(cmd *cobra.Command, _ []string) error {
 	// where the sweeper goroutine calls ReleaseExpiredClaims on a closed store.
 	defer func() {
 		if closeErr := store.Close(ctx); closeErr != nil {
-			fmt.Fprintf(os.Stderr, "warning: close store: %v\n", closeErr)
+			slog.LogAttrs(context.Background(), slog.LevelWarn, "close store", slog.Any("error", closeErr))
 		}
 	}()
 	sweeperCtx, stopSweeper := context.WithCancel(ctx)
@@ -132,7 +152,7 @@ func runServe(cmd *cobra.Command, _ []string) error {
 	}
 	defer func() {
 		if closeErr := authStore.Close(ctx); closeErr != nil {
-			slog.Warn("auth store close", "error", closeErr)
+			slog.LogAttrs(context.Background(), slog.LevelWarn, "auth store close", slog.Any("error", closeErr))
 		}
 	}()
 
@@ -169,7 +189,10 @@ func runServe(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("OIDC provider %s: %w", pc.ID, oidcErr)
 		}
 		verifiers = append(verifiers, v)
-		slog.Info("auth: OIDC provider configured", "id", pc.ID, "issuer", pc.Issuer)
+		slog.LogAttrs(context.Background(), slog.LevelInfo, "auth: OIDC provider configured",
+			slog.String("id", pc.ID),
+			slog.String("issuer", pc.Issuer),
+		)
 	}
 
 	// usagetracker for async TouchLastUsed.
@@ -181,12 +204,13 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer shutdownCancel()
 		if trackerErr := tracker.Close(shutdownCtx); trackerErr != nil {
-			slog.Warn("usagetracker close", "error", trackerErr)
+			slog.LogAttrs(context.Background(), slog.LevelWarn, "usagetracker close", slog.Any("error", trackerErr))
 		}
 		if dropped := tracker.Dropped(); dropped > 0 {
-			slog.Warn("usagetracker dropped touches over session lifetime",
-				"count", dropped,
-				"hint", "increase auth usagetracker BufferSize or decrease FlushInterval")
+			slog.LogAttrs(context.Background(), slog.LevelWarn, "usagetracker dropped touches over session lifetime",
+				slog.Uint64("count", dropped),
+				slog.String("hint", "increase auth usagetracker BufferSize or decrease FlushInterval"),
+			)
 		}
 	}()
 
@@ -228,7 +252,7 @@ func runServe(cmd *cobra.Command, _ []string) error {
 	// HasAuth signal for the existing warn path.
 	hasAuth, hasAuthErr := resolver.HasAuth(ctx)
 	if hasAuthErr != nil {
-		slog.Warn("auth: HasAuth check failed at startup", "error", hasAuthErr)
+		slog.LogAttrs(context.Background(), slog.LevelWarn, "auth: HasAuth check failed at startup", slog.Any("error", hasAuthErr))
 	}
 	if !hasAuth {
 		warnIfNoAuthOnPublicListen(cfg.Server.Listen, false)
@@ -337,10 +361,10 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		select {
 		case <-ctx.Done():
 		case probeErr := <-probeErrCh:
-			slog.Error("probe listener died; triggering shutdown", "error", probeErr)
+			slog.LogAttrs(context.Background(), slog.LevelError, "probe listener died; triggering shutdown", slog.Any("error", probeErr))
 			cancel()
 		}
-		fmt.Println("\nShutting down...")
+		slog.LogAttrs(context.Background(), slog.LevelInfo, "server shutting down")
 		stopSweeper()
 		// Shut down main and probe servers in parallel so a slow main-server
 		// drain can't starve the probe server's graceful close (and vice versa).
@@ -351,7 +375,7 @@ func runServe(cmd *cobra.Command, _ []string) error {
 			mainCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 			if err := srv.Shutdown(mainCtx); err != nil {
-				slog.Warn("main server shutdown", "error", err)
+				slog.LogAttrs(context.Background(), slog.LevelWarn, "main server shutdown", slog.Any("error", err))
 			}
 		}()
 		if probeSrv != nil {
@@ -361,16 +385,16 @@ func runServe(cmd *cobra.Command, _ []string) error {
 				probeCtx, cancel := context.WithTimeout(context.Background(), probeShutdownTimeout)
 				defer cancel()
 				if err := probeSrv.Shutdown(probeCtx); err != nil {
-					slog.Warn("probe server shutdown", "error", err)
+					slog.LogAttrs(context.Background(), slog.LevelWarn, "probe server shutdown", slog.Any("error", err))
 				}
 			}()
 		}
 		wg.Wait()
 	}()
 
-	server.StartSweeper(sweeperCtx, store, 60*time.Second, slog.Default())
-	fmt.Printf("SpecGraph server running at http://%s\n", addr)
-	slog.Info("MCP endpoint available", "path", "/mcp/")
+	server.StartSweeper(sweeperCtx, store, 60*time.Second)
+	slog.LogAttrs(context.Background(), slog.LevelInfo, "server listening", slog.String("addr", "http://"+addr))
+	slog.LogAttrs(context.Background(), slog.LevelInfo, "MCP endpoint available", slog.String("path", "/mcp/"))
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
 		return err
 	}
@@ -413,9 +437,10 @@ func warnIfNoAuthOnPublicListen(listen string, hasAuth bool) {
 	if hasAuth || isLoopbackAddr(listen) {
 		return
 	}
-	slog.Warn("server listening without authentication on non-loopback interface",
-		"addr", listen,
-		"risk", "configure API keys or OIDC providers")
+	slog.LogAttrs(context.Background(), slog.LevelWarn, "server listening without authentication on non-loopback interface",
+		slog.String("addr", listen),
+		slog.String("risk", "configure API keys or OIDC providers"),
+	)
 }
 
 // validateServerConfig runs cross-section validation the main serve path
@@ -457,14 +482,21 @@ func startProbeListener(ctx context.Context, pinger probes.Pinger, cfg config.Pr
 		Handler:           h.Mux(),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
-	slog.Info("probe endpoints listening", "addr", srv.Addr, "livez", "/livez", "readyz", "/readyz")
+	slog.LogAttrs(ctx, slog.LevelInfo, "probe endpoints listening",
+		slog.String("addr", srv.Addr),
+		slog.String("livez", "/livez"),
+		slog.String("readyz", "/readyz"),
+	)
 	errCh := make(chan error, 1)
 	go func() {
 		serveErr := srv.Serve(ln)
 		if serveErr == nil || errors.Is(serveErr, http.ErrServerClosed) {
 			return
 		}
-		slog.Error("probe server failed", "addr", srv.Addr, "error", serveErr)
+		slog.LogAttrs(ctx, slog.LevelError, "probe server failed",
+			slog.String("addr", srv.Addr),
+			slog.Any("error", serveErr),
+		)
 		errCh <- serveErr
 	}()
 	return srv, errCh, nil
@@ -479,11 +511,11 @@ func mcpHeaderLogger(next http.Handler) http.Handler {
 		for k := range r.Header {
 			keys = append(keys, k)
 		}
-		slog.Debug("mcp: inbound request",
-			"method", r.Method,
-			"path", r.URL.Path,
-			"raw_query", r.URL.RawQuery,
-			"header_keys", keys,
+		slog.LogAttrs(r.Context(), slog.LevelDebug, "mcp: inbound request",
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.String("raw_query", r.URL.RawQuery),
+			slog.Any("header_keys", keys),
 		)
 		next.ServeHTTP(w, r)
 	})

--- a/internal/auth/engine.go
+++ b/internal/auth/engine.go
@@ -244,7 +244,7 @@ func resourceEntity(r ResourceRef) (uid cedar.EntityUID, ent cedar.Entity) {
 // Evaluate maps the EvalRequest into a cedar.Request, merges the principal,
 // resource, and precomputed action entities, and calls cedar.Authorize
 // against the current policy set (loaded lock-free from the atomic pointer).
-func (e *cedarEngine) Evaluate(_ context.Context, req EvalRequest) (PolicyDecision, error) {
+func (e *cedarEngine) Evaluate(ctx context.Context, req EvalRequest) (PolicyDecision, error) {
 	if req.Identity == nil {
 		return PolicyDecision{}, fmt.Errorf("cedar: Evaluate: nil Identity")
 	}
@@ -289,13 +289,13 @@ func (e *cedarEngine) Evaluate(_ context.Context, req EvalRequest) (PolicyDecisi
 		evalErrs = append(evalErrs, de.String())
 	}
 
-	slog.Debug("cedar decision",
-		"action", req.Action,
-		"principal", req.Identity.Subject,
-		"role", string(req.Identity.EffectiveRole),
-		"allowed", decision == cedar.Allow,
-		"policies", matched,
-		"errors", evalErrs,
+	slog.LogAttrs(ctx, slog.LevelDebug, "cedar decision",
+		slog.String("action", req.Action),
+		slog.String("principal", req.Identity.Subject),
+		slog.String("role", string(req.Identity.EffectiveRole)),
+		slog.Bool("allowed", decision == cedar.Allow),
+		slog.Any("policies", matched),
+		slog.Any("errors", evalErrs),
 	)
 
 	return PolicyDecision{

--- a/internal/auth/identitystore.go
+++ b/internal/auth/identitystore.go
@@ -307,8 +307,8 @@ func (s *pgIdentityStore) resolveAPIKey(ctx context.Context, token string) (*Ide
 		// Security-observable: a valid credential for a soft-deleted user.
 		// Worth a warn — could indicate a credential that should have been
 		// revoked, or an offboarding gap.
-		slog.Warn("auth: credential resolved to soft-deleted user (api-key)",
-			"user_id", user.ID, "key_id", key.ID)
+		slog.LogAttrs(ctx, slog.LevelWarn, "auth: credential resolved to soft-deleted user (api-key)",
+			slog.String("user_id", user.ID), slog.String("key_id", key.ID))
 		return nil, ErrUnauthenticated
 	}
 	s.tracker.Touch(key.ID)
@@ -369,8 +369,8 @@ func (s *pgIdentityStore) resolveJWT(ctx context.Context, token string) (*Identi
 	// (unverified) payload while being validly signed under verifier A's
 	// configured issuer differing from the embedded claim.
 	if claims.Issuer != issuer {
-		slog.Warn("auth: JWT issuer mismatch between peek and verified claim",
-			"peek", issuer, "verified", claims.Issuer)
+		slog.LogAttrs(ctx, slog.LevelWarn, "auth: JWT issuer mismatch between peek and verified claim",
+			slog.String("peek", issuer), slog.String("verified", claims.Issuer))
 		return nil, ErrUnauthenticated
 	}
 	// Binding lookup + user load. JIT path fires on binding miss (Task 18).
@@ -396,8 +396,8 @@ func (s *pgIdentityStore) resolveJWT(ctx context.Context, token string) (*Identi
 		// Security-observable: a valid OIDC binding for a soft-deleted user.
 		// The binding wasn't unbound at offboarding; the deleted_at gate
 		// catches it, but log so operators can notice the gap.
-		slog.Warn("auth: token resolved to soft-deleted user (oidc)",
-			"user_id", user.ID, "subject", claims.Subject)
+		slog.LogAttrs(ctx, slog.LevelWarn, "auth: token resolved to soft-deleted user (oidc)",
+			slog.String("user_id", user.ID), slog.String("subject", claims.Subject))
 		return nil, ErrUnauthenticated
 	}
 	return &Identity{
@@ -425,13 +425,13 @@ func (s *pgIdentityStore) jitResolve(ctx context.Context, claims *OIDCClaims) (*
 	if len(s.jitEmailAllowlist) > 0 {
 		domain := emailDomain(claims.Email)
 		if domain == "" {
-			slog.Warn("auth: JIT refused — empty email claim with non-empty allowlist",
-				"issuer", claims.Issuer)
+			slog.LogAttrs(ctx, slog.LevelWarn, "auth: JIT refused — empty email claim with non-empty allowlist",
+				slog.String("issuer", claims.Issuer))
 			return nil, ErrUnauthenticated
 		}
 		if !s.jitEmailAllowlist[domain] {
-			slog.Warn("auth: JIT refused — email domain not in allowlist",
-				"issuer", claims.Issuer, "domain", domain)
+			slog.LogAttrs(ctx, slog.LevelWarn, "auth: JIT refused — email domain not in allowlist",
+				slog.String("issuer", claims.Issuer), slog.String("domain", domain))
 			return nil, ErrUnauthenticated
 		}
 	}
@@ -443,8 +443,8 @@ func (s *pgIdentityStore) jitResolve(ctx context.Context, claims *OIDCClaims) (*
 	// against the backend for free.
 	limiter := s.rateLimiterFor(claims.Issuer)
 	if !limiter.Allow() {
-		slog.Warn("auth: JIT rate-limit exceeded",
-			"issuer", claims.Issuer, "subject", claims.Subject)
+		slog.LogAttrs(ctx, slog.LevelWarn, "auth: JIT rate-limit exceeded",
+			slog.String("issuer", claims.Issuer), slog.String("subject", claims.Subject))
 		return nil, ErrUnauthenticated
 	}
 

--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -31,18 +31,18 @@ func NewAuthInterceptor(resolver Resolver, authorizer Authorizer) connect.UnaryI
 
 			decision, err := authorizer.Authorize(ctx, id, procedure, req.Any())
 			if err != nil {
-				slog.Error("auth: authorizer error",
-					"procedure", procedure, "error", err.Error())
+				slog.LogAttrs(ctx, slog.LevelError, "auth: authorizer error",
+					slog.String("procedure", procedure), slog.Any("error", err))
 				return nil, connect.NewError(connect.CodeInternal, nil)
 			}
 			if !decision.Allowed {
-				slog.Warn("auth: permission denied",
-					"subject", id.Subject, "procedure", procedure, "reason", decision.Reason)
+				slog.LogAttrs(ctx, slog.LevelWarn, "auth: permission denied",
+					slog.String("subject", id.Subject), slog.String("procedure", procedure), slog.String("reason", decision.Reason))
 				return nil, connect.NewError(connect.CodePermissionDenied, nil)
 			}
 
-			slog.Info("auth: authenticated",
-				"subject", id.Subject, "procedure", procedure)
+			slog.LogAttrs(ctx, slog.LevelInfo, "auth: authenticated",
+				slog.String("subject", id.Subject), slog.String("procedure", procedure))
 			return next(WithIdentity(ctx, id), req)
 		}
 	}
@@ -94,19 +94,24 @@ func extractBearerToken(headers http.Header) string {
 func mapAuthError(procedure string, err error) error {
 	switch {
 	case errors.Is(err, context.Canceled):
-		slog.Debug("auth: request canceled", "procedure", procedure)
+		slog.LogAttrs(context.Background(), slog.LevelDebug, "auth: request canceled",
+			slog.String("procedure", procedure))
 		return connect.NewError(connect.CodeCanceled, nil)
 	case errors.Is(err, context.DeadlineExceeded):
-		slog.Debug("auth: request deadline exceeded", "procedure", procedure)
+		slog.LogAttrs(context.Background(), slog.LevelDebug, "auth: request deadline exceeded",
+			slog.String("procedure", procedure))
 		return connect.NewError(connect.CodeDeadlineExceeded, nil)
 	case errors.Is(err, ErrTransient):
-		slog.Warn("auth: transient backend error", "procedure", procedure, "error", err.Error())
+		slog.LogAttrs(context.Background(), slog.LevelWarn, "auth: transient backend error",
+			slog.String("procedure", procedure), slog.Any("error", err))
 		return connect.NewError(connect.CodeUnavailable, nil)
 	case errors.Is(err, ErrUnauthenticated):
-		slog.Info("auth: unauthenticated", "procedure", procedure)
+		slog.LogAttrs(context.Background(), slog.LevelInfo, "auth: unauthenticated",
+			slog.String("procedure", procedure))
 		return connect.NewError(connect.CodeUnauthenticated, nil)
 	default:
-		slog.Error("auth: unexpected error category", "procedure", procedure, "error", err.Error())
+		slog.LogAttrs(context.Background(), slog.LevelError, "auth: unexpected error category",
+			slog.String("procedure", procedure), slog.Any("error", err))
 		return connect.NewError(connect.CodeInternal, nil)
 	}
 }

--- a/internal/auth/oidc_verifier.go
+++ b/internal/auth/oidc_verifier.go
@@ -67,8 +67,8 @@ func (v *OIDCVerifier) ProviderID() string { return v.providerID }
 func (v *OIDCVerifier) Verify(ctx context.Context, rawToken string) (*OIDCClaims, error) {
 	idToken, err := v.verifier.Verify(ctx, rawToken)
 	if err != nil {
-		slog.Warn("auth: OIDC token verification failed",
-			"provider", v.providerID, "error", err.Error())
+		slog.LogAttrs(ctx, slog.LevelWarn, "auth: OIDC token verification failed",
+			slog.String("provider", v.providerID), slog.Any("error", err))
 		return nil, fmt.Errorf("oidc verify: %w", err)
 	}
 	var raw map[string]json.RawMessage

--- a/internal/auth/usagetracker/usagetracker.go
+++ b/internal/auth/usagetracker/usagetracker.go
@@ -70,8 +70,8 @@ func (m *Manager) Touch(keyID string) {
 	case m.ch <- keyID:
 	default:
 		m.dropped.Add(1)
-		slog.Warn("usagetracker: touch dropped on overflow",
-			"keyID", keyID, "total_dropped", m.dropped.Load())
+		slog.LogAttrs(context.Background(), slog.LevelWarn, "usagetracker: touch dropped on overflow",
+			slog.String("keyID", keyID), slog.Uint64("total_dropped", m.dropped.Load()))
 	}
 }
 
@@ -113,7 +113,8 @@ func (m *Manager) flushAll() {
 	for id := range pending {
 		// Per-key error isolation: a failed key logs and the loop continues.
 		if err := m.backend.TouchLastUsed(ctx, id); err != nil {
-			slog.Warn("usagetracker: TouchLastUsed failed", "keyID", id, "error", err)
+			slog.LogAttrs(ctx, slog.LevelWarn, "usagetracker: TouchLastUsed failed",
+				slog.String("keyID", id), slog.Any("error", err))
 		}
 	}
 }

--- a/internal/authoring/composer.go
+++ b/internal/authoring/composer.go
@@ -144,7 +144,7 @@ func (c *Composer) ComposeStagePrompt(ctx context.Context, in ComposeInput) (res
 
 	defer func() {
 		if retErr != nil {
-			slog.ErrorContext(ctx, "composer.invocation_failed",
+			slog.LogAttrs(ctx, slog.LevelError, "composer.invocation_failed",
 				slog.String("stage", string(in.Stage)),
 				slog.String("slug", in.Slug),
 				slog.String("posture", in.Posture),
@@ -182,7 +182,7 @@ func (c *Composer) ComposeStagePrompt(ctx context.Context, in ComposeInput) (res
 	fmt.Fprintf(&b, "\n---\nserver-version: %s\n", versionString())
 
 	totalTokens := approxTokens(b.String())
-	slog.InfoContext(ctx, "composer.invocation",
+	slog.LogAttrs(ctx, slog.LevelInfo, "composer.invocation",
 		slog.String("stage", string(in.Stage)),
 		slog.String("slug", in.Slug),
 		slog.String("posture", in.Posture),
@@ -250,7 +250,7 @@ func (c *Composer) appendDynamicState(ctx context.Context, b *strings.Builder, i
 		var validRelated []*RelatedSpec
 		for _, r := range related {
 			if !r.Relationship.IsValid() {
-				slog.WarnContext(ctx, "composer.invalid_relationship_skipped",
+				slog.LogAttrs(ctx, slog.LevelWarn, "composer.invalid_relationship_skipped",
 					slog.String("slug", r.Slug),
 					slog.String("relationship", string(r.Relationship)),
 				)

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -4,8 +4,10 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -40,8 +42,11 @@ func WithFlags(flags *pflag.FlagSet) LoadOption {
 // flagKeyMap maps serve-command flag names to dotted koanf keys. Flags absent
 // from this map (e.g. cors-origin) are not config keys and are ignored.
 var flagKeyMap = map[string]string{
-	"listen": "server.listen",
-	"pg-url": "server.postgres.url",
+	"listen":     "server.listen",
+	"pg-url":     "server.postgres.url",
+	"log-level":  "log.level",
+	"log-format": "log.format",
+	"log-output": "log.output",
 }
 
 // DefaultProbeInterval/Timeout are chosen so the 5s cache refresh stays
@@ -58,6 +63,69 @@ type GlobalConfig struct {
 	Client ClientConfig  `yaml:"client" koanf:"client"`
 	Auth   AuthConfig    `yaml:"auth" koanf:"auth"`
 	Export ExportConfig  `yaml:"export" koanf:"export"`
+	Log    LogConfig     `yaml:"log" koanf:"log"`
+}
+
+// LogConfig configures the server's structured-logging output. All three
+// fields are settable via YAML, environment variable (SPECGRAPH_LOG_LEVEL,
+// SPECGRAPH_LOG_FORMAT, SPECGRAPH_LOG_OUTPUT), or the --log-level /
+// --log-format / --log-output serve flags.
+type LogConfig struct {
+	// Level is the minimum log level: debug, info, warn, or error.
+	Level string `yaml:"level" koanf:"level"`
+	// Format selects the handler: json (default) or text (logfmt).
+	Format string `yaml:"format" koanf:"format"`
+	// Output selects the destination stream: stdout (default) or stderr.
+	Output string `yaml:"output" koanf:"output"`
+}
+
+// Build constructs a [slog.Logger] writing to the stream named by lc.Output
+// (stdout or stderr). It returns an error for unrecognised Level, Format, or
+// Output values. Call [slog.SetDefault] on the returned logger to activate it
+// globally.
+func (lc LogConfig) Build() (*slog.Logger, error) {
+	var w io.Writer
+	switch strings.ToLower(lc.Output) {
+	case "", "stdout":
+		w = os.Stdout
+	case "stderr":
+		w = os.Stderr
+	default:
+		return nil, fmt.Errorf("invalid log output %q: must be stdout or stderr", lc.Output)
+	}
+	return lc.BuildWith(w)
+}
+
+// BuildWith is like [LogConfig.Build] but writes to w instead of the
+// configured output stream. Useful in tests and when an explicit [io.Writer]
+// is already available.
+func (lc LogConfig) BuildWith(w io.Writer) (*slog.Logger, error) {
+	levelStr := lc.Level
+	if levelStr == "" {
+		levelStr = "info"
+	}
+	var level slog.Level
+	if err := level.UnmarshalText([]byte(levelStr)); err != nil {
+		return nil, fmt.Errorf("invalid log level %q: must be debug, info, warn, or error", lc.Level)
+	}
+
+	formatStr := strings.ToLower(lc.Format)
+	if formatStr == "" {
+		formatStr = "json"
+	}
+
+	opts := &slog.HandlerOptions{Level: level}
+	var h slog.Handler
+	switch formatStr {
+	case "json":
+		h = slog.NewJSONHandler(w, opts)
+	case "text", "logfmt":
+		h = slog.NewTextHandler(w, opts)
+	default:
+		return nil, fmt.Errorf("invalid log format %q: must be json or text", lc.Format)
+	}
+
+	return slog.New(h), nil
 }
 
 // ExportConfig holds settings for project export and import operations.
@@ -216,7 +284,7 @@ func decoderConf(out *GlobalConfig) koanf.UnmarshalConf {
 func applyPostLoad(cfg *GlobalConfig) {
 	if len(cfg.Auth.OIDCProviders) > 0 && len(cfg.Auth.OIDC.Providers) == 0 {
 		cfg.Auth.OIDC.Providers = cfg.Auth.OIDCProviders
-		slog.Warn("auth.oidc_providers is deprecated; move providers under auth.oidc.providers")
+		slog.LogAttrs(context.Background(), slog.LevelWarn, "auth.oidc_providers is deprecated; move providers under auth.oidc.providers")
 	}
 	// Edge-case guard: if an operator explicitly clears the backend but leaves a
 	// postgres URL, default the backend to postgres. The common case never hits
@@ -326,6 +394,11 @@ func globalDefaults() *GlobalConfig {
 		},
 		Client: ClientConfig{
 			DefaultServer: "http://127.0.0.1:9090",
+		},
+		Log: LogConfig{
+			Level:  "info",
+			Format: "json",
+			Output: "stdout",
 		},
 	}
 }

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -4,6 +4,9 @@
 package config_test
 
 import (
+	"bytes"
+	"context"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -433,4 +436,176 @@ func TestLoadGlobal_EnvCoercesNonStringScalars(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, cfg.Server.Docker)
 	assert.Equal(t, 7*time.Second, cfg.Server.Probes.Interval)
+}
+
+// ---------------------------------------------------------------------------
+// LogConfig tests
+// ---------------------------------------------------------------------------
+
+func TestLoadGlobal_LogDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	cfg, err := config.LoadGlobal(path)
+	require.NoError(t, err)
+	assert.Equal(t, "info", cfg.Log.Level)
+	assert.Equal(t, "json", cfg.Log.Format)
+	assert.Equal(t, "stdout", cfg.Log.Output)
+}
+
+func TestLoadGlobal_LogFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	body := `
+log:
+  level: debug
+  format: text
+  output: stderr
+`
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+
+	cfg, err := config.LoadGlobal(path)
+	require.NoError(t, err)
+	assert.Equal(t, "debug", cfg.Log.Level)
+	assert.Equal(t, "text", cfg.Log.Format)
+	assert.Equal(t, "stderr", cfg.Log.Output)
+}
+
+func TestLoadGlobal_EnvOverridesLogLevel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(""), 0o600))
+	t.Setenv("SPECGRAPH_LOG_LEVEL", "debug")
+
+	cfg, err := config.LoadGlobalExplicit(path)
+	require.NoError(t, err)
+	assert.Equal(t, "debug", cfg.Log.Level)
+}
+
+func TestLoadGlobal_EnvOverridesLogFormat(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(""), 0o600))
+	t.Setenv("SPECGRAPH_LOG_FORMAT", "text")
+
+	cfg, err := config.LoadGlobalExplicit(path)
+	require.NoError(t, err)
+	assert.Equal(t, "text", cfg.Log.Format)
+}
+
+func TestLoadGlobal_EnvOverridesLogOutput(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(""), 0o600))
+	t.Setenv("SPECGRAPH_LOG_OUTPUT", "stderr")
+
+	cfg, err := config.LoadGlobalExplicit(path)
+	require.NoError(t, err)
+	assert.Equal(t, "stderr", cfg.Log.Output)
+}
+
+func TestLogConfig_BuildWith_JSONFormat(t *testing.T) {
+	lc := config.LogConfig{Level: "info", Format: "json", Output: "stdout"}
+	var buf bytes.Buffer
+	logger, err := lc.BuildWith(&buf)
+	require.NoError(t, err)
+	require.NotNil(t, logger)
+
+	logger.Info("hello", "key", "value")
+	out := buf.String()
+	assert.Contains(t, out, `"msg":"hello"`)
+	assert.Contains(t, out, `"key":"value"`)
+}
+
+func TestLogConfig_BuildWith_TextFormat(t *testing.T) {
+	lc := config.LogConfig{Level: "info", Format: "text", Output: "stderr"}
+	var buf bytes.Buffer
+	logger, err := lc.BuildWith(&buf)
+	require.NoError(t, err)
+	require.NotNil(t, logger)
+
+	logger.Info("hello", "key", "value")
+	out := buf.String()
+	assert.Contains(t, out, "hello")
+	assert.Contains(t, out, "key=value")
+	assert.NotContains(t, out, `"msg"`) // not JSON
+}
+
+func TestLogConfig_BuildWith_LogfmtAlias(t *testing.T) {
+	lc := config.LogConfig{Level: "info", Format: "logfmt"}
+	var buf bytes.Buffer
+	logger, err := lc.BuildWith(&buf)
+	require.NoError(t, err)
+	require.NotNil(t, logger)
+
+	logger.Info("ping")
+	assert.NotContains(t, buf.String(), `"msg"`) // logfmt, not JSON
+}
+
+func TestLogConfig_BuildWith_DebugLevel(t *testing.T) {
+	lc := config.LogConfig{Level: "debug", Format: "json"}
+	var buf bytes.Buffer
+	logger, err := lc.BuildWith(&buf)
+	require.NoError(t, err)
+
+	assert.True(t, logger.Enabled(context.Background(), slog.LevelDebug))
+	assert.True(t, logger.Enabled(context.Background(), slog.LevelInfo))
+}
+
+func TestLogConfig_BuildWith_InfoLevelSuppressesDebug(t *testing.T) {
+	lc := config.LogConfig{Level: "info", Format: "json"}
+	var buf bytes.Buffer
+	logger, err := lc.BuildWith(&buf)
+	require.NoError(t, err)
+
+	logger.Debug("should not appear")
+	assert.Empty(t, buf.String())
+
+	logger.Info("should appear")
+	assert.NotEmpty(t, buf.String())
+}
+
+func TestLogConfig_BuildWith_WarnLevel(t *testing.T) {
+	lc := config.LogConfig{Level: "warn", Format: "json"}
+	var buf bytes.Buffer
+	logger, err := lc.BuildWith(&buf)
+	require.NoError(t, err)
+
+	assert.False(t, logger.Enabled(context.Background(), slog.LevelInfo))
+	assert.True(t, logger.Enabled(context.Background(), slog.LevelWarn))
+	assert.True(t, logger.Enabled(context.Background(), slog.LevelError))
+}
+
+func TestLogConfig_BuildWith_EmptyLevelDefaultsToInfo(t *testing.T) {
+	lc := config.LogConfig{Level: "", Format: "json"}
+	var buf bytes.Buffer
+	logger, err := lc.BuildWith(&buf)
+	require.NoError(t, err)
+
+	assert.False(t, logger.Enabled(context.Background(), slog.LevelDebug))
+	assert.True(t, logger.Enabled(context.Background(), slog.LevelInfo))
+}
+
+func TestLogConfig_BuildWith_InvalidLevel(t *testing.T) {
+	lc := config.LogConfig{Level: "verbose", Format: "json"}
+	_, err := lc.BuildWith(&bytes.Buffer{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid log level")
+	assert.Contains(t, err.Error(), "verbose")
+}
+
+func TestLogConfig_BuildWith_InvalidFormat(t *testing.T) {
+	lc := config.LogConfig{Level: "info", Format: "yaml"}
+	_, err := lc.BuildWith(&bytes.Buffer{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid log format")
+	assert.Contains(t, err.Error(), "yaml")
+}
+
+func TestLogConfig_Build_InvalidOutput(t *testing.T) {
+	lc := config.LogConfig{Level: "info", Format: "json", Output: "file"}
+	_, err := lc.Build()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid log output")
+	assert.Contains(t, err.Error(), "file")
 }

--- a/internal/config/managedfiles/markdownblock.go
+++ b/internal/config/managedfiles/markdownblock.go
@@ -5,6 +5,7 @@ package managedfiles
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -38,7 +39,8 @@ func (markdownBlockStrategy) Sync(cwd string, mf ManagedFile, params ProjectPara
 	}
 	defer func() {
 		if uerr := unlock(); uerr != nil {
-			slog.Error("unlock failed", "path", full, "error", uerr)
+			slog.LogAttrs(context.Background(), slog.LevelError, "unlock failed",
+				slog.String("path", full), slog.Any("error", uerr))
 		}
 	}()
 

--- a/internal/config/managedfiles/wholefile.go
+++ b/internal/config/managedfiles/wholefile.go
@@ -5,6 +5,7 @@ package managedfiles
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -42,7 +43,8 @@ func (wholeFileStrategy) Sync(cwd string, mf ManagedFile, _ ProjectParams, opts 
 	}
 	defer func() {
 		if uerr := unlock(); uerr != nil {
-			slog.Error("unlock failed", "path", full, "error", uerr)
+			slog.LogAttrs(context.Background(), slog.LevelError, "unlock failed",
+				slog.String("path", full), slog.Any("error", uerr))
 		}
 	}()
 

--- a/internal/drift/drift.go
+++ b/internal/drift/drift.go
@@ -82,7 +82,7 @@ func (e *Engine) Check(ctx context.Context, slug, scope string) (*CheckResult, e
 	for _, spec := range specs {
 		report, err := e.checkSpec(ctx, spec, scope)
 		if err != nil {
-			e.logger.Warn("drift check failed for spec",
+			slog.LogAttrs(ctx, slog.LevelWarn, "drift check failed for spec",
 				slog.String("slug", spec.Slug),
 				slog.Any("error", err))
 			reports = append(reports, storage.DriftReport{

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -99,10 +99,10 @@ func NewServer(client *Client) *Server {
 
 	hooks.AddAfterInitialize(func(ctx context.Context, _ any, msg *sdkmcp.InitializeRequest, _ *sdkmcp.InitializeResult) {
 		profile := ProfileFromClientInfo(&msg.Params.ClientInfo)
-		slog.Info("mcp: client initialized",
-			"client_name", msg.Params.ClientInfo.Name,
-			"client_version", msg.Params.ClientInfo.Version,
-			"profile", profile,
+		slog.LogAttrs(ctx, slog.LevelInfo, "mcp: client initialized",
+			slog.String("client_name", msg.Params.ClientInfo.Name),
+			slog.String("client_version", msg.Params.ClientInfo.Version),
+			slog.Any("profile", profile),
 		)
 		if profile == ProfileExecution {
 			return

--- a/internal/notify/impact.go
+++ b/internal/notify/impact.go
@@ -29,9 +29,9 @@ func (l *ImpactLogger) OnSpecChanged(ctx context.Context, event *storage.ChangeE
 
 	refs, err := graph.GetImpact(ctx, event.Slug)
 	if err != nil {
-		slog.Warn("impact analysis failed",
-			"slug", event.Slug,
-			"error", err.Error(),
+		slog.LogAttrs(ctx, slog.LevelWarn, "impact analysis failed",
+			slog.String("slug", event.Slug),
+			slog.Any("error", err),
 		)
 		return
 	}
@@ -41,10 +41,10 @@ func (l *ImpactLogger) OnSpecChanged(ctx context.Context, event *storage.ChangeE
 		slugs[i] = r.Slug
 	}
 
-	slog.Info("spec change impact",
-		"slug", event.Slug,
-		"version", event.Version,
-		"impacted_count", len(refs),
-		"impacted", slugs,
+	slog.LogAttrs(ctx, slog.LevelInfo, "spec change impact",
+		slog.String("slug", event.Slug),
+		slog.Int("version", int(event.Version)),
+		slog.Int("impacted_count", len(refs)),
+		slog.Any("impacted", slugs),
 	)
 }

--- a/internal/server/analytical_pass_handler.go
+++ b/internal/server/analytical_pass_handler.go
@@ -67,7 +67,7 @@ func (h *AnalyticalPassHandler) RunAnalyticalPass(ctx context.Context, req *conn
 
 	tmplBytes, err := h.loadTemplate(pt)
 	if err != nil {
-		slog.Error("analyticalPassError: template load failed", slog.Any("error", err))
+		slog.LogAttrs(ctx, slog.LevelError, "analyticalPassError: template load failed", slog.Any("error", err))
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 
@@ -359,7 +359,7 @@ func analyticalPassError(err error) error {
 	case errors.Is(err, storage.ErrSpecNotFound):
 		return connect.NewError(connect.CodeNotFound, errors.New("spec not found"))
 	default:
-		slog.Error("analyticalPassError: internal error", slog.Any("error", err))
+		slog.LogAttrs(context.Background(), slog.LevelError, "analyticalPassError: internal error", slog.Any("error", err))
 		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 }

--- a/internal/server/authoring_handler.go
+++ b/internal/server/authoring_handler.go
@@ -28,7 +28,6 @@ const maxElements = 100
 // RunInTransaction, providing atomic rollback if any step fails.
 type AuthoringHandler struct {
 	scoper storage.Scoper
-	logger *slog.Logger
 }
 
 var _ specgraphv1connect.AuthoringServiceHandler = (*AuthoringHandler)(nil)
@@ -65,7 +64,7 @@ func (h *AuthoringHandler) Spark(ctx context.Context, req *connect.Request[specv
 	}
 	// Posture-absent warning (design §Posture).
 	if msg.GetPosture() == specv1.Posture_POSTURE_UNSPECIFIED {
-		h.logger.Warn("posture-absent", slog.String("stage", "spark"), slog.String("slug", msg.Slug))
+		slog.LogAttrs(ctx, slog.LevelWarn, "posture-absent", slog.String("stage", "spark"), slog.String("slug", msg.Slug))
 	}
 	// CreateSpec sets stage to "spark" as part of spec creation; no separate
 	// TransitionStage call is needed because the initial stage is set atomically.
@@ -177,7 +176,7 @@ func (h *AuthoringHandler) Shape(ctx context.Context, req *connect.Request[specv
 
 	// Posture-absent warning (design §Posture).
 	if msg.GetPosture() == specv1.Posture_POSTURE_UNSPECIFIED {
-		h.logger.Warn("posture-absent", slog.String("stage", "shape"), slog.String("slug", msg.Slug))
+		slog.LogAttrs(ctx, slog.LevelWarn, "posture-absent", slog.String("stage", "shape"), slog.String("slug", msg.Slug))
 	}
 
 	// Four-op transaction: transition → store output → safety → record conversation.
@@ -296,7 +295,7 @@ func (h *AuthoringHandler) Specify(ctx context.Context, req *connect.Request[spe
 
 	// Posture-absent warning (design §Posture).
 	if msg.GetPosture() == specv1.Posture_POSTURE_UNSPECIFIED {
-		h.logger.Warn("posture-absent", slog.String("stage", "specify"), slog.String("slug", msg.Slug))
+		slog.LogAttrs(ctx, slog.LevelWarn, "posture-absent", slog.String("stage", "specify"), slog.String("slug", msg.Slug))
 	}
 
 	// Four-op transaction: transition → store output → safety → record conversation.
@@ -387,7 +386,7 @@ func (h *AuthoringHandler) Decompose(ctx context.Context, req *connect.Request[s
 
 	// Posture-absent warning (design §Posture).
 	if msg.GetPosture() == specv1.Posture_POSTURE_UNSPECIFIED {
-		h.logger.Warn("posture-absent", slog.String("stage", "decompose"), slog.String("slug", msg.Slug))
+		slog.LogAttrs(ctx, slog.LevelWarn, "posture-absent", slog.String("stage", "decompose"), slog.String("slug", msg.Slug))
 	}
 
 	// Four-op transaction: transition → store output → safety → record conversation.
@@ -448,7 +447,7 @@ func (h *AuthoringHandler) Approve(ctx context.Context, req *connect.Request[spe
 
 	switch req.Msg.GetAction() {
 	case specv1.ApproveAction_APPROVE_ACTION_UNSPECIFIED:
-		h.logger.InfoContext(ctx, "approve action unspecified, defaulting to accept",
+		slog.LogAttrs(ctx, slog.LevelInfo, "approve action unspecified, defaulting to accept",
 			slog.String("slug", slug))
 		fallthrough
 	case specv1.ApproveAction_APPROVE_ACTION_ACCEPT:
@@ -460,7 +459,7 @@ func (h *AuthoringHandler) Approve(ctx context.Context, req *connect.Request[spe
 				return store.TransitionStage(txCtx, slug, storage.SpecStageDecompose, storage.SpecStageApproved)
 			},
 			func(txCtx context.Context) error {
-				return acceptLinkedDecisions(txCtx, h.logger, store, store, slug)
+				return acceptLinkedDecisions(txCtx, store, store, slug)
 			},
 			func(txCtx context.Context) error {
 				var err error
@@ -474,8 +473,8 @@ func (h *AuthoringHandler) Approve(ctx context.Context, req *connect.Request[spe
 			return nil, h.stageError(err)
 		}
 		if spec.UpdatedAt.IsZero() {
-			h.logger.ErrorContext(ctx, "spec.UpdatedAt is zero after TransitionStage",
-				"slug", slug, "specID", spec.ID, "stage", "approved")
+			slog.LogAttrs(ctx, slog.LevelError, "spec.UpdatedAt is zero after TransitionStage",
+				slog.String("slug", slug), slog.String("specID", spec.ID), slog.String("stage", "approved"))
 			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 		}
 		approvedAt := timestamppb.New(spec.UpdatedAt)
@@ -534,7 +533,7 @@ func (h *AuthoringHandler) Approve(ctx context.Context, req *connect.Request[spe
 			return nil, h.stageError(err)
 		}
 		if currentStage == "" {
-			h.logger.ErrorContext(ctx, "reject path: currentStage not populated after successful tx",
+			slog.LogAttrs(ctx, slog.LevelError, "reject path: currentStage not populated after successful tx",
 				slog.String("slug", slug))
 			return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 		}
@@ -579,7 +578,8 @@ func (h *AuthoringHandler) Amend(ctx context.Context, req *connect.Request[specv
 	}
 	protoStage := stageToProto(result.Stage)
 	if protoStage == specv1.AuthoringStage_AUTHORING_STAGE_UNSPECIFIED {
-		h.logger.Error("unknown stage returned from storage", slog.String("stage", string(result.Stage)), slog.String("slug", req.Msg.Slug))
+		slog.LogAttrs(ctx, slog.LevelError, "unknown stage returned from storage",
+			slog.String("stage", string(result.Stage)), slog.String("slug", req.Msg.Slug))
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 	return connect.NewResponse(&specv1.AmendResponse{
@@ -651,7 +651,7 @@ func (h *AuthoringHandler) GetPrompts(_ context.Context, req *connect.Request[sp
 // DECIDED_IN edges and transitions them from proposed to accepted. Returns an
 // error if any decision acceptance fails. graphBackend and decisionBackend are
 // obtained from the scoped store (ScopedBackend embeds both interfaces).
-func acceptLinkedDecisions(ctx context.Context, logger *slog.Logger, graphBackend storage.GraphBackend, decisionBackend storage.DecisionBackend, slug string) error {
+func acceptLinkedDecisions(ctx context.Context, graphBackend storage.GraphBackend, decisionBackend storage.DecisionBackend, slug string) error {
 	edges, err := graphBackend.ListEdges(ctx, slug, storage.EdgeTypeDecidedIn)
 	if err != nil {
 		return fmt.Errorf("list DECIDED_IN edges for %q: %w", slug, err)
@@ -662,8 +662,8 @@ func acceptLinkedDecisions(ctx context.Context, logger *slog.Logger, graphBacken
 		// Use ToID as the decision slug; FromID should be the spec.
 		decisionSlug := edge.ToID
 		if decisionSlug == slug {
-			logger.WarnContext(ctx, "DECIDED_IN edge has unexpected direction (ToID is spec, not decision)",
-				"slug", slug, "fromID", edge.FromID, "toID", edge.ToID)
+			slog.LogAttrs(ctx, slog.LevelWarn, "DECIDED_IN edge has unexpected direction (ToID is spec, not decision)",
+				slog.String("slug", slug), slog.String("fromID", edge.FromID), slog.String("toID", edge.ToID))
 			decisionSlug = edge.FromID
 		}
 		if decisionSlug == "" || decisionSlug == slug {
@@ -763,7 +763,7 @@ func RegisterAuthoringService(mux *http.ServeMux, scoper storage.Scoper, opts ..
 	if scoper == nil {
 		panic("RegisterAuthoringService: scoper must not be nil")
 	}
-	handler := &AuthoringHandler{scoper: scoper, logger: slog.Default()}
+	handler := &AuthoringHandler{scoper: scoper}
 	path, h := specgraphv1connect.NewAuthoringServiceHandler(handler, opts...)
 	mux.Handle(path, h)
 }
@@ -925,7 +925,7 @@ func postureToString(p specv1.Posture) string {
 	case specv1.Posture_POSTURE_SUPPORT:
 		return "support"
 	default:
-		slog.Warn("postureToString: unrecognized posture enum, storing empty string",
+		slog.LogAttrs(context.Background(), slog.LevelWarn, "postureToString: unrecognized posture enum, storing empty string",
 			slog.Int("posture_int", int(p)))
 		return ""
 	}
@@ -1097,7 +1097,7 @@ func (h *AuthoringHandler) stageError(err error) error {
 	if errors.Is(err, storage.ErrSpecSuperseded) {
 		return connect.NewError(connect.CodeFailedPrecondition, errors.New("spec has been superseded"))
 	}
-	h.logger.Error("stageError: internal error", slog.Any("error", err))
+	slog.LogAttrs(context.Background(), slog.LevelError, "stageError: internal error", slog.Any("error", err))
 	return connect.NewError(connect.CodeInternal, errors.New("internal error"))
 }
 

--- a/internal/server/claim_handler.go
+++ b/internal/server/claim_handler.go
@@ -106,7 +106,7 @@ func claimError(err error) error {
 	case errors.Is(err, storage.ErrSpecNotClaimed):
 		return connect.NewError(connect.CodeNotFound, errors.New("spec is not claimed"))
 	default:
-		slog.Error("claimError: internal error", slog.Any("error", err))
+		slog.LogAttrs(context.Background(), slog.LevelError, "claimError: internal error", slog.Any("error", err))
 		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 }

--- a/internal/server/constitution_handler.go
+++ b/internal/server/constitution_handler.go
@@ -269,7 +269,7 @@ func constitutionError(err error) error {
 	case errors.Is(err, storage.ErrConstitutionNotFound):
 		return connect.NewError(connect.CodeNotFound, errors.New("constitution not found"))
 	default:
-		slog.Error("constitutionError: internal error", slog.Any("error", err))
+		slog.LogAttrs(context.Background(), slog.LevelError, "constitutionError: internal error", slog.Any("error", err))
 		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 }

--- a/internal/server/execution_handler.go
+++ b/internal/server/execution_handler.go
@@ -117,7 +117,7 @@ func (h *ExecutionHandler) getPrimeProject(ctx context.Context, composer *prime.
 	}
 	pview, err := primeProjectViewToProto(view)
 	if err != nil {
-		slog.Error("GetPrime: convert project view", slog.Any("error", err))
+		slog.LogAttrs(ctx, slog.LevelError, "GetPrime: convert project view", slog.Any("error", err))
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 	return connect.NewResponse(&specv1.PrimeResponse{
@@ -135,7 +135,7 @@ func (h *ExecutionHandler) getPrimeSpec(ctx context.Context, store storage.Scope
 	}
 	pSpecView, err := primeSpecViewToProto(sview)
 	if err != nil {
-		slog.Error("GetPrime: convert spec view", slog.Any("error", err))
+		slog.LogAttrs(ctx, slog.LevelError, "GetPrime: convert spec view", slog.Any("error", err))
 		return nil, connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 
@@ -304,7 +304,7 @@ func executionError(err error) error {
 	case errors.Is(err, storage.ErrAgentNotClaimOwner):
 		return connect.NewError(connect.CodePermissionDenied, errors.New("agent does not hold the claim for this spec"))
 	default:
-		slog.Error("executionError: internal error", slog.Any("error", err))
+		slog.LogAttrs(context.Background(), slog.LevelError, "executionError: internal error", slog.Any("error", err))
 		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 }

--- a/internal/server/graph_handler.go
+++ b/internal/server/graph_handler.go
@@ -210,7 +210,7 @@ func graphError(err error) error {
 	case errors.Is(err, storage.ErrEdgeNotFound):
 		return connect.NewError(connect.CodeNotFound, errors.New("edge not found"))
 	default:
-		slog.Error("graphError: internal error", slog.Any("error", err))
+		slog.LogAttrs(context.Background(), slog.LevelError, "graphError: internal error", slog.Any("error", err))
 		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 }

--- a/internal/server/lifecycle_handler.go
+++ b/internal/server/lifecycle_handler.go
@@ -208,7 +208,7 @@ func (h *LifecycleHandler) AcknowledgeDrift(ctx context.Context, req *connect.Re
 	if h.driftChecker != nil {
 		result, driftErr := h.driftChecker.Check(ctx, msg.Slug, "")
 		if driftErr != nil {
-			h.logger.Error("AcknowledgeDrift: drift re-check failed",
+			slog.LogAttrs(ctx, slog.LevelError, "AcknowledgeDrift: drift re-check failed",
 				slog.String("slug", msg.Slug), slog.Any("error", driftErr))
 			report.ErrorMessage = "drift re-check failed after acknowledgment"
 		} else if result != nil {

--- a/internal/server/probes/probes.go
+++ b/internal/server/probes/probes.go
@@ -80,17 +80,17 @@ func (h *Handler) probe(ctx context.Context, pinger Pinger, timeout time.Duratio
 		// tailing for readiness failures see something. A silent boot
 		// against a permanently-down DB would otherwise reveal the
 		// failure only via 503 bodies on /readyz.
-		slog.Warn("readiness probe failed on first attempt", "error", err)
+		slog.LogAttrs(ctx, slog.LevelWarn, "readiness probe failed on first attempt", slog.Any("error", err))
 	case prev == nil:
 		// First probe is healthy — happy path, stay silent.
 	case err != nil && prev.ready:
-		slog.Warn("readiness probe failed", "error", err)
+		slog.LogAttrs(ctx, slog.LevelWarn, "readiness probe failed", slog.Any("error", err))
 	case err == nil && !prev.ready:
-		slog.Info("readiness probe recovered")
+		slog.LogAttrs(ctx, slog.LevelInfo, "readiness probe recovered")
 	case err != nil && prev.err != nil && prev.err.Error() != err.Error():
 		// Mid-outage error shape changed (e.g., connection-refused →
 		// auth-failed). Re-log so logs mirror what /readyz now returns.
-		slog.Warn("readiness probe error changed", "error", err)
+		slog.LogAttrs(ctx, slog.LevelWarn, "readiness probe error changed", slog.Any("error", err))
 	}
 }
 

--- a/internal/server/project.go
+++ b/internal/server/project.go
@@ -61,7 +61,7 @@ func scopeStore(ctx context.Context, scoper storage.Scoper) (storage.ScopedBacke
 	}
 	store, err := scoper.Scoped(ctx, project)
 	if err != nil {
-		slog.Error("scopeStore: failed to scope storage", slog.Any("error", err))
+		slog.LogAttrs(ctx, slog.LevelError, "scopeStore: failed to scope storage", slog.Any("error", err))
 		return nil, connect.NewError(connect.CodeInternal,
 			errors.New("internal error"))
 	}

--- a/internal/server/spec_handler.go
+++ b/internal/server/spec_handler.go
@@ -304,7 +304,7 @@ func specError(err error) error {
 	case errors.Is(err, storage.ErrVersionNotFound):
 		return connect.NewError(connect.CodeNotFound, errors.New("version not found"))
 	default:
-		slog.Error("specError: internal error", slog.Any("error", err))
+		slog.LogAttrs(context.Background(), slog.LevelError, "specError: internal error", slog.Any("error", err))
 		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 }

--- a/internal/server/sweeper.go
+++ b/internal/server/sweeper.go
@@ -16,7 +16,7 @@ type ClaimSweeper interface {
 
 // StartSweeper launches a background goroutine that periodically releases expired claims.
 // It stops when the context is cancelled.
-func StartSweeper(ctx context.Context, store ClaimSweeper, interval time.Duration, logger *slog.Logger) {
+func StartSweeper(ctx context.Context, store ClaimSweeper, interval time.Duration) {
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -27,11 +27,11 @@ func StartSweeper(ctx context.Context, store ClaimSweeper, interval time.Duratio
 			case <-ticker.C:
 				released, err := store.ReleaseExpiredClaims(ctx)
 				if err != nil {
-					logger.Error("release expired claims", "error", err)
+					slog.LogAttrs(ctx, slog.LevelError, "release expired claims", slog.Any("error", err))
 					continue
 				}
 				if released > 0 {
-					logger.Info("released expired claims", "count", released)
+					slog.LogAttrs(ctx, slog.LevelInfo, "released expired claims", slog.Int("count", released))
 				}
 			}
 		}

--- a/internal/server/sweeper_test.go
+++ b/internal/server/sweeper_test.go
@@ -5,7 +5,6 @@ package server_test
 
 import (
 	"context"
-	"log/slog"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,7 +27,7 @@ func TestSweeper_RunsOnInterval(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	server.StartSweeper(ctx, mock, 50*time.Millisecond, slog.Default())
+	server.StartSweeper(ctx, mock, 50*time.Millisecond)
 
 	// Poll until the sweeper has run at least twice, with a hard timeout.
 	deadline := time.After(500 * time.Millisecond)
@@ -46,7 +45,7 @@ func TestSweeper_StopsOnCancel(t *testing.T) {
 	mock := &mockSweeper{}
 	ctx, cancel := context.WithCancel(context.Background())
 
-	server.StartSweeper(ctx, mock, 50*time.Millisecond, slog.Default())
+	server.StartSweeper(ctx, mock, 50*time.Millisecond)
 
 	// Wait for the first sweep to actually run, with a timeout.
 	deadline := time.After(500 * time.Millisecond)

--- a/internal/server/sync_handler.go
+++ b/internal/server/sync_handler.go
@@ -77,7 +77,8 @@ func (h *SyncHandler) SyncGitHub(ctx context.Context, req *connect.Request[specv
 
 func (h *SyncHandler) syncWithAdapter(ctx context.Context, store storage.ScopedBackend, adapter syncpkg.Adapter, config *specv1.SyncConfig) (*connect.Response[specv1.SyncResponse], error) {
 	if err := adapter.Available(ctx); err != nil {
-		slog.ErrorContext(ctx, "adapter unavailable", "adapter", adapter.Name(), "error", err)
+		slog.LogAttrs(ctx, slog.LevelError, "adapter unavailable",
+			slog.Any("adapter", adapter.Name()), slog.Any("error", err))
 		return nil, connect.NewError(connect.CodeUnavailable, errors.New("sync adapter not available"))
 	}
 
@@ -91,7 +92,7 @@ func (h *SyncHandler) syncWithAdapter(ctx context.Context, store storage.ScopedB
 
 	specs, err := store.ListSpecs(ctx, stage, priority, 0)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to list specs", "error", err)
+		slog.LogAttrs(ctx, slog.LevelError, "failed to list specs", slog.Any("error", err))
 		return nil, connect.NewError(connect.CodeInternal, errors.New("failed to list specs"))
 	}
 
@@ -110,7 +111,8 @@ func (h *SyncHandler) syncWithAdapter(ctx context.Context, store storage.ScopedB
 			continue
 		}
 		if getErr != nil && !errors.Is(getErr, storage.ErrSyncMappingNotFound) {
-			slog.WarnContext(ctx, "failed to check sync state", "spec", spec.Slug, "adapter", adapter.Name(), "error", getErr)
+			slog.LogAttrs(ctx, slog.LevelWarn, "failed to check sync state",
+				slog.String("spec", spec.Slug), slog.Any("adapter", adapter.Name()), slog.Any("error", getErr))
 			result.State = specv1.SyncState_SYNC_STATE_ERROR
 			result.Message = "failed to check sync state"
 			resp.Errors++
@@ -128,7 +130,8 @@ func (h *SyncHandler) syncWithAdapter(ctx context.Context, store storage.ScopedB
 
 		externalID, created, pushErr := adapter.FindOrCreate(ctx, spec)
 		if pushErr != nil {
-			slog.WarnContext(ctx, "failed to push spec to adapter", "spec", spec.Slug, "adapter", adapter.Name(), "error", pushErr)
+			slog.LogAttrs(ctx, slog.LevelWarn, "failed to push spec to adapter",
+				slog.String("spec", spec.Slug), slog.Any("adapter", adapter.Name()), slog.Any("error", pushErr))
 			result.State = specv1.SyncState_SYNC_STATE_ERROR
 			result.Message = "failed to push to adapter"
 			resp.Errors++
@@ -148,9 +151,9 @@ func (h *SyncHandler) syncWithAdapter(ctx context.Context, store storage.ScopedB
 			}
 			// Retry once — transient store failures should not orphan external items.
 			if ctx.Err() != nil {
-				slog.ErrorContext(ctx, "sync mapping record failed after push (context cancelled before retry)",
-					"spec", spec.Slug, "adapter", adapter.Name(), "external_id", externalID,
-					"error", createErr)
+				slog.LogAttrs(ctx, slog.LevelError, "sync mapping record failed after push (context cancelled before retry)",
+					slog.String("spec", spec.Slug), slog.Any("adapter", adapter.Name()), slog.String("external_id", externalID),
+					slog.Any("error", createErr))
 				result.ExternalId = externalID
 				result.State = specv1.SyncState_SYNC_STATE_ERROR
 				result.Message = "pushed to adapter but failed to record mapping - external_id preserved for reconciliation"
@@ -169,9 +172,9 @@ func (h *SyncHandler) syncWithAdapter(ctx context.Context, store storage.ScopedB
 					resp.Results = append(resp.Results, result)
 					continue
 				}
-				slog.ErrorContext(ctx, "sync mapping record failed after push (orphaned external item)",
-					"spec", spec.Slug, "adapter", adapter.Name(), "external_id", externalID,
-					"initial_error", createErr, "error", retryErr)
+				slog.LogAttrs(ctx, slog.LevelError, "sync mapping record failed after push (orphaned external item)",
+					slog.String("spec", spec.Slug), slog.Any("adapter", adapter.Name()), slog.String("external_id", externalID),
+					slog.Any("initial_error", createErr), slog.Any("error", retryErr))
 				result.ExternalId = externalID
 				result.State = specv1.SyncState_SYNC_STATE_ERROR
 				result.Message = "pushed to adapter but failed to record mapping - external_id preserved for reconciliation"
@@ -207,7 +210,7 @@ func (h *SyncHandler) GetSyncStatus(ctx context.Context, req *connect.Request[sp
 	}
 	mappings, err := store.ListSyncMappings(ctx, adapterFilter, req.Msg.SpecSlug)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to list sync mappings", "error", err)
+		slog.LogAttrs(ctx, slog.LevelError, "failed to list sync mappings", slog.Any("error", err))
 		return nil, connect.NewError(connect.CodeInternal, errors.New("failed to list sync mappings"))
 	}
 
@@ -215,7 +218,7 @@ func (h *SyncHandler) GetSyncStatus(ctx context.Context, req *connect.Request[sp
 	for _, m := range mappings {
 		pm, convErr := syncMappingToProto(m)
 		if convErr != nil {
-			slog.ErrorContext(ctx, "failed to convert sync mapping", "error", convErr)
+			slog.LogAttrs(ctx, slog.LevelError, "failed to convert sync mapping", slog.Any("error", convErr))
 			return nil, connect.NewError(connect.CodeInternal, errors.New("failed to convert sync mapping"))
 		}
 		protoMappings = append(protoMappings, pm)

--- a/internal/storage/postgres/graph.go
+++ b/internal/storage/postgres/graph.go
@@ -493,7 +493,8 @@ func (s *Store) GetFullGraph(ctx context.Context) (*storage.FullGraph, error) {
 			return nil, fmt.Errorf("postgres: get full graph nodes: scan: %w", scanErr)
 		}
 		if seen[slug] {
-			slog.Warn("duplicate node slug in project — data integrity issue", "slug", slug, "project", s.project)
+			slog.LogAttrs(ctx, slog.LevelWarn, "duplicate node slug in project — data integrity issue",
+				slog.String("slug", slug), slog.String("project", s.project))
 			continue
 		}
 		seen[slug] = true

--- a/internal/storage/postgres/migrate.go
+++ b/internal/storage/postgres/migrate.go
@@ -4,6 +4,7 @@
 package postgres
 
 import (
+	"context"
 	"database/sql"
 	"embed"
 	"fmt"
@@ -32,7 +33,8 @@ func runMigrations(connString string) error {
 	}
 	defer func() {
 		if cErr := db.Close(); cErr != nil {
-			slog.Error("close migration connection", "error", cErr)
+			slog.LogAttrs(context.Background(), slog.LevelError, "close migration connection",
+				slog.Any("error", cErr))
 		}
 	}()
 

--- a/internal/storage/postgres/tx.go
+++ b/internal/storage/postgres/tx.go
@@ -50,7 +50,7 @@ func (s *Store) RunInTransaction(ctx context.Context, fn func(ctx context.Contex
 	txCtx := txToContext(ctx, tx)
 	if fnErr := fn(txCtx); fnErr != nil {
 		if rbErr := tx.Rollback(ctx); rbErr != nil {
-			slog.Error("postgres: rollback failed", "error", rbErr)
+			slog.LogAttrs(ctx, slog.LevelError, "postgres: rollback failed", slog.Any("error", rbErr))
 		}
 		return fnErr
 	}
@@ -117,10 +117,10 @@ func (s *Store) dispatchChangeEvents(ctx context.Context) {
 			func() {
 				defer func() {
 					if r := recover(); r != nil {
-						slog.Error("change subscriber panicked",
-							"subscriber", fmt.Sprintf("%T", sub),
-							"slug", events[i].Slug,
-							"panic", r,
+						slog.LogAttrs(context.Background(), slog.LevelError, "change subscriber panicked",
+							slog.String("subscriber", fmt.Sprintf("%T", sub)),
+							slog.String("slug", events[i].Slug),
+							slog.Any("panic", r),
 						)
 					}
 				}()

--- a/internal/sync/exec.go
+++ b/internal/sync/exec.go
@@ -48,7 +48,8 @@ func (r *ExecRunner) Run(ctx context.Context, name string, args ...string) ([]by
 		return out, fmt.Errorf("exec %s: %w", name, err)
 	}
 	if stderr.Len() > 0 {
-		slog.Debug("exec stderr (non-fatal)", "cmd", name, "stderr", stderr.String())
+		slog.LogAttrs(ctx, slog.LevelDebug, "exec stderr (non-fatal)",
+			slog.String("cmd", name), slog.String("stderr", stderr.String()))
 	}
 	return out, nil
 }


### PR DESCRIPTION
## Summary

Adds structured log configuration and enforces consistent `slog.LogAttrs` usage across the server binary.

## Changes

### New: `LogConfig` + serve flags
- `LogConfig` struct (`level`, `format`, `output`) added to `GlobalConfig` with `Build()`/`BuildWith(w io.Writer)` methods
- `--log-level`, `--log-format`, `--log-output` flags wired into `serveCmd`; env-var derivation via `flagKeyMap`
- Defaults: `info` / `json` / `stdout` (JSON to stdout for Knative log collection)

### New: `sloglint` enforcement
`.golangci.yaml` gains `sloglint` with:
- `attr-only: true` — all key-value args must be typed `slog.Attr`
- `context: scope` — context-aware variant required when ctx is in scope
- `static-msg: true`, `no-mixed-args: true`
- Excluded from `_test.go` files

### Refactor: `slog.LogAttrs` migration
All server-side slog calls migrated to `slog.LogAttrs(ctx, level, msg, slog.Attr...)`:

| Package | Notes |
|---|---|
| `cmd/specgraph/serve.go` | Full migration; gosec G118 fix (use closure ctx) |
| `internal/auth/` | engine, identitystore, interceptor, oidc\_verifier |
| `internal/auth/usagetracker/` | Touch + flushBatch |
| `internal/authoring/composer.go` | — |
| `internal/config/` | global.go, managedfiles (markdownblock, wholefile) |
| `internal/drift/drift.go` | — |
| `internal/mcp/server.go` | — |
| `internal/notify/impact.go` | int32 Version cast via slog.Int |
| `internal/server/` | All handlers + probes + sweeper + lifecycle |
| `internal/storage/postgres/` | graph.go, migrate.go, tx.go |
| `internal/sync/exec.go` | — |

### Cleanup
- Removed `logger *slog.Logger` field from `AuthoringHandler` struct
- Removed `logger` param from `acceptLinkedDecisions` (and its call site)
- Removed `logger *slog.Logger` param from `StartSweeper`; updated callers and test

## Testing

`task check` passes: fmt, license, lint (0 issues), build, unit tests.