### PR TITLE
fix(serve): bind liveness probe before Postgres connect; bound the dial

### DIFF
--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -333,6 +333,32 @@ func runServe(cmd *cobra.Command, _ []string) error {
 
 	pol := defaultBackoffPolicy()
 
+	// Bind the probe listener BEFORE the first (potentially slow) Postgres
+	// connect. Liveness must never wait on storage: /livez answers 200 from
+	// t≈0 and /readyz is a truthful 503 while we connect, so a kubelet liveness
+	// probe can't kill the pod during a degraded boot. The dial is bounded
+	// (postgres.defaultConnectTimeout), but even a bounded stall must not delay
+	// the port binding past the liveness window. The readiness probe LOOP is
+	// started later (probeHandler.Start, after the path decision) so a healthy
+	// boot stays log-silent.
+	probeHandler := probes.NewHandler()
+	probeSrv, probeErrCh, err := startProbeListener(ctx, probeHandler, probesCfg)
+	if err != nil {
+		return err
+	}
+	// stopProbe shuts the probe listener down on a fatal early return that
+	// happens before the shutdown goroutine (which otherwise owns it) is wired.
+	stopProbe := func() {
+		if probeSrv == nil {
+			return
+		}
+		shutCtx, c := context.WithTimeout(context.Background(), probeShutdownTimeout)
+		defer c()
+		if shErr := probeSrv.Shutdown(shutCtx); shErr != nil {
+			slog.LogAttrs(context.Background(), slog.LevelWarn, "probe server shutdown", slog.Any("error", shErr))
+		}
+	}
+
 	// Decide the boot path BEFORE starting any server or shutdown goroutine, so
 	// a fatal docker:true / credential failure starts nothing (unchanged).
 	var (
@@ -342,12 +368,14 @@ func runServe(cmd *cobra.Command, _ []string) error {
 	if cfg.Server.Docker {
 		r, connErr := connectStore(ctx, connURL)
 		if connErr != nil {
+			stopProbe()
 			return fmt.Errorf("connect to postgres: %w", connErr)
 		}
 		res, haveConn = r, true
 	} else {
 		r, degrade, connErr := firstConnect(ctx, connURL, pol)
 		if connErr != nil {
+			stopProbe()
 			return connErr // credential-exhausted fatal, or ctx cancelled
 		}
 		if !degrade {
@@ -457,22 +485,25 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	// Happy path: wire and swap in the real handler BEFORE opening the port,
-	// so clients never observe a 503 window. activate also sets the pinger's
-	// store, so the probe listener's first probe is healthy (no spurious WARN).
-	// If activation fails here, no listener has been opened yet — clean return.
+	// Happy path: wire and swap in the real handler BEFORE opening the main
+	// port, so clients never observe a 503 window. activate also sets the
+	// pinger's store, so the probe loop's first probe (started below) is
+	// healthy (no spurious WARN). The probe listener is already bound, so a
+	// failure here must stop it before returning.
 	if haveConn {
 		if actErr := activate(res); actErr != nil {
 			stopSweeper()
+			stopProbe()
 			return actErr
 		}
 	}
 
-	// Open the ports. On the happy path handlerRef already holds the real
+	// Open the main port. On the happy path handlerRef already holds the real
 	// handler; in the degraded window it holds the blanket-503 handler.
 	mainLn, err := net.Listen("tcp", addr)
 	if err != nil {
 		stopSweeper()
+		stopProbe()
 		runCleanup()
 		return fmt.Errorf("main listener bind %s: %w", addr, err)
 	}
@@ -484,14 +515,13 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		IdleTimeout:       120 * time.Second,
 	}
 
-	probeSrv, probeErrCh, err := startProbeListener(ctx, pinger, probesCfg)
-	if err != nil {
-		stopSweeper()
-		if closeErr := mainLn.Close(); closeErr != nil {
-			slog.LogAttrs(context.Background(), slog.LevelWarn, "main listener close", slog.Any("error", closeErr))
-		}
-		runCleanup()
-		return err
+	// Now start the readiness probe loop. The listener was bound up front; on
+	// the happy path the pinger's store is already set (silent first probe), on
+	// the degraded path it is nil (first probe legitimately fails → one WARN).
+	// Skip when probes are disabled (no listener) to preserve "probes off → no
+	// probe goroutine, readiness not observable".
+	if probeSrv != nil {
+		probeHandler.Start(ctx, pinger, probesCfg.Interval, probesCfg.Timeout)
 	}
 	mainErrCh := startMainServer(srv, mainLn)
 
@@ -640,17 +670,22 @@ func validateServerConfig(cfg *config.GlobalConfig) (config.ProbesConfig, error)
 	return probesCfg, nil
 }
 
-// startProbeListener binds a plain-HTTP listener serving /livez and /readyz
-// using tuning from a resolved ProbesConfig. Returns (nil, nil, nil) when
-// Listen is empty so callers treat probes as off. Bind errors abort startup
-// rather than leaving a running API that kubelet can never mark ready.
+// startProbeListener binds a plain-HTTP listener serving the handler's /livez
+// and /readyz on the resolved ProbesConfig address. Returns (nil, nil, nil)
+// when Listen is empty so callers treat probes as off. Bind errors abort
+// startup rather than leaving a running API that kubelet can never mark ready.
+//
+// The listener is bound but the readiness probe loop is NOT started here — the
+// caller owns that (handler.Start) so it can bring liveness up early (before
+// the dependency connects) yet defer readiness probing until the dependency
+// wiring is ready, keeping a healthy boot log-silent.
 //
 // The returned error channel fires once if the background Serve returns a
 // non-ErrServerClosed error — a dead probe listener while the main server
 // keeps serving traffic is a silent split-brain that kubelet can't recover
 // from on its own, so the caller should treat a send on this channel as a
 // shutdown trigger.
-func startProbeListener(ctx context.Context, pinger probes.Pinger, cfg config.ProbesConfig) (*http.Server, <-chan error, error) {
+func startProbeListener(ctx context.Context, handler *probes.Handler, cfg config.ProbesConfig) (*http.Server, <-chan error, error) {
 	if cfg.Listen == "" {
 		return nil, nil, nil
 	}
@@ -658,12 +693,11 @@ func startProbeListener(ctx context.Context, pinger probes.Pinger, cfg config.Pr
 	if err != nil {
 		return nil, nil, fmt.Errorf("probe listener bind %s: %w", cfg.Listen, err)
 	}
-	h := probes.New(ctx, pinger, cfg.Interval, cfg.Timeout)
 	srv := &http.Server{
 		// Addr reflects the resolved listener address, not the caller's
 		// input, so callers passing ":0" can observe the ephemeral port.
 		Addr:              ln.Addr().String(),
-		Handler:           h.Mux(),
+		Handler:           handler.Mux(),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	slog.LogAttrs(ctx, slog.LevelInfo, "probe endpoints listening",

--- a/cmd/specgraph/serve_probes_test.go
+++ b/cmd/specgraph/serve_probes_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/server/probes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,17 +34,50 @@ func TestStartProbeListener_DisabledWhenEmpty(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	srv, errCh, err := startProbeListener(ctx, &stubPinger{}, probesCfg(""))
+	srv, errCh, err := startProbeListener(ctx, probes.NewHandler(), probesCfg(""))
 	require.NoError(t, err)
 	assert.Nil(t, srv, "empty addr disables probes — no listener should be created")
 	assert.Nil(t, errCh, "no death channel when probes are disabled")
+}
+
+// TestStartProbeListener_LivezUpBeforeProbing is the core liveness-decoupling
+// guarantee: the listener answers /livez with 200 and /readyz with 503 as soon
+// as it binds — before Start runs any probe. This is what keeps kubelet from
+// killing the pod while Postgres is still connecting.
+func TestStartProbeListener_LivezUpBeforeProbing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, _, err := startProbeListener(ctx, probes.NewHandler(), probesCfg("127.0.0.1:0"))
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	t.Cleanup(func() {
+		shutCtx, shutCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer shutCancel()
+		_ = srv.Shutdown(shutCtx)
+	})
+	base := "http://" + srv.Addr
+
+	resp, err := http.Get(base + "/livez") //nolint:noctx // test probe, no ctx threading needed
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"/livez must be 200 immediately on bind, with no probe loop started")
+
+	ready, err := http.Get(base + "/readyz") //nolint:noctx // test probe
+	require.NoError(t, err)
+	require.NoError(t, ready.Body.Close())
+	assert.Equal(t, http.StatusServiceUnavailable, ready.StatusCode,
+		"/readyz must be 503 until a probe runs")
 }
 
 func TestStartProbeListener_ServesLivezAndReadyz(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	srv, _, err := startProbeListener(ctx, &stubPinger{}, probesCfg("127.0.0.1:0"))
+	cfg := probesCfg("127.0.0.1:0")
+	h := probes.NewHandler()
+	srv, _, err := startProbeListener(ctx, h, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, srv)
 	t.Cleanup(func() {
@@ -59,6 +93,8 @@ func TestStartProbeListener_ServesLivezAndReadyz(t *testing.T) {
 	require.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
+	// Readiness only flips once the probe loop is started with a healthy pinger.
+	h.Start(ctx, &stubPinger{}, cfg.Interval, cfg.Timeout)
 	require.Eventually(t, func() bool {
 		r, getErr := http.Get(base + "/readyz") //nolint:noctx // retried via Eventually
 		if getErr != nil {
@@ -78,7 +114,7 @@ func TestStartProbeListener_BindFailureReturnsError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	srv, errCh, err := startProbeListener(ctx, &stubPinger{}, probesCfg(addr))
+	srv, errCh, err := startProbeListener(ctx, probes.NewHandler(), probesCfg(addr))
 	assert.Nil(t, srv)
 	assert.Nil(t, errCh)
 	require.Error(t, err)
@@ -90,7 +126,7 @@ func TestStartProbeListener_ShutdownClosesListener(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	srv, errCh, err := startProbeListener(ctx, &stubPinger{}, probesCfg("127.0.0.1:0"))
+	srv, errCh, err := startProbeListener(ctx, probes.NewHandler(), probesCfg("127.0.0.1:0"))
 	require.NoError(t, err)
 	require.NotNil(t, srv)
 
@@ -126,8 +162,9 @@ func TestStartProbeListener_ReadyzReportsPingerFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	pinger := &stubPinger{err: errors.New("db unreachable")}
-	srv, _, err := startProbeListener(ctx, pinger, probesCfg("127.0.0.1:0"))
+	cfg := probesCfg("127.0.0.1:0")
+	h := probes.NewHandler()
+	srv, _, err := startProbeListener(ctx, h, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, srv)
 	t.Cleanup(func() {
@@ -136,6 +173,7 @@ func TestStartProbeListener_ReadyzReportsPingerFailure(t *testing.T) {
 		_ = srv.Shutdown(shutCtx)
 	})
 
+	h.Start(ctx, &stubPinger{err: errors.New("db unreachable")}, cfg.Interval, cfg.Timeout)
 	require.Eventually(t, func() bool {
 		r, getErr := http.Get("http://" + srv.Addr + "/readyz") //nolint:noctx // retried
 		if getErr != nil {
@@ -150,7 +188,7 @@ func TestStartProbeListener_ListenerDeathSignalsErrCh(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	srv, errCh, err := startProbeListener(ctx, &stubPinger{}, probesCfg("127.0.0.1:0"))
+	srv, errCh, err := startProbeListener(ctx, probes.NewHandler(), probesCfg("127.0.0.1:0"))
 	require.NoError(t, err)
 	require.NotNil(t, srv)
 	t.Cleanup(func() {
@@ -169,6 +207,6 @@ func TestStartProbeListener_ListenerDeathSignalsErrCh(t *testing.T) {
 		t.Fatalf("Close → ErrServerClosed must not signal death, got %v", deadErr)
 	case <-time.After(100 * time.Millisecond):
 	}
-	// Drain any lingering stubPinger goroutines.
+	// Drain any lingering goroutines.
 	_, _ = io.Copy(io.Discard, new(strings.Reader))
 }

--- a/internal/server/probes/probes.go
+++ b/internal/server/probes/probes.go
@@ -36,13 +36,28 @@ type Handler struct {
 	state atomic.Pointer[probeState]
 }
 
-// New starts a background goroutine that probes pinger every interval using
-// probeTimeout per call. The goroutine exits when ctx is cancelled. The
-// first probe runs immediately so readiness reflects current state without
-// waiting a full interval.
-func New(ctx context.Context, pinger Pinger, interval, probeTimeout time.Duration) *Handler {
-	h := &Handler{}
+// NewHandler returns a Handler that serves /livez (always 200) and /readyz
+// (503 until the first probe completes). It does NOT probe — bind it to a
+// listener to bring liveness up immediately, independent of the gated
+// dependency, then call Start once the dependency wiring is ready. Until Start
+// runs, /readyz is a truthful, silent 503 ("probe has not yet completed").
+func NewHandler() *Handler {
+	return &Handler{}
+}
+
+// Start launches the background probe loop: it probes pinger every interval
+// using probeTimeout per call, updating /readyz. The first probe runs
+// immediately so readiness reflects current state without waiting a full
+// interval. The goroutine exits when ctx is cancelled. Call Start at most once.
+func (h *Handler) Start(ctx context.Context, pinger Pinger, interval, probeTimeout time.Duration) {
 	go h.run(ctx, pinger, interval, probeTimeout)
+}
+
+// New binds and starts in one call: NewHandler followed immediately by Start.
+// Retained for callers whose pinger is already live when the listener binds.
+func New(ctx context.Context, pinger Pinger, interval, probeTimeout time.Duration) *Handler {
+	h := NewHandler()
+	h.Start(ctx, pinger, interval, probeTimeout)
 	return h
 }
 

--- a/internal/server/probes/split_test.go
+++ b/internal/server/probes/split_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package probes_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/specgraph/specgraph/internal/server/probes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewHandler_LivezUpBeforeProbing locks in the core liveness-decoupling
+// guarantee: a Handler that has NOT been Started answers /livez with 200 (so
+// kubelet never kills the pod while the gated dependency connects) and /readyz
+// with a silent 503 — without spawning a probe goroutine or logging anything.
+func TestNewHandler_LivezUpBeforeProbing(t *testing.T) {
+	buf := &syncBuffer{}
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	h := probes.NewHandler()
+
+	livez := httptest.NewRecorder()
+	h.Livez(livez, httptest.NewRequest(http.MethodGet, "/livez", http.NoBody))
+	assert.Equal(t, http.StatusOK, livez.Code,
+		"/livez must be 200 before any probe runs — liveness is storage-independent")
+
+	readyz := httptest.NewRecorder()
+	h.Readyz(readyz, httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody))
+	assert.Equal(t, http.StatusServiceUnavailable, readyz.Code,
+		"/readyz must be 503 until the first probe completes")
+	assert.Contains(t, readyz.Body.String(), "probe has not yet completed")
+
+	assert.NotContains(t, buf.String(), "readiness probe",
+		"a bound-but-not-started handler must be silent — no spurious readiness log on boot")
+}
+
+// TestHandler_Start_HealthyPinger_FlipsReadyzSilently proves Start begins
+// probing and, when the pinger is already healthy (happy path: store set before
+// Start), flips /readyz to 200 without logging a spurious failure.
+func TestHandler_Start_HealthyPinger_FlipsReadyzSilently(t *testing.T) {
+	buf := &syncBuffer{}
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h := probes.NewHandler()
+	h.Start(ctx, &fakePinger{}, 5*time.Millisecond, 50*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		rec := httptest.NewRecorder()
+		h.Readyz(rec, httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody))
+		return rec.Code == http.StatusOK
+	}, 2*time.Second, 5*time.Millisecond, "Start must probe and flip /readyz to 200 when the pinger is healthy")
+
+	assert.NotContains(t, buf.String(), "readiness probe failed",
+		"a healthy first probe must stay silent — no spurious WARN")
+}

--- a/internal/storage/postgres/postgres.go
+++ b/internal/storage/postgres/postgres.go
@@ -69,6 +69,37 @@ func WithSliceOps(ops storage.SliceBackend) Option {
 	return func(s *Store) { s.sliceOps = ops }
 }
 
+// defaultConnectTimeout bounds each connection dial. Without it pgx inherits
+// the caller's context deadline, and the server's startup connect runs under an
+// unbounded context — so a blackholed host (TCP SYN silently dropped by a
+// NetworkPolicy, security group, or a database that is reachable by DNS but not
+// yet accepting connections) blocks for the OS SYN-retransmit budget (~127s on
+// Linux). That stalls server startup long past the Kubernetes liveness window,
+// because the /livez+/readyz probe listeners only bind after the first connect
+// returns. Bounding the dial turns a hang into a fast, retryable error so the
+// degraded-startup path engages and the probe listeners come up.
+const defaultConnectTimeout = 5 * time.Second
+
+// buildPoolConfig parses connString into a pgxpool.Config and applies a default
+// per-dial ConnectTimeout when the parsed value is zero.
+//
+// A zero ConnectTimeout means either "unset" or an explicit connect_timeout=0
+// (libpq's "wait indefinitely") — pgconn parses both to the same zero value, so
+// they are indistinguishable here. Both are intentionally clamped to
+// defaultConnectTimeout: an unbounded dial is exactly the startup hang this
+// guards against, so honoring an explicit "infinite" would reintroduce the
+// liveness hazard. A non-zero connect_timeout in the DSN is preserved.
+func buildPoolConfig(connString string) (*pgxpool.Config, error) {
+	poolCfg, err := pgxpool.ParseConfig(connString)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: parse config: %w", err)
+	}
+	if poolCfg.ConnConfig.ConnectTimeout == 0 {
+		poolCfg.ConnConfig.ConnectTimeout = defaultConnectTimeout
+	}
+	return poolCfg, nil
+}
+
 // New creates a new PostgreSQL-backed Store, runs migrations, and ensures the
 // project row exists.
 func New(ctx context.Context, connString string, opts ...Option) (*Store, error) {
@@ -81,9 +112,9 @@ func New(ctx context.Context, connString string, opts ...Option) (*Store, error)
 		return nil, fmt.Errorf("postgres: project slug required: use postgres.WithProject(slug)")
 	}
 
-	poolCfg, err := pgxpool.ParseConfig(connString)
+	poolCfg, err := buildPoolConfig(connString)
 	if err != nil {
-		return nil, fmt.Errorf("postgres: parse config: %w", err)
+		return nil, err
 	}
 	if s.tracingEnabled {
 		poolCfg.ConnConfig.Tracer = otelpgx.NewTracer(otelpgx.WithTrimSQLInSpanName())

--- a/internal/storage/postgres/postgres_config_test.go
+++ b/internal/storage/postgres/postgres_config_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package postgres
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPoolConfig_DefaultsConnectTimeout(t *testing.T) {
+	cfg, err := buildPoolConfig("postgres://u:p@example.invalid:5432/db?sslmode=disable")
+	require.NoError(t, err)
+	assert.Equal(t, defaultConnectTimeout, cfg.ConnConfig.ConnectTimeout,
+		"a blackholed dial must fail within a bounded timeout, not block on the OS SYN-retransmit budget (~127s) and starve the probe listeners")
+}
+
+func TestBuildPoolConfig_PreservesExplicitConnectTimeout(t *testing.T) {
+	cfg, err := buildPoolConfig("postgres://u:p@example.invalid:5432/db?sslmode=disable&connect_timeout=3")
+	require.NoError(t, err)
+	assert.Equal(t, 3*time.Second, cfg.ConnConfig.ConnectTimeout,
+		"an operator-specified connect_timeout must win over the default")
+}
+
+func TestBuildPoolConfig_ClampsExplicitZeroToDefault(t *testing.T) {
+	// libpq's connect_timeout=0 means "wait indefinitely", which pgconn parses
+	// to a zero ConnectTimeout — indistinguishable from unset. Both are clamped
+	// to the default: an unbounded dial is the startup hang this guards against.
+	cfg, err := buildPoolConfig("postgres://u:p@example.invalid:5432/db?sslmode=disable&connect_timeout=0")
+	require.NoError(t, err)
+	assert.Equal(t, defaultConnectTimeout, cfg.ConnConfig.ConnectTimeout,
+		"an explicit connect_timeout=0 (infinite) is intentionally clamped to avoid reintroducing the unbounded-dial hang")
+}
+
+func TestBuildPoolConfig_InvalidConnString(t *testing.T) {
+	_, err := buildPoolConfig("://not-a-valid-dsn")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "postgres: parse config")
+}


### PR DESCRIPTION
## Problem

On a slow or blackholed external Postgres connect (`server.docker: false`), the dedicated probe port (`/livez`, `/readyz`) returned **503 for both paths** until startup finished. With an Istio/Knative sidecar in front, an unbound port surfaces as 503, so kubelet failed the liveness probe at `initialDelaySeconds` and killed the pod in a loop.

The #984 non-fatal degraded-startup path only engages when the first connect **fails fast** — it never engaged when the connect **hung**, and the probe listener only bound *after* that first connect returned.

## Root cause

1. `postgres.New` ran `pool.Ping(ctx)` under an **unbounded** context, and pgx applies no default `connect_timeout`. A blackholed dial (NetworkPolicy DROP, security group, or a DB not yet accepting connections) blocked startup for the OS SYN-retransmit budget (~127s) — far past the liveness window.
2. The probe listener bound only after the synchronous first connect, so `/livez` was unavailable during that window.

## Fix

- **Bound the dial** (`internal/storage/postgres/postgres.go`): `buildPoolConfig` defaults `ConnConfig.ConnectTimeout` to **5s** when the parsed value is zero. A non-zero `connect_timeout` in the DSN is preserved. Note: `connect_timeout=0` (libpq "infinite") parses to the same zero value as "unset" and is **intentionally clamped** to the default — honoring an infinite dial would reintroduce the exact liveness hang this guards against.
- **Bind liveness before storage** (`internal/server/probes/probes.go`, `cmd/specgraph/serve.go`): split `probes.New` into `NewHandler()` (bind endpoints) + `Start()` (run the probe loop). `runServe` now binds the probe listener **before** the connect decision and starts the probe loop **after** the path decision. `/livez` answers 200 from t≈0 with no binding window; healthy boots stay log-silent (no spurious "readiness probe failed/recovered"). `stopProbe` cleans up the now-earlier listener on every fatal early return.

## Behavior

- `/livez` → 200 from t≈0, independent of Postgres state
- `/readyz` → silent 503 until connected, then 200
- A blackholed/slow DB now drives the documented degraded-startup path instead of hanging

## Testing

- TDD throughout (RED→GREEN) for `buildPoolConfig` (incl. the `connect_timeout=0` clamp), `NewHandler`/`Start`, and the new `startProbeListener` contract
- `go test ./...` green; `-race` clean on touched packages; `gofmt`/`go vet` (incl. `-tags 'e2e integration'`)/`golangci-lint` clean
- Integration/e2e (`task pr-prep`) require Docker and were not run here