### PR TITLE
feat(server): per-request access logging

### DIFF
--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -697,11 +697,15 @@ func startProbeListener(ctx context.Context, handler *probes.Handler, cfg config
 	if err != nil {
 		return nil, nil, fmt.Errorf("probe listener bind %s: %w", cfg.Listen, err)
 	}
+	probeHandler := handler.Mux()
+	if cfg.LogRequests {
+		probeHandler = server.AccessLog(probeHandler)
+	}
 	srv := &http.Server{
 		// Addr reflects the resolved listener address, not the caller's
 		// input, so callers passing ":0" can observe the ephemeral port.
 		Addr:              ln.Addr().String(),
-		Handler:           handler.Mux(),
+		Handler:           probeHandler,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	slog.LogAttrs(ctx, slog.LevelInfo, "probe endpoints listening",

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -170,13 +170,13 @@ func buildAppHandler(_ context.Context, cfg *config.GlobalConfig, deps *appDeps,
 
 	interceptor := auth.NewAuthInterceptor(resolver, deps.authorizer)
 	maxBytes := connect.WithReadMaxBytes(4 << 20)
-	interceptors := []connect.Interceptor{}
+	interceptors := []connect.Interceptor{server.AccessLogInterceptor()} // outermost: always runs, sees final code
 	otelIC, otelErr := telemetry.ServerInterceptor(telState.enabled)
 	if otelErr != nil {
 		return appHandler{}, fmt.Errorf("otel interceptor: %w", otelErr)
 	}
 	if otelIC != nil {
-		interceptors = append(interceptors, otelIC) // outermost: before auth
+		interceptors = append(interceptors, otelIC) // before auth (AccessLogInterceptor is outermost)
 	}
 	interceptors = append(interceptors, interceptor) // existing auth interceptor
 	opts := connect.WithInterceptors(interceptors...)
@@ -230,7 +230,11 @@ func buildAppHandler(_ context.Context, cfg *config.GlobalConfig, deps *appDeps,
 
 	mux.Handle("/", server.StaticHandler(deps.webFS))
 
-	handler := server.SecurityHeaders(server.ProjectMiddleware(mux))
+	var rootHandler http.Handler = mux
+	if cfg.Log.Requests {
+		rootHandler = server.AccessLog(mux)
+	}
+	handler := server.SecurityHeaders(server.ProjectMiddleware(rootHandler))
 	if telState.enabled {
 		handler = telemetry.WrapHTTPHandler(handler)
 	}

--- a/cmd/specgraph/serve_probes_test.go
+++ b/cmd/specgraph/serve_probes_test.go
@@ -4,9 +4,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"strings"
@@ -209,4 +211,56 @@ func TestStartProbeListener_ListenerDeathSignalsErrCh(t *testing.T) {
 	}
 	// Drain any lingering goroutines.
 	_, _ = io.Copy(io.Discard, new(strings.Reader))
+}
+
+func TestStartProbeListener_LogsWhenEnabled(t *testing.T) {
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := probesCfg("127.0.0.1:0")
+	cfg.LogRequests = true
+	srv, _, err := startProbeListener(ctx, probes.NewHandler(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	t.Cleanup(func() {
+		shutCtx, c := context.WithTimeout(context.Background(), 2*time.Second)
+		defer c()
+		_ = srv.Shutdown(shutCtx)
+	})
+
+	resp, err := http.Get("http://" + srv.Addr + "/livez") //nolint:noctx // test probe
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	require.Eventually(t, func() bool { return strings.Contains(buf.String(), `"path":"/livez"`) },
+		2*time.Second, 10*time.Millisecond, "probe access line must appear when LogRequests is true")
+}
+
+func TestStartProbeListener_SilentWhenDisabled(t *testing.T) {
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, _, err := startProbeListener(ctx, probes.NewHandler(), probesCfg("127.0.0.1:0")) // LogRequests false
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	t.Cleanup(func() {
+		shutCtx, c := context.WithTimeout(context.Background(), 2*time.Second)
+		defer c()
+		_ = srv.Shutdown(shutCtx)
+	})
+	resp, err := http.Get("http://" + srv.Addr + "/livez") //nolint:noctx // test probe
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	assert.NotContains(t, buf.String(), `"path":"/livez"`, "probe logging must be off by default")
 }

--- a/docs/superpowers/plans/2026-06-11-server-request-logging.md
+++ b/docs/superpowers/plans/2026-06-11-server-request-logging.md
@@ -1,0 +1,1001 @@
+# Per-request Access Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Emit one idiomatic access-log line per request (HTTP fields + RPC procedure/code/identity, outcome-based level), with probe-endpoint logging gated behind config.
+
+**Architecture:** An edge HTTP middleware `AccessLog` (innermost, around the mux) emits the single line; an outermost Connect interceptor and the auth layer enrich a shared mutable `*reqctx.RequestInfo` carrier passed through `context`. `project`/`trace_id` come from the existing telemetry-enriched slog handler (the middleware must not re-add them). Probe-listener logging is wrapped only when `server.probes.log_requests` is true; the master switch is `log.requests` (default true).
+
+**Tech Stack:** Go, `log/slog`, `connectrpc.com/connect` v1.19.1, `github.com/felixge/httpsnoop` v1.0.4 (already in `go.sum`, indirect).
+
+**Design spec:** `docs/superpowers/specs/2026-06-11-server-request-logging-design.md`
+
+**Key constraint (import cycle):** `internal/server` imports `internal/auth`, so the carrier CANNOT live in `internal/server` (auth could not import it back). It lives in a new leaf package `internal/reqctx` that imports only `context`; both `internal/server` and `internal/auth` import `reqctx`.
+
+---
+
+## File structure
+
+- `internal/reqctx/reqctx.go` (new) — the `RequestInfo` carrier + context helpers. Leaf package.
+- `internal/reqctx/reqctx_test.go` (new) — carrier tests.
+- `internal/server/access_log.go` (new) — `AccessLog` middleware, status recorder, `remoteIP`, `requestLevel`.
+- `internal/server/access_log_test.go` (new) — middleware tests.
+- `internal/server/access_log_interceptor.go` (new) — `AccessLogInterceptor` + `connectCode`.
+- `internal/server/access_log_interceptor_test.go` (new) — interceptor tests.
+- `internal/auth/interceptor.go` (modify) — write `info.Identity` on the unary path.
+- `internal/auth/middleware.go` (modify) — write `info.Identity` in `RequireAuth`.
+- `internal/auth/identity_carrier_test.go` (new) — identity-write tests for both paths.
+- `internal/config/global.go` (modify) — `LogConfig.Requests` (default true) + `ProbesConfig.LogRequests`.
+- `internal/config/loader_internal_test.go` (modify) — config default/override tests.
+- `cmd/specgraph/serve.go` (modify) — prepend interceptor; wrap main chain; pass probe flag.
+- `cmd/specgraph/serve_probes_test.go` (modify) — probe access-log test.
+- `go.mod` (modify via `go mod tidy`) — httpsnoop indirect → direct.
+
+---
+
+## Task 1: `reqctx` carrier package
+
+**Files:**
+
+- Create: `internal/reqctx/reqctx.go`
+- Test: `internal/reqctx/reqctx_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package reqctx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/reqctx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromContext_AbsentReturnsNil(t *testing.T) {
+	assert.Nil(t, reqctx.FromContext(context.Background()),
+		"no carrier seeded → FromContext must return nil so writers can guard")
+}
+
+func TestNewContext_RoundTripAndPointerMutationVisible(t *testing.T) {
+	ctx, info := reqctx.NewContext(context.Background())
+	require.NotNil(t, info)
+
+	// A downstream layer looks the carrier up and mutates it through the pointer.
+	got := reqctx.FromContext(ctx)
+	require.Same(t, info, got, "FromContext must return the same pointer NewContext seeded")
+	got.Procedure = "/svc/Method"
+	got.Code = "ok"
+	got.Identity = "apikey:abc"
+
+	// The seeder's original pointer observes the mutation (no re-injection needed).
+	assert.Equal(t, "/svc/Method", info.Procedure)
+	assert.Equal(t, "ok", info.Code)
+	assert.Equal(t, "apikey:abc", info.Identity)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/reqctx/ -run TestFromContext -v`
+Expected: FAIL — `package github.com/specgraph/specgraph/internal/reqctx is not in std` / undefined `reqctx`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+// Package reqctx carries request-scoped log fields that are produced by
+// different layers (HTTP edge middleware, Connect interceptor, auth) and
+// consumed by the access-log middleware. It is a leaf package (imports only
+// context) so both internal/server and internal/auth can use it without an
+// import cycle.
+package reqctx
+
+import "context"
+
+// RequestInfo holds fields the access-log line cannot otherwise obtain at the
+// HTTP edge: the RPC procedure, the connect outcome code, and the
+// authenticated principal. Fields are exported because separate packages set
+// them. A pointer is seeded into the context by NewContext; inner layers
+// mutate it in place, and the seeder reads it after the handler returns.
+type RequestInfo struct {
+	Procedure string // RPC procedure, e.g. /specgraph.v1.GraphService/AddEdge
+	Code      string // connect code string: "ok", "invalid_argument", ...
+	Identity  string // authenticated principal (Identity.Subject), or ""
+}
+
+type ctxKey struct{}
+
+// NewContext returns a context carrying a fresh *RequestInfo plus that pointer.
+func NewContext(ctx context.Context) (context.Context, *RequestInfo) {
+	info := &RequestInfo{}
+	return context.WithValue(ctx, ctxKey{}, info), info
+}
+
+// FromContext returns the *RequestInfo carried by ctx, or nil if none.
+func FromContext(ctx context.Context) *RequestInfo {
+	info, _ := ctx.Value(ctxKey{}).(*RequestInfo)
+	return info
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/reqctx/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/reqctx/
+git commit -s -m "feat(reqctx): request-scoped log-field carrier package"
+```
+
+---
+
+## Task 2: Config fields (`log.requests`, `server.probes.log_requests`)
+
+**Files:**
+
+- Modify: `internal/config/global.go` (LogConfig ~73-80, ProbesConfig ~150-154, globalDefaults ~384-403)
+- Test: `internal/config/loader_internal_test.go`
+
+- [ ] **Step 1: Write the failing test** (append to `internal/config/loader_internal_test.go`)
+
+```go
+func TestGlobalDefaults_LogRequestsDefaultsTrue(t *testing.T) {
+	assert.True(t, globalDefaults().Log.Requests,
+		"access logging must be on by default")
+	assert.False(t, globalDefaults().Server.Probes.LogRequests,
+		"probe-request logging must be off by default")
+}
+
+func TestLoadGlobal_LogRequestsExplicitFalseOverrides(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("log:\n  requests: false\n"), 0o600))
+
+	cfg, err := LoadGlobalExplicit(path)
+	require.NoError(t, err)
+	assert.False(t, cfg.Log.Requests, "explicit log.requests:false must override the true default")
+}
+```
+
+Ensure the test file imports `os`, `path/filepath`, `github.com/stretchr/testify/assert`, `github.com/stretchr/testify/require` (add any missing).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/config/ -run 'TestGlobalDefaults_LogRequests|TestLoadGlobal_LogRequestsExplicit' -v`
+Expected: FAIL — `cfg.Log.Requests undefined` / `Probes.LogRequests undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `internal/config/global.go`, add the field to `LogConfig` (after `Output`):
+
+```go
+	// Requests enables one access-log line per request on the main listener.
+	Requests bool `yaml:"requests" koanf:"requests"`
+```
+
+Add the field to `ProbesConfig` (after `Timeout`):
+
+```go
+	// LogRequests enables access logging on the probe listener. Off by default
+	// so kubelet's frequent /livez,/readyz polls don't flood the logs.
+	LogRequests bool `yaml:"log_requests,omitempty" koanf:"log_requests"`
+```
+
+In `globalDefaults()`, set `Requests: true` in the `Log` literal:
+
+```go
+		Log: LogConfig{
+			Level:    "info",
+			Format:   "json",
+			Output:   "stdout",
+			Requests: true,
+		},
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/config/ -run 'TestGlobalDefaults_LogRequests|TestLoadGlobal_LogRequestsExplicit' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/global.go internal/config/loader_internal_test.go
+git commit -s -m "feat(config): add log.requests + server.probes.log_requests"
+```
+
+---
+
+## Task 3: Level mapping + status recorder + remote_ip helper
+
+**Files:**
+
+- Create: `internal/server/access_log.go`
+- Test: `internal/server/access_log_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestLevel(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		code   string
+		want   slog.Level
+	}{
+		{"2xx no code", 200, "", slog.LevelInfo},
+		{"3xx", 302, "", slog.LevelInfo},
+		{"4xx", 404, "", slog.LevelWarn},
+		{"5xx", 500, "", slog.LevelError},
+		{"ok code on 200", 200, "ok", slog.LevelInfo},
+		{"invalid_argument on 200", 200, "invalid_argument", slog.LevelWarn},
+		{"internal on 200", 200, "internal", slog.LevelError},
+		{"unknown on 200", 200, "unknown", slog.LevelError},
+		{"client code never lowers 5xx", 500, "invalid_argument", slog.LevelError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, requestLevel(tt.status, tt.code))
+		})
+	}
+}
+
+func TestRemoteIP(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	r.RemoteAddr = "10.0.0.5:54321"
+	assert.Equal(t, "10.0.0.5", remoteIP(r), "falls back to RemoteAddr host")
+
+	r.Header.Set("X-Forwarded-For", "203.0.113.7, 10.0.0.1")
+	assert.Equal(t, "203.0.113.7", remoteIP(r), "uses first XFF hop when present")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/server/ -run 'TestRequestLevel|TestRemoteIP' -v`
+Expected: FAIL — `undefined: requestLevel` / `undefined: remoteIP`.
+
+- [ ] **Step 3: Write minimal implementation** (create `internal/server/access_log.go`)
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// requestLevel picks the access-log level as the more severe of the HTTP
+// status level and the connect-code level. gRPC/gRPC-Web errors arrive as
+// HTTP 200 with the code in a trailer, so the code dimension is load-bearing.
+func requestLevel(status int, code string) slog.Level {
+	level := slog.LevelInfo
+	switch {
+	case status >= 500:
+		level = slog.LevelError
+	case status >= 400:
+		level = slog.LevelWarn
+	}
+	switch code {
+	case "", "ok":
+		// status governs
+	case "internal", "unknown", "unavailable", "data_loss", "deadline_exceeded":
+		if level < slog.LevelError {
+			level = slog.LevelError
+		}
+	default:
+		if level < slog.LevelWarn {
+			level = slog.LevelWarn
+		}
+	}
+	return level
+}
+
+// remoteIP returns the first X-Forwarded-For hop when present (NOTE:
+// client-spoofable unless a trusted proxy overwrites it — informational only),
+// else the host part of RemoteAddr.
+func remoteIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if i := strings.IndexByte(xff, ','); i >= 0 {
+			return strings.TrimSpace(xff[:i])
+		}
+		return strings.TrimSpace(xff)
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// statusRecorder captures the response status and byte count for the access
+// log. status defaults to 200 (handlers that write a body without an explicit
+// WriteHeader implicitly send 200).
+type statusRecorder struct {
+	status int
+	bytes  int
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/server/ -run 'TestRequestLevel|TestRemoteIP' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/access_log.go internal/server/access_log_test.go
+git commit -s -m "feat(server): access-log level mapping + remote_ip helper"
+```
+
+---
+
+## Task 4: `AccessLog` middleware
+
+**Files:**
+
+- Modify: `internal/server/access_log.go`
+- Modify: `internal/server/access_log_test.go`
+
+- [ ] **Step 1: Write the failing test** (append to `internal/server/access_log_test.go`)
+
+Add imports: `bytes`, `context`, `encoding/json`, `strings`, `github.com/felixge/httpsnoop` is NOT needed in the test, `github.com/specgraph/specgraph/internal/reqctx`, `github.com/stretchr/testify/require`.
+
+```go
+// captureLogs swaps slog.Default for a JSON logger writing to a buffer and
+// returns the buffer + a restore func.
+func captureLogs(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	return buf, func() { slog.SetDefault(prev) }
+}
+
+func decodeLine(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	line := strings.TrimSpace(buf.String())
+	require.NotEmpty(t, line, "expected one access-log line")
+	require.NotContains(t, line, "\n", "expected exactly one line")
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &m))
+	return m
+}
+
+func TestAccessLog_BasicLineFields(t *testing.T) {
+	buf, restore := captureLogs(t)
+	defer restore()
+
+	h := AccessLog(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/v1/things?token=secret", http.NoBody)
+	req.Header.Set("Authorization", "Bearer supersecret")
+	req.RemoteAddr = "10.0.0.5:1234"
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	m := decodeLine(t, buf)
+	assert.Equal(t, "request", m["msg"])
+	assert.Equal(t, "GET", m["method"])
+	assert.Equal(t, "/v1/things", m["path"], "query string must be stripped")
+	assert.Equal(t, float64(204), m["status"])
+	assert.Equal(t, "10.0.0.5", m["remote_ip"])
+	assert.Contains(t, m, "duration_ms")
+	assert.NotContains(t, buf.String(), "secret", "no query/auth secrets in the line")
+}
+
+func TestAccessLog_CarrierEnrichment(t *testing.T) {
+	buf, restore := captureLogs(t)
+	defer restore()
+
+	// Inner handler simulates the interceptor/auth filling the carrier.
+	h := AccessLog(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		info := reqctx.FromContext(r.Context())
+		require.NotNil(t, info, "AccessLog must seed the carrier")
+		info.Procedure = "/specgraph.v1.GraphService/AddEdge"
+		info.Code = "invalid_argument"
+		info.Identity = "apikey:k1"
+		w.WriteHeader(http.StatusOK)
+	}))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/rpc", http.NoBody))
+
+	m := decodeLine(t, buf)
+	assert.Equal(t, "/specgraph.v1.GraphService/AddEdge", m["procedure"])
+	assert.Equal(t, "invalid_argument", m["code"])
+	assert.Equal(t, "apikey:k1", m["identity"])
+	assert.Equal(t, "WARN", m["level"], "invalid_argument escalates a 200 to WARN")
+}
+
+func TestAccessLog_PanicLogs500AndRepanics(t *testing.T) {
+	buf, restore := captureLogs(t)
+	defer restore()
+
+	h := AccessLog(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("boom")
+	}))
+
+	assert.Panics(t, func() {
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/x", http.NoBody))
+	}, "panic must propagate after logging")
+
+	m := decodeLine(t, buf)
+	assert.Equal(t, float64(500), m["status"])
+	assert.Equal(t, "ERROR", m["level"])
+}
+
+func TestAccessLog_NoProjectKeyAddedByMiddleware(t *testing.T) {
+	buf, restore := captureLogs(t)
+	defer restore()
+	h := AccessLog(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) }))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+	// AccessLog must NOT emit project itself (the enrich handler owns it).
+	assert.NotContains(t, decodeLine(t, buf), "project")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/server/ -run TestAccessLog -v`
+Expected: FAIL — `undefined: AccessLog`.
+
+- [ ] **Step 3: Write minimal implementation** (append to `internal/server/access_log.go`)
+
+Add imports to the file: `time`, `github.com/felixge/httpsnoop`, `github.com/specgraph/specgraph/internal/reqctx`.
+
+```go
+// AccessLog logs one line per request. It seeds a reqctx.RequestInfo carrier
+// (filled by the Connect interceptor and the auth layer), captures status and
+// byte count via httpsnoop.Wrap (which preserves Flusher/Hijacker for the MCP
+// streamable endpoint), and emits the line in a defer so a panic still logs.
+//
+// The line is emitted with the post-next r.Context() so the telemetry-enriched
+// slog handler can add trace_id/span_id/project. AccessLog deliberately does
+// NOT add those itself (that would duplicate the enriched keys).
+func AccessLog(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		ctx, info := reqctx.NewContext(r.Context())
+		r = r.WithContext(ctx)
+
+		rec := &statusRecorder{status: http.StatusOK}
+		ww := httpsnoop.Wrap(w, httpsnoop.Hooks{
+			WriteHeader: func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+				return func(code int) { rec.status = code; next(code) }
+			},
+			Write: func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+				return func(b []byte) (int, error) {
+					n, err := next(b)
+					rec.bytes += n
+					return n, err
+				}
+			},
+		})
+
+		defer func() {
+			rec2 := recover()
+			status := rec.status
+			if rec2 != nil {
+				status = http.StatusInternalServerError
+			}
+			attrs := []slog.Attr{
+				slog.String("method", r.Method),
+				slog.String("path", r.URL.Path),
+				slog.Int("status", status),
+				slog.Int64("duration_ms", time.Since(start).Milliseconds()),
+				slog.Int("bytes", rec.bytes),
+				slog.String("remote_ip", remoteIP(r)),
+			}
+			if info.Procedure != "" {
+				attrs = append(attrs, slog.String("procedure", info.Procedure))
+			}
+			if info.Code != "" {
+				attrs = append(attrs, slog.String("code", info.Code))
+			}
+			if info.Identity != "" {
+				attrs = append(attrs, slog.String("identity", info.Identity))
+			}
+			slog.LogAttrs(r.Context(), requestLevel(status, info.Code), "request", attrs...)
+			if rec2 != nil {
+				panic(rec2)
+			}
+		}()
+
+		next.ServeHTTP(ww, r)
+	})
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/server/ -run TestAccessLog -v`
+Expected: PASS (all four).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/access_log.go internal/server/access_log_test.go
+git commit -s -m "feat(server): AccessLog edge middleware (one line per request)"
+```
+
+---
+
+## Task 5: `AccessLogInterceptor` + `connectCode`
+
+**Files:**
+
+- Create: `internal/server/access_log_interceptor.go`
+- Test: `internal/server/access_log_interceptor_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/specgraph/specgraph/internal/reqctx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectCode(t *testing.T) {
+	assert.Equal(t, "ok", connectCode(nil))
+	assert.Equal(t, "unknown", connectCode(errors.New("plain")))
+	assert.Equal(t, "invalid_argument",
+		connectCode(connect.NewError(connect.CodeInvalidArgument, errors.New("x"))))
+}
+
+// fakeRequest is a minimal connect.AnyRequest for Spec().Procedure.
+func TestAccessLogInterceptor_FillsCarrier(t *testing.T) {
+	ctx, info := reqctx.NewContext(context.Background())
+
+	ic := AccessLogInterceptor()
+	var called bool
+	next := connect.UnaryFunc(func(ctx context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+		called = true
+		return connect.NewResponse(&struct{}{}), nil
+	})
+	// Wrap and invoke with a request carrying a Spec.
+	req := connect.NewRequest(&struct{}{})
+	req.Spec().Procedure = "/svc/M" // set below via helper if needed
+	_, err := ic.WrapUnary(next)(ctx, req)
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, "ok", info.Code)
+}
+
+func TestAccessLogInterceptor_CapturesErrorCodeFromInner(t *testing.T) {
+	ctx, info := reqctx.NewContext(context.Background())
+	ic := AccessLogInterceptor()
+	next := connect.UnaryFunc(func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
+		return nil, connect.NewError(connect.CodePermissionDenied, errors.New("denied"))
+	})
+	_, err := ic.WrapUnary(next)(ctx, connect.NewRequest(&struct{}{}))
+	require.Error(t, err)
+	assert.Equal(t, "permission_denied", info.Code,
+		"outermost interceptor must observe an inner reject-without-next code")
+}
+
+func TestAccessLogInterceptor_NoCarrierIsNoop(t *testing.T) {
+	ic := AccessLogInterceptor()
+	next := connect.UnaryFunc(func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
+		return connect.NewResponse(&struct{}{}), nil
+	})
+	// context.Background() has no carrier; must not panic.
+	_, err := ic.WrapUnary(next)(context.Background(), connect.NewRequest(&struct{}{}))
+	require.NoError(t, err)
+}
+```
+
+> NOTE for the implementer: `connect.NewRequest(&struct{}{}).Spec().Procedure` is empty in a unit test (Spec is populated by the framework). The `FillsCarrier` test asserts `Code`, which is reliable; if you want to assert `Procedure`, drive it through a real handler/client instead. Keep the `Code` assertions as the contract.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/server/ -run 'TestConnectCode|TestAccessLogInterceptor' -v`
+Expected: FAIL — `undefined: connectCode` / `undefined: AccessLogInterceptor`.
+
+- [ ] **Step 3: Write minimal implementation** (create `internal/server/access_log_interceptor.go`)
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	"github.com/specgraph/specgraph/internal/reqctx"
+)
+
+// connectCode returns the access-log code string for an RPC outcome.
+// connect.CodeOf(nil) is Unknown, so nil is special-cased to "ok" first; a
+// plain (non-connect) handler error yields "unknown" → ERROR, the desired
+// unexpected-failure signal.
+func connectCode(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	return connect.CodeOf(err).String()
+}
+
+// AccessLogInterceptor enriches the reqctx carrier with the RPC procedure and
+// outcome code. It never logs — the edge AccessLog middleware emits the line.
+// It MUST be registered OUTERMOST (first in the interceptor list) so it runs
+// even when an inner interceptor (auth) rejects without calling next, and so
+// it observes the final outcome code.
+func AccessLogInterceptor() connect.Interceptor {
+	return interceptorFunc{}
+}
+
+type interceptorFunc struct{}
+
+func (interceptorFunc) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		resp, err := next(ctx, req)
+		if info := reqctx.FromContext(ctx); info != nil {
+			info.Procedure = req.Spec().Procedure
+			info.Code = connectCode(err)
+		}
+		return resp, err
+	}
+}
+
+func (interceptorFunc) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next // server process only; no client enrichment
+}
+
+func (interceptorFunc) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
+		err := next(ctx, conn)
+		if info := reqctx.FromContext(ctx); info != nil {
+			info.Procedure = conn.Spec().Procedure
+			info.Code = connectCode(err)
+		}
+		return err
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/server/ -run 'TestConnectCode|TestAccessLogInterceptor' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/access_log_interceptor.go internal/server/access_log_interceptor_test.go
+git commit -s -m "feat(server): AccessLogInterceptor enriches carrier with procedure+code"
+```
+
+---
+
+## Task 6: Identity capture in the auth layer
+
+**Files:**
+
+- Modify: `internal/auth/interceptor.go:27-46`
+- Modify: `internal/auth/middleware.go:17-29`
+- Test: `internal/auth/identity_carrier_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/specgraph/specgraph/internal/reqctx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubResolver resolves any token to a fixed identity.
+type stubResolver struct{ id *Identity }
+
+func (s stubResolver) Resolve(context.Context, string) (*Identity, error) { return s.id, nil }
+
+func TestRequireAuth_WritesIdentityToCarrier(t *testing.T) {
+	res := stubResolver{id: &Identity{Subject: "apikey:k1", Role: RoleAdmin}}
+	ctx, info := reqctx.NewContext(context.Background())
+
+	var sawIdentity string
+	h := RequireAuth(res)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if info := reqctx.FromContext(r.Context()); info != nil {
+			sawIdentity = info.Identity
+		}
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/x", http.NoBody).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer t")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "apikey:k1", sawIdentity, "RequireAuth must write identity into the carrier")
+	assert.Equal(t, "apikey:k1", info.Identity)
+}
+```
+
+> NOTE: adjust the `Identity` literal fields (`Role`, etc.) to whatever the auth package requires to be non-zero for `RequireAuth` to proceed; the assertion is on `info.Identity`. If `RoleAdmin` is not a valid identifier, use any valid `Role` constant from the package.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/auth/ -run TestRequireAuth_WritesIdentityToCarrier -v`
+Expected: FAIL — `info.Identity` is empty (no write yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `internal/auth/middleware.go`, add the import `"github.com/specgraph/specgraph/internal/reqctx"` and write the identity after successful authenticate (replace the final `next.ServeHTTP(...)` line, ~29):
+
+```go
+			if info := reqctx.FromContext(r.Context()); info != nil {
+				info.Identity = id.Subject
+			}
+			next.ServeHTTP(w, r.WithContext(WithIdentity(r.Context(), id)))
+```
+
+In `internal/auth/interceptor.go`, add the import `"github.com/specgraph/specgraph/internal/reqctx"` and write the identity right after `id` is resolved (after line 30, before `authorizer.Authorize`), so even an authorization denial still logs the principal:
+
+```go
+			if info := reqctx.FromContext(ctx); info != nil {
+				info.Identity = id.Subject
+			}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/auth/ -run TestRequireAuth_WritesIdentityToCarrier -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/middleware.go internal/auth/interceptor.go internal/auth/identity_carrier_test.go
+git commit -s -m "feat(auth): record authenticated subject in request-log carrier"
+```
+
+---
+
+## Task 7: Wire into the main listener
+
+**Files:**
+
+- Modify: `cmd/specgraph/serve.go:173-182` (interceptor list), `:233-239` (handler chain)
+
+- [ ] **Step 1: Prepend the interceptor**
+
+In `cmd/specgraph/serve.go`, change the interceptor assembly so `AccessLogInterceptor` is FIRST (outermost). Replace lines ~173-181:
+
+```go
+	interceptors := []connect.Interceptor{server.AccessLogInterceptor()} // outermost: always runs, sees final code
+	otelIC, otelErr := telemetry.ServerInterceptor(telState.enabled)
+	if otelErr != nil {
+		return appHandler{}, fmt.Errorf("otel interceptor: %w", otelErr)
+	}
+	if otelIC != nil {
+		interceptors = append(interceptors, otelIC)
+	}
+	interceptors = append(interceptors, interceptor) // existing auth interceptor
+```
+
+- [ ] **Step 2: Wrap the mux with AccessLog when enabled**
+
+Replace the handler-chain line (~233):
+
+```go
+	var rootHandler http.Handler = mux
+	if cfg.Log.Requests {
+		rootHandler = server.AccessLog(mux)
+	}
+	handler := server.SecurityHeaders(server.ProjectMiddleware(rootHandler))
+```
+
+(Leave the subsequent `telemetry.WrapHTTPHandler` and `CORSMiddleware` wrapping unchanged — they stay outer, so AccessLog's context has the span + project.)
+
+- [ ] **Step 3: Build**
+
+Run: `go build ./cmd/specgraph/`
+Expected: no output (success).
+
+- [ ] **Step 4: Run the package tests**
+
+Run: `go test ./cmd/specgraph/ ./internal/server/ ./internal/auth/`
+Expected: PASS (web/build placeholder must exist; if `pattern all:build` error, run `mkdir -p web/build && printf '<!doctype html>' > web/build/index.html`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/specgraph/serve.go
+git commit -s -m "feat(serve): wire access logging (outermost interceptor + edge middleware)"
+```
+
+---
+
+## Task 8: Gate + wire probe-listener logging
+
+**Files:**
+
+- Modify: `cmd/specgraph/serve.go:688` (`startProbeListener`)
+- Test: `cmd/specgraph/serve_probes_test.go`
+
+- [ ] **Step 1: Write the failing test** (append to `cmd/specgraph/serve_probes_test.go`)
+
+Add imports if missing: `bytes`, `encoding/json`, `log/slog`, `strings`.
+
+```go
+func TestStartProbeListener_LogsWhenEnabled(t *testing.T) {
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := probesCfg("127.0.0.1:0")
+	cfg.LogRequests = true
+	srv, _, err := startProbeListener(ctx, probes.NewHandler(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+	t.Cleanup(func() {
+		shutCtx, c := context.WithTimeout(context.Background(), 2*time.Second)
+		defer c()
+		_ = srv.Shutdown(shutCtx)
+	})
+
+	resp, err := http.Get("http://" + srv.Addr + "/livez") //nolint:noctx // test probe
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	require.Eventually(t, func() bool { return strings.Contains(buf.String(), `"path":"/livez"`) },
+		2*time.Second, 10*time.Millisecond, "probe access line must appear when LogRequests is true")
+}
+
+func TestStartProbeListener_SilentWhenDisabled(t *testing.T) {
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, _, err := startProbeListener(ctx, probes.NewHandler(), probesCfg("127.0.0.1:0")) // LogRequests false
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		shutCtx, c := context.WithTimeout(context.Background(), 2*time.Second)
+		defer c()
+		_ = srv.Shutdown(shutCtx)
+	})
+	resp, err := http.Get("http://" + srv.Addr + "/livez") //nolint:noctx // test probe
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	assert.NotContains(t, buf.String(), `"path":"/livez"`, "probe logging must be off by default")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/specgraph/ -run TestStartProbeListener_Logs -v`
+Expected: FAIL — `cfg.LogRequests` field exists (Task 2) but `startProbeListener` does not wrap with AccessLog, so no `/livez` line.
+
+- [ ] **Step 3: Implement the wrap** (in `startProbeListener`, where the `http.Server` Handler is set, ~at the `Handler: handler.Mux()` assignment)
+
+Replace the handler assignment so the mux is wrapped when enabled:
+
+```go
+	var probeHandler http.Handler = handler.Mux()
+	if cfg.LogRequests {
+		probeHandler = server.AccessLog(probeHandler)
+	}
+	srv := &http.Server{
+		Addr:              ln.Addr().String(),
+		Handler:           probeHandler,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+```
+
+Ensure `cmd/specgraph/serve.go` imports `github.com/specgraph/specgraph/internal/server` (it already does) and `net/http` (already does).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./cmd/specgraph/ -run TestStartProbeListener -v`
+Expected: PASS (both new tests + the existing probe tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/specgraph/serve.go cmd/specgraph/serve_probes_test.go
+git commit -s -m "feat(serve): gate probe-listener access logging on server.probes.log_requests"
+```
+
+---
+
+## Task 9: Tidy module + full gate
+
+**Files:**
+
+- Modify: `go.mod`, `go.sum`
+
+- [ ] **Step 1: Promote httpsnoop to a direct dependency**
+
+Run: `go mod tidy`
+Expected: `github.com/felixge/httpsnoop` loses its `// indirect` comment in `go.mod`.
+
+- [ ] **Step 2: Run the full unit suite**
+
+Run: `go test ./...`
+Expected: PASS (exit 0). If a `web/build` embed error appears, create the placeholder (`mkdir -p web/build && printf '<!doctype html>' > web/build/index.html`) and re-run.
+
+- [ ] **Step 3: Race + lint the touched packages**
+
+Run: `go test -race ./internal/server/ ./internal/auth/ ./internal/reqctx/ ./cmd/specgraph/`
+Run: `golangci-lint run ./internal/server/... ./internal/auth/... ./internal/reqctx/... ./cmd/specgraph/...`
+Expected: PASS / `0 issues`.
+
+- [ ] **Step 4: Quality gate**
+
+Run: `task check`
+Expected: PASS (fmt, license headers, lint, build, version-stamp guard, unit tests). Run `task license:add` if the license-header check flags the new files.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go.mod go.sum
+git commit -s -m "build: promote felixge/httpsnoop to a direct dependency"
+```
+
+---
+
+## Self-review notes (verified against the spec)
+
+- **Coverage:** carrier (Task 1) ↔ spec §1; config (Task 2) ↔ spec §Config; level/remote_ip (Task 3) ↔ spec §7/§2; `AccessLog` incl. panic + post-`next` ctx + no-`project` (Task 4) ↔ spec §2/§Field-ownership; interceptor outermost + `connectCode` nil/unknown (Task 5) ↔ spec §3/§7; identity writes unary + RequireAuth (Task 6) ↔ spec §4; serve wiring prepend + chain placement (Task 7) ↔ spec §3/§5; probe gating (Task 8) ↔ spec §6; httpsnoop direct dep (Task 9) ↔ spec §Files.
+- **Type consistency:** `reqctx.RequestInfo{Procedure,Code,Identity}`, `reqctx.NewContext`/`FromContext`, `server.AccessLog`, `server.AccessLogInterceptor`, `connectCode`, `requestLevel`, `remoteIP`, `statusRecorder`, `LogConfig.Requests`, `ProbesConfig.LogRequests` are used identically across tasks.
+- **Known doc-level caveats carried from the spec (not bugs):** streaming RPCs carry no `identity` (unary auth interceptor); panic lines carry empty `code` (status drives ERROR); telemetry-off lines omit `project`/`trace_id`; a panic also yields net/http's secondary plain `ErrorLog` line.

--- a/docs/superpowers/specs/2026-06-11-server-request-logging-design.md
+++ b/docs/superpowers/specs/2026-06-11-server-request-logging-design.md
@@ -80,24 +80,29 @@ Rationale for the split:
 
 ### 1. Per-request carrier
 
-A small mutable struct behind a context key in `internal/server`:
+A small mutable struct behind a context key in a leaf package `internal/reqctx`
+(it imports only `context`). It lives in its own package — not `internal/server`
+— because both `internal/server` (the middleware) and `internal/auth` (the
+identity write) must reference it, and `internal/server` already imports
+`internal/auth`; a shared leaf package avoids the import cycle.
 
 ```go
-type requestInfo struct {
-    procedure string // RPC procedure, e.g. /specgraph.v1.GraphService/AddEdge
-    code      string // connect code string: "ok", "invalid_argument", ...
-    identity  string // authenticated principal, set by the auth layer
+type RequestInfo struct {
+    Procedure string // RPC procedure, e.g. /specgraph.v1.GraphService/AddEdge
+    Code      string // connect code string: "ok", "invalid_argument", ...
+    Identity  string // authenticated principal, set by the auth layer
 }
 ```
 
-- `AccessLog` allocates a `requestInfo`, keeps a **local pointer**, and seeds
-  that same pointer into the request context before calling `next`.
-- Inner layers look it up via `requestInfoFromContext(ctx) *requestInfo` and
+- `AccessLog` calls `reqctx.NewContext(ctx)`, which returns a context carrying a
+  fresh `*RequestInfo` plus that pointer; it keeps the **local pointer** and
+  passes the context to `next`.
+- Inner layers look it up via `reqctx.FromContext(ctx) *RequestInfo` and
   mutate it **through the pointer**. Connect's handler context descends from
   `r.Context()` (verified), so the pointer is visible to the interceptor and
   to the auth layer. `AccessLog` reads its local pointer after `next` returns —
   pointer mutation is visible without re-injection.
-- `requestInfoFromContext` returns `nil` when absent (e.g. on the probe
+- `reqctx.FromContext` returns `nil` when absent (e.g. on the probe
   listener, which runs no interceptor and seeds no carrier unless logging is
   enabled).
 
@@ -111,7 +116,8 @@ func AccessLog(next http.Handler) http.Handler
 
 Per request:
 
-1. Allocate `info := &requestInfo{}`; seed it into the context.
+1. Allocate the carrier via `reqctx.NewContext(r.Context())`; keep the
+   returned `*RequestInfo` pointer and use the returned context for `next`.
 2. Wrap the `ResponseWriter` with a lightweight recorder (status defaulting to
    200, plus a byte counter), composed via `httpsnoop.Wrap` so optional
    interfaces (`http.Flusher`/`http.Hijacker`) are preserved — required for the
@@ -154,7 +160,7 @@ A `connect.Interceptor` (unary + streaming) that, around each call:
   the `nil` check must come first; a plain non-connect handler error yields
   `Unknown` → ERROR, which is the desired "unexpected failure" signal).
 
-It looks up the carrier via `requestInfoFromContext`; if absent it is a no-op.
+It looks up the carrier via `reqctx.FromContext`; if absent it is a no-op.
 It **never logs** — it only enriches. **It MUST be registered as the OUTERMOST
 interceptor** (prepended to the list), because connect runs the first
 interceptor outermost (see `cmd/specgraph/serve.go`, where the otel interceptor
@@ -162,7 +168,7 @@ is prepended "outermost: before auth"). The auth interceptor returns
 `Unauthenticated`/`PermissionDenied` **without calling `next`**, so an
 innermost access-log interceptor would never run for rejected RPCs — exactly
 the security-relevant denials we most want logged. Outermost placement
-guarantees it runs and observes the final outcome code.
+guarantees it runs and observes the outcome code.
 
 ### 4. Identity capture (auth layer)
 
@@ -172,7 +178,7 @@ principal, best-effort:
 - the auth **interceptor** (RPC path), after it resolves the identity, and
 - `RequireAuth` (REST/MCP path),
 
-each do a guarded `if info := requestInfoFromContext(ctx); info != nil { info.identity = id.Subject }`.
+each do a guarded `if info := reqctx.FromContext(ctx); info != nil { info.Identity = id.Subject }`.
 No auth signatures change; this is a single additive write on each path. When a
 request is unauthenticated/rejected, `identity` is simply empty.
 
@@ -315,8 +321,11 @@ Probe listener (via `startProbeListener` + `httptest`):
 
 ## Files touched
 
-- `internal/server/access_log.go` (new) — `requestInfo` carrier, accessor,
-  `AccessLog` middleware (recorder + recover-based panic path), level mapping.
+- `internal/reqctx/reqctx.go` (new) — the `RequestInfo` carrier + `NewContext`/
+  `FromContext` helpers (leaf package; imports only `context`).
+- `internal/server/access_log.go` (new) — `AccessLog` middleware
+  (recorder + recover-based panic path) + level mapping + `remoteIP`; uses the
+  `RequestInfo` carrier from `internal/reqctx`.
 - `internal/server/access_log_interceptor.go` (new) — `AccessLogInterceptor`
   - `connectCode` helper.
 - `internal/auth/` — one guarded carrier write each in the auth interceptor and

--- a/docs/superpowers/specs/2026-06-11-server-request-logging-design.md
+++ b/docs/superpowers/specs/2026-06-11-server-request-logging-design.md
@@ -1,0 +1,334 @@
+# Per-request access logging
+
+**Date:** 2026-06-11
+**Status:** Design approved, revised after adversarial review, pending spec review
+
+## Problem
+
+The server emits almost no per-request signal. The only request-scoped log
+is `mcpHeaderLogger`, which records `/mcp/` header *names* at `DEBUG`.
+`otelhttp`/`otelconnect` produce spans and metrics, but no human-readable
+access log. Operators have no idiomatic "one line per request" view of
+traffic, latency, or error outcomes.
+
+We want a standard access log — one line per request with method, path,
+status, duration, and (for RPCs) procedure + connect code — emitted at a
+level that reflects the outcome, with the high-frequency probe endpoints
+gated behind a config flag so kubelet traffic doesn't flood the logs.
+
+## Goals
+
+- One access-log line per request covering **all** main-listener traffic:
+  ConnectRPC, REST handlers, `/mcp/`, and the static web UI.
+- RPC lines additionally carry the `procedure` and connect `code`.
+- Outcome-based level so errors are filterable/alertable (`2xx/3xx` INFO,
+  `4xx` WARN, `5xx` ERROR; connect codes mapped similarly).
+- Probe-endpoint logging **off by default**, enabled via config for debugging.
+- A master switch to disable main access logging (volume/cost control).
+- No sensitive data in logs (no `Authorization`, no query strings, no bodies).
+
+## Non-goals
+
+- Request/response **body** logging.
+- Sampling / rate-limiting of access logs (deferred; see "Static-asset volume").
+- Changing the telemetry (trace/metric) pipeline. Access logging is additive
+  and reuses the existing trace-enriched slog handler.
+- A second, separate RPC log line. The interceptor enriches the single edge
+  line rather than emitting its own.
+
+## Decisions (from brainstorming)
+
+| Question | Decision |
+|----------|----------|
+| Logging layer | Edge HTTP middleware **and** a Connect interceptor, composed as one line |
+| Composition | Single enriched line via a per-request carrier (interceptor fills it) |
+| Probe gating | Probe-listener logging **off by default**, config flag to enable |
+| Field set | Standard idiomatic set (below); query/auth/bodies never logged |
+| Level | Outcome-based (status + connect code → INFO/WARN/ERROR) |
+| Config shape | `log.requests` (default true) + `server.probes.log_requests` (default false) |
+
+## Field ownership (resolves the enrichment/duplication question)
+
+The telemetry-enriched slog handler (`internal/telemetry/logging.go`) already
+adds attributes to **every** log record whose context carries them:
+`trace_id`, `span_id` (from the span), `project` (via
+`server.ProjectFromContext`), and `identity` (via `auth.IdentityFromContext`).
+To avoid **duplicate keys**, `AccessLog` must NOT re-add anything the enrich
+handler adds for a context it can see. Concretely:
+
+| Field | Source | Present when telemetry OFF? |
+|-------|--------|------------------------------|
+| `method`, `path`, `status`, `duration_ms`, `bytes`, `remote_ip` | `AccessLog` (always) | yes |
+| `procedure`, `code` | carrier (filled by interceptor) → `AccessLog` | yes |
+| `identity` | carrier (filled by auth) → `AccessLog` | yes |
+| `project` | enrich handler (context already has it at the edge) | **no** |
+| `trace_id`, `span_id` | enrich handler (span in context) | **no** |
+
+Rationale for the split:
+
+- `project` lives in the context at the edge (`ProjectMiddleware` is *outer*
+  to `AccessLog`), so the enrich handler adds it; `AccessLog` adding it too
+  would emit a duplicate `project` key (slog does not dedupe). When telemetry
+  is off, `project` is simply absent — acceptable for the dev/degraded path.
+- `identity` is set **downstream** of `AccessLog` (inside the auth
+  interceptor / `RequireAuth`), so it is NOT in `AccessLog`'s context and the
+  enrich handler never adds it to the access line. `AccessLog` therefore emits
+  `identity` itself, sourced from the carrier — no duplication, and it works
+  telemetry-off. Key name is `identity` to match the enrich handler.
+
+## Architecture
+
+### 1. Per-request carrier
+
+A small mutable struct behind a context key in `internal/server`:
+
+```go
+type requestInfo struct {
+    procedure string // RPC procedure, e.g. /specgraph.v1.GraphService/AddEdge
+    code      string // connect code string: "ok", "invalid_argument", ...
+    identity  string // authenticated principal, set by the auth layer
+}
+```
+
+- `AccessLog` allocates a `requestInfo`, keeps a **local pointer**, and seeds
+  that same pointer into the request context before calling `next`.
+- Inner layers look it up via `requestInfoFromContext(ctx) *requestInfo` and
+  mutate it **through the pointer**. Connect's handler context descends from
+  `r.Context()` (verified), so the pointer is visible to the interceptor and
+  to the auth layer. `AccessLog` reads its local pointer after `next` returns —
+  pointer mutation is visible without re-injection.
+- `requestInfoFromContext` returns `nil` when absent (e.g. on the probe
+  listener, which runs no interceptor and seeds no carrier unless logging is
+  enabled).
+
+### 2. Edge middleware: `AccessLog`
+
+`internal/server/access_log.go`:
+
+```go
+func AccessLog(next http.Handler) http.Handler
+```
+
+Per request:
+
+1. Allocate `info := &requestInfo{}`; seed it into the context.
+2. Wrap the `ResponseWriter` with a lightweight recorder (status defaulting to
+   200, plus a byte counter), composed via `httpsnoop.Wrap` so optional
+   interfaces (`http.Flusher`/`http.Hijacker`) are preserved — required for the
+   `/mcp/` streamable endpoint.
+3. In a `defer` (so it runs during a panic unwind), emit **one** line with
+   `msg="request"`. The line MUST be emitted with the post-`next`
+   **`r.Context()`** (via `slog.LogAttrs(r.Context(), …)`), not
+   `context.Background()` — otherwise the enrich handler can't read the span or
+   project and `project`/`trace_id`/`span_id` silently vanish. `duration_ms` is
+   measured from `AccessLog` entry (before `next`), so it excludes outer
+   otelhttp/CORS overhead. Fields:
+   - `method`, `path` (`r.URL.Path` only — query string stripped),
+     `status`, `duration_ms`, `bytes`, `remote_ip`.
+   - When the carrier is populated: `procedure`, `code`, `identity`.
+   - **Not** `project`/`trace_id`/`span_id` — those come from the enrich
+     handler (see "Field ownership").
+4. **Panic handling:** the `defer` calls `recover()`. If a panic occurred, log
+   the line at ERROR with `status=500`, then re-`panic(rec)` so net/http's
+   per-connection recovery still tears the connection down. (`httpsnoop`'s
+   return-value `CaptureMetrics` form is NOT used: it returns metrics only on
+   normal completion, so a panic would lose the captured status — hence the
+   explicit recorder + `recover`.)
+5. Level chosen per "Level mapping".
+
+`remote_ip`: first hop of `X-Forwarded-For` when present, else the host part of
+`RemoteAddr`. **This value is client-spoofable** unless a trusted L7 proxy
+overwrites `X-Forwarded-For`; it is informational, not an authentication or
+audit source. Behind a mesh, `RemoteAddr` is the sidecar.
+
+The middleware is only added to the chain when `log.requests` is true.
+
+### 3. Connect interceptor: `AccessLogInterceptor`
+
+A `connect.Interceptor` (unary + streaming) that, around each call:
+
+- sets `info.procedure` from the request/connection `Spec().Procedure`,
+- after the inner call, sets `info.code = connectCode(err)`, where
+  `connectCode` returns `"ok"` for `err == nil` and otherwise
+  `connect.CodeOf(err).String()` (note: `connect.CodeOf(nil)` is `Unknown`, so
+  the `nil` check must come first; a plain non-connect handler error yields
+  `Unknown` → ERROR, which is the desired "unexpected failure" signal).
+
+It looks up the carrier via `requestInfoFromContext`; if absent it is a no-op.
+It **never logs** — it only enriches. **It MUST be registered as the OUTERMOST
+interceptor** (prepended to the list), because connect runs the first
+interceptor outermost (see `cmd/specgraph/serve.go`, where the otel interceptor
+is prepended "outermost: before auth"). The auth interceptor returns
+`Unauthenticated`/`PermissionDenied` **without calling `next`**, so an
+innermost access-log interceptor would never run for rejected RPCs — exactly
+the security-relevant denials we most want logged. Outermost placement
+guarantees it runs and observes the final outcome code.
+
+### 4. Identity capture (auth layer)
+
+`identity` is populated through the carrier by the code that resolves the
+principal, best-effort:
+
+- the auth **interceptor** (RPC path), after it resolves the identity, and
+- `RequireAuth` (REST/MCP path),
+
+each do a guarded `if info := requestInfoFromContext(ctx); info != nil { info.identity = id.Subject }`.
+No auth signatures change; this is a single additive write on each path. When a
+request is unauthenticated/rejected, `identity` is simply empty.
+
+**Scope note:** the auth interceptor is a `connect.UnaryInterceptorFunc`, so it
+covers unary RPCs only. Streaming RPCs are not authenticated by it today (a
+pre-existing fact) and therefore carry no `identity`. This is acceptable and
+out of scope to change here.
+
+### 5. Chain placement
+
+Actual main-handler wiring is `SecurityHeaders(ProjectMiddleware(mux))`, then
+optionally wrapped by `otelhttp` (telemetry on) and `CORSMiddleware` (when a
+CORS origin is set). `AccessLog` is inserted **innermost, around the mux**:
+
+```text
+[CORS] → [otelhttp] → SecurityHeaders → ProjectMiddleware → AccessLog → mux(+interceptors)
+```
+
+(`[...]` = applied conditionally.) i.e. `SecurityHeaders(ProjectMiddleware(AccessLog(mux)))`.
+
+This placement gives `AccessLog`'s logging context the span (`trace_id`, since
+otelhttp is outer) and the project (since `ProjectMiddleware` is outer, so the
+enrich handler adds `project`), while keeping `AccessLog` outside the mux so
+the carrier pointer flows into the connect interceptors. The
+`AccessLogInterceptor` is **prepended** to the interceptor list (see §3).
+
+### 6. Probe listener
+
+The probe listener (`startProbeListener`) is a separate `http.Server` whose
+handler is `probeHandler.Mux()`. When `server.probes.log_requests` is true, its
+mux is wrapped with `AccessLog`; otherwise it is left bare (today's silent
+behavior). Probe requests run no interceptor and no `ProjectMiddleware`/otelhttp
+wrap, so a probe line carries `method/path/status/duration_ms/bytes/remote_ip`
+only (no `procedure`/`code`/`identity`/`project`/`trace_id`). `startProbeListener`
+receives the flag (via the resolved `ProbesConfig`).
+
+### 7. Level mapping
+
+Level is the more severe of the HTTP-status level and the connect-code level:
+
+- HTTP: `< 400` → INFO, `4xx` → WARN, `≥ 500` → ERROR.
+- Connect code: `Internal`, `Unknown`, `Unavailable`, `DataLoss`,
+  `DeadlineExceeded` → ERROR; other non-`ok` codes
+  (`InvalidArgument`, `NotFound`, `AlreadyExists`, `PermissionDenied`,
+  `Unauthenticated`, `FailedPrecondition`, `ResourceExhausted`, …) → WARN;
+  `ok`/absent → defer to the HTTP-status level.
+
+The connect-code dimension matters because gRPC/gRPC-Web clients return
+**HTTP 200** with the error only in the trailer; without it, a denied RPC would
+be logged INFO. Because lines are leveled, raising `log.level` to `warn` keeps
+only the problem requests.
+
+## Config
+
+`internal/config/global.go`:
+
+- `LogConfig.Requests bool` — `yaml:"requests" koanf:"requests"`. Defaulted to
+  **true** in `globalDefaults()`. An explicit `log.requests: false` overrides
+  (koanf last-write-wins), matching the established `Server.Docker` default-true
+  pattern.
+- `ProbesConfig.LogRequests bool` — `yaml:"log_requests" koanf:"log_requests"`.
+  Zero value **false**; no default entry needed.
+
+No new validation is required; both are plain booleans.
+
+## Sensitive data
+
+Never logged:
+
+- the `Authorization` header (and any other header values),
+- the URL query string (credential params such as `access_token`/`token`
+  ride there — see `internal/constitution/fetch`),
+- request or response bodies.
+
+Only `r.URL.Path` (path, no query) is logged. `remote_ip` is informational and
+spoofable (see §2) — not for audit.
+
+## Edge cases
+
+- **MCP / REST / static get no `procedure`/`code`.** `/mcp/` is a plain
+  `http.Handler` chain (not a connect handler), and REST/static likewise run no
+  connect interceptor, so those lines carry HTTP fields only — by construction.
+- **MCP SSE / long-lived GET stream**: the line emits when `ServeHTTP` returns
+  (stream close), so an in-flight stream produces no line until then;
+  `duration_ms` reflects the stream lifetime, bounded by the main server's
+  `WriteTimeout` (60s). `otelhttp` already excludes `/mcp/` GET from spans, so
+  those lines also lack `trace_id`. Acceptable; can be excluded later if noisy.
+- **Panic in a handler**: handled by the `recover()` in `AccessLog`'s defer —
+  logs ERROR/`status=500`, then re-panics so existing connection teardown is
+  unchanged (§2.4). connect-go does NOT recover handler panics by default
+  (`WithRecover` is opt-in and unused here), so this path is real for RPC
+  handlers too. Two caveats: (a) the `info.code` assignment runs *after*
+  `next`, so a panic line carries `procedure` but an **empty `code`** — status
+  500 still drives the ERROR level correctly; (b) net/http's per-connection
+  recovery emits its own `http: panic serving` line to `http.Server.ErrorLog`
+  (currently the default std logger → plain-text stderr), so a panic yields the
+  structured `AccessLog` line **plus** that secondary plain line. Optionally set
+  `srv.ErrorLog` to a slog-backed writer for a single structured stream.
+- **CORS preflight**: `CORSMiddleware` is outermost and may answer `OPTIONS`
+  preflights without calling `next`, so `AccessLog` won't log them. CORS is
+  dev-only (gated on `--cors-origin`); acceptable.
+- **Telemetry disabled**: `project`/`trace_id`/`span_id` are absent (no enrich
+  handler, no otelhttp span); the line still carries the HTTP fields plus
+  `procedure`/`code`/`identity` from the carrier.
+- **Static-asset volume**: `AccessLog` logs every static UI asset (JS/CSS/img)
+  on the main listener; a dashboard page view can produce many lines. The
+  master switch (`log.requests`) is the volume control; per-path sampling is a
+  deferred non-goal.
+
+## Testing
+
+Unit (slog captured to a buffer + `httptest`):
+
+- Emits exactly one `msg="request"` line per request.
+- Level mapping table: `200`→INFO, `404`→WARN, `500`→ERROR; connect
+  `internal`→ERROR, `invalid_argument`→WARN, `ok`→status-driven; and the
+  `nil`-error (→`ok`) vs non-connect-error (→`unknown`→ERROR) boundary.
+- Carrier enrichment: an inner handler/interceptor that fills the carrier
+  yields `procedure`/`code`/`identity`; absent carrier → no RPC/identity fields.
+- **No duplicate `project`**: with a project in context and the enrich handler
+  active, exactly one `project` key appears.
+- **Interceptor runs on auth denial**: with the access-log interceptor
+  outermost and an auth interceptor that rejects without calling `next`, the
+  `code` is still captured (e.g. `permission_denied`) and the level is WARN.
+- **Panic → 500**: a handler that panics yields one ERROR line with
+  `status=500` and the panic still propagates.
+- Redaction: query string omitted from `path`; no `Authorization` value
+  anywhere in the line.
+- `trace_id` present when the context carries a span; absent telemetry-off.
+
+Config:
+
+- `log.requests` defaults true; explicit `false` honored.
+- `server.probes.log_requests` defaults false; explicit `true` honored.
+
+Probe listener (via `startProbeListener` + `httptest`):
+
+- Default (flag off): `/livez` produces no access line.
+- Flag on: `/livez` produces a plain HTTP access line (no `procedure`/`code`).
+
+## Files touched
+
+- `internal/server/access_log.go` (new) — `requestInfo` carrier, accessor,
+  `AccessLog` middleware (recorder + recover-based panic path), level mapping.
+- `internal/server/access_log_interceptor.go` (new) — `AccessLogInterceptor`
+  - `connectCode` helper.
+- `internal/auth/` — one guarded carrier write each in the auth interceptor and
+  `RequireAuth` to populate `identity` (no signature changes).
+- `internal/config/global.go` — `LogConfig.Requests` (default true) +
+  `ProbesConfig.LogRequests`.
+- `cmd/specgraph/serve.go` — **prepend** the interceptor to the list; wrap the
+  main chain with `AccessLog` when `log.requests`; pass the probe flag into
+  `startProbeListener` and wrap the probe mux when enabled.
+- `go.mod` — `github.com/felixge/httpsnoop` moves from indirect to direct.
+- New tests alongside `access_log.go`, the interceptor, and the config/serve
+  changes.
+
+No proto, storage-interface, handler, or connect-interceptor **signature**
+changes.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/exaring/otelpgx v0.11.1
+	github.com/felixge/httpsnoop v1.0.4
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/google/go-cmp v0.7.0
@@ -107,7 +108,6 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
-	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/internal/auth/identity_carrier_test.go
+++ b/internal/auth/identity_carrier_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/reqctx"
+	"github.com/stretchr/testify/assert"
+)
+
+// stubResolver resolves any token to a fixed identity.
+type stubResolver struct{ id *Identity }
+
+func (s stubResolver) Resolve(context.Context, string) (*Identity, error) { return s.id, nil }
+
+func (s stubResolver) HasAuth(context.Context) (bool, error) { return true, nil }
+
+func TestRequireAuth_WritesIdentityToCarrier(t *testing.T) {
+	res := stubResolver{id: &Identity{Subject: "apikey:k1"}}
+	ctx, info := reqctx.NewContext(context.Background())
+
+	var sawIdentity string
+	h := RequireAuth(res)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if got := reqctx.FromContext(r.Context()); got != nil {
+			sawIdentity = got.Identity
+		}
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/x", http.NoBody).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer t")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "apikey:k1", sawIdentity, "RequireAuth must write identity into the carrier")
+	assert.Equal(t, "apikey:k1", info.Identity)
+}

--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
+
+	"github.com/specgraph/specgraph/internal/reqctx"
 )
 
 // NewAuthInterceptor returns a ConnectRPC unary interceptor that
@@ -27,6 +29,10 @@ func NewAuthInterceptor(resolver Resolver, authorizer Authorizer) connect.UnaryI
 			id, err := authenticate(ctx, resolver, req.Header())
 			if err != nil {
 				return nil, mapAuthError(procedure, err)
+			}
+
+			if info := reqctx.FromContext(ctx); info != nil {
+				info.Identity = id.Subject
 			}
 
 			decision, err := authorizer.Authorize(ctx, id, procedure, req.Any())

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"net/http"
+
+	"github.com/specgraph/specgraph/internal/reqctx"
 )
 
 // RequireAuth returns HTTP middleware that authenticates requests via
@@ -25,6 +27,9 @@ func RequireAuth(resolver Resolver) func(http.Handler) http.Handler {
 					http.Error(w, `{"error":"unauthenticated"}`, http.StatusUnauthorized)
 				}
 				return
+			}
+			if info := reqctx.FromContext(r.Context()); info != nil {
+				info.Identity = id.Subject
 			}
 			next.ServeHTTP(w, r.WithContext(WithIdentity(r.Context(), id)))
 		})

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -77,6 +77,8 @@ type LogConfig struct {
 	Format string `yaml:"format" koanf:"format"`
 	// Output selects the destination stream: stdout (default) or stderr.
 	Output string `yaml:"output" koanf:"output"`
+	// Requests enables one access-log line per request on the main listener.
+	Requests bool `yaml:"requests" koanf:"requests"`
 }
 
 // Build constructs a [slog.Logger] writing to the stream named by lc.Output
@@ -151,6 +153,9 @@ type ProbesConfig struct {
 	Listen   string        `yaml:"listen,omitempty" koanf:"listen"`
 	Interval time.Duration `yaml:"interval,omitempty" koanf:"interval"`
 	Timeout  time.Duration `yaml:"timeout,omitempty" koanf:"timeout"`
+	// LogRequests enables access logging on the probe listener. Off by default
+	// so kubelet's frequent /livez,/readyz polls don't flood the logs.
+	LogRequests bool `yaml:"log_requests,omitempty" koanf:"log_requests"`
 }
 
 // Resolved returns a copy with zero-valued Interval/Timeout filled from
@@ -396,9 +401,10 @@ func globalDefaults() *GlobalConfig {
 			DefaultServer: "http://127.0.0.1:9090",
 		},
 		Log: LogConfig{
-			Level:  "info",
-			Format: "json",
-			Output: "stdout",
+			Level:    "info",
+			Format:   "json",
+			Output:   "stdout",
+			Requests: true,
 		},
 	}
 }

--- a/internal/config/loader_internal_test.go
+++ b/internal/config/loader_internal_test.go
@@ -4,6 +4,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -44,4 +46,21 @@ func TestEnvKeyMapper_NoEnvFormCollisions(t *testing.T) {
 		form := "SPECGRAPH_" + strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
 		assert.Equal(t, key, m(form), "scalar key %q must round-trip via its env form", key)
 	}
+}
+
+func TestGlobalDefaults_LogRequestsDefaultsTrue(t *testing.T) {
+	assert.True(t, globalDefaults().Log.Requests,
+		"access logging must be on by default")
+	assert.False(t, globalDefaults().Server.Probes.LogRequests,
+		"probe-request logging must be off by default")
+}
+
+func TestLoadGlobal_LogRequestsExplicitFalseOverrides(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("log:\n  requests: false\n"), 0o600))
+
+	cfg, err := LoadGlobalExplicit(path)
+	require.NoError(t, err)
+	assert.False(t, cfg.Log.Requests, "explicit log.requests:false must override the true default")
 }

--- a/internal/reqctx/reqctx.go
+++ b/internal/reqctx/reqctx.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+// Package reqctx carries request-scoped log fields that are produced by
+// different layers (HTTP edge middleware, Connect interceptor, auth) and
+// consumed by the access-log middleware. It is a leaf package (imports only
+// context) so both internal/server and internal/auth can use it without an
+// import cycle.
+package reqctx
+
+import "context"
+
+// RequestInfo holds fields the access-log line cannot otherwise obtain at the
+// HTTP edge: the RPC procedure, the connect outcome code, and the
+// authenticated principal. Fields are exported because separate packages set
+// them. A pointer is seeded into the context by NewContext; inner layers
+// mutate it in place, and the seeder reads it after the handler returns.
+type RequestInfo struct {
+	Procedure string // RPC procedure, e.g. /specgraph.v1.GraphService/AddEdge
+	Code      string // connect code string: "ok", "invalid_argument", ...
+	Identity  string // authenticated principal (Identity.Subject), or ""
+}
+
+type ctxKey struct{}
+
+// NewContext returns a context carrying a fresh *RequestInfo plus that pointer.
+func NewContext(ctx context.Context) (context.Context, *RequestInfo) {
+	info := &RequestInfo{}
+	return context.WithValue(ctx, ctxKey{}, info), info
+}
+
+// FromContext returns the *RequestInfo carried by ctx, or nil if none.
+func FromContext(ctx context.Context) *RequestInfo {
+	info, ok := ctx.Value(ctxKey{}).(*RequestInfo)
+	if !ok {
+		return nil
+	}
+	return info
+}

--- a/internal/reqctx/reqctx_test.go
+++ b/internal/reqctx/reqctx_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package reqctx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/reqctx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromContext_AbsentReturnsNil(t *testing.T) {
+	assert.Nil(t, reqctx.FromContext(context.Background()),
+		"no carrier seeded → FromContext must return nil so writers can guard")
+}
+
+func TestNewContext_RoundTripAndPointerMutationVisible(t *testing.T) {
+	ctx, info := reqctx.NewContext(context.Background())
+	require.NotNil(t, info)
+
+	got := reqctx.FromContext(ctx)
+	require.Same(t, info, got, "FromContext must return the same pointer NewContext seeded")
+	got.Procedure = "/svc/Method"
+	got.Code = "ok"
+	got.Identity = "apikey:abc"
+
+	assert.Equal(t, "/svc/Method", info.Procedure)
+	assert.Equal(t, "ok", info.Code)
+	assert.Equal(t, "apikey:abc", info.Identity)
+}

--- a/internal/server/access_log.go
+++ b/internal/server/access_log.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// requestLevel picks the access-log level as the more severe of the HTTP
+// status level and the connect-code level. gRPC/gRPC-Web errors arrive as
+// HTTP 200 with the code in a trailer, so the code dimension is load-bearing.
+func requestLevel(status int, code string) slog.Level {
+	level := slog.LevelInfo
+	switch {
+	case status >= 500:
+		level = slog.LevelError
+	case status >= 400:
+		level = slog.LevelWarn
+	}
+	switch code {
+	case "", "ok":
+		// status governs
+	case "internal", "unknown", "unavailable", "data_loss", "deadline_exceeded":
+		if level < slog.LevelError {
+			level = slog.LevelError
+		}
+	default:
+		if level < slog.LevelWarn {
+			level = slog.LevelWarn
+		}
+	}
+	return level
+}
+
+// remoteIP returns the first X-Forwarded-For hop when present (NOTE:
+// client-spoofable unless a trusted proxy overwrites it — informational only),
+// else the host part of RemoteAddr.
+func remoteIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if i := strings.IndexByte(xff, ','); i >= 0 {
+			return strings.TrimSpace(xff[:i])
+		}
+		return strings.TrimSpace(xff)
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// statusRecorder captures the response status and byte count for the access
+// log. status defaults to 200 (handlers that write a body without an explicit
+// WriteHeader implicitly send 200).
+type statusRecorder struct {
+	status int
+	bytes  int
+}

--- a/internal/server/access_log.go
+++ b/internal/server/access_log.go
@@ -8,6 +8,10 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
+
+	"github.com/felixge/httpsnoop"
+	"github.com/specgraph/specgraph/internal/reqctx"
 )
 
 // requestLevel picks the access-log level as the more severe of the HTTP
@@ -59,4 +63,67 @@ func remoteIP(r *http.Request) string {
 type statusRecorder struct {
 	status int
 	bytes  int
+}
+
+// AccessLog logs one line per request. It seeds a reqctx.RequestInfo carrier
+// (filled by the Connect interceptor and the auth layer), captures status and
+// byte count via httpsnoop.Wrap (which preserves Flusher/Hijacker for the MCP
+// streamable endpoint), and emits the line in a defer so a panic still logs.
+//
+// The line is emitted with the post-next r.Context() so the telemetry-enriched
+// slog handler can add trace_id/span_id/project. AccessLog deliberately does
+// NOT add those itself (that would duplicate the enriched keys). Consequently,
+// when telemetry is disabled there is no enrich handler, so access lines omit
+// project/trace_id/span_id; identity still appears (it is carrier-sourced).
+func AccessLog(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		ctx, info := reqctx.NewContext(r.Context())
+		r = r.WithContext(ctx)
+
+		rec := &statusRecorder{status: http.StatusOK}
+		ww := httpsnoop.Wrap(w, httpsnoop.Hooks{
+			WriteHeader: func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+				return func(code int) { rec.status = code; next(code) }
+			},
+			Write: func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+				return func(b []byte) (int, error) {
+					n, err := next(b)
+					rec.bytes += n
+					return n, err
+				}
+			},
+		})
+
+		defer func() {
+			rec2 := recover()
+			status := rec.status
+			if rec2 != nil {
+				status = http.StatusInternalServerError
+			}
+			attrs := []slog.Attr{
+				slog.String("method", r.Method),
+				slog.String("path", r.URL.Path),
+				slog.Int("status", status),
+				slog.Int64("duration_ms", time.Since(start).Milliseconds()),
+				slog.Int("bytes", rec.bytes),
+				slog.String("remote_ip", remoteIP(r)),
+			}
+			if info.Procedure != "" {
+				attrs = append(attrs, slog.String("procedure", info.Procedure))
+			}
+			if info.Code != "" {
+				attrs = append(attrs, slog.String("code", info.Code))
+			}
+			if info.Identity != "" {
+				attrs = append(attrs, slog.String("identity", info.Identity))
+			}
+			slog.LogAttrs(r.Context(), requestLevel(status, info.Code), "request", attrs...)
+			if rec2 != nil {
+				panic(rec2)
+			}
+		}()
+
+		next.ServeHTTP(ww, r)
+	})
 }

--- a/internal/server/access_log_interceptor.go
+++ b/internal/server/access_log_interceptor.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	"github.com/specgraph/specgraph/internal/reqctx"
+)
+
+// connectCode returns the access-log code string for an RPC outcome.
+// connect.CodeOf(nil) is Unknown, so nil is special-cased to "ok" first; a
+// plain (non-connect) handler error yields "unknown" -> ERROR, the desired
+// unexpected-failure signal.
+func connectCode(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	return connect.CodeOf(err).String()
+}
+
+// AccessLogInterceptor enriches the reqctx carrier with the RPC procedure and
+// outcome code. It never logs - the edge AccessLog middleware emits the line.
+// It MUST be registered OUTERMOST (first in the interceptor list) so it runs
+// even when an inner interceptor (auth) rejects without calling next, and so
+// it observes the final outcome code.
+func AccessLogInterceptor() connect.Interceptor {
+	return accessLogInterceptor{}
+}
+
+type accessLogInterceptor struct{}
+
+func (accessLogInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		resp, err := next(ctx, req)
+		if info := reqctx.FromContext(ctx); info != nil {
+			info.Procedure = req.Spec().Procedure
+			info.Code = connectCode(err)
+		}
+		return resp, err
+	}
+}
+
+func (accessLogInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next // server process only; no client enrichment
+}
+
+func (accessLogInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
+		err := next(ctx, conn)
+		if info := reqctx.FromContext(ctx); info != nil {
+			info.Procedure = conn.Spec().Procedure
+			info.Code = connectCode(err)
+		}
+		return err
+	}
+}

--- a/internal/server/access_log_interceptor_test.go
+++ b/internal/server/access_log_interceptor_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/specgraph/specgraph/internal/reqctx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectCode(t *testing.T) {
+	assert.Equal(t, "ok", connectCode(nil))
+	assert.Equal(t, "unknown", connectCode(errors.New("plain")))
+	assert.Equal(t, "invalid_argument",
+		connectCode(connect.NewError(connect.CodeInvalidArgument, errors.New("x"))))
+}
+
+func TestAccessLogInterceptor_FillsCodeOnSuccess(t *testing.T) {
+	ctx, info := reqctx.NewContext(context.Background())
+	ic := AccessLogInterceptor()
+	var called bool
+	next := connect.UnaryFunc(func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
+		called = true
+		return connect.NewResponse(&struct{}{}), nil
+	})
+	_, err := ic.WrapUnary(next)(ctx, connect.NewRequest(&struct{}{}))
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, "ok", info.Code)
+}
+
+func TestAccessLogInterceptor_CapturesErrorCodeFromInner(t *testing.T) {
+	ctx, info := reqctx.NewContext(context.Background())
+	ic := AccessLogInterceptor()
+	next := connect.UnaryFunc(func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
+		return nil, connect.NewError(connect.CodePermissionDenied, errors.New("denied"))
+	})
+	_, err := ic.WrapUnary(next)(ctx, connect.NewRequest(&struct{}{}))
+	require.Error(t, err)
+	assert.Equal(t, "permission_denied", info.Code,
+		"outermost interceptor must observe an inner reject-without-next code")
+}
+
+func TestAccessLogInterceptor_NoCarrierIsNoop(t *testing.T) {
+	ic := AccessLogInterceptor()
+	next := connect.UnaryFunc(func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
+		return connect.NewResponse(&struct{}{}), nil
+	})
+	_, err := ic.WrapUnary(next)(context.Background(), connect.NewRequest(&struct{}{}))
+	require.NoError(t, err)
+}

--- a/internal/server/access_log_test.go
+++ b/internal/server/access_log_test.go
@@ -4,12 +4,19 @@
 package server
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/json"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/specgraph/specgraph/internal/reqctx"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRequestLevel(t *testing.T) {
@@ -43,4 +50,129 @@ func TestRemoteIP(t *testing.T) {
 
 	r.Header.Set("X-Forwarded-For", "203.0.113.7, 10.0.0.1")
 	assert.Equal(t, "203.0.113.7", remoteIP(r), "uses first XFF hop when present")
+}
+
+// captureLogs swaps slog.Default for a JSON logger writing to a buffer.
+func captureLogs(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	return buf, func() { slog.SetDefault(prev) }
+}
+
+func decodeLine(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	line := strings.TrimSpace(buf.String())
+	require.NotEmpty(t, line, "expected one access-log line")
+	require.NotContains(t, line, "\n", "expected exactly one line")
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &m))
+	return m
+}
+
+func TestAccessLog_BasicLineFields(t *testing.T) {
+	buf, restore := captureLogs(t)
+	defer restore()
+
+	h := AccessLog(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/v1/things?token=secret", http.NoBody)
+	req.Header.Set("Authorization", "Bearer supersecret")
+	req.RemoteAddr = "10.0.0.5:1234"
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	m := decodeLine(t, buf)
+	assert.Equal(t, "request", m["msg"])
+	assert.Equal(t, "GET", m["method"])
+	assert.Equal(t, "/v1/things", m["path"], "query string must be stripped")
+	assert.Equal(t, float64(204), m["status"])
+	assert.Equal(t, "10.0.0.5", m["remote_ip"])
+	assert.Contains(t, m, "duration_ms")
+	assert.NotContains(t, buf.String(), "secret", "no query/auth secrets in the line")
+}
+
+func TestAccessLog_CarrierEnrichment(t *testing.T) {
+	buf, restore := captureLogs(t)
+	defer restore()
+
+	h := AccessLog(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		info := reqctx.FromContext(r.Context())
+		require.NotNil(t, info, "AccessLog must seed the carrier")
+		info.Procedure = "/specgraph.v1.GraphService/AddEdge"
+		info.Code = "invalid_argument"
+		info.Identity = "apikey:k1"
+		w.WriteHeader(http.StatusOK)
+	}))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/rpc", http.NoBody))
+
+	m := decodeLine(t, buf)
+	assert.Equal(t, "/specgraph.v1.GraphService/AddEdge", m["procedure"])
+	assert.Equal(t, "invalid_argument", m["code"])
+	assert.Equal(t, "apikey:k1", m["identity"])
+	assert.Equal(t, "WARN", m["level"], "invalid_argument escalates a 200 to WARN")
+}
+
+func TestAccessLog_PanicLogs500AndRepanics(t *testing.T) {
+	buf, restore := captureLogs(t)
+	defer restore()
+
+	h := AccessLog(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("boom")
+	}))
+
+	assert.Panics(t, func() {
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/x", http.NoBody))
+	}, "panic must propagate after logging")
+
+	m := decodeLine(t, buf)
+	assert.Equal(t, float64(500), m["status"])
+	assert.Equal(t, "ERROR", m["level"])
+}
+
+func TestAccessLog_NoProjectKeyAddedByMiddleware(t *testing.T) {
+	buf, restore := captureLogs(t)
+	defer restore()
+	h := AccessLog(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) }))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+	assert.NotContains(t, decodeLine(t, buf), "project")
+}
+
+func TestAccessLog_BytesAndImplicitStatus(t *testing.T) {
+	buf, restore := captureLogs(t)
+	defer restore()
+
+	h := AccessLog(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("hello ")) // 6 bytes, implicit 200
+		_, _ = w.Write([]byte("world"))  // 5 bytes
+	}))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+
+	m := decodeLine(t, buf)
+	assert.Equal(t, float64(200), m["status"], "implicit 200 when a body is written without WriteHeader")
+	assert.Equal(t, float64(11), m["bytes"], "bytes must accumulate across multiple Write calls")
+}
+
+// hijackableRecorder is an httptest recorder that also satisfies http.Hijacker,
+// so we can assert AccessLog's wrapper preserves both Flusher and Hijacker
+// (required for the MCP streamable/SSE endpoint).
+type hijackableRecorder struct {
+	*httptest.ResponseRecorder
+}
+
+func (hijackableRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) { return nil, nil, nil }
+
+func TestAccessLog_PreservesFlusherAndHijacker(t *testing.T) {
+	var okFlusher, okHijacker bool
+	h := AccessLog(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, okFlusher = w.(http.Flusher)
+		_, okHijacker = w.(http.Hijacker)
+		w.WriteHeader(http.StatusOK)
+	}))
+	rw := hijackableRecorder{httptest.NewRecorder()}
+	h.ServeHTTP(rw, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+
+	assert.True(t, okFlusher, "wrapped ResponseWriter must still satisfy http.Flusher")
+	assert.True(t, okHijacker, "wrapped ResponseWriter must still satisfy http.Hijacker")
 }

--- a/internal/server/access_log_test.go
+++ b/internal/server/access_log_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestLevel(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		code   string
+		want   slog.Level
+	}{
+		{"2xx no code", 200, "", slog.LevelInfo},
+		{"3xx", 302, "", slog.LevelInfo},
+		{"4xx", 404, "", slog.LevelWarn},
+		{"5xx", 500, "", slog.LevelError},
+		{"ok code on 200", 200, "ok", slog.LevelInfo},
+		{"invalid_argument on 200", 200, "invalid_argument", slog.LevelWarn},
+		{"internal on 200", 200, "internal", slog.LevelError},
+		{"unknown on 200", 200, "unknown", slog.LevelError},
+		{"client code never lowers 5xx", 500, "invalid_argument", slog.LevelError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, requestLevel(tt.status, tt.code))
+		})
+	}
+}
+
+func TestRemoteIP(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	r.RemoteAddr = "10.0.0.5:54321"
+	assert.Equal(t, "10.0.0.5", remoteIP(r), "falls back to RemoteAddr host")
+
+	r.Header.Set("X-Forwarded-For", "203.0.113.7, 10.0.0.1")
+	assert.Equal(t, "203.0.113.7", remoteIP(r), "uses first XFF hop when present")
+}


### PR DESCRIPTION
## Summary

Adds an idiomatic access log: **one outcome-leveled line per request** on the main listener, covering ConnectRPC, REST, MCP, and the static UI. Probe-endpoint logging is gated behind config so kubelet polling doesn't flood the logs.

Each line carries `method`, `path` (query stripped), `status`, `duration_ms`, `bytes`, `remote_ip`, plus `procedure`/`code`/`identity` for RPCs. `trace_id`/`span_id`/`project` come from the existing telemetry-enriched slog handler (the middleware deliberately doesn't re-emit them, avoiding duplicate keys). Level = max severity of HTTP status and connect code (2xx/3xx INFO, 4xx WARN, 5xx/Internal/Unavailable/… ERROR).

## How it works

- **`internal/reqctx`** — a leaf carrier package (`RequestInfo{Procedure,Code,Identity}`) shared by `server` and `auth` to avoid an import cycle; mutated in place through a context-held pointer.
- **`server.AccessLog`** edge middleware — seeds the carrier, captures status/bytes via `httpsnoop.Wrap` (preserves Flusher/Hijacker for MCP SSE), emits one line in a `defer` (panic → 500, then re-panic). Logs with the post-`next` `r.Context()` so enrichment works.
- **`server.AccessLogInterceptor`** — registered **outermost** so it records the connect `procedure`/`code` even when the auth interceptor rejects without calling `next`.
- **auth** — the unary interceptor and `RequireAuth` write the authenticated subject into the carrier (before authorization, so denials still log *who*).
- **config** — `log.requests` (default **true**, master switch) and `server.probes.log_requests` (default **false**).
- **serve** — prepends the interceptor and wraps the mux/probe-mux accordingly.

## Config

```yaml
log:
  requests: true          # main-listener access logging (default true)
server:
  probes:
    log_requests: false   # probe listener (default false)
```

## Sensitive data

Never logged: `Authorization` (or any header values), query strings (credential params ride there), request/response bodies. Only `r.URL.Path` is logged. `remote_ip` (first `X-Forwarded-For` hop or `RemoteAddr`) is informational and proxy-spoofable — not for audit.

## Testing

- TDD throughout. Unit tests for: line fields + redaction, level mapping (status × connect code incl. nil/unknown boundary), carrier enrichment, panic→500 + re-panic, Flusher/Hijacker preservation, byte accumulation/implicit-200, identity write, and probe-listener gate on/off.
- `task check` green (fmt, license, Go+markdown+yaml lint, skills validate, web+proto build, version-stamp guard, unit tests); `go test -race` clean on touched packages.
- Two adversarial design-review rounds + a final holistic code review (verdict: ready).

## Follow-ups (non-blocking, can be tracked separately)

- Add an integration test composing `AccessLog` → telemetry enrich handler asserting each correlation key appears exactly once.
- Reconsider `deadline_exceeded` → ERROR (often client-induced).

Design spec + plan: `docs/superpowers/specs/2026-06-11-server-request-logging-design.md`, `docs/superpowers/plans/2026-06-11-server-request-logging.md`.