### PR TITLE
fix(auth): fall back to preferred_username when OIDC email claim is absent

### DIFF
--- a/internal/auth/oidc_verifier.go
+++ b/internal/auth/oidc_verifier.go
@@ -80,10 +80,20 @@ func (v *OIDCVerifier) Verify(ctx context.Context, rawToken string) (*OIDCClaims
 		Subject: idToken.Subject,
 		Raw:     raw,
 	}
-	if rawEmail, ok := raw["email"]; ok {
-		var email string
-		if jsonErr := json.Unmarshal(rawEmail, &email); jsonErr == nil {
-			c.Email = email
+	// Prefer the authoritative "email" claim. Fall back to "preferred_username"
+	// for providers that omit "email" by default — notably Microsoft Entra
+	// (Azure AD) v2.0 access tokens, where "preferred_username" carries the
+	// user's UPN in email format. An empty or absent "email" claim falls
+	// through to the next candidate. See GitHub issue #990.
+	for _, claim := range []string{"email", "preferred_username"} {
+		rawVal, ok := raw[claim]
+		if !ok {
+			continue
+		}
+		var s string
+		if jsonErr := json.Unmarshal(rawVal, &s); jsonErr == nil && s != "" {
+			c.Email = s
+			break
 		}
 	}
 	return c, nil

--- a/internal/auth/oidc_verifier_test.go
+++ b/internal/auth/oidc_verifier_test.go
@@ -83,6 +83,82 @@ func TestOIDCVerifier_VerifyValidToken(t *testing.T) {
 	require.Equal(t, "alice@example.com", claims.Email)
 }
 
+// TestOIDCVerifier_PreferredUsernameFallback proves that when an access token
+// omits the email claim (the common Microsoft Entra v2.0 configuration), the
+// verifier falls back to preferred_username, which carries the user's UPN in
+// email format. Without this fallback, OIDCClaims.Email is empty and JIT user
+// creation fails at the email-domain allowlist check.
+func TestOIDCVerifier_PreferredUsernameFallback(t *testing.T) {
+	ctx := context.Background()
+	p := newOIDCTestIssuer(t)
+	v, err := auth.NewOIDCVerifier(ctx, config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "aud-1",
+	})
+	require.NoError(t, err)
+
+	token := p.mintToken(t, map[string]any{
+		"iss":                p.server.URL,
+		"sub":                "user-123",
+		"aud":                "aud-1",
+		"exp":                time.Now().Add(time.Hour).Unix(),
+		"iat":                time.Now().Unix(),
+		"preferred_username": "bob@example.com",
+	})
+	claims, err := v.Verify(ctx, token)
+	require.NoError(t, err)
+	require.Equal(t, "bob@example.com", claims.Email)
+}
+
+// TestOIDCVerifier_EmailTakesPrecedenceOverPreferredUsername proves that when
+// both claims are present, the authoritative email claim wins. This preserves
+// standard OIDC correctness while still handling Entra's email-less tokens.
+func TestOIDCVerifier_EmailTakesPrecedenceOverPreferredUsername(t *testing.T) {
+	ctx := context.Background()
+	p := newOIDCTestIssuer(t)
+	v, err := auth.NewOIDCVerifier(ctx, config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "aud-1",
+	})
+	require.NoError(t, err)
+
+	token := p.mintToken(t, map[string]any{
+		"iss":                p.server.URL,
+		"sub":                "user-123",
+		"aud":                "aud-1",
+		"exp":                time.Now().Add(time.Hour).Unix(),
+		"iat":                time.Now().Unix(),
+		"email":              "authoritative@example.com",
+		"preferred_username": "fallback@example.com",
+	})
+	claims, err := v.Verify(ctx, token)
+	require.NoError(t, err)
+	require.Equal(t, "authoritative@example.com", claims.Email)
+}
+
+// TestOIDCVerifier_EmptyEmailFallsThroughToPreferredUsername proves that an
+// empty-string email claim does not shadow a usable preferred_username. Entra
+// can emit an empty email when the directory mail attribute is unset.
+func TestOIDCVerifier_EmptyEmailFallsThroughToPreferredUsername(t *testing.T) {
+	ctx := context.Background()
+	p := newOIDCTestIssuer(t)
+	v, err := auth.NewOIDCVerifier(ctx, config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "aud-1",
+	})
+	require.NoError(t, err)
+
+	token := p.mintToken(t, map[string]any{
+		"iss":                p.server.URL,
+		"sub":                "user-123",
+		"aud":                "aud-1",
+		"exp":                time.Now().Add(time.Hour).Unix(),
+		"iat":                time.Now().Unix(),
+		"email":              "",
+		"preferred_username": "fallback@example.com",
+	})
+	claims, err := v.Verify(ctx, token)
+	require.NoError(t, err)
+	require.Equal(t, "fallback@example.com", claims.Email)
+}
+
 func TestOIDCVerifier_RejectsBadAudience(t *testing.T) {
 	ctx := context.Background()
 	p := newOIDCTestIssuer(t)


### PR DESCRIPTION
## Summary

Microsoft Entra (Azure AD) v2.0 access tokens omit the `email` claim by default — it is only present when configured as an optional claim **and** the user's directory `mail` attribute is set, which many Entra deployments do not configure. `OIDCVerifier.Verify()` read only `raw["email"]`, so `OIDCClaims.Email` was empty for Entra tokens, causing JIT user creation to fail at the email-domain allowlist check:

```
level=WARN msg="auth: JIT refused — empty email claim with non-empty allowlist"
```

## Fix

In `internal/auth/oidc_verifier.go`, try the authoritative `email` claim first, then fall back to `preferred_username` (the UPN — always present in delegated-flow tokens and email-formatted for standard accounts). Empty or absent values fall through to the next candidate, preserving standard OIDC correctness while handling Entra's common configuration.

## Tests

Added to `oidc_verifier_test.go` (TDD — written first, confirmed failing, then passing):

- `TestOIDCVerifier_PreferredUsernameFallback` — `email` absent → uses `preferred_username`
- `TestOIDCVerifier_EmailTakesPrecedenceOverPreferredUsername` — both present → `email` wins
- `TestOIDCVerifier_EmptyEmailFallsThroughToPreferredUsername` — empty `email` → falls through

## Verification

- `go build ./...` — OK
- `go test ./internal/auth/...` — all pass
- `gofumpt` clean; `golangci-lint run ./internal/auth/` — 0 issues

Fixes #990