### PR TITLE
fix(docker): refresh alpine 3.23 base digest to rebuild with patched openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 RUN --mount=type=secret,id=extra-certs,target=/tmp/extra-ca-bundle.pem,required=false \
     if [ -s /tmp/extra-ca-bundle.pem ]; then cat /tmp/extra-ca-bundle.pem >> /etc/ssl/certs/ca-certificates.crt; fi && \
     apk upgrade --no-cache && apk add --no-cache ca-certificates && \


### PR DESCRIPTION
## Context

The `v0.11.1` Release run ([failed run](https://github.com/specgraph/specgraph/actions/runs/27450263935)) published the tag, GitHub Release, and `ghcr.io/specgraph/specgraph:0.11.1` image, then **failed at the Trivy image-scan gate**:

```
ghcr.io/specgraph/specgraph:0.11.1 (alpine 3.23.3)  HIGH: 2
libcrypto3 / libssl3  CVE-2026-45447  3.5.6-r0 → fixed 3.5.7-r0
openssl: Heap Use-After-Free in PKCS7_verify()
```

The scan gate is `severity: CRITICAL,HIGH` + `ignore-unfixed: true` + `exit-code: 1`, so a HIGH with a published fix blocks the release. As a result the binary/image **provenance attestation** steps never ran — `v0.11.1`'s image is vulnerable and unattested.

This CVE is in the **alpine base image**, unrelated to the OIDC change that happened to ride in that release.

## Root cause

A propagation race: alpine published `openssl 3.5.7-r0` to the `v3.23` repo just **after** the image built. Confirmed:

- aports `3.23-stable` now has `pkgver=3.5.7`; its `secfixes` lists `CVE-2026-45447` under `3.5.7-r0`
- `libcrypto3-3.5.7-r0.apk` is live on the CDN (HTTP 200, x86_64 + aarch64)

The Dockerfile already runs `apk upgrade --no-cache`, so a **fresh build now pulls the patched packages** — no code change required.

## Change

Bump the pinned `alpine:3.23` base digest `25109184…` → `5b10f432…` (current `alpine:3.23`). This provides a clean, bumpable commit so cog can cut **v0.11.2**, whose rebuild pulls `openssl 3.5.7-r0` → Trivy scan passes → attestations run. The refreshed digest also keeps the base layer current and minimizes the delta `apk upgrade` must patch.

## Verification

- Current `alpine:3.23` index digest confirmed via `docker buildx imagetools inspect alpine:3.23`
- Fix package availability confirmed (CDN 200 + aports secfixes)
- No Dockerfile linter in CI; Go fmt/lint/build/test unaffected by a base-digest change

## Follow-up after merge

Dispatch the **Release** workflow on `main` to cut **v0.11.2** (clean image + provenance attestations), superseding the degraded `v0.11.1`.