### PR TITLE
feat: interactive OIDC login for the web UI

### DIFF
--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -75,7 +75,7 @@ type appDeps struct {
 
 func buildAppDeps(ctx context.Context, cfg *config.GlobalConfig, cmd *cobra.Command) (appDeps, error) {
 	verifiers := make([]*auth.OIDCVerifier, 0, len(cfg.Auth.OIDC.Providers))
-	for _, pc := range cfg.Auth.OIDC.Providers {
+	for _, pc := range cfg.Auth.OIDC.Providers { //nolint:gocritic // rangeValCopy: provider list is small and startup-only
 		issuerCtx, issuerCancel := context.WithTimeout(ctx, 10*time.Second)
 		v, oidcErr := auth.NewOIDCVerifier(issuerCtx, pc)
 		issuerCancel()
@@ -770,7 +770,7 @@ func mcpHeaderLogger(next http.Handler) http.Handler {
 // slice. Consumed by auth.IdentityStoreConfig.JITClaimsMapping at startup.
 func buildClaimsMappingByIssuer(providers []config.OIDCProviderConfig) map[string][]config.ClaimMapping {
 	out := make(map[string][]config.ClaimMapping, len(providers))
-	for _, pc := range providers {
+	for _, pc := range providers { //nolint:gocritic // rangeValCopy: provider list is small and startup-only
 		if len(pc.ClaimsMapping) > 0 {
 			out[pc.Issuer] = pc.ClaimsMapping
 		}

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -64,12 +64,13 @@ func init() {
 // before this refactor: a broken binary, bad OIDC config, or bad CORS flag
 // should fail fast on every boot regardless of database availability.
 type appDeps struct {
-	verifiers  []*auth.OIDCVerifier
-	authorizer *auth.CedarAuthorizer
-	knownRoles map[auth.Role]bool
-	skillsSrc  skills.Source
-	webFS      fs.FS
-	corsOrigin string
+	verifiers      []*auth.OIDCVerifier
+	loginProviders []auth.LoginProvider
+	authorizer     *auth.CedarAuthorizer
+	knownRoles     map[auth.Role]bool
+	skillsSrc      skills.Source
+	webFS          fs.FS
+	corsOrigin     string
 }
 
 func buildAppDeps(ctx context.Context, cfg *config.GlobalConfig, cmd *cobra.Command) (appDeps, error) {
@@ -84,6 +85,11 @@ func buildAppDeps(ctx context.Context, cfg *config.GlobalConfig, cmd *cobra.Comm
 		verifiers = append(verifiers, v)
 		slog.LogAttrs(context.Background(), slog.LevelInfo, "auth: OIDC provider configured",
 			slog.String("id", pc.ID), slog.String("issuer", pc.Issuer))
+	}
+
+	loginProviders, lpErr := auth.BuildLoginProviders(ctx, cfg.Auth.OIDC.Providers, cfg.Auth.OIDC.BaseURL)
+	if lpErr != nil {
+		return appDeps{}, fmt.Errorf("OIDC login providers: %w", lpErr)
 	}
 
 	knownRoles := auth.KnownRolesFrom(cfg.Auth.Roles)
@@ -114,12 +120,13 @@ func buildAppDeps(ctx context.Context, cfg *config.GlobalConfig, cmd *cobra.Comm
 	}
 
 	return appDeps{
-		verifiers:  verifiers,
-		authorizer: authorizer,
-		knownRoles: knownRoles,
-		skillsSrc:  skillsSrc,
-		webFS:      webFS,
-		corsOrigin: corsOrigin,
+		verifiers:      verifiers,
+		loginProviders: loginProviders,
+		authorizer:     authorizer,
+		knownRoles:     knownRoles,
+		skillsSrc:      skillsSrc,
+		webFS:          webFS,
+		corsOrigin:     corsOrigin,
 	}, nil
 }
 
@@ -154,6 +161,7 @@ func buildAppHandler(_ context.Context, cfg *config.GlobalConfig, deps *appDeps,
 
 	resolver, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
 		Users:                   res.authStore,
+		WebAuth:                 res.authStore,
 		Verifiers:               deps.verifiers,
 		Tracker:                 tracker,
 		KnownRoles:              deps.knownRoles,
@@ -203,7 +211,16 @@ func buildAppHandler(_ context.Context, cfg *config.GlobalConfig, deps *appDeps,
 	syncHandler.RegisterAdapter(syncpkg.NewGitHubAdapter(runner, ""))
 
 	server.RegisterAPIHandlers(mux, store, auth.RequireAuth(resolver))
-	server.RegisterAuthHandlers(mux, resolver, auth.RequireAuth(resolver))
+	server.RegisterAuthHandlers(mux, resolver, res.authStore, auth.RequireAuth(resolver))
+	server.RegisterOIDCLoginHandlers(mux, server.OIDCLoginConfig{
+		Providers:  deps.loginProviders,
+		Resolver:   resolver,
+		WebAuth:    res.authStore,
+		BaseURL:    cfg.Auth.OIDC.BaseURL,
+		SessionTTL: cfg.Auth.OIDC.SessionTTL,
+		FlowTTL:    5 * time.Minute,
+		Limiter:    server.NewIPRateLimiterForOIDC(cfg.Server.TrustedProxy),
+	})
 
 	loopbackClient := newHTTPClient("")
 	loopbackClient.Transport = telemetry.LoopbackTransport(telState.enabled, loopbackClient.Transport)
@@ -476,6 +493,7 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		}
 
 		server.StartSweeper(sweeperCtx, r.store, 60*time.Second)
+		server.StartWebAuthSweeper(sweeperCtx, r.authStore, 60*time.Second)
 
 		cleanupMu.Lock()
 		cleanup = func() {

--- a/docs/superpowers/plans/2026-06-12-oidc-interactive-ui-login.md
+++ b/docs/superpowers/plans/2026-06-12-oidc-interactive-ui-login.md
@@ -1,0 +1,2684 @@
+# Interactive OIDC Login for the Web UI — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Sign in with <provider>" Authorization Code + PKCE flow to the SpecGraph web UI that issues a server-side opaque session, reusing the existing cookie/resolver path.
+
+**Architecture:** New endpoints (`/api/auth/oidc/{providers,start,callback}`) drive a server-side OAuth2 code flow. Handshake state (`state`/`nonce`/`code_verifier`) and the issued session both live in Postgres (new `oidc_login_flows` + `web_sessions` tables behind a `WebAuthStore`). The session cookie carries only an opaque `spgr_ws_` id, resolved per-request by a new `resolveSession` path in the identity resolver. Interactive logins reuse the existing `resolveJWT`/JIT machinery (limiter bypassed via a context marker).
+
+**Tech Stack:** Go 1.26, pgx v5 + goose migrations, `coreos/go-oidc/v3`, `golang.org/x/oauth2`, `golang.org/x/time/rate`, ConnectRPC, SvelteKit (Svelte 5 runes) embedded via `//go:embed`.
+
+**Design spec:** `docs/superpowers/specs/2026-06-12-oidc-interactive-ui-login-design.md`
+
+---
+
+## Conventions in this codebase (read before starting)
+
+- **Postgres access:** positional `row.Scan(&...)`, **no** `RowToStructByName`, **no** `db:` struct tags. Not-found → `errors.Is(err, pgx.ErrNoRows)` mapped to a `storage.Err*NotFound` sentinel. Mutation timestamps use the injectable `s.now()`; insert timestamps use SQL `DEFAULT now()` returned via `RETURNING`.
+- **Auth store:** `*postgres.AuthStore` (`internal/storage/postgres/auth.go`) borrows `*Store`'s pool, owns the identity tables, runs `auth_migrations/*.sql` under the `goose_db_version_auth` table.
+- **Resolver errors:** `auth.ErrUnauthenticated` (→ HTTP 401 / Connect `CodeUnauthenticated`) and `auth.ErrTransient` (→ HTTP 503 / `CodeUnavailable`). DB errors MUST wrap `ErrTransient`: `fmt.Errorf("%w: %w", ErrTransient, err)`.
+- **Context keys:** unexported `struct{}` key types with `WithX`/`XFromContext` helpers (`internal/auth/context.go`).
+- **Tests:** Go unit tests with testify (`require`/`assert`). Integration tests are `//go:build integration` + `package <pkg>_test`, using `postgrestest.SharedPool(t, ctx)`.
+- **Run a single Go test:** `go test ./internal/<pkg>/ -run TestName -v`
+- **Run integration tests:** `go test -tags integration ./internal/storage/postgres/ -run TestName -v` (requires Docker).
+- **Build:** `task build` (regenerates proto + web). For Go-only: `go build ./...`.
+- **Commit style:** Conventional Commits, DCO sign-off required. Use `git commit -s -m "feat(scope): ..."`.
+
+## File structure (what each new/modified file is responsible for)
+
+**New files:**
+
+- `internal/storage/web_auth_domain.go` — `Session` + `LoginFlow` domain structs.
+- `internal/storage/web_auth.go` — `WebAuthStore` interface.
+- `internal/storage/postgres/auth_migrations/002_web_auth.sql` — `web_sessions` + `oidc_login_flows` tables.
+- `internal/storage/postgres/web_auth.go` — `WebAuthStore` impl on `*AuthStore`.
+- `internal/storage/postgres/web_auth_test.go` — integration tests for the store.
+- `internal/auth/loginprovider.go` — `loginProvider` interface + `oidc` impl + `BuildLoginProviders`.
+- `internal/auth/loginprovider_test.go` — unit tests for build/validate/exchange.
+- `internal/server/auth_oidc_handler.go` — `/providers`, `/start`, `/callback` handlers + per-IP rate limiter.
+- `internal/server/auth_oidc_handler_test.go` — httptest flow tests.
+- `web/src/lib/oidc.svelte.ts` — OIDC provider-list fetch + `auth_error` message map.
+- `site/docs/guides/oidc-login.md` — operator guide (Entra, Okta, GitHub-via-broker).
+
+**Modified files:**
+
+- `internal/config/global.go` — extend `OIDCProviderConfig` + `OIDCConfig`; add `ServerSection.TrustedProxy`.
+- `internal/auth/oidc_verifier.go` — `OIDCClaims.Nonce` + `VerifyWithNonce`.
+- `internal/auth/context.go` — `WithInteractiveLogin` / `InteractiveLoginFromContext`.
+- `internal/auth/identitystore.go` — `WebAuth` field, `resolveSession`, `Resolve` dispatch, `jitResolve` limiter bypass.
+- `internal/storage/errors.go` — `ErrSessionNotFound`, `ErrLoginFlowNotFound`.
+- `internal/server/auth_handler.go` — `sessionCookie()` → `SameSite=Lax`, `establishSession`, logout revocation, `RegisterAuthHandlers` signature.
+- `cmd/specgraph/serve.go` — build login providers, wire `WebAuthStore`, register handlers, start web-auth sweeper.
+- `web/src/lib/components/LoginModal.svelte` — provider buttons.
+- `web/src/routes/+layout.svelte` — surface `?auth_error=`.
+- `site/docs/architecture.md` — describe interactive flow.
+
+**Task order:** storage types/errors → migration → store impl + tests → verifier nonce → context marker → resolver session path → login providers → rate limiter → handlers → auth_handler changes → serve wiring → frontend → docs.
+
+---
+
+### Task 1: Extend config structs (provider fields + base_url/session_ttl + trusted_proxy)
+
+**Files:**
+
+- Modify: `internal/config/global.go` (`OIDCProviderConfig` ~237-244, `OIDCConfig` ~195-200, `ServerSection`)
+- Test: `internal/config/global_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/config/global_test.go`:
+
+```go
+func TestLoadGlobal_OIDCInteractiveFields(t *testing.T) {
+	yamlBody := []byte(`
+auth:
+  oidc:
+    base_url: https://specgraph.example.com
+    session_ttl: 8h
+    providers:
+      - id: entra
+        kind: oidc
+        interactive: true
+        display_name: Microsoft Entra
+        issuer: https://login.microsoftonline.com/tenant/v2.0
+        client_id: app-id
+        client_secret_env: SPECGRAPH_OIDC_ENTRA_SECRET
+        scopes: [openid, profile, email]
+`)
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, yamlBody, 0o600))
+
+	cfg, err := config.LoadGlobal(path)
+	require.NoError(t, err)
+	require.Equal(t, "https://specgraph.example.com", cfg.Auth.OIDC.BaseURL)
+	require.Equal(t, 8*time.Hour, cfg.Auth.OIDC.SessionTTL)
+	require.Len(t, cfg.Auth.OIDC.Providers, 1)
+	p := cfg.Auth.OIDC.Providers[0]
+	require.Equal(t, "oidc", p.Kind)
+	require.True(t, p.Interactive)
+	require.Equal(t, "Microsoft Entra", p.DisplayName)
+	require.Equal(t, "SPECGRAPH_OIDC_ENTRA_SECRET", p.ClientSecretEnv)
+	require.Equal(t, []string{"openid", "profile", "email"}, p.Scopes)
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails to compile**
+
+Run: `go test ./internal/config/ -run TestLoadGlobal_OIDCInteractiveFields -v`
+Expected: compile error — unknown fields `BaseURL`, `SessionTTL`, `Kind`, `Interactive`, etc.
+
+- [ ] **Step 3: Extend the structs**
+
+In `internal/config/global.go`, replace `OIDCConfig` (lines ~195-200) with:
+
+```go
+// OIDCConfig wraps the OIDC provider list and JIT settings under a
+// nested auth.oidc key. Replaces the flat AuthConfig.OIDCProviders.
+type OIDCConfig struct {
+	Providers []OIDCProviderConfig `yaml:"providers" koanf:"providers"`
+	JITCreate JITCreateConfig      `yaml:"jit_create" koanf:"jit_create"`
+	// BaseURL overrides the request-derived origin used to build the OIDC
+	// redirect_uri. Required behind a proxy that rewrites Host. Empty = derive
+	// from the request.
+	BaseURL string `yaml:"base_url" koanf:"base_url"`
+	// SessionTTL is the absolute lifetime of a web session minted by the
+	// interactive login flow. Zero = default (12h, applied in applyPostLoad).
+	SessionTTL time.Duration `yaml:"session_ttl" koanf:"session_ttl"`
+}
+```
+
+Replace `OIDCProviderConfig` (lines ~237-244) with:
+
+```go
+// OIDCProviderConfig defines a single OIDC identity provider.
+type OIDCProviderConfig struct {
+	ID            string         `yaml:"id" koanf:"id"`
+	Kind          string         `yaml:"kind" koanf:"kind"`               // "oidc" (default); reserved for "oauth2"
+	Interactive   bool           `yaml:"interactive" koanf:"interactive"` // opt-in to the UI login flow
+	DisplayName   string         `yaml:"display_name" koanf:"display_name"`
+	Issuer        string         `yaml:"issuer" koanf:"issuer"`
+	ClientID      string         `yaml:"client_id" koanf:"client_id"`
+	ClientSecret  string         `yaml:"client_secret" koanf:"client_secret"`         // dev-only plaintext fallback
+	ClientSecretEnv string       `yaml:"client_secret_env" koanf:"client_secret_env"` // preferred: env var name
+	Audience      string         `yaml:"audience" koanf:"audience"`
+	Scopes        []string       `yaml:"scopes" koanf:"scopes"`
+	ClaimsMapping []ClaimMapping `yaml:"claims_mapping" koanf:"claims_mapping"`
+}
+```
+
+Add a `TrustedProxy` field to `ServerSection` (find the struct; add alongside existing fields):
+
+```go
+	// TrustedProxy, when true, lets request-IP extraction trust
+	// X-Forwarded-For/X-Real-Ip (e.g. behind a load balancer) for the OIDC
+	// per-IP rate limiter. Default false → use RemoteAddr.
+	TrustedProxy bool `yaml:"trusted_proxy" koanf:"trusted_proxy"`
+```
+
+Confirm `time` is imported in `global.go` (it is — `time.Duration` is used elsewhere). `decoderConf` already wires `StringToTimeDurationHookFunc`, so `session_ttl: 8h` decodes correctly.
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `go test ./internal/config/ -run TestLoadGlobal_OIDCInteractiveFields -v`
+Expected: PASS
+
+- [ ] **Step 5: Add session_ttl default in applyPostLoad**
+
+In `applyPostLoad` (lines ~282-296), before the closing brace add:
+
+```go
+	if cfg.Auth.OIDC.SessionTTL <= 0 {
+		cfg.Auth.OIDC.SessionTTL = 12 * time.Hour
+	}
+```
+
+Add a quick assertion to the test from Step 1 is unnecessary; instead add a tiny test:
+
+```go
+func TestLoadGlobal_SessionTTLDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("server:\n  backend: memory\n"), 0o600))
+	cfg, err := config.LoadGlobal(path)
+	require.NoError(t, err)
+	require.Equal(t, 12*time.Hour, cfg.Auth.OIDC.SessionTTL)
+}
+```
+
+Run: `go test ./internal/config/ -run 'TestLoadGlobal_(OIDCInteractiveFields|SessionTTLDefault)' -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/global.go internal/config/global_test.go
+git commit -s -m "feat(config): add interactive OIDC provider fields, base_url, session_ttl, trusted_proxy"
+```
+
+---
+
+### Task 2: Add nonce-checked verification to OIDCVerifier
+
+**Files:**
+
+- Modify: `internal/auth/oidc_verifier.go`
+- Test: `internal/auth/oidc_verifier_test.go` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Create/append `internal/auth/oidc_verifier_test.go`. We test the nonce-comparison logic directly via a small helper so we don't need a live IdP:
+
+```go
+package auth
+
+import "testing"
+
+func TestNonceMatches(t *testing.T) {
+	if !nonceMatches("abc", "abc") {
+		t.Fatal("equal nonces should match")
+	}
+	if nonceMatches("abc", "xyz") {
+		t.Fatal("different nonces must not match")
+	}
+	if nonceMatches("", "abc") {
+		t.Fatal("empty expected nonce must not match")
+	}
+}
+```
+
+- [ ] **Step 2: Run it to confirm failure**
+
+Run: `go test ./internal/auth/ -run TestNonceMatches -v`
+Expected: FAIL — `nonceMatches` undefined.
+
+- [ ] **Step 3: Implement nonce field, helper, and VerifyWithNonce**
+
+In `internal/auth/oidc_verifier.go`:
+
+Add `"crypto/subtle"` to the imports.
+
+Add a `Nonce` field to `OIDCClaims`:
+
+```go
+type OIDCClaims struct {
+	Issuer  string
+	Subject string
+	Email   string
+	Nonce   string
+	Raw     map[string]json.RawMessage
+}
+```
+
+In `Verify`, after constructing `c`, set `c.Nonce = idToken.Nonce` (add the line right after `Raw: raw,` block, i.e. after the struct literal):
+
+```go
+	c.Nonce = idToken.Nonce
+```
+
+Add at the end of the file:
+
+```go
+// nonceMatches reports whether got equals want in constant time. An empty
+// want is never a match (a login flow always sets a non-empty nonce).
+func nonceMatches(got, want string) bool {
+	if want == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+}
+
+// VerifyWithNonce validates the token like Verify and additionally requires
+// the id_token's nonce claim to equal expectedNonce. Used by the interactive
+// login callback; the bearer-token path uses Verify (no nonce).
+func (v *OIDCVerifier) VerifyWithNonce(ctx context.Context, rawToken, expectedNonce string) (*OIDCClaims, error) {
+	claims, err := v.Verify(ctx, rawToken)
+	if err != nil {
+		return nil, err
+	}
+	if !nonceMatches(claims.Nonce, expectedNonce) {
+		slog.LogAttrs(ctx, slog.LevelWarn, "auth: OIDC nonce mismatch", slog.String("provider", v.providerID))
+		return nil, fmt.Errorf("oidc verify: nonce mismatch")
+	}
+	return claims, nil
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `go test ./internal/auth/ -run TestNonceMatches -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/oidc_verifier.go internal/auth/oidc_verifier_test.go
+git commit -s -m "feat(auth): add VerifyWithNonce and Nonce claim to OIDCVerifier"
+```
+
+---
+
+### Task 3: Storage sentinel errors + domain types
+
+**Files:**
+
+- Modify: `internal/storage/errors.go`
+- Create: `internal/storage/web_auth_domain.go`
+
+- [ ] **Step 1: Add sentinel errors**
+
+In `internal/storage/errors.go`, in the `// --- Identity errors ---` section, add:
+
+```go
+// ErrSessionNotFound is returned when a web session does not exist (or is expired/revoked at lookup).
+var ErrSessionNotFound = errors.New("web session not found")
+
+// ErrLoginFlowNotFound is returned when an OIDC login-flow row does not exist or has expired.
+var ErrLoginFlowNotFound = errors.New("oidc login flow not found")
+```
+
+- [ ] **Step 2: Create the domain types**
+
+Create `internal/storage/web_auth_domain.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package storage
+
+import "time"
+
+// Session is a SpecGraph-issued opaque web session minted by the interactive
+// OIDC login flow. The raw token is never stored — only its SHA-256 hash.
+type Session struct {
+	ID          string
+	TokenHash   []byte // SHA-256 of the opaque session token
+	UserID      string
+	Issuer      string // OIDC issuer (audit)
+	OIDCSubject string // audit
+	CreatedAt   time.Time
+	ExpiresAt   time.Time
+	RevokedAt   *time.Time // nil = active
+}
+
+// IsActive reports whether the session is neither revoked nor expired as of now.
+func (s *Session) IsActive(now time.Time) bool {
+	if s.RevokedAt != nil {
+		return false
+	}
+	return s.ExpiresAt.After(now)
+}
+
+// LoginFlow is server-side OAuth2 handshake state for one interactive login
+// attempt. The opaque flow id (ID) is carried in the short-lived tx cookie;
+// state/nonce/code_verifier never leave the server.
+type LoginFlow struct {
+	ID           string // opaque flow id (tx cookie value)
+	State        string // CSRF token, constant-time compared at callback
+	Nonce        string
+	CodeVerifier string // PKCE
+	ProviderID   string
+	CreatedAt    time.Time
+	ExpiresAt    time.Time
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `go build ./internal/storage/`
+Expected: success (no test yet — types are exercised in Task 5).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/storage/errors.go internal/storage/web_auth_domain.go
+git commit -s -m "feat(storage): add Session/LoginFlow domain types and sentinel errors"
+```
+
+---
+
+### Task 4: WebAuthStore interface
+
+**Files:**
+
+- Create: `internal/storage/web_auth.go`
+
+- [ ] **Step 1: Create the interface**
+
+Create `internal/storage/web_auth.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package storage
+
+import "context"
+
+// WebAuthStore persists interactive-login web sessions and short-lived OAuth2
+// login-flow handshake state. Kept separate from UsersBackend so existing
+// UsersBackend implementations/fakes are unaffected. Implemented by
+// *postgres.AuthStore.
+type WebAuthStore interface {
+	// --- sessions ---
+
+	// CreateSession inserts a new session row. s.ExpiresAt must be set.
+	CreateSession(ctx context.Context, s *Session) (*Session, error)
+
+	// LookupSessionByHash returns the session with the given token hash.
+	// Returns ErrSessionNotFound on miss. Does NOT filter expired/revoked —
+	// the caller (resolver) gates on Session.IsActive.
+	LookupSessionByHash(ctx context.Context, tokenHash []byte) (*Session, error)
+
+	// RevokeSession marks the session revoked by token hash. Idempotent.
+	RevokeSession(ctx context.Context, tokenHash []byte) error
+
+	// DeleteExpiredSessions removes expired/long-revoked rows; returns count.
+	DeleteExpiredSessions(ctx context.Context) (int64, error)
+
+	// --- login-flow state ---
+
+	// CreateLoginFlow inserts a flow row and returns its opaque id (the PK).
+	CreateLoginFlow(ctx context.Context, f *LoginFlow) (flowID string, err error)
+
+	// ConsumeLoginFlow atomically deletes and returns the flow for flowID.
+	// Returns ErrLoginFlowNotFound if the id is unknown or already expired.
+	ConsumeLoginFlow(ctx context.Context, flowID string) (*LoginFlow, error)
+
+	// DeleteExpiredLoginFlows removes expired flow rows; returns count.
+	DeleteExpiredLoginFlows(ctx context.Context) (int64, error)
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `go build ./internal/storage/`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/storage/web_auth.go
+git commit -s -m "feat(storage): add WebAuthStore interface"
+```
+
+---
+
+### Task 5: Migration — web_sessions + oidc_login_flows
+
+**Files:**
+
+- Create: `internal/storage/postgres/auth_migrations/002_web_auth.sql`
+
+- [ ] **Step 1: Create the migration**
+
+Create `internal/storage/postgres/auth_migrations/002_web_auth.sql`:
+
+```sql
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 Sean Brandt
+
+-- +goose Up
+
+CREATE TABLE web_sessions (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    token_hash    bytea NOT NULL UNIQUE,
+    user_id       uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    issuer        text NOT NULL DEFAULT '' CHECK (length(issuer) <= 512),
+    oidc_subject  text NOT NULL DEFAULT '' CHECK (length(oidc_subject) <= 255),
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    expires_at    timestamptz NOT NULL,
+    revoked_at    timestamptz
+);
+
+CREATE INDEX web_sessions_user   ON web_sessions(user_id);
+CREATE INDEX web_sessions_expiry ON web_sessions(expires_at) WHERE revoked_at IS NULL;
+
+CREATE TABLE oidc_login_flows (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    state         text NOT NULL CHECK (length(state) <= 512),
+    nonce         text NOT NULL CHECK (length(nonce) <= 512),
+    code_verifier text NOT NULL CHECK (length(code_verifier) <= 256),
+    provider_id   text NOT NULL CHECK (length(provider_id) <= 128),
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    expires_at    timestamptz NOT NULL
+);
+
+CREATE INDEX oidc_login_flows_expiry ON oidc_login_flows(expires_at);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS oidc_login_flows_expiry;
+DROP TABLE IF EXISTS oidc_login_flows;
+DROP INDEX IF EXISTS web_sessions_expiry;
+DROP INDEX IF EXISTS web_sessions_user;
+DROP TABLE IF EXISTS web_sessions;
+```
+
+- [ ] **Step 2: Verify the migration applies (integration)**
+
+Run: `go test -tags integration ./internal/storage/postgres/ -run TestAuthStore_NewAuth_RunsMigrations -v`
+Expected: PASS — the existing migration test brings the schema up and now also runs 002 (no assertions on the new tables yet; Task 6 adds them). If Docker is unavailable, skip and rely on Task 6's tests in CI.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/storage/postgres/auth_migrations/002_web_auth.sql
+git commit -s -m "feat(storage): add web_sessions and oidc_login_flows migration"
+```
+
+---
+
+### Task 6: Postgres WebAuthStore implementation
+
+**Files:**
+
+- Create: `internal/storage/postgres/web_auth.go`
+- Modify: `internal/storage/postgres/auth.go` (add compile-time assertion)
+
+- [ ] **Step 1: Add the compile-time assertion**
+
+In `internal/storage/postgres/auth.go`, just below the existing `var _ storage.UsersBackend = (*AuthStore)(nil)` (line ~27), add:
+
+```go
+// Compile-time assertion that *AuthStore implements WebAuthStore.
+var _ storage.WebAuthStore = (*AuthStore)(nil)
+```
+
+- [ ] **Step 2: Implement the methods**
+
+Create `internal/storage/postgres/web_auth.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// CreateSession inserts a web session row, returning the generated id and
+// created_at.
+func (s *AuthStore) CreateSession(ctx context.Context, sess *storage.Session) (*storage.Session, error) {
+	if len(sess.TokenHash) == 0 {
+		return nil, errors.New("CreateSession: TokenHash required")
+	}
+	if sess.UserID == "" {
+		return nil, errors.New("CreateSession: UserID required")
+	}
+	if sess.ExpiresAt.IsZero() {
+		return nil, errors.New("CreateSession: ExpiresAt required")
+	}
+	const q = `
+		INSERT INTO web_sessions (token_hash, user_id, issuer, oidc_subject, expires_at)
+		SELECT $1, $2::uuid, $3, $4, $5
+		WHERE EXISTS (SELECT 1 FROM users WHERE id = $2::uuid AND deleted_at IS NULL)
+		RETURNING id, created_at`
+	var id string
+	var createdAt time.Time
+	err := s.pool.QueryRow(ctx, q, sess.TokenHash, sess.UserID, sess.Issuer, sess.OIDCSubject, sess.ExpiresAt).
+		Scan(&id, &createdAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("create session: %w", storage.ErrUserNotFound)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("create session: %w", err)
+	}
+	sess.ID = id
+	sess.CreatedAt = createdAt
+	return sess, nil
+}
+
+// LookupSessionByHash returns the session for the given token hash.
+func (s *AuthStore) LookupSessionByHash(ctx context.Context, tokenHash []byte) (*storage.Session, error) {
+	const q = `
+		SELECT id, token_hash, user_id, issuer, oidc_subject, created_at, expires_at, revoked_at
+		FROM web_sessions
+		WHERE token_hash = $1`
+	row := s.pool.QueryRow(ctx, q, tokenHash)
+	var sess storage.Session
+	err := row.Scan(&sess.ID, &sess.TokenHash, &sess.UserID, &sess.Issuer,
+		&sess.OIDCSubject, &sess.CreatedAt, &sess.ExpiresAt, &sess.RevokedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, storage.ErrSessionNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan session: %w", err)
+	}
+	return &sess, nil
+}
+
+// RevokeSession marks the session revoked by token hash. Idempotent.
+func (s *AuthStore) RevokeSession(ctx context.Context, tokenHash []byte) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE web_sessions SET revoked_at = $1
+		WHERE token_hash = $2 AND revoked_at IS NULL`, s.now(), tokenHash)
+	if err != nil {
+		return fmt.Errorf("revoke session: %w", err)
+	}
+	return nil
+}
+
+// DeleteExpiredSessions removes expired rows. Revoked rows are left to expire
+// naturally so a revoked id never silently reappears as "not found vs revoked".
+func (s *AuthStore) DeleteExpiredSessions(ctx context.Context) (int64, error) {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM web_sessions WHERE expires_at <= $1`, s.now())
+	if err != nil {
+		return 0, fmt.Errorf("delete expired sessions: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// CreateLoginFlow inserts a flow row and returns its opaque id.
+func (s *AuthStore) CreateLoginFlow(ctx context.Context, f *storage.LoginFlow) (string, error) {
+	if f.State == "" || f.Nonce == "" || f.CodeVerifier == "" || f.ProviderID == "" {
+		return "", errors.New("CreateLoginFlow: state, nonce, code_verifier, provider_id required")
+	}
+	if f.ExpiresAt.IsZero() {
+		return "", errors.New("CreateLoginFlow: ExpiresAt required")
+	}
+	const q = `
+		INSERT INTO oidc_login_flows (state, nonce, code_verifier, provider_id, expires_at)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id`
+	var id string
+	if err := s.pool.QueryRow(ctx, q, f.State, f.Nonce, f.CodeVerifier, f.ProviderID, f.ExpiresAt).Scan(&id); err != nil {
+		return "", fmt.Errorf("create login flow: %w", err)
+	}
+	return id, nil
+}
+
+// ConsumeLoginFlow atomically deletes and returns the (unexpired) flow.
+func (s *AuthStore) ConsumeLoginFlow(ctx context.Context, flowID string) (*storage.LoginFlow, error) {
+	// DELETE ... RETURNING is atomic single-use; the expiry guard rejects
+	// stale rows even before the sweeper runs. An invalid UUID text errors at
+	// the cast — treat as not-found.
+	const q = `
+		DELETE FROM oidc_login_flows
+		WHERE id = $1::uuid AND expires_at > $2
+		RETURNING id, state, nonce, code_verifier, provider_id, created_at, expires_at`
+	row := s.pool.QueryRow(ctx, q, flowID, s.now())
+	var f storage.LoginFlow
+	err := row.Scan(&f.ID, &f.State, &f.Nonce, &f.CodeVerifier, &f.ProviderID, &f.CreatedAt, &f.ExpiresAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, storage.ErrLoginFlowNotFound
+	}
+	if err != nil {
+		// A malformed flowID (not a uuid) yields a cast error; map to not-found
+		// so the handler returns auth_error=expired rather than 500.
+		return nil, storage.ErrLoginFlowNotFound
+	}
+	return &f, nil
+}
+
+// DeleteExpiredLoginFlows removes expired flow rows.
+func (s *AuthStore) DeleteExpiredLoginFlows(ctx context.Context) (int64, error) {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM oidc_login_flows WHERE expires_at <= $1`, s.now())
+	if err != nil {
+		return 0, fmt.Errorf("delete expired login flows: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `go build ./internal/storage/postgres/`
+Expected: success — the `var _ storage.WebAuthStore` assertion confirms the method set.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/storage/postgres/web_auth.go internal/storage/postgres/auth.go
+git commit -s -m "feat(storage/postgres): implement WebAuthStore on AuthStore"
+```
+
+---
+
+### Task 7: WebAuthStore integration tests
+
+**Files:**
+
+- Create: `internal/storage/postgres/web_auth_test.go`
+
+- [ ] **Step 1: Write the tests**
+
+Create `internal/storage/postgres/web_auth_test.go`. Uses the existing helpers `authTestSetup`, `sharedTestPool`, `truncateAuthTables` from `auth_helpers_test.go`. We seed a user via direct SQL.
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+func seedUser(t *testing.T, ctx context.Context, pool interface {
+	QueryRow(context.Context, string, ...any) pgxRow
+}) string {
+	t.Helper()
+	var id string
+	require.NoError(t, pool.QueryRow(ctx,
+		`INSERT INTO users (kind, display_name, email, role) VALUES ('human','U','u@example.com','reader') RETURNING id`).Scan(&id))
+	return id
+}
+
+func TestWebAuth_SessionLifecycle(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	var userID string
+	require.NoError(t, pool.QueryRow(ctx,
+		`INSERT INTO users (kind, display_name, email, role) VALUES ('human','U','u@example.com','reader') RETURNING id`).Scan(&userID))
+
+	hash := []byte("0123456789abcdef0123456789abcdef") // 32 bytes stand-in
+	sess, err := auth.CreateSession(ctx, &storage.Session{
+		TokenHash: hash, UserID: userID, Issuer: "iss", OIDCSubject: "sub",
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, sess.ID)
+
+	got, err := auth.LookupSessionByHash(ctx, hash)
+	require.NoError(t, err)
+	require.Equal(t, userID, got.UserID)
+	require.True(t, got.IsActive(time.Now()))
+
+	require.NoError(t, auth.RevokeSession(ctx, hash))
+	got, err = auth.LookupSessionByHash(ctx, hash)
+	require.NoError(t, err)
+	require.False(t, got.IsActive(time.Now()))
+
+	_, err = auth.LookupSessionByHash(ctx, []byte("nope"))
+	require.ErrorIs(t, err, storage.ErrSessionNotFound)
+}
+
+func TestWebAuth_CreateSessionUnknownUser(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	_, err := auth.CreateSession(ctx, &storage.Session{
+		TokenHash: []byte("x"), UserID: "00000000-0000-0000-0000-000000000000",
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+}
+
+func TestWebAuth_DeleteExpiredSessions(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	var userID string
+	require.NoError(t, pool.QueryRow(ctx,
+		`INSERT INTO users (kind, display_name, email, role) VALUES ('human','U','u@example.com','reader') RETURNING id`).Scan(&userID))
+
+	_, err := auth.CreateSession(ctx, &storage.Session{
+		TokenHash: []byte("expired-hash"), UserID: userID,
+		ExpiresAt: time.Now().Add(-time.Minute),
+	})
+	require.NoError(t, err)
+	n, err := auth.DeleteExpiredSessions(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, n, int64(1))
+}
+
+func TestWebAuth_LoginFlowConsumeSingleUse(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	id, err := auth.CreateLoginFlow(ctx, &storage.LoginFlow{
+		State: "st", Nonce: "no", CodeVerifier: "cv", ProviderID: "entra",
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, id)
+
+	f, err := auth.ConsumeLoginFlow(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "st", f.State)
+	require.Equal(t, "entra", f.ProviderID)
+
+	// Replay → gone.
+	_, err = auth.ConsumeLoginFlow(ctx, id)
+	require.ErrorIs(t, err, storage.ErrLoginFlowNotFound)
+
+	// Bad uuid → not-found, not error.
+	_, err = auth.ConsumeLoginFlow(ctx, "not-a-uuid")
+	require.ErrorIs(t, err, storage.ErrLoginFlowNotFound)
+}
+
+func TestWebAuth_LoginFlowExpired(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	id, err := auth.CreateLoginFlow(ctx, &storage.LoginFlow{
+		State: "st", Nonce: "no", CodeVerifier: "cv", ProviderID: "entra",
+		ExpiresAt: time.Now().Add(-time.Minute),
+	})
+	require.NoError(t, err)
+	_, err = auth.ConsumeLoginFlow(ctx, id)
+	require.ErrorIs(t, err, storage.ErrLoginFlowNotFound)
+}
+```
+
+Note: delete the unused `seedUser`/`pgxRow` helper stub above — it was illustrative; each test inlines the seed insert. (If you keep a shared helper, give it the real `*pgxpool.Pool` type and a concrete return.)
+
+- [ ] **Step 2: Run the tests**
+
+Run: `go test -tags integration ./internal/storage/postgres/ -run TestWebAuth -v`
+Expected: PASS (requires Docker).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/storage/postgres/web_auth_test.go
+git commit -s -m "test(storage/postgres): integration tests for WebAuthStore"
+```
+
+---
+
+### Task 8: Context marker for interactive login
+
+**Files:**
+
+- Modify: `internal/auth/context.go`
+- Test: `internal/auth/context_test.go` (create/append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/auth/context_test.go` (create if absent, `package auth`):
+
+```go
+package auth
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInteractiveLoginContext(t *testing.T) {
+	ctx := context.Background()
+	if InteractiveLoginFromContext(ctx) {
+		t.Fatal("plain context must not be marked interactive")
+	}
+	ctx = WithInteractiveLogin(ctx)
+	if !InteractiveLoginFromContext(ctx) {
+		t.Fatal("marked context must report interactive")
+	}
+}
+```
+
+- [ ] **Step 2: Run it to confirm failure**
+
+Run: `go test ./internal/auth/ -run TestInteractiveLoginContext -v`
+Expected: FAIL — undefined `WithInteractiveLogin` / `InteractiveLoginFromContext`.
+
+- [ ] **Step 3: Implement the helpers**
+
+Append to `internal/auth/context.go`:
+
+```go
+type interactiveLoginKey struct{}
+
+// WithInteractiveLogin marks the context as originating from the interactive
+// OIDC login callback. Consumed by jitResolve to bypass the per-issuer JIT
+// rate limiter (the limiter targets unsolicited bearer-JWT JIT; an interactive
+// login is user-driven and IdP+PKCE+nonce authenticated). Set ONLY by the
+// callback handler — bearer entry points never set it.
+func WithInteractiveLogin(ctx context.Context) context.Context {
+	return context.WithValue(ctx, interactiveLoginKey{}, true)
+}
+
+// InteractiveLoginFromContext reports whether the context was marked by
+// WithInteractiveLogin.
+func InteractiveLoginFromContext(ctx context.Context) bool {
+	v, _ := ctx.Value(interactiveLoginKey{}).(bool)
+	return v
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `go test ./internal/auth/ -run TestInteractiveLoginContext -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/context.go internal/auth/context_test.go
+git commit -s -m "feat(auth): add WithInteractiveLogin context marker"
+```
+
+---
+
+### Task 9: Resolver — session resolution path, dispatch, JIT limiter bypass
+
+**Files:**
+
+- Modify: `internal/auth/identitystore.go`
+- Test: `internal/auth/identitystore_test.go` (append; or wherever resolver tests live)
+
+This task adds: (a) a `WebAuth` field on `IdentityStoreConfig` + `pgIdentityStore`; (b) `resolveSession`; (c) a `spgr_ws_` branch in `Resolve`; (d) a limiter bypass in `jitResolve` keyed off the context marker.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to the resolver test file. We need a `WebAuthStore` fake; define a minimal one inline. We also reuse whatever `UsersBackend` fake already exists in the package's tests (the explore report noted `auth/usersbackend_stub_test.go`). The test below assumes a constructor pattern matching existing resolver tests — adapt the `UsersBackend` stub variable name to the existing one (`stubUsers`/`fakeUsers`).
+
+```go
+// fakeWebAuth is a minimal in-memory WebAuthStore for resolver tests.
+type fakeWebAuth struct {
+	sessions map[string]*storage.Session // keyed by hex(token_hash)
+	err      error                       // forced lookup error (transient test)
+}
+
+func (f *fakeWebAuth) CreateSession(_ context.Context, s *storage.Session) (*storage.Session, error) {
+	if f.sessions == nil {
+		f.sessions = map[string]*storage.Session{}
+	}
+	s.ID = "sess-" + s.UserID
+	f.sessions[string(s.TokenHash)] = s
+	return s, nil
+}
+func (f *fakeWebAuth) LookupSessionByHash(_ context.Context, h []byte) (*storage.Session, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	s, ok := f.sessions[string(h)]
+	if !ok {
+		return nil, storage.ErrSessionNotFound
+	}
+	return s, nil
+}
+func (f *fakeWebAuth) RevokeSession(_ context.Context, h []byte) error { delete(f.sessions, string(h)); return nil }
+func (f *fakeWebAuth) DeleteExpiredSessions(context.Context) (int64, error) { return 0, nil }
+func (f *fakeWebAuth) CreateLoginFlow(context.Context, *storage.LoginFlow) (string, error) { return "id", nil }
+func (f *fakeWebAuth) ConsumeLoginFlow(context.Context, string) (*storage.LoginFlow, error) { return nil, storage.ErrLoginFlowNotFound }
+func (f *fakeWebAuth) DeleteExpiredLoginFlows(context.Context) (int64, error) { return 0, nil }
+```
+
+```go
+func TestResolveSession(t *testing.T) {
+	// Build a resolver wired with a fake UsersBackend that returns an active
+	// user for ID "u1", plus a fakeWebAuth. Use the same NewIdentityStore
+	// construction the other resolver tests in this file use; set Now to a
+	// fixed clock if the existing tests do.
+	wa := &fakeWebAuth{}
+	users := newStubUsers() // existing helper; must return an active user for GetUserByID("u1")
+	users.addActiveUser("u1", "reader")
+
+	r, err := NewIdentityStore(IdentityStoreConfig{
+		Users:   users,
+		Tracker: noopTracker{}, // existing test tracker
+		WebAuth: wa,
+	})
+	require.NoError(t, err)
+
+	// Seed an active session whose token is "spgr_ws_TOKEN".
+	token := "spgr_ws_TOKEN"
+	sum := sha256.Sum256([]byte(token))
+	wa.sessions = map[string]*storage.Session{
+		string(sum[:]): {TokenHash: sum[:], UserID: "u1", OIDCSubject: "sub-1", ExpiresAt: time.Now().Add(time.Hour)},
+	}
+
+	id, err := r.Resolve(context.Background(), token)
+	require.NoError(t, err)
+	require.Equal(t, "u1", id.UserID)
+	require.Equal(t, "oidc:sub-1", id.Subject)
+	require.Equal(t, "oidc", id.Source)
+}
+
+func TestResolveSession_Errors(t *testing.T) {
+	users := newStubUsers()
+	users.addActiveUser("u1", "reader")
+
+	// Missing → ErrUnauthenticated.
+	r, _ := NewIdentityStore(IdentityStoreConfig{Users: users, Tracker: noopTracker{}, WebAuth: &fakeWebAuth{}})
+	_, err := r.Resolve(context.Background(), "spgr_ws_unknown")
+	require.ErrorIs(t, err, ErrUnauthenticated)
+
+	// DB error → ErrTransient.
+	r2, _ := NewIdentityStore(IdentityStoreConfig{Users: users, Tracker: noopTracker{}, WebAuth: &fakeWebAuth{err: errors.New("db down")}})
+	_, err = r2.Resolve(context.Background(), "spgr_ws_anything")
+	require.ErrorIs(t, err, ErrTransient)
+
+	// Nil WebAuth → ErrUnauthenticated (no panic).
+	r3, _ := NewIdentityStore(IdentityStoreConfig{Users: users, Tracker: noopTracker{}})
+	_, err = r3.Resolve(context.Background(), "spgr_ws_anything")
+	require.ErrorIs(t, err, ErrUnauthenticated)
+}
+```
+
+Ensure the test file imports `crypto/sha256`, `errors`, `time`, `context`, and `storage`.
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `go test ./internal/auth/ -run 'TestResolveSession' -v`
+Expected: FAIL — `WebAuth` field undefined; `resolveSession` not wired.
+
+- [ ] **Step 3: Add the WebAuth field**
+
+In `internal/auth/identitystore.go`, add to `IdentityStoreConfig` (after `Users`):
+
+```go
+	// WebAuth persists/looks up interactive-login web sessions. Optional: when
+	// nil, spgr_ws_-prefixed tokens resolve to ErrUnauthenticated.
+	WebAuth storage.WebAuthStore
+```
+
+Add to the `pgIdentityStore` struct (after `users`):
+
+```go
+	webAuth storage.WebAuthStore
+```
+
+In `NewIdentityStore`, set it in the returned struct literal (after `users: cfg.Users,`):
+
+```go
+		webAuth:            cfg.WebAuth,
+```
+
+- [ ] **Step 4: Add the dispatch branch + sessionTokenPrefix const + resolveSession**
+
+In `Resolve` (lines ~150-158), insert the session branch BEFORE the api-key fallback:
+
+```go
+func (s *pgIdentityStore) Resolve(ctx context.Context, token string) (*Identity, error) {
+	if token == "" {
+		return nil, ErrUnauthenticated
+	}
+	if isJWTShaped(token) {
+		return s.resolveJWT(ctx, token)
+	}
+	if strings.HasPrefix(token, sessionTokenPrefix) {
+		return s.resolveSession(ctx, token)
+	}
+	return s.resolveAPIKey(ctx, token)
+}
+```
+
+Add a const near `apiKeyPrefix` (lines ~175-179):
+
+```go
+const sessionTokenPrefix = "spgr_ws_" //nolint:gosec // G101: token-format prefix, not a credential
+```
+
+Add `"crypto/sha256"` to the imports. Add the method (place after `resolveAPIKey`):
+
+```go
+// resolveSession resolves an opaque web-session token (spgr_ws_...). Mirrors
+// resolveAPIKey's error discipline: not-found/revoked/expired/soft-deleted →
+// ErrUnauthenticated; any other backend error → ErrTransient.
+func (s *pgIdentityStore) resolveSession(ctx context.Context, token string) (*Identity, error) {
+	if s.webAuth == nil {
+		return nil, ErrUnauthenticated
+	}
+	sum := sha256.Sum256([]byte(token))
+	sess, err := s.webAuth.LookupSessionByHash(ctx, sum[:])
+	if err != nil {
+		if errors.Is(err, storage.ErrSessionNotFound) {
+			return nil, ErrUnauthenticated
+		}
+		return nil, fmt.Errorf("%w: %w", ErrTransient, err)
+	}
+	if !sess.IsActive(s.now()) {
+		return nil, ErrUnauthenticated
+	}
+	user, err := s.users.GetUserByID(ctx, sess.UserID)
+	if err != nil {
+		if errors.Is(err, storage.ErrUserNotFound) {
+			return nil, ErrUnauthenticated
+		}
+		return nil, fmt.Errorf("%w: %w", ErrTransient, err)
+	}
+	if user.DeletedAt != nil {
+		slog.LogAttrs(ctx, slog.LevelWarn, "auth: session resolved to soft-deleted user",
+			slog.String("user_id", user.ID), slog.String("subject", sess.OIDCSubject))
+		return nil, ErrUnauthenticated
+	}
+	return &Identity{
+		UserID:        user.ID,
+		Subject:       "oidc:" + sess.OIDCSubject,
+		DisplayName:   user.DisplayName,
+		Email:         user.Email,
+		Role:          Role(user.Role),
+		EffectiveRole: Role(user.Role),
+		Source:        "oidc",
+	}, nil
+}
+```
+
+- [ ] **Step 5: Add the JIT limiter bypass**
+
+In `jitResolve` (lines ~423-449), wrap the rate-limit gate so the interactive context skips it. Replace the limiter block:
+
+```go
+	// (2) Per-issuer rate-limit gate — bounds eligible creation attempts.
+	// Skipped for interactive logins (user-driven, IdP+PKCE+nonce verified);
+	// the limiter targets unsolicited bearer-JWT JIT. The email-domain
+	// allowlist (step 1, above) still applies.
+	if !InteractiveLoginFromContext(ctx) {
+		limiter := s.rateLimiterFor(claims.Issuer)
+		if !limiter.Allow() {
+			slog.LogAttrs(ctx, slog.LevelWarn, "auth: JIT rate-limit exceeded",
+				slog.String("issuer", claims.Issuer), slog.String("subject", claims.Subject))
+			return nil, ErrUnauthenticated
+		}
+	}
+```
+
+- [ ] **Step 6: Run resolver tests**
+
+Run: `go test ./internal/auth/ -run 'TestResolveSession' -v`
+Expected: PASS
+
+Add a bypass test:
+
+```go
+func TestJITResolve_InteractiveBypassesLimiter(t *testing.T) {
+	// Construct a resolver with JITRateBurstPerHour=1 and JIT enabled, a
+	// claims mapping/allowlist permissive, and a fake UsersBackend whose
+	// LookupOIDCBinding misses and JITCreateHuman succeeds. Call the internal
+	// jitResolve twice with WithInteractiveLogin(ctx): both succeed (no
+	// limiter decrement). Then call once on a plain context after exhausting
+	// the bucket to assert the bearer path still limits.
+	// (Adapt to existing jitResolve test helpers in this file.)
+}
+```
+
+Implement it against the existing jit test scaffolding in the file; run:
+Run: `go test ./internal/auth/ -run TestJITResolve_InteractiveBypassesLimiter -v`
+Expected: PASS
+
+- [ ] **Step 7: Run the whole auth package**
+
+Run: `go test ./internal/auth/ -v`
+Expected: PASS (no regressions in existing resolver tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/auth/identitystore.go internal/auth/identitystore_test.go
+git commit -s -m "feat(auth): add resolveSession path and interactive JIT limiter bypass"
+```
+
+---
+
+### Task 10: Login-provider abstraction, oidc impl, and BuildLoginProviders
+
+**Files:**
+
+- Create: `internal/auth/loginprovider.go`
+- Test: `internal/auth/loginprovider_test.go`
+
+This builds the `oauth2.Config`-backed provider plus the startup builder that validates config and resolves the secret from env. `golang.org/x/oauth2` is already an indirect dep (`go.mod`); it becomes direct here.
+
+- [ ] **Step 1: Write failing tests (validation + secret resolution + AuthCodeURL)**
+
+Create `internal/auth/loginprovider_test.go`:
+
+```go
+package auth
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/config"
+)
+
+func TestBuildLoginProviders_SkipsNonInteractive(t *testing.T) {
+	provs, err := BuildLoginProviders(nil, []config.OIDCProviderConfig{
+		{ID: "verify-only", Issuer: "https://x", ClientID: "c"}, // interactive=false
+	}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(provs) != 0 {
+		t.Fatalf("non-interactive provider must not yield a login provider, got %d", len(provs))
+	}
+}
+
+func TestBuildLoginProviders_MissingSecret(t *testing.T) {
+	_, err := BuildLoginProviders(nil, []config.OIDCProviderConfig{
+		{ID: "entra", Interactive: true, Issuer: "https://x", ClientID: "c"},
+	}, "")
+	if err == nil || !strings.Contains(err.Error(), "client secret") {
+		t.Fatalf("expected missing-secret error, got %v", err)
+	}
+}
+
+func TestBuildLoginProviders_AudienceMismatch(t *testing.T) {
+	t.Setenv("TEST_SECRET", "shh")
+	_, err := BuildLoginProviders(nil, []config.OIDCProviderConfig{
+		{ID: "entra", Interactive: true, Issuer: "https://x", ClientID: "c",
+			Audience: "different", ClientSecretEnv: "TEST_SECRET"},
+	}, "")
+	if err == nil || !strings.Contains(err.Error(), "audience") {
+		t.Fatalf("expected audience error, got %v", err)
+	}
+}
+
+func TestResolveClientSecret(t *testing.T) {
+	t.Setenv("MY_SECRET", "value")
+	got, err := resolveClientSecret(config.OIDCProviderConfig{ClientSecretEnv: "MY_SECRET"})
+	if err != nil || got != "value" {
+		t.Fatalf("env resolution: got %q err %v", got, err)
+	}
+	got, err = resolveClientSecret(config.OIDCProviderConfig{ClientSecret: "plain"})
+	if err != nil || got != "plain" {
+		t.Fatalf("plaintext fallback: got %q err %v", got, err)
+	}
+	if _, err := resolveClientSecret(config.OIDCProviderConfig{ClientSecretEnv: "UNSET_VAR_XYZ"}); err == nil {
+		t.Fatal("unset env var must error")
+	}
+}
+
+func TestOIDCLoginProvider_AuthCodeURL(t *testing.T) {
+	p := &oidcLoginProvider{
+		id:          "entra",
+		displayName: "Entra",
+		authURL:     "https://idp/authorize",
+		clientID:    "client-1",
+		scopes:      []string{"openid", "email"},
+	}
+	got := p.AuthCodeURL("STATE", "NONCE", "CHALLENGE", "https://app/api/auth/oidc/callback")
+	for _, want := range []string{
+		"https://idp/authorize?", "client_id=client-1", "state=STATE",
+		"nonce=NONCE", "code_challenge=CHALLENGE", "code_challenge_method=S256",
+		"scope=openid+email", "response_type=code",
+		"redirect_uri=https%3A%2F%2Fapp%2Fapi%2Fauth%2Foidc%2Fcallback",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("AuthCodeURL missing %q in %q", want, got)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `go test ./internal/auth/ -run 'TestBuildLoginProviders|TestResolveClientSecret|TestOIDCLoginProvider' -v`
+Expected: FAIL — undefined symbols.
+
+- [ ] **Step 3: Implement loginprovider.go**
+
+Create `internal/auth/loginprovider.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+
+	"github.com/specgraph/specgraph/internal/config"
+)
+
+// LoginProvider drives the interactive OAuth2 Authorization Code flow for one
+// provider. The oidc implementation verifies the returned id_token (incl.
+// nonce) and returns the raw token for the resolver to materialize identity.
+type LoginProvider interface {
+	ID() string
+	DisplayName() string
+	AuthCodeURL(state, nonce, codeChallenge, redirectURI string) string
+	// Exchange swaps the authorization code for a nonce-verified raw id_token.
+	Exchange(ctx context.Context, code, codeVerifier, nonce, redirectURI string) (idToken string, err error)
+}
+
+type oidcLoginProvider struct {
+	id          string
+	displayName string
+	authURL     string
+	tokenURL    string
+	clientID    string
+	secret      string
+	scopes      []string
+	verifier    *OIDCVerifier
+}
+
+func (p *oidcLoginProvider) ID() string          { return p.id }
+func (p *oidcLoginProvider) DisplayName() string { return p.displayName }
+
+func (p *oidcLoginProvider) AuthCodeURL(state, nonce, codeChallenge, redirectURI string) string {
+	cfg := p.oauth2Config(redirectURI)
+	return cfg.AuthCodeURL(state,
+		oidc.Nonce(nonce),
+		oauth2.SetAuthURLParam("code_challenge", codeChallenge),
+		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+	)
+}
+
+func (p *oidcLoginProvider) Exchange(ctx context.Context, code, codeVerifier, nonce, redirectURI string) (string, error) {
+	cfg := p.oauth2Config(redirectURI)
+	tok, err := cfg.Exchange(ctx, code, oauth2.SetAuthURLParam("code_verifier", codeVerifier))
+	if err != nil {
+		return "", fmt.Errorf("oidc exchange: %w", err)
+	}
+	rawID, ok := tok.Extra("id_token").(string)
+	if !ok || rawID == "" {
+		return "", fmt.Errorf("oidc exchange: no id_token in response")
+	}
+	if _, err := p.verifier.VerifyWithNonce(ctx, rawID, nonce); err != nil {
+		return "", err
+	}
+	return rawID, nil
+}
+
+func (p *oidcLoginProvider) oauth2Config(redirectURI string) oauth2.Config {
+	return oauth2.Config{
+		ClientID:     p.clientID,
+		ClientSecret: p.secret,
+		Endpoint:     oauth2.Endpoint{AuthURL: p.authURL, TokenURL: p.tokenURL},
+		RedirectURL:  redirectURI,
+		Scopes:       p.scopes,
+	}
+}
+
+// resolveClientSecret returns the provider's client secret from
+// ClientSecretEnv (preferred) or the plaintext ClientSecret fallback.
+func resolveClientSecret(pc config.OIDCProviderConfig) (string, error) {
+	if pc.ClientSecretEnv != "" {
+		v := os.Getenv(pc.ClientSecretEnv)
+		if v == "" {
+			return "", fmt.Errorf("client secret env var %q is unset", pc.ClientSecretEnv)
+		}
+		return v, nil
+	}
+	if pc.ClientSecret != "" {
+		return pc.ClientSecret, nil
+	}
+	return "", fmt.Errorf("no client secret (set client_secret_env or client_secret)")
+}
+
+// defaultScopes is applied when a provider configures none.
+var defaultScopes = []string{"openid", "email", "profile"}
+
+// BuildLoginProviders discovers and constructs a LoginProvider for each
+// interactive OIDC provider. Non-interactive providers are skipped. All
+// failures (unknown kind, missing secret, bad audience, discovery failure)
+// are fatal — the caller treats a non-nil error as a startup abort.
+//
+// discover is the discovery function (oidc.NewProvider); pass nil to use the
+// default. The extra param exists for tests that need to avoid a network call.
+func BuildLoginProviders(ctx context.Context, providers []config.OIDCProviderConfig, _ string) ([]LoginProvider, error) {
+	var out []LoginProvider
+	for _, pc := range providers {
+		if !pc.Interactive {
+			continue
+		}
+		kind := pc.Kind
+		if kind == "" {
+			kind = "oidc"
+		}
+		if kind != "oidc" {
+			return nil, fmt.Errorf("OIDC provider %s: unsupported kind %q (only \"oidc\")", pc.ID, kind)
+		}
+		if pc.Audience != "" && pc.Audience != pc.ClientID {
+			return nil, fmt.Errorf("OIDC provider %s: interactive audience must be empty or equal client_id", pc.ID)
+		}
+		secret, err := resolveClientSecret(pc)
+		if err != nil {
+			return nil, fmt.Errorf("OIDC provider %s: %w", pc.ID, err)
+		}
+		// Discover endpoints + build a nonce-capable verifier.
+		dctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		provider, err := oidc.NewProvider(dctx, pc.Issuer)
+		cancel()
+		if err != nil {
+			return nil, fmt.Errorf("OIDC provider %s discovery: %w", pc.ID, err)
+		}
+		verifier, err := NewOIDCVerifier(ctx, pc)
+		if err != nil {
+			return nil, fmt.Errorf("OIDC provider %s verifier: %w", pc.ID, err)
+		}
+		scopes := pc.Scopes
+		if len(scopes) == 0 {
+			scopes = defaultScopes
+		}
+		scopes = ensureOpenID(scopes)
+		display := pc.DisplayName
+		if display == "" {
+			display = pc.ID
+		}
+		ep := provider.Endpoint()
+		out = append(out, &oidcLoginProvider{
+			id:          pc.ID,
+			displayName: display,
+			authURL:     ep.AuthURL,
+			tokenURL:    ep.TokenURL,
+			clientID:    pc.ClientID,
+			secret:      secret,
+			scopes:      scopes,
+			verifier:    verifier,
+		})
+	}
+	return out, nil
+}
+
+// ensureOpenID guarantees the openid scope is present.
+func ensureOpenID(scopes []string) []string {
+	for _, s := range scopes {
+		if s == "openid" {
+			return scopes
+		}
+	}
+	return append([]string{"openid"}, scopes...)
+}
+
+// RedirectURI builds the OIDC callback URL from the request, honoring an
+// explicit base override (auth.oidc.base_url) when set.
+func RedirectURI(baseURL string, tls bool, host, fwdProto, fwdHost string) string {
+	if baseURL != "" {
+		return strings.TrimRight(baseURL, "/") + "/api/auth/oidc/callback"
+	}
+	scheme := "http"
+	if tls || fwdProto == "https" {
+		scheme = "https"
+	}
+	h := host
+	if fwdHost != "" {
+		h = fwdHost
+	}
+	u := url.URL{Scheme: scheme, Host: h, Path: "/api/auth/oidc/callback"}
+	return u.String()
+}
+```
+
+Note: the `TestBuildLoginProviders_*` tests that reach discovery (`MissingSecret`, `AudienceMismatch`) intentionally fail BEFORE `oidc.NewProvider` (secret/audience checks precede discovery), so they need no network. `SkipsNonInteractive` returns before any check. Keep these validation checks ordered before discovery exactly as written.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `go test ./internal/auth/ -run 'TestBuildLoginProviders|TestResolveClientSecret|TestOIDCLoginProvider' -v`
+Expected: PASS
+
+- [ ] **Step 5: Add a RedirectURI unit test**
+
+```go
+func TestRedirectURI(t *testing.T) {
+	// base_url override wins
+	if got := RedirectURI("https://app.example.com", false, "ignored", "", ""); got != "https://app.example.com/api/auth/oidc/callback" {
+		t.Fatalf("override: %q", got)
+	}
+	// derived from request, https via X-Forwarded-Proto + X-Forwarded-Host
+	if got := RedirectURI("", false, "internal:9090", "https", "app.example.com"); got != "https://app.example.com/api/auth/oidc/callback" {
+		t.Fatalf("derived: %q", got)
+	}
+	// plain http from Host
+	if got := RedirectURI("", false, "localhost:9090", "", ""); got != "http://localhost:9090/api/auth/oidc/callback" {
+		t.Fatalf("http: %q", got)
+	}
+}
+```
+
+Run: `go test ./internal/auth/ -run TestRedirectURI -v`
+Expected: PASS
+
+- [ ] **Step 6: Tidy modules and commit**
+
+```bash
+go mod tidy
+git add internal/auth/loginprovider.go internal/auth/loginprovider_test.go go.mod go.sum
+git commit -s -m "feat(auth): add LoginProvider, oidc impl, BuildLoginProviders, RedirectURI"
+```
+
+---
+
+### Task 11: Per-IP rate limiter middleware
+
+**Files:**
+
+- Create: `internal/server/ratelimit.go`
+- Test: `internal/server/ratelimit_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/server/ratelimit_test.go`:
+
+```go
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPerIPRateLimiter(t *testing.T) {
+	rl := newIPRateLimiter(1, 1, false) // 1/sec, burst 1
+	h := rl.wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, req)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first request should pass, got %d", rec1.Code)
+	}
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req)
+	if rec2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request should be 429, got %d", rec2.Code)
+	}
+	if rec2.Header().Get("Retry-After") == "" {
+		t.Fatal("429 must set Retry-After")
+	}
+
+	// Different IP gets its own bucket.
+	req2 := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req2.RemoteAddr = "10.0.0.2:1234"
+	rec3 := httptest.NewRecorder()
+	h.ServeHTTP(rec3, req2)
+	if rec3.Code != http.StatusOK {
+		t.Fatalf("new IP should pass, got %d", rec3.Code)
+	}
+}
+
+func TestClientIP_TrustedProxy(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.RemoteAddr = "10.0.0.9:5555"
+	req.Header.Set("X-Forwarded-For", "203.0.113.7, 10.0.0.9")
+
+	if ip := clientIP(req, false); ip != "10.0.0.9" {
+		t.Fatalf("untrusted: want RemoteAddr host, got %q", ip)
+	}
+	if ip := clientIP(req, true); ip != "203.0.113.7" {
+		t.Fatalf("trusted: want leftmost XFF, got %q", ip)
+	}
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `go test ./internal/server/ -run 'TestPerIPRateLimiter|TestClientIP' -v`
+Expected: FAIL — undefined `newIPRateLimiter`, `clientIP`.
+
+- [ ] **Step 3: Implement the limiter**
+
+Create `internal/server/ratelimit.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+
+	"golang.org/x/time/rate"
+)
+
+// ipRateLimiter is a per-client-IP token-bucket limiter. Buckets are created
+// lazily and kept in memory for the process lifetime (bounded by distinct IPs;
+// acceptable for the public OIDC start/callback endpoints). Used to bound the
+// unauthenticated DB writes performed by /api/auth/oidc/start.
+type ipRateLimiter struct {
+	mu           sync.Mutex
+	buckets      map[string]*rate.Limiter
+	r            rate.Limit
+	burst        int
+	trustedProxy bool
+}
+
+// newIPRateLimiter returns a limiter allowing r events/sec with the given
+// burst, per client IP. trustedProxy selects X-Forwarded-For extraction.
+func newIPRateLimiter(perSec float64, burst int, trustedProxy bool) *ipRateLimiter {
+	return &ipRateLimiter{
+		buckets:      map[string]*rate.Limiter{},
+		r:            rate.Limit(perSec),
+		burst:        burst,
+		trustedProxy: trustedProxy,
+	}
+}
+
+func (l *ipRateLimiter) limiterFor(ip string) *rate.Limiter {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	lim, ok := l.buckets[ip]
+	if !ok {
+		lim = rate.NewLimiter(l.r, l.burst)
+		l.buckets[ip] = lim
+	}
+	return lim
+}
+
+// wrap returns middleware that rejects over-limit requests with 429.
+func (l *ipRateLimiter) wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip := clientIP(r, l.trustedProxy)
+		if !l.limiterFor(ip).Allow() {
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, `{"error":"rate limited"}`, http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// clientIP returns the client IP. When trustedProxy is true it uses the
+// leftmost X-Forwarded-For entry (then X-Real-Ip); otherwise the TCP peer.
+func clientIP(r *http.Request, trustedProxy bool) string {
+	if trustedProxy {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			if first, _, ok := strings.Cut(xff, ","); ok {
+				return strings.TrimSpace(first)
+			}
+			return strings.TrimSpace(xff)
+		}
+		if xr := r.Header.Get("X-Real-Ip"); xr != "" {
+			return strings.TrimSpace(xr)
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `go test ./internal/server/ -run 'TestPerIPRateLimiter|TestClientIP' -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/ratelimit.go internal/server/ratelimit_test.go
+git commit -s -m "feat(server): add per-IP rate limiter middleware"
+```
+
+---
+
+### Task 12: OIDC handlers (providers / start / callback)
+
+**Files:**
+
+- Create: `internal/server/auth_oidc_handler.go`
+- Test: `internal/server/auth_oidc_handler_test.go`
+
+The handler reuses `sessionCookie` and `writeJSONError` from `auth_handler.go` (same package). It needs: the `[]auth.LoginProvider`, the `auth.Resolver`, the `storage.WebAuthStore`, the config `base_url`, the `session_ttl`, and a rate limiter.
+
+- [ ] **Step 1: Implement the handler**
+
+Create `internal/server/auth_oidc_handler.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+const txCookieName = "specgraph_oidc_tx"
+
+// OIDCLoginConfig parametrizes the interactive login handlers.
+type OIDCLoginConfig struct {
+	Providers  []auth.LoginProvider
+	Resolver   auth.Resolver
+	WebAuth    storage.WebAuthStore
+	BaseURL    string
+	SessionTTL time.Duration
+	FlowTTL    time.Duration // default 5m
+	Limiter    *ipRateLimiter
+}
+
+type oidcLoginHandler struct {
+	byID       map[string]auth.LoginProvider
+	resolver   auth.Resolver
+	webAuth    storage.WebAuthStore
+	baseURL    string
+	sessionTTL time.Duration
+	flowTTL    time.Duration
+}
+
+// RegisterOIDCLoginHandlers wires /api/auth/oidc/{providers,start,callback}.
+// Endpoints are public (no RequireAuth); start/callback are per-IP rate
+// limited. No-op when no interactive providers are configured.
+func RegisterOIDCLoginHandlers(mux *http.ServeMux, cfg OIDCLoginConfig) {
+	if len(cfg.Providers) == 0 {
+		return
+	}
+	flowTTL := cfg.FlowTTL
+	if flowTTL <= 0 {
+		flowTTL = 5 * time.Minute
+	}
+	h := &oidcLoginHandler{
+		byID:       map[string]auth.LoginProvider{},
+		resolver:   cfg.Resolver,
+		webAuth:    cfg.WebAuth,
+		baseURL:    cfg.BaseURL,
+		sessionTTL: cfg.SessionTTL,
+		flowTTL:    flowTTL,
+	}
+	for _, p := range cfg.Providers {
+		h.byID[p.ID()] = p
+	}
+
+	limit := cfg.Limiter.wrap
+	mux.HandleFunc("/api/auth/oidc/providers", h.handleProviders)
+	mux.Handle("/api/auth/oidc/callback", limit(http.HandlerFunc(h.handleCallback)))
+	// {provider}/start — Go 1.22+ wildcard pattern.
+	mux.Handle("/api/auth/oidc/{provider}/start", limit(http.HandlerFunc(h.handleStart)))
+}
+
+type providerInfo struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+}
+
+func (h *oidcLoginHandler) handleProviders(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	infos := make([]providerInfo, 0, len(h.byID))
+	for _, p := range h.byID {
+		infos = append(infos, providerInfo{ID: p.ID(), DisplayName: p.DisplayName()})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"providers": infos}) //nolint:errcheck // best-effort write
+}
+
+func (h *oidcLoginHandler) handleStart(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	p, ok := h.byID[r.PathValue("provider")]
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "unknown provider")
+		return
+	}
+	state, err := randToken()
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal")
+		return
+	}
+	nonce, err := randToken()
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal")
+		return
+	}
+	verifier := oauth2.GenerateVerifier()
+	challenge := oauth2.S256ChallengeFromVerifier(verifier)
+
+	flowID, err := h.webAuth.CreateLoginFlow(r.Context(), &storage.LoginFlow{
+		State: state, Nonce: nonce, CodeVerifier: verifier, ProviderID: p.ID(),
+		ExpiresAt: time.Now().Add(h.flowTTL),
+	})
+	if err != nil {
+		slog.LogAttrs(r.Context(), slog.LevelError, "oidc: create login flow", slog.Any("error", err))
+		writeJSONError(w, http.StatusServiceUnavailable, "temporary")
+		return
+	}
+	http.SetCookie(w, h.txCookie(flowID, r))
+
+	redirectURI := auth.RedirectURI(h.baseURL, r.TLS != nil, r.Host,
+		r.Header.Get("X-Forwarded-Proto"), r.Header.Get("X-Forwarded-Host"))
+	http.Redirect(w, r, p.AuthCodeURL(state, nonce, challenge, redirectURI), http.StatusFound)
+}
+
+func (h *oidcLoginHandler) handleCallback(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	// Always delete the tx cookie on the response.
+	http.SetCookie(w, h.deleteTxCookie(r))
+
+	fail := func(reason string) { http.Redirect(w, r, "/?auth_error="+reason, http.StatusFound) }
+
+	c, err := r.Cookie(txCookieName)
+	if err != nil || c.Value == "" {
+		fail("expired")
+		return
+	}
+	if errParam := r.URL.Query().Get("error"); errParam != "" {
+		fail("denied")
+		return
+	}
+	flow, err := h.webAuth.ConsumeLoginFlow(r.Context(), c.Value)
+	if err != nil {
+		fail("expired")
+		return
+	}
+	if r.URL.Query().Get("state") != flow.State {
+		fail("state")
+		return
+	}
+	p, ok := h.byID[flow.ProviderID]
+	if !ok {
+		slog.LogAttrs(r.Context(), slog.LevelWarn, "oidc: provider removed mid-flow", slog.String("provider", flow.ProviderID))
+		fail("exchange")
+		return
+	}
+	redirectURI := auth.RedirectURI(h.baseURL, r.TLS != nil, r.Host,
+		r.Header.Get("X-Forwarded-Proto"), r.Header.Get("X-Forwarded-Host"))
+	idToken, err := p.Exchange(r.Context(), r.URL.Query().Get("code"), flow.CodeVerifier, flow.Nonce, redirectURI)
+	if err != nil {
+		slog.LogAttrs(r.Context(), slog.LevelWarn, "oidc: exchange failed", slog.String("provider", p.ID()), slog.Any("error", err))
+		fail("exchange")
+		return
+	}
+	// Resolve identity (triggers binding lookup / JIT), limiter bypassed.
+	id, err := h.resolver.Resolve(auth.WithInteractiveLogin(r.Context()), idToken)
+	if err != nil {
+		if errors.Is(err, auth.ErrTransient) {
+			fail("temporary")
+			return
+		}
+		fail("unauthorized")
+		return
+	}
+	// Mint the server session.
+	token, err := randSessionToken()
+	if err != nil {
+		fail("temporary")
+		return
+	}
+	sum := sha256.Sum256([]byte(token))
+	if _, err := h.webAuth.CreateSession(r.Context(), &storage.Session{
+		TokenHash: sum[:], UserID: id.UserID, OIDCSubject: subjectOnly(id.Subject),
+		ExpiresAt: time.Now().Add(h.sessionTTL),
+	}); err != nil {
+		slog.LogAttrs(r.Context(), slog.LevelError, "oidc: create session", slog.Any("error", err))
+		fail("temporary")
+		return
+	}
+	establishSession(w, r, token)
+	http.Redirect(w, r, "/", http.StatusFound)
+}
+
+func (h *oidcLoginHandler) txCookie(value string, r *http.Request) *http.Cookie {
+	return &http.Cookie{
+		Name:     txCookieName,
+		Value:    value,
+		Path:     "/api/auth/oidc",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+		MaxAge:   300,
+	}
+}
+
+func (h *oidcLoginHandler) deleteTxCookie(r *http.Request) *http.Cookie {
+	c := h.txCookie("", r)
+	c.MaxAge = -1
+	return c
+}
+
+// subjectOnly strips the "oidc:" prefix the resolver adds to Identity.Subject.
+func subjectOnly(subject string) string {
+	const p = "oidc:"
+	if len(subject) > len(p) && subject[:len(p)] == p {
+		return subject[len(p):]
+	}
+	return subject
+}
+
+func randToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// randSessionToken returns the opaque spgr_ws_ session token.
+func randSessionToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return "spgr_ws_" + base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+var _ = context.Background // keep context import if unused after edits
+```
+
+Remove the trailing `var _ = context.Background` line if `context` ends up used (it is used via `r.Context()` returning `context.Context` only implicitly; if the import is unused, drop the import instead). Verify with `go build`.
+
+- [ ] **Step 2: Write the flow tests**
+
+Create `internal/server/auth_oidc_handler_test.go`. Use a fake `LoginProvider`, a fake `WebAuthStore`, and a fake `Resolver`.
+
+```go
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+type fakeProvider struct{ id string; exchangeErr error; idToken string }
+
+func (f *fakeProvider) ID() string          { return f.id }
+func (f *fakeProvider) DisplayName() string { return "Fake" }
+func (f *fakeProvider) AuthCodeURL(state, nonce, challenge, redirect string) string {
+	return "https://idp/authorize?state=" + state
+}
+func (f *fakeProvider) Exchange(_ context.Context, _, _, _, _ string) (string, error) {
+	return f.idToken, f.exchangeErr
+}
+
+type fakeWA struct {
+	flows    map[string]*storage.LoginFlow
+	sessions map[string]*storage.Session
+	createErr error
+}
+
+func (f *fakeWA) CreateSession(_ context.Context, s *storage.Session) (*storage.Session, error) {
+	if f.createErr != nil { return nil, f.createErr }
+	if f.sessions == nil { f.sessions = map[string]*storage.Session{} }
+	s.ID = "s1"; f.sessions[string(s.TokenHash)] = s; return s, nil
+}
+func (f *fakeWA) LookupSessionByHash(context.Context, []byte) (*storage.Session, error) { return nil, storage.ErrSessionNotFound }
+func (f *fakeWA) RevokeSession(context.Context, []byte) error { return nil }
+func (f *fakeWA) DeleteExpiredSessions(context.Context) (int64, error) { return 0, nil }
+func (f *fakeWA) CreateLoginFlow(_ context.Context, fl *storage.LoginFlow) (string, error) {
+	if f.flows == nil { f.flows = map[string]*storage.LoginFlow{} }
+	fl.ID = "flow-1"; f.flows[fl.ID] = fl; return fl.ID, nil
+}
+func (f *fakeWA) ConsumeLoginFlow(_ context.Context, id string) (*storage.LoginFlow, error) {
+	fl, ok := f.flows[id]; if !ok { return nil, storage.ErrLoginFlowNotFound }
+	delete(f.flows, id); return fl, nil
+}
+func (f *fakeWA) DeleteExpiredLoginFlows(context.Context) (int64, error) { return 0, nil }
+
+type fakeResolver struct{ id *auth.Identity; err error }
+func (f *fakeResolver) Resolve(context.Context, string) (*auth.Identity, error) { return f.id, f.err }
+func (f *fakeResolver) HasAuth(context.Context) (bool, error) { return true, nil }
+
+func newTestMux(provs []auth.LoginProvider, wa storage.WebAuthStore, res auth.Resolver) *http.ServeMux {
+	mux := http.NewServeMux()
+	RegisterOIDCLoginHandlers(mux, OIDCLoginConfig{
+		Providers: provs, Resolver: res, WebAuth: wa,
+		SessionTTL: time.Hour, FlowTTL: time.Minute,
+		Limiter: newIPRateLimiter(1000, 1000, false),
+	})
+	return mux
+}
+
+func TestStart_RedirectsAndSetsCookie(t *testing.T) {
+	wa := &fakeWA{}
+	mux := newTestMux([]auth.LoginProvider{&fakeProvider{id: "entra"}}, wa, &fakeResolver{})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/auth/oidc/entra/start", nil))
+	if rec.Code != http.StatusFound { t.Fatalf("want 302, got %d", rec.Code) }
+	if loc := rec.Header().Get("Location"); !strings.HasPrefix(loc, "https://idp/authorize") {
+		t.Fatalf("bad location %q", loc)
+	}
+	if len(wa.flows) != 1 { t.Fatalf("want 1 flow, got %d", len(wa.flows)) }
+	if !strings.Contains(rec.Header().Get("Set-Cookie"), txCookieName) {
+		t.Fatal("missing tx cookie")
+	}
+}
+
+func TestStart_UnknownProvider404(t *testing.T) {
+	mux := newTestMux([]auth.LoginProvider{&fakeProvider{id: "entra"}}, &fakeWA{}, &fakeResolver{})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/auth/oidc/nope/start", nil))
+	if rec.Code != http.StatusNotFound { t.Fatalf("want 404, got %d", rec.Code) }
+}
+
+func TestCallback_HappyPath(t *testing.T) {
+	wa := &fakeWA{}
+	wa.CreateLoginFlow(context.Background(), &storage.LoginFlow{State: "S", Nonce: "N", CodeVerifier: "V", ProviderID: "entra", ExpiresAt: time.Now().Add(time.Minute)})
+	res := &fakeResolver{id: &auth.Identity{UserID: "u1", Subject: "oidc:sub-1"}}
+	mux := newTestMux([]auth.LoginProvider{&fakeProvider{id: "entra", idToken: "tok"}}, wa, res)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?state=S&code=abc", nil)
+	req.AddCookie(&http.Cookie{Name: txCookieName, Value: "flow-1"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound || rec.Header().Get("Location") != "/" {
+		t.Fatalf("want 302 to /, got %d %q", rec.Code, rec.Header().Get("Location"))
+	}
+	if len(wa.sessions) != 1 { t.Fatalf("want 1 session, got %d", len(wa.sessions)) }
+	sc := rec.Result().Cookies()
+	var hasSession bool
+	for _, c := range sc {
+		if c.Name == "specgraph_session" && strings.HasPrefix(c.Value, "spgr_ws_") { hasSession = true }
+	}
+	if !hasSession { t.Fatal("missing spgr_ws_ session cookie") }
+}
+
+func TestCallback_Failures(t *testing.T) {
+	cases := []struct {
+		name   string
+		setup  func(*fakeWA, *fakeResolver, *fakeProvider)
+		cookie bool
+		query  string
+		reason string
+	}{
+		{"missing-tx", func(*fakeWA, *fakeResolver, *fakeProvider) {}, false, "state=S", "expired"},
+		{"unknown-flow", func(*fakeWA, *fakeResolver, *fakeProvider) {}, true, "state=S", "expired"},
+		{"idp-error", func(w *fakeWA, _ *fakeResolver, _ *fakeProvider) {
+			w.CreateLoginFlow(context.Background(), &storage.LoginFlow{State: "S", Nonce: "N", CodeVerifier: "V", ProviderID: "entra", ExpiresAt: time.Now().Add(time.Minute)})
+		}, true, "error=access_denied", "denied"},
+		{"state-mismatch", func(w *fakeWA, _ *fakeResolver, _ *fakeProvider) {
+			w.CreateLoginFlow(context.Background(), &storage.LoginFlow{State: "S", Nonce: "N", CodeVerifier: "V", ProviderID: "entra", ExpiresAt: time.Now().Add(time.Minute)})
+		}, true, "state=WRONG&code=x", "state"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wa := &fakeWA{}
+			res := &fakeResolver{id: &auth.Identity{UserID: "u1", Subject: "oidc:sub"}}
+			prov := &fakeProvider{id: "entra", idToken: "tok"}
+			tc.setup(wa, res, prov)
+			mux := newTestMux([]auth.LoginProvider{prov}, wa, res)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?"+tc.query, nil)
+			if tc.cookie { req.AddCookie(&http.Cookie{Name: txCookieName, Value: "flow-1"}) }
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			loc := rec.Header().Get("Location")
+			if !strings.Contains(loc, "auth_error="+tc.reason) {
+				t.Fatalf("want auth_error=%s, got %q", tc.reason, loc)
+			}
+		})
+	}
+}
+
+func TestCallback_Unauthorized(t *testing.T) {
+	wa := &fakeWA{}
+	wa.CreateLoginFlow(context.Background(), &storage.LoginFlow{State: "S", Nonce: "N", CodeVerifier: "V", ProviderID: "entra", ExpiresAt: time.Now().Add(time.Minute)})
+	res := &fakeResolver{err: auth.ErrUnauthenticated}
+	mux := newTestMux([]auth.LoginProvider{&fakeProvider{id: "entra", idToken: "tok"}}, wa, res)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?state=S&code=x", nil)
+	req.AddCookie(&http.Cookie{Name: txCookieName, Value: "flow-1"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Header().Get("Location"), "auth_error=unauthorized") {
+		t.Fatalf("want unauthorized, got %q", rec.Header().Get("Location"))
+	}
+	if len(wa.sessions) != 0 { t.Fatal("no session must be minted on unauthorized") }
+}
+```
+
+This test depends on `establishSession` and `auth.Resolver`/`auth.Identity` shapes. `establishSession` is added in Task 13 — if you run Task 12 tests before Task 13, the package won't compile. **Do Task 13 Step 3 (add `establishSession`) before running these tests.** Alternatively reorder: implement `establishSession` first. The plan assumes Task 13's `establishSession` exists when these run.
+
+- [ ] **Step 3: Run the flow tests (after Task 13's establishSession exists)**
+
+Run: `go test ./internal/server/ -run 'TestStart_|TestCallback_' -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/server/auth_oidc_handler.go internal/server/auth_oidc_handler_test.go
+git commit -s -m "feat(server): add interactive OIDC login handlers"
+```
+
+---
+
+### Task 13: auth_handler.go — SameSite=Lax, establishSession, logout revocation, signature
+
+**Files:**
+
+- Modify: `internal/server/auth_handler.go`
+- Test: `internal/server/auth_handler_test.go`
+
+- [ ] **Step 1: Switch sessionCookie to SameSite=Lax**
+
+In `internal/server/auth_handler.go`, in `sessionCookie()` (lines ~126-138), change:
+
+```go
+		SameSite: http.SameSiteStrictMode,
+```
+
+to:
+
+```go
+		SameSite: http.SameSiteLaxMode,
+```
+
+Update the doc comment above the function to note: `SameSite=Lax so the cookie is sent on the post-IdP redirect top-level navigation; safe because no GET endpoint mutates state.`
+
+- [ ] **Step 2: Add establishSession**
+
+Add to `internal/server/auth_handler.go` (near `sessionCookie`):
+
+```go
+// establishSession sets the session cookie to the given token value. It is the
+// single seam that seats a web session (OIDC flow uses it). MUST reuse
+// sessionCookie()'s exact name and Path so a callback's Set-Cookie
+// deterministically overwrites any pre-existing session cookie and logout's
+// clear always deletes it.
+func establishSession(w http.ResponseWriter, r *http.Request, token string) {
+	http.SetCookie(w, sessionCookie(token, r))
+}
+```
+
+- [ ] **Step 3: Change RegisterAuthHandlers signature + revoke on logout**
+
+Replace the `RegisterAuthHandlers` signature and the logout registration. New signature adds a `webAuth storage.WebAuthStore` (may be nil):
+
+```go
+// RegisterAuthHandlers registers login, logout, and whoami endpoints.
+// authMW is applied to protected routes (whoami). It must not be nil.
+// resolver validates credentials at login. webAuth (may be nil) is used to
+// revoke the server session on logout.
+func RegisterAuthHandlers(mux *http.ServeMux, resolver auth.Resolver, webAuth storage.WebAuthStore, authMW func(http.Handler) http.Handler) {
+	if authMW == nil {
+		panic("RegisterAuthHandlers: authMW must not be nil")
+	}
+
+	mux.HandleFunc("/api/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		handleLogin(w, r, resolver)
+	})
+
+	mux.HandleFunc("/api/auth/logout", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		handleLogout(w, r, webAuth)
+	})
+
+	mux.Handle("/api/auth/whoami", authMW(cookieToAuthHeader(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		handleWhoami(w, r)
+	}))))
+}
+```
+
+Replace `handleLogout` (lines ~83-89) with a version that revokes a `spgr_ws_` session:
+
+```go
+// handleLogout revokes the server session (if the cookie holds a spgr_ws_
+// token) and clears the session cookie. A legacy API-key cookie value is
+// never hashed/looked-up.
+func handleLogout(w http.ResponseWriter, r *http.Request, webAuth storage.WebAuthStore) {
+	if c, err := r.Cookie(sessionCookieName); err == nil && webAuth != nil &&
+		strings.HasPrefix(c.Value, "spgr_ws_") {
+		sum := sha256.Sum256([]byte(c.Value))
+		if revErr := webAuth.RevokeSession(r.Context(), sum[:]); revErr != nil {
+			slog.LogAttrs(r.Context(), slog.LevelWarn, "logout: revoke session", slog.Any("error", revErr))
+		}
+	}
+	c := sessionCookie("", r) //nolint:gosec // G124: sessionCookie sets HttpOnly/SameSite/dynamic Secure
+	c.MaxAge = -1
+	http.SetCookie(w, c)
+	w.WriteHeader(http.StatusNoContent)
+}
+```
+
+Add imports to `auth_handler.go`: `"crypto/sha256"`, `"log/slog"`, and `"github.com/specgraph/specgraph/internal/storage"`. (`strings` is already imported.)
+
+- [ ] **Step 4: Update the existing RegisterAuthHandlers test caller**
+
+In `internal/server/auth_handler_test.go`, find the `RegisterAuthHandlers(...)` call (the explore report noted one at `auth_handler_test.go:48`) and add a `nil` webAuth argument:
+
+```go
+RegisterAuthHandlers(mux, resolver, nil, auth.RequireAuth(resolver))
+```
+
+Add a logout-revocation test:
+
+```go
+func TestLogout_RevokesSession(t *testing.T) {
+	revoked := false
+	wa := &logoutFakeWA{onRevoke: func() { revoked = true }}
+	mux := http.NewServeMux()
+	// resolver can be a stub that returns ErrUnauthenticated; logout doesn't resolve.
+	RegisterAuthHandlers(mux, stubResolver{}, wa, func(h http.Handler) http.Handler { return h })
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: "specgraph_session", Value: "spgr_ws_abc"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent { t.Fatalf("want 204, got %d", rec.Code) }
+	if !revoked { t.Fatal("expected RevokeSession to be called") }
+}
+```
+
+Define a minimal `logoutFakeWA` (implement the `WebAuthStore` methods; only `RevokeSession` matters — others can return zero values) and a `stubResolver`. (If a resolver stub already exists in this test file, reuse it.)
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./internal/server/ -run 'TestLogout|TestStart_|TestCallback_' -v`
+Expected: PASS (this also makes Task 12's tests compile + pass now that `establishSession` exists).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/server/auth_handler.go internal/server/auth_handler_test.go
+git commit -s -m "feat(server): SameSite=Lax session cookie, establishSession, logout session revocation"
+```
+
+---
+
+### Task 14: Wire everything in serve.go (build providers, register handlers, sweeper)
+
+**Files:**
+
+- Modify: `cmd/specgraph/serve.go`
+- Modify: `internal/server/sweeper.go` (add web-auth sweeper)
+
+- [ ] **Step 1: Add the web-auth sweeper**
+
+In `internal/server/sweeper.go`, add:
+
+```go
+// WebAuthSweeper releases expired web sessions and login flows.
+type WebAuthSweeper interface {
+	DeleteExpiredSessions(ctx context.Context) (int64, error)
+	DeleteExpiredLoginFlows(ctx context.Context) (int64, error)
+}
+
+// StartWebAuthSweeper launches a goroutine that periodically GCs expired web
+// sessions and OIDC login flows. Stops when ctx is cancelled.
+func StartWebAuthSweeper(ctx context.Context, store WebAuthSweeper, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if n, err := store.DeleteExpiredSessions(ctx); err != nil {
+					slog.LogAttrs(ctx, slog.LevelError, "sweep expired sessions", slog.Any("error", err))
+				} else if n > 0 {
+					slog.LogAttrs(ctx, slog.LevelDebug, "swept expired sessions", slog.Int64("count", n))
+				}
+				if n, err := store.DeleteExpiredLoginFlows(ctx); err != nil {
+					slog.LogAttrs(ctx, slog.LevelError, "sweep expired login flows", slog.Any("error", err))
+				} else if n > 0 {
+					slog.LogAttrs(ctx, slog.LevelDebug, "swept expired login flows", slog.Int64("count", n))
+				}
+			}
+		}
+	}()
+}
+```
+
+- [ ] **Step 2: Build login providers in buildAppDeps (fatal on error)**
+
+In `cmd/specgraph/serve.go`, add a field to `appDeps`:
+
+```go
+	loginProviders []auth.LoginProvider
+```
+
+In `buildAppDeps`, after the existing verifier loop (after line ~87), add:
+
+```go
+	loginProviders, lpErr := auth.BuildLoginProviders(ctx, cfg.Auth.OIDC.Providers, cfg.Auth.OIDC.BaseURL)
+	if lpErr != nil {
+		return appDeps{}, fmt.Errorf("OIDC login providers: %w", lpErr)
+	}
+```
+
+Add `loginProviders: loginProviders,` to the returned `appDeps{...}` literal.
+
+- [ ] **Step 3: Wire WebAuthStore into the resolver**
+
+In `buildAppHandler`, in the `auth.NewIdentityStore(auth.IdentityStoreConfig{...})` literal (lines ~155-165), add:
+
+```go
+		WebAuth:                 res.authStore,
+```
+
+(`res.authStore` is `*postgres.AuthStore`, which now implements `storage.WebAuthStore`.)
+
+- [ ] **Step 4: Register the OIDC handlers + update RegisterAuthHandlers call**
+
+In `buildAppHandler`, replace the existing `server.RegisterAuthHandlers(...)` line (line ~206) with:
+
+```go
+	server.RegisterAuthHandlers(mux, resolver, res.authStore, auth.RequireAuth(resolver))
+	server.RegisterOIDCLoginHandlers(mux, server.OIDCLoginConfig{
+		Providers:  deps.loginProviders,
+		Resolver:   resolver,
+		WebAuth:    res.authStore,
+		BaseURL:    cfg.Auth.OIDC.BaseURL,
+		SessionTTL: cfg.Auth.OIDC.SessionTTL,
+		FlowTTL:    5 * time.Minute,
+		Limiter:    server.NewIPRateLimiterForOIDC(cfg.Server.TrustedProxy),
+	})
+```
+
+Add an exported constructor to `internal/server/ratelimit.go` so serve.go doesn't reach into unexported internals:
+
+```go
+// NewIPRateLimiterForOIDC returns the rate limiter used for the public OIDC
+// start/callback endpoints: 10 requests/min, burst 20, per client IP.
+func NewIPRateLimiterForOIDC(trustedProxy bool) *ipRateLimiter {
+	return newIPRateLimiter(10.0/60.0, 20, trustedProxy)
+}
+```
+
+- [ ] **Step 5: Start the web-auth sweeper alongside the claim sweeper**
+
+In `serve.go` `activate`, find the existing `server.StartSweeper(sweeperCtx, r.store, 60*time.Second)` call (line ~446) and add immediately after it:
+
+```go
+		server.StartWebAuthSweeper(sweeperCtx, r.authStore, 60*time.Second)
+```
+
+- [ ] **Step 6: Build and run the full suite**
+
+Run: `go build ./...`
+Expected: success.
+
+Run: `go test ./internal/server/ ./internal/auth/ ./internal/config/ -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/specgraph/serve.go internal/server/sweeper.go internal/server/ratelimit.go
+git commit -s -m "feat(server): wire interactive OIDC login providers, handlers, and session sweeper"
+```
+
+---
+
+### Task 15: Frontend — provider buttons + auth_error surfacing
+
+**Files:**
+
+- Create: `web/src/lib/oidc.svelte.ts`
+- Modify: `web/src/lib/components/LoginModal.svelte`
+- Modify: `web/src/routes/+layout.svelte`
+- Modify: `web/package.json` (add vitest for the pure-logic test)
+- Create: `web/src/lib/oidc.test.ts`
+
+- [ ] **Step 1: Create the OIDC client module**
+
+Create `web/src/lib/oidc.svelte.ts`:
+
+```ts
+export interface OidcProvider {
+  id: string;
+  displayName: string;
+}
+
+// fetchProviders returns the configured interactive OIDC providers (empty on
+// error or when none are configured).
+export async function fetchProviders(): Promise<OidcProvider[]> {
+  try {
+    const resp = await fetch('/api/auth/oidc/providers');
+    if (!resp.ok) return [];
+    const data = await resp.json();
+    return (data.providers ?? []).map((p: { id: string; display_name: string }) => ({
+      id: p.id,
+      displayName: p.display_name,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+// authErrorMessage maps a backend auth_error reason token to a friendly message.
+export function authErrorMessage(reason: string | null): string {
+  switch (reason) {
+    case 'denied': return 'Sign-in was cancelled or denied by the provider.';
+    case 'unauthorized': return 'Your account is not permitted to sign in. Contact an administrator.';
+    case 'expired': return 'The sign-in attempt expired. Please try again.';
+    case 'state': return 'The sign-in could not be verified. Please try again.';
+    case 'exchange': return 'Sign-in failed during authentication. Please try again.';
+    case 'temporary': return 'The server is temporarily unavailable. Please try again shortly.';
+    default: return 'Sign-in failed. Please try again.';
+  }
+}
+```
+
+- [ ] **Step 2: Add a vitest unit test for the pure logic**
+
+Add vitest to `web/package.json` devDependencies and a `test` script:
+
+```json
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest run"
+  },
+```
+
+Add to `devDependencies`: `"vitest": "^3.0.0"`. Then create `web/src/lib/oidc.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { authErrorMessage } from './oidc.svelte';
+
+describe('authErrorMessage', () => {
+  it('maps known reasons', () => {
+    expect(authErrorMessage('denied')).toContain('cancelled');
+    expect(authErrorMessage('unauthorized')).toContain('not permitted');
+    expect(authErrorMessage('temporary')).toContain('temporarily');
+  });
+  it('falls back for unknown reasons', () => {
+    expect(authErrorMessage('weird')).toBe('Sign-in failed. Please try again.');
+    expect(authErrorMessage(null)).toBe('Sign-in failed. Please try again.');
+  });
+});
+```
+
+- [ ] **Step 3: Run the frontend test**
+
+Run (in `web/`): `pnpm install && pnpm test`
+Expected: PASS (2 tests).
+
+- [ ] **Step 4: Add provider buttons to LoginModal**
+
+Edit `web/src/lib/components/LoginModal.svelte`. Replace the `<script>` block and the markup above the API-key input. New `<script>`:
+
+```svelte
+<script lang="ts">
+  import { login } from '$lib/auth.svelte';
+  import { fetchProviders, authErrorMessage, type OidcProvider } from '$lib/oidc.svelte';
+  import { onMount } from 'svelte';
+
+  let key = $state('');
+  let error = $state('');
+  let loading = $state(false);
+  let providers = $state<OidcProvider[]>([]);
+
+  let { onSuccess, authError = null } = $props<{ onSuccess: () => Promise<void>; authError?: string | null }>();
+
+  onMount(async () => {
+    providers = await fetchProviders();
+    if (authError) error = authErrorMessage(authError);
+  });
+
+  async function handleSubmit(e: Event) {
+    e.preventDefault();
+    error = '';
+    loading = true;
+    try {
+      const ok = await login(key);
+      if (ok) {
+        await onSuccess();
+      } else {
+        error = 'Invalid API key. Check your key and try again.';
+        key = '';
+      }
+    } catch {
+      error = 'Connection error. Please try again.';
+    } finally {
+      loading = false;
+    }
+  }
+</script>
+```
+
+In the markup, insert provider buttons and a divider above the `<p>Enter your API key...</p>` line, inside `<form class="login-card">` after `<h2>SpecGraph</h2>`:
+
+```svelte
+    {#if providers.length > 0}
+      <div class="providers">
+        {#each providers as p}
+          <a class="oidc-btn" href={`/api/auth/oidc/${p.id}/start`}>Sign in with {p.displayName}</a>
+        {/each}
+      </div>
+      <div class="divider"><span>or</span></div>
+    {/if}
+```
+
+Add styles inside the `<style>` block:
+
+```svelte
+  .providers { display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 0.75rem; }
+  .oidc-btn {
+    display: block; text-align: center; text-decoration: none;
+    padding: 0.5rem; border: 1px solid #1a1a2e; border-radius: 4px;
+    color: #1a1a2e; font-size: 0.9rem;
+  }
+  .oidc-btn:hover { background: #f1f5f9; }
+  .divider { display: flex; align-items: center; text-align: center; color: #94a3b8; font-size: 0.8rem; margin: 0.25rem 0 0.75rem; }
+  .divider::before, .divider::after { content: ''; flex: 1; border-bottom: 1px solid #e2e8f0; }
+  .divider span { padding: 0 0.5rem; }
+```
+
+- [ ] **Step 5: Surface auth_error in +layout.svelte**
+
+Edit `web/src/routes/+layout.svelte`. In the `<script>` block, after the `let ready` line, add:
+
+```js
+  let authError = $state(null);
+```
+
+In `onMount`, after `await checkAuth();`, add (read + strip the query param):
+
+```js
+    const params = new URLSearchParams(window.location.search);
+    const ae = params.get('auth_error');
+    if (ae) {
+      authError = ae;
+      params.delete('auth_error');
+      const qs = params.toString();
+      history.replaceState({}, '', window.location.pathname + (qs ? '?' + qs : ''));
+    }
+```
+
+Pass it to the modal — change:
+
+```svelte
+  <LoginModal onSuccess={handleLoginSuccess} />
+```
+
+to:
+
+```svelte
+  <LoginModal onSuccess={handleLoginSuccess} {authError} />
+```
+
+- [ ] **Step 6: Build the web bundle**
+
+Run (in `web/`): `pnpm build`
+Expected: build succeeds, output in `web/build/`.
+
+- [ ] **Step 7: Manual smoke (documented, not automated)**
+
+With a configured interactive provider and `task build && ./specgraph serve`, open the dashboard: the modal shows a "Sign in with <provider>" button above the API-key field; visiting `/?auth_error=denied` shows the friendly message and strips the param. Record the result in the PR description.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/lib/oidc.svelte.ts web/src/lib/oidc.test.ts web/src/lib/components/LoginModal.svelte web/src/routes/+layout.svelte web/package.json web/pnpm-lock.yaml
+git commit -s -m "feat(web): OIDC provider buttons and auth_error surfacing in login modal"
+```
+
+---
+
+### Task 16: Documentation — operator guide + architecture update
+
+**Files:**
+
+- Create: `site/docs/guides/oidc-login.md`
+- Modify: `site/docs/architecture.md`
+
+- [ ] **Step 1: Write the guide**
+
+Create `site/docs/guides/oidc-login.md` covering, with copy-pasteable YAML:
+
+- **Overview:** interactive login mints a server-side session (`auth.oidc.session_ttl`); the session cookie is opaque; multi-replica safe (no sticky sessions needed because handshake state is server-side).
+- **Common config:** redirect URI `https://<host>/api/auth/oidc/callback`; `auth.oidc.base_url` is **required behind any proxy that rewrites Host**; set `server.trusted_proxy: true` when behind a trusted load balancer so the per-IP rate limit keys on the real client IP; secret via `client_secret_env` (never commit plaintext).
+- **Entra ID:** tenant-specific issuer `https://login.microsoftonline.com/<tenant>/v2.0` (NOT `common`/`organizations` — the resolver routes by exact `iss`); app registration must emit the `groups` claim for `groups`→role mapping; beware groups overage. Full provider block with `interactive: true`, `client_secret_env`, `claims_mapping`.
+- **Okta:** issuer `https://<org>.okta.com/oauth2/default`; OIDC "Web" app; `groups` claim mapping.
+- **GitHub via OIDC broker:** explicit callout that GitHub-direct is not OIDC (opaque token, no `id_token`); federate through a broker (Entra External ID / Auth0 / Keycloak / Dex) and point `issuer` at the broker. Note native GitHub is a deferred follow-up.
+- **Security notes:** interactive logins bypass the JIT rate limiter, so configure `auth.oidc.jit_create.email_domain_allowlist` for internet-facing deployments; logout revokes the server session but not the IdP SSO session.
+
+Use the verbatim Entra block from the design spec (`docs/superpowers/specs/2026-06-12-oidc-interactive-ui-login-design.md` §1) as the canonical example.
+
+- [ ] **Step 2: Update architecture.md**
+
+In `site/docs/architecture.md`, find the Authentication section (~lines 176-192, currently describes OIDC as token-only) and add a paragraph describing the interactive browser login flow + server-side session, with a link to `guides/oidc-login.md`.
+
+- [ ] **Step 3: Lint the docs**
+
+Run: `task lint` (runs markdown lint among others)
+Expected: PASS (fix any rumdl/markdownlint issues in the new file).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add site/docs/guides/oidc-login.md site/docs/architecture.md
+git commit -s -m "docs: add interactive OIDC login guide and update architecture"
+```
+
+---
+
+### Task 17: File the deferred follow-up + final verification
+
+**Files:** none (issue tracker + full gate)
+
+- [ ] **Step 1: File the native-GitHub follow-up issue**
+
+Create a beads issue (per AGENTS.md, use `bd`) for "native generic OAuth2 + userinfo provider (GitHub-direct)": a new `kind: oauth2` LoginProvider doing authorize + token + `GET userinfo`, building Identity from userinfo, pairing with the server session. Reference this plan and the design spec.
+
+```bash
+bd create "Native generic OAuth2 + userinfo login provider (GitHub-direct)" --type feature
+```
+
+- [ ] **Step 2: Run the full quality gate**
+
+Run: `task check`
+Expected: fmt → license → lint → build → unit tests all PASS.
+
+- [ ] **Step 3: Run integration tests (Docker)**
+
+Run: `go test -tags integration ./internal/storage/postgres/ -run TestWebAuth -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit any fixups, then push per the session-completion protocol**
+
+```bash
+git add -A
+git commit -s -m "chore: oidc interactive login fixups" # only if needed
+```
+
+---
+
+## Self-review checklist (completed by plan author)
+
+- **Spec coverage:** config fields (T1) ✓; nonce verify B3 (T2); errors+domain (T3); WebAuthStore iface (T4); migration (T5); store impl (T6) + integration (T7); interactive ctx marker MA-2 (T8); resolveSession + dispatch + JIT bypass B4/MA-3 (T9); login providers + secret resolution B1/B2/M2 + RedirectURI (T10); per-IP rate limit MAJOR-1 (T11); providers/start/callback + tx cookie + provider-removed MINOR-2 + tx-cookie clear MINOR-4 (T12); SameSite=Lax M3 + establishSession MINOR-5 + logout revoke M6 + signature MINOR-2 (T13); serve wiring + sweeper MI-1 (T14); frontend buttons + auth_error (T15); docs incl. Entra `common`/groups/proxy MINOR-1/M-a/M-b/M-d (T16); follow-up + gates (T17). ✓
+- **Type consistency:** `LoginProvider` (exported) used consistently T10/T12/T14; `storage.WebAuthStore` T4/T6/T9/T13/T14; `establishSession` defined T13, used T12; `OIDCLoginConfig`/`RegisterOIDCLoginHandlers` T12/T14; `NewIPRateLimiterForOIDC` T11/T14; `auth.RedirectURI` T10/T12. ✓
+- **Cross-task dependency flagged:** T12's handler tests need `establishSession` from T13 — noted in T12 Step 2/3 and T13 Step 5.
+- **Placeholder scan:** the only intentionally-abstract step is T9 Step 6's `TestJITResolve_InteractiveBypassesLimiter` body and T16's prose-described doc content; both reference the concrete existing scaffolding/spec to fill from. No TBD/TODO in code steps.
+
+## Execution handoff
+
+See the offer in the chat after this plan.

--- a/docs/superpowers/specs/2026-06-12-oidc-interactive-ui-login-design.md
+++ b/docs/superpowers/specs/2026-06-12-oidc-interactive-ui-login-design.md
@@ -1,0 +1,668 @@
+# Interactive OIDC login for the web UI
+
+**Date:** 2026-06-12
+**Status:** Design revised after two adversarial-review rounds, pending spec review
+
+## Problem
+
+SpecGraph's server already **verifies** OIDC ID tokens. The verifier
+(`internal/auth/oidc_verifier.go`) discovers a provider via
+`.well-known/openid-configuration`, validates a presented JWT's
+signature/audience/expiry, and the identity resolver
+(`internal/auth/identitystore.go`) routes JWT-shaped tokens through it, with
+just-in-time (JIT) user provisioning. Per-provider config lives under
+`auth.oidc.providers` (`internal/config/global.go:237`).
+
+But there is **no interactive login flow**. The web dashboard
+(`web/`, a SvelteKit app embedded into the binary) authenticates **only via
+API key**: `LoginModal.svelte` shows an "Enter your API key" box, posts it to
+`POST /api/auth/login` (`internal/server/auth_handler.go:52`), which resolves
+the value and stores it in an HttpOnly `specgraph_session` cookie that the auth
+middleware re-resolves per request (`cookieToAuthHeader`, `auth_handler.go:105`).
+
+To use OIDC today, a user must obtain a JWT out-of-band and either present it as
+a bearer token (CLI/API) or paste it into the modal's key field. There is no
+"Sign in with &lt;provider&gt;" button, no authorize redirect, and no callback.
+
+We want the dashboard to offer a real **"Sign in with &lt;provider&gt;"** button
+that runs the standard OAuth2 Authorization Code flow and lands the user
+authenticated.
+
+## Review history (what changed and why)
+
+**Round 1** found the original "store the IdP ID token in the cookie" approach
+breaks for the design's own headline case: Entra ID tokens **with a `groups`
+claim** routinely exceed the ~4 KB cookie limit (silently dropped → login loop).
+It also caught a non-existent `${env:}` secret mechanism, a backward-compat
+regression, a silently-skipped nonce check, and a JIT-disabled login loop. The
+fix pulled the **server-side session** forward.
+
+**Round 2** verified those fixes are sound but caught: a self-contradictory
+"non-fatal discovery" claim (unbuildable against the immutable verifier map), an
+**ephemeral tx-cookie key that breaks multi-replica login**, **interactive login
+silently consuming the JIT rate-limit budget**, and an unspecified
+transient-vs-unauthenticated path in session resolution that would log users out
+on a DB blip. This revision resolves all of them (see "Resolved review
+findings").
+
+## Goals
+
+- A **"Sign in with &lt;provider&gt;"** button per configured interactive
+  provider, alongside the existing API-key field.
+- A server-side **Authorization Code flow with PKCE** that, on success, issues a
+  **SpecGraph-issued opaque server-side session** (small id in the cookie;
+  session row in storage), decoupled from IdP token lifetime.
+- **Entra ID** and **Okta** native; **GitHub** documented via an OIDC broker
+  (not OIDC for sign-in — see below), native generic-OAuth2 deferred.
+- Existing **token-only OIDC** configs keep working unchanged, no secret
+  required.
+- Multi-replica / rolling-deploy safe.
+
+## Non-goals
+
+- No silent refresh of IdP tokens (server session has its own TTL; re-login on
+  expiry; no IdP refresh tokens stored).
+- No native GitHub-direct login now (deferred follow-up).
+- No CLI browser-login flow. Web UI only.
+- No change to JIT policy semantics, claim mapping, the role model, or the
+  bearer-token verification path (other than the interactive-login limiter
+  bypass, §6).
+
+## Why GitHub is not native OIDC
+
+Confirmed against GitHub's OAuth docs: GitHub's web flow issues an **opaque
+access token** (`gho_...`) and **no `id_token`**; there is no user-facing
+`.well-known/openid-configuration`. Identity comes from
+`GET https://api.github.com/user`. Our flow verifies an ID token, so GitHub
+needs a separate OAuth2+userinfo path (the deferred follow-up). The supported
+path **today** is to federate GitHub through an OIDC broker (Entra External ID,
+Auth0, Okta, Keycloak, Dex) and point SpecGraph at the broker's issuer.
+
+## Behavior contract
+
+| Scenario | Outcome |
+|----------|---------|
+| No interactive providers configured | Modal shows API-key field only (today's behavior, unchanged). |
+| 1+ interactive providers configured | Button per provider **above** the API-key field. |
+| Click "Sign in with X" | Full-page nav to `/api/auth/oidc/{id}/start` → 302 to IdP authorize. |
+| IdP success, identity resolves | callback exchanges code, verifies ID token (+nonce), resolves identity, mints a server session, sets the session cookie, 302 to `/`. |
+| IdP success but identity unauthorized (JIT off / not allowlisted) | 302 to `/?auth_error=unauthorized` — **no cookie seated**. |
+| Backend/DB error during resolve or mint | 302 to `/?auth_error=temporary`. |
+| Server session later expires / revoked | Next request 401 → modal; user re-clicks the button. |
+| Session lookup hits a DB outage | Request gets **503** (ErrTransient), not 401 — user stays logged in. |
+| IdP returns `error` / user cancels | 302 to `/?auth_error=denied`. |
+| flow-state mismatch / tx cookie missing/expired | 302 to `/?auth_error=state` / `=expired`. |
+| token exchange / verification fails | 302 to `/?auth_error=exchange`. |
+| Provider removed from config between `start` and `callback` | 302 to `/?auth_error=exchange` (logged). |
+| `start`/`callback` per-IP rate limit exceeded | **429** with `Retry-After`. |
+| Unknown `{provider}` in path (at `start`) | 404. |
+| Provider misconfigured (bad kind / interactive without secret / bad audience) | **Fatal at startup**. |
+| Provider discovery (IdP) unreachable at startup | **Fatal at startup** (see "Startup behavior"). |
+
+## Architecture
+
+A server-side OAuth2 Authorization Code + PKCE flow added as HTTP endpoints in
+`internal/server/`, login-provider construction at startup, a new
+**web-auth store** (sessions + login-flow state) in the storage layer, a new
+**session resolution path** in the resolver, and small frontend additions. The
+cookies hold only opaque ids; all sensitive/bulky data lives server-side.
+
+### 1. Provider config: interactive opt-in + secret resolution (fixes B1, B2, M2)
+
+`OIDCProviderConfig` (`internal/config/global.go:237`) gains:
+
+```yaml
+auth:
+  oidc:
+    base_url: "https://specgraph.example.com"   # NEW (optional); see redirect URI
+    session_ttl: 12h                              # NEW (optional); default 12h
+    providers:
+      - id: entra
+        kind: oidc                 # NEW; only "oidc" now (default "oidc")
+        interactive: true          # NEW; opt-in to the login flow
+        display_name: "Microsoft Entra"   # NEW; button label, defaults to id
+        issuer: https://login.microsoftonline.com/<tenant>/v2.0
+        client_id: <app-id>
+        client_secret_env: SPECGRAPH_OIDC_ENTRA_SECRET  # NEW; preferred
+        client_secret: ""          # NEW; plaintext fallback (dev only), discouraged
+        # audience omitted -> defaults to client_id (required for interactive)
+        scopes: [openid, profile, email]   # NEW; default [openid, email, profile]
+        claims_mapping:
+          - { claim: groups, value: <group-oid>, role: admin }
+```
+
+- **`interactive`** (default `false`) is the opt-in. Only interactive providers
+  require a secret, get an `oauth2.Config`, are built into the login-provider
+  set, and render a button. `interactive: false` providers behave exactly as
+  today: a bearer-JWT verifier, **no secret required** (fixes the B2 regression).
+- **Secret resolution (fixes B1):** `auth.oidc.providers` is a slice, so the
+  `SPECGRAPH_*` env mapper cannot reach a per-provider field
+  (`global.go:411,429-435`), and there is no `${env:...}` interpolation in the
+  loader. We add **`client_secret_env`**: the name of an env var read at
+  **provider-build time** in `serve.go` (no koanf changes). `client_secret`
+  (plaintext) remains a dev-only fallback. An interactive provider MUST resolve a
+  non-empty secret from exactly one of the two; an unset named var is a **fatal**
+  startup error. Secret never logged. (Verified no code dumps the full config;
+  `writeGlobal` only persists `globalDefaults()`, never a loaded secret —
+  `global.go:329,438`.)
+- **`kind`** defaults to `oidc`; unknown → fatal. Reserves space for a future
+  `oauth2` kind (Seam below).
+- **`audience` (M2):** for interactive providers, validate at startup that
+  `audience` is empty or equals `client_id` (an interactive `id_token` always has
+  `aud=client_id`). Custom-audience bearer flows use a separate non-interactive
+  entry. Documented.
+- **`scopes`** default `[openid, email, profile]`; `openid` forced.
+- **`session_ttl`** default 12h; absolute server-session lifetime.
+- Additive and backward compatible; the deprecated `auth.oidc_providers`
+  migration (`applyPostLoad`, `global.go:285`) is untouched.
+
+### 2. Login-provider abstraction (seam for future native GitHub)
+
+```go
+type loginProvider interface {
+    ID() string
+    DisplayName() string
+    AuthCodeURL(state, nonce, codeChallenge, redirectURI string) string
+    Exchange(ctx context.Context, code, codeVerifier, nonce, redirectURI string) (idToken string, err error)
+}
+```
+
+- The **`oidc`** impl wraps an `*oauth2.Config` (endpoints from go-oidc discovery
+  via `provider.Endpoint()`) and a verifier. `Exchange` does the confidential-
+  client token exchange (`client_secret` + PKCE `code_verifier`), pulls
+  `id_token` from the `*oauth2.Token` extra, verifies it **with nonce** (§3), and
+  returns the raw ID token for the callback to resolve (§7).
+- A future **`oauth2`** kind (userinfo-based, GitHub) implements the same
+  interface — **deferred follow-up.**
+- Built once at startup for interactive providers only.
+
+### 3. Nonce-checked verification (fixes B3)
+
+`OIDCVerifier.Verify` passes no `oidc.Nonce(...)` and `OIDCClaims` has no nonce
+field (`oidc_verifier.go:48,78`), so "wrapping it" would silently skip nonce.
+Add `OIDCVerifier.VerifyWithNonce(ctx, rawToken, expectedNonce)` (passes
+`oidc.Nonce(expectedNonce)` / constant-time compares `idToken.Nonce`) and add a
+`Nonce` field to `OIDCClaims`. The bearer path keeps the existing `Verify`
+(unchanged — we don't mint bearer tokens). Test: wrong/missing nonce fails.
+
+### 4. Web-auth store (sessions + login-flow state)
+
+One new goose migration
+`internal/storage/postgres/auth_migrations/002_web_auth.sql` with **two** tables.
+Both run under the dedicated `goose_db_version_auth` table (`auth.go:106`),
+isolated from project migrations; `gen_random_uuid()`/pgcrypto already enabled
+(`001_initial.sql:6`).
+
+```sql
+-- +goose Up
+CREATE TABLE web_sessions (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    token_hash    bytea NOT NULL UNIQUE,         -- SHA-256 of the opaque session token
+    user_id       uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    issuer        text NOT NULL DEFAULT '',      -- audit / future RP-logout
+    oidc_subject  text NOT NULL DEFAULT '',      -- audit
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    expires_at    timestamptz NOT NULL,
+    revoked_at    timestamptz
+);
+CREATE INDEX web_sessions_user   ON web_sessions(user_id);
+CREATE INDEX web_sessions_expiry ON web_sessions(expires_at) WHERE revoked_at IS NULL;
+
+CREATE TABLE oidc_login_flows (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),  -- the opaque flow id (in the tx cookie)
+    state         text NOT NULL,                -- CSRF token, constant-time compared
+    nonce         text NOT NULL,
+    code_verifier text NOT NULL,                -- PKCE
+    provider_id   text NOT NULL,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    expires_at    timestamptz NOT NULL          -- now + ~5m (short TTL bounds table growth)
+);
+CREATE INDEX oidc_login_flows_expiry ON oidc_login_flows(expires_at);
+
+-- +goose Down
+DROP INDEX IF EXISTS oidc_login_flows_expiry;
+DROP TABLE IF EXISTS oidc_login_flows;
+DROP INDEX IF EXISTS web_sessions_expiry;
+DROP INDEX IF EXISTS web_sessions_user;
+DROP TABLE IF EXISTS web_sessions;
+```
+
+New `storage.WebAuthStore` interface (separate from `UsersBackend`, so existing
+`UsersBackend` fakes/stubs are unaffected), implemented by `*postgres.AuthStore`
+(which already owns the identity tables, `connector.go`):
+
+```go
+type WebAuthStore interface {
+    // sessions
+    CreateSession(ctx, *Session) (*Session, error)
+    LookupSessionByHash(ctx, tokenHash []byte) (*Session, error) // ErrSessionNotFound on miss
+    RevokeSession(ctx, tokenHash []byte) error                   // idempotent
+    DeleteExpiredSessions(ctx) (int64, error)
+    // login-flow state (server-side; survives multi-replica — fixes MA-1)
+    CreateLoginFlow(ctx, *LoginFlow) (flowID string, err error)
+    ConsumeLoginFlow(ctx, flowID string) (*LoginFlow, error)     // atomic read+delete; ErrLoginFlowNotFound on miss/expired
+    DeleteExpiredLoginFlows(ctx) (int64, error)
+}
+```
+
+- Session token: **32 random bytes**, shown to the browser as
+  `spgr_ws_<base64url>`; only its **SHA-256 hash** is stored (high-entropy →
+  SHA-256 sufficient; argon2 is only for low-entropy pasteable secrets like API
+  keys). Lookup by hash. There is **no `last_used_at`** column and no idle
+  timeout — absolute `session_ttl` only — so resolution stays read-only (no
+  per-request write).
+- `ConsumeLoginFlow` is a single `DELETE ... RETURNING` (atomic, single-use),
+  rejecting expired rows.
+- **Plaintext-at-rest (deliberate, MINOR-3):** unlike `web_sessions` (which
+  stores only a SHA-256 hash), `oidc_login_flows` stores `state`/`nonce`/
+  `code_verifier` in cleartext. This is safe: a DB-read attacker still cannot
+  complete a hijacked handshake without the authorization `code`, which the IdP
+  delivers only to the victim's browser and which never touches the DB. Rows are
+  short-lived (~5m) and single-use.
+- A periodic sweeper (see §7 wiring) GCs both expired sessions and flows on a
+  tight interval (e.g. 1m), bounding `oidc_login_flows` together with the per-IP
+  rate limit on `start` (§7) and the short TTL.
+
+### 5. Resolver: session resolution path (fixes B4 cleanly + MA-3)
+
+Add a branch to `pgIdentityStore.Resolve` (`identitystore.go:150`):
+
+```text
+if isJWTShaped(token)                     -> resolveJWT      (bearer / OIDC JWT, unchanged)
+if strings.HasPrefix(token, "spgr_ws_")   -> resolveSession  (NEW)
+else                                       -> resolveAPIKey   (unchanged)
+```
+
+A `spgr_ws_<base64url>` token has zero dots (base64url contains no `.`), so it is
+never JWT-shaped (`isJWTShaped`, `identitystore.go:171`); the new prefix branch
+must precede the api-key fallback (a `spgr_ws_` token fails `parseAPIKey`).
+
+`resolveSession` mirrors `resolveAPIKey`'s error discipline (**MA-3**):
+SHA-256 the token, `LookupSessionByHash`, then:
+
+- `ErrSessionNotFound` / `revoked_at != nil` / `expires_at <= now` / soft-deleted
+  user → **`ErrUnauthenticated`**;
+- **any other** lookup/`GetUserByID` error → **`fmt.Errorf("%w: %w",
+  ErrTransient, err)`** (so a Postgres outage yields 503, not a 401 that logs
+  everyone out).
+Returns an `Identity{Source:"oidc", Subject:"oidc:"+OIDCSubject,
+EffectiveRole:user.Role}`.
+
+The resolver gains a `WebAuth storage.WebAuthStore` field on
+`IdentityStoreConfig`. **Nil-guard (MI-3):** if `WebAuth == nil`, a `spgr_ws_`
+token resolves to `ErrUnauthenticated` (never a nil panic), so existing
+resolver constructions/tests that don't wire it stay safe.
+
+Resolver construction ordering is fine: the resolver is built in
+`buildAppHandler`, which runs only **after** a live DB connection exists
+(degraded boot serves a blanket 503 until then), so `resolveSession` is never
+called without a store.
+
+### 6. Interactive login bypasses the JIT rate limiter (fixes MA-2)
+
+The callback resolves identity via `resolver.Resolve(idToken)` → `resolveJWT` →
+(on binding miss, JIT) `jitResolve`, which consumes a per-issuer rate-limit
+token (`identitystore.go:444`, default 100/hr) shared with the bearer path. That
+limiter exists to bound **unsolicited bearer-JWT** JIT; an interactive login is
+user-driven and already IdP+PKCE+nonce authenticated, so the abuse vector is
+weak and an onboarding burst shouldn't lock users out.
+
+The callback marks the context via a new `auth.WithInteractiveLogin(ctx)`;
+`jitResolve` checks it and **skips the rate-limit gate** for that path. The
+**email-domain allowlist and claims-mapping role derivation still apply** — only
+the rate counter is bypassed. Bearer-path JIT is unchanged. Test: an interactive
+JIT create does not decrement the issuer bucket; allowlist still rejects
+out-of-domain.
+
+**Residual risk (MINOR-1), documented:** bypassing the limiter removes the only
+backpressure on JIT user creation from the interactive path, so an actor
+controlling many valid IdP accounts in an allowed domain (or any account when no
+allowlist is set) could mass-create `users`/`web_sessions` rows. This is weaker
+than an anonymous flood — each create costs a full IdP auth + code + nonce
+round-trip and is fully attributable — and the mitigating control is the
+**email-domain allowlist**, which the guide recommends configuring for any
+internet-facing deployment that enables JIT. The marker is an unexported context
+key set **only** in the callback, so no bearer request can forge the bypass
+(both bearer entry points resolve on the unmarked request context —
+`interceptor.go`, `middleware.go`).
+
+### 7. New endpoints (`internal/server/auth_oidc_handler.go`)
+
+Registered with bare `mux.HandleFunc` (no `RequireAuth`) next to the existing
+auth handlers (`serve.go:206`). Go ServeMux pattern matching routes
+`/api/auth/oidc/...` ahead of the `/` SPA handler; `ProjectMiddleware` passes
+through (reads only `X-Specgraph-Project`). The handlers receive the
+`[]loginProvider`, the `resolver`, and the `WebAuthStore`.
+
+**Per-IP rate limit (fixes MAJOR-1).** `start` and `callback` are public and
+`start` performs an unauthenticated DB write (`CreateLoginFlow`); with no
+existing rate-limiting middleware in the server, this is a write-amplification /
+table-growth DoS vector. Both endpoints are wrapped in a per-client-IP
+token-bucket limiter (a `sync.Map` of `golang.org/x/time/rate.Limiter` keyed by
+IP — the same library the JIT limiter uses), e.g. ~10/min burst 20 per IP;
+over-limit → **429** with `Retry-After`. Client IP is taken from
+`X-Forwarded-For`/`X-Real-IP` **only when** a trusted-proxy setting is enabled
+(reusing the same proxy-trust posture as the `X-Forwarded-Proto` `Secure`
+decision), else `RemoteAddr`; the docs state that behind a proxy the trusted-
+header config is required or all clients share one bucket. This per-IP bound,
+plus the ~5m TTL and the 1m sweeper (§4), bounds `oidc_login_flows`.
+
+1. **`GET /api/auth/oidc/providers`** — public, **no DB access** (reads the
+   in-memory provider list). Returns
+   `{"providers":[{"id","display_name"}]}` for **interactive** providers; empty
+   when none.
+
+2. **`GET /api/auth/oidc/{provider}/start`** (per-IP rate limited)
+   - Look up interactive provider; unknown → 404.
+   - Generate `state` (32 random bytes, base64url), `nonce`, PKCE
+     `code_verifier` + `S256` `code_challenge`.
+   - `CreateLoginFlow{state,nonce,code_verifier,provider_id, expires_at:+5m}` →
+     **opaque flow id**; set `specgraph_oidc_tx` cookie to that id (HttpOnly,
+     `SameSite=Lax`, `Secure` dynamic, `Path=/api/auth/oidc`, `Max-Age` ~300s).
+     No signing key needed — the cookie carries only an unguessable id; the
+     secret material lives server-side (**fixes MA-1; multi-replica safe**).
+   - 302 to `provider.AuthCodeURL(...)`.
+
+3. **`GET /api/auth/oidc/callback`** (per-IP rate limited)
+   - Read `specgraph_oidc_tx`; missing → `auth_error=expired`. Always emit a
+     `Max-Age=-1` delete for `specgraph_oidc_tx` (`Path=/api/auth/oidc`) on this
+     response, success or failure (MINOR-4 hygiene; the flow id is inert once
+     consumed).
+   - `ConsumeLoginFlow(flowID)` (atomic single-use); miss/expired →
+     `auth_error=expired`.
+   - IdP `error` param → `auth_error=denied`.
+   - Constant-time compare the IdP `state` against the flow's `state` → mismatch
+     `auth_error=state`.
+   - Resolve the provider from `flow.ProviderID`; **if it is no longer a
+     configured interactive provider** (config edited mid-flow, MINOR-2) →
+     `auth_error=exchange` (logged).
+   - `provider.Exchange(code, flow.CodeVerifier, flow.Nonce, redirectURI)` → raw
+     ID token; failure → `auth_error=exchange`.
+   - **Resolve identity (fixes B4):**
+     `resolver.Resolve(auth.WithInteractiveLogin(ctx), idToken)` → `resolveJWT`
+     (binding lookup or JIT at login time, limiter bypassed per §6). The nonce
+     was already checked in `Exchange`; `resolveJWT` re-verifies
+     signature/aud/expiry via the existing `Verify` — which requires the
+     interactive provider's issuer to be in the resolver verifier map, so
+     `serve.go` builds a verifier for **every** provider (interactive or not) and
+     passes them all to `NewIdentityStore`, exactly as today; `interactive` only
+     gates the additional `oauth2.Config`/login-provider build. On
+     `ErrUnauthenticated` → `auth_error=unauthorized` (no cookie). On
+     `ErrTransient` → `auth_error=temporary`.
+   - **Mint session:** `CreateSession` (user id, issuer, subject,
+     `expires_at = now + session_ttl`); `establishSession` sets
+     `specgraph_session` to the opaque `spgr_ws_...` token.
+   - 302 to `/`.
+   - All failure reasons are generic tokens; no internal text leaks; full errors
+     logged server-side with provider id.
+
+**Sweeper wiring (MI-1):** the existing `StartSweeper` is hardcoded to
+`ClaimSweeper.ReleaseExpiredClaims` (`sweeper.go:13`), so add a small parallel
+`StartWebAuthSweeper` (calling `DeleteExpiredSessions` + `DeleteExpiredLoginFlows`
+on an interval), started in `activate` after the connection is live and stopped
+on graceful shutdown.
+
+### 8. Cookies (fixes M1, M3, M4 via server-side state)
+
+- **`specgraph_session`** carries the small opaque `spgr_ws_...` id (4 KB issue
+  moot). Switch `sessionCookie()` (`auth_handler.go:135`) from `SameSiteStrict`
+  to **`SameSiteLax`** (M3): redirect-based login lands via a cross-site
+  top-level GET, and Lax is the standard CSRF-safe choice. **Invariant this
+  depends on (MI-8):** no GET endpoint mutates state — all state-changing calls
+  are POST/Connect-RPC (Connect-RPC is POST; `interceptor.go`), on which Lax
+  withholds the cookie cross-site. This relaxation applies to the legacy API-key
+  session cookie too, which is acceptable under the same invariant. Stated as an
+  explicit design constraint to preserve.
+- **Session-fixation / cookie-pinning invariant (MINOR-5):** `establishSession`
+  MUST reuse `sessionCookie()`'s exact name (`specgraph_session`) and `Path=/`,
+  so a callback's `Set-Cookie` deterministically overwrites any pre-existing
+  session cookie (stale API key or old session) and `handleLogout`'s clear
+  (also `Path=/`) always deletes it. A divergent name/path would leave a stale
+  cookie that "wins" — disallowed.
+- **`specgraph_oidc_tx`** carries only the opaque flow id (no secret, no HMAC
+  key); HttpOnly, `SameSite=Lax`, `Secure` dynamic, `Path=/api/auth/oidc`,
+  ~300s; explicitly deleted by the callback (§7).
+- **Concurrent logins (M5):** the fixed-name tx cookie means a second `start`
+  (another tab) overwrites the flow id; the first tab's callback then gets
+  `auth_error=expired` — an accepted, clearly-surfaced limitation (not silent).
+  Completed server sessions are independent.
+
+### 9. Logout (fixes M6; MI-2)
+
+`RegisterAuthHandlers`/`handleLogout` (`auth_handler.go:84`) gain access to the
+`WebAuthStore` (signature change, noted in Files touched). On logout: if the
+`specgraph_session` cookie value is `spgr_ws_`-prefixed, `RevokeSession` its hash
+(guarded so a legacy API-key cookie value is never hashed/looked-up); then clear
+the cookie. **v1 limitations (MI-6), documented:** re-login mints a new session
+and leaves prior rows valid until TTL/sweep; logout revokes only the current
+session (no "log out everywhere"); RP-initiated IdP logout
+(`end_session_endpoint`) is out of scope, so local logout leaves the IdP SSO
+session intact (shared-machine caveat).
+
+### 10. Frontend (`web/`)
+
+- `auth.svelte.ts`: `fetchProviders()` → `GET /api/auth/oidc/providers` on modal
+  mount.
+- `LoginModal.svelte`: a "Sign in with {display_name}" button per provider
+  **above** the API-key field (kept verbatim); buttons are full-page navigations
+  to `/api/auth/oidc/{id}/start` (not `fetch`). Empty list → today's modal.
+  (`SecurityHeaders` sets no CSP, so navigations/inline errors are unaffected.)
+- `+layout.svelte`: read `?auth_error=<reason>` on load, map to a friendly
+  message, show inline, strip via `history.replaceState`.
+
+## Startup behavior for IdP discovery (decision on M7 / BL-1)
+
+Login-provider/verifier construction (discovery) stays **fatal at startup**, as
+the existing verifier construction is today (`serve.go:79-83`). The round-1 idea
+of "non-fatal discovery with background retry" was **rejected**: it is
+unbuildable against the resolver's immutable, lock-free verifier map
+(`identitystore.go:38,91-100,357`), where a missing issuer returns
+`ErrUnauthenticated` (a hard 401), not a retryable `ErrTransient`
+(`identitystore.go:358`). The non-fatal-Postgres precedent does not transfer —
+Postgres has a reconnect seam; the verifier map has none. Making discovery
+resilient would require a concurrency-safe verifier registry with a
+"configured-but-initializing" state — a separate, larger change, explicitly
+**out of scope** here and recorded as a possible future follow-up. Deterministic
+config errors (unknown `kind`, interactive without a resolvable secret, bad
+`audience`) are likewise fatal.
+
+## Seam — native generic OAuth2 + userinfo (GitHub-direct), deferred
+
+The `kind` field + `loginProvider` interface reserve space for an `oauth2`
+implementation (authorize + token + `GET userinfo`, identity from userinfo).
+It pairs naturally with the server-side session. **Deferred to a follow-up.**
+
+## Security
+
+- **state**: 32 random bytes, single-use (atomic `ConsumeLoginFlow`),
+  constant-time compare.
+- **nonce**: sent in authorize, validated via `VerifyWithNonce` (§3).
+- **PKCE `S256`**: per-attempt `code_verifier`, defense-in-depth atop the
+  confidential-client secret.
+- **login-flow state** lives server-side; the tx cookie is just an unguessable
+  opaque id (no signing key; multi-replica safe).
+- **session cookie**: opaque id only, HttpOnly, `SameSite=Lax`, `Secure`
+  dynamic; server session is revocable and absolute-TTL-bounded.
+- **session token at rest**: SHA-256 hash only; raw token never logged.
+- **client secret**: from `client_secret_env` (preferred) or dev plaintext
+  fallback; never logged.
+- **open-redirect**: callback only 302s to fixed same-origin `/` or
+  `/?auth_error=...`.
+- **CSRF**: relies on `SameSite=Lax` + the "no GET mutates state" invariant (§8).
+- **unauthenticated-endpoint backpressure (MAJOR-1)**: per-IP rate limit on
+  `start`/`callback` + ~5m flow TTL + 1m sweeper bound the unauthenticated DB
+  write. `/providers` is in-memory (no DB).
+- **login-flow plaintext-at-rest**: deliberate (MINOR-3) — useless to a DB-read
+  attacker without the browser-delivered authorization `code`.
+
+## Example docs (grounded)
+
+New guide `site/docs/guides/oidc-login.md`, copy-pasteable real config:
+
+- **Entra ID** — app registration; redirect URI
+  `https://<host>/api/auth/oidc/callback`; issuer
+  `https://login.microsoftonline.com/<tenant>/v2.0` (discovery confirmed: scopes
+  `openid profile email offline_access`, RS256 id_token). **Use a tenant-specific
+  issuer**, not `common`/`organizations` — the resolver routes by exact `iss`
+  match (`identitystore.go:357`) and `common` yields a templated issuer that
+  won't match a token's concrete `iss` (M-a). Document that the app registration
+  must **emit the `groups` claim** (and beware "groups overage") for `groups`→
+  role mapping (M-b). Secret via `client_secret_env`. Note the **multi-replica**
+  requirement is satisfied automatically (server-side flow state) — no sticky
+  sessions needed.
+- **Okta** — OIDC "Web" app; issuer `https://<org>.okta.com/oauth2/default` (or a
+  custom/org authorization server); redirect URI; scopes; `groups` mapping.
+- **GitHub (via OIDC broker)** — explicit callout that GitHub-direct is not OIDC;
+  worked example via a broker; "native GitHub is a deferred follow-up" pointer.
+- Update `site/docs/architecture.md` auth section (currently token-only) to
+  describe the interactive flow + server session, and link the guide.
+
+## Testing
+
+### Unit
+
+- **Config validation:** unknown `kind` → error; `interactive` without a
+  resolvable secret → error; `interactive` with `audience != client_id` → error;
+  non-interactive secret-less OIDC config loads fine (**B2 regression**);
+  `scopes`/`display_name`/`session_ttl` defaults; `openid` forced.
+- **Secret resolution (B1):** `client_secret_env` reads the var; unset → fatal;
+  plaintext fallback works; secret never in logs.
+- **VerifyWithNonce (B3):** correct nonce passes; wrong/missing fails; `Nonce`
+  populated.
+- **state/nonce/PKCE:** high-entropy; `S256` challenge matches; constant-time
+  compare.
+- **redirect URI (M-d):** derived from request; `base_url` override wins.
+- **resolveSession (B4/MA-3):** valid hash → identity; missing/revoked/expired →
+  `ErrUnauthenticated`; soft-deleted → `ErrUnauthenticated`; **DB error →
+  `ErrTransient`**; `WebAuth==nil` → `ErrUnauthenticated` (no panic); prefix
+  routes ahead of api-key path.
+- **interactive limiter bypass (MA-2):** interactive JIT does not decrement the
+  issuer bucket; allowlist still rejects out-of-domain; bearer-path JIT still
+  limited.
+- **establishSession:** cookie attributes (HttpOnly, `SameSite=Lax`, `Secure`
+  dynamic).
+- **providers endpoint:** only interactive; empty when none; `display_name`
+  default.
+- **auth_error mapping:** each reason → friendly message; no internal text.
+- **per-IP rate limit (MAJOR-1):** `start`/`callback` over-limit → 429 with
+  `Retry-After`; client-IP extraction honors trusted-proxy headers only when
+  configured.
+
+### Flow (httptest, behind `loginProvider` + a fake OIDC issuer)
+
+- `start`: 302 with correct `client_id`/`redirect_uri`/`scope`/`state`/
+  `code_challenge`/`nonce`; creates a login-flow row; sets tx cookie with the
+  flow id; unknown provider → 404.
+- `callback` happy path: stubbed token endpoint + verifier → resolves identity,
+  creates a `web_sessions` row, sets `spgr_ws_` cookie, 302 `/`; subsequent
+  request with that cookie resolves via `resolveSession`; the login-flow row is
+  consumed (single-use — replay → `auth_error=expired`); the tx cookie is
+  deleted on the callback response (MINOR-4).
+- `callback` failures: missing tx → `expired`; consumed/expired flow → `expired`;
+  tampered state → `state`; IdP `error` → `denied`; exchange/verify failure →
+  `exchange`; **provider removed mid-flow → `exchange` (MINOR-2)**; **JIT-disabled
+  binding miss → `unauthorized`, no cookie (B4)**; resolve `ErrTransient` →
+  `temporary`.
+- **logout (M6):** revokes the session row; the token no longer resolves; a
+  legacy API-key cookie value is not hashed/looked-up.
+
+### Integration (testcontainers, `//go:build integration`)
+
+- Session + login-flow CRUD, atomic `ConsumeLoginFlow` single-use, expiry GC,
+  cascade delete on user purge; `resolveSession` end-to-end.
+
+### Regression
+
+- Existing API-key login, `/whoami`, and the bearer-JWT path unchanged; a
+  secret-less token-only OIDC config still verifies bearer JWTs.
+
+## Files touched (anticipated)
+
+- `internal/config/global.go` — `OIDCProviderConfig` fields (`kind`,
+  `interactive`, `display_name`, `client_secret`, `client_secret_env`, `scopes`),
+  `OIDCConfig.base_url` + `session_ttl`, validation.
+- `internal/auth/oidc_verifier.go` — `VerifyWithNonce` + `OIDCClaims.Nonce`.
+- `internal/auth/` — `loginProvider` interface + `oidc` impl; `resolveSession` +
+  `Resolve` dispatch + `WebAuth` field + nil-guard; `WithInteractiveLogin` ctx
+  marker + `jitResolve` bypass.
+- `internal/storage/` — `WebAuthStore` interface, `Session` + `LoginFlow` domain
+  types, `ErrSessionNotFound` + `ErrLoginFlowNotFound`.
+- `internal/storage/postgres/` — `002_web_auth.sql` migration + impl on
+  `AuthStore`; web-auth sweeper.
+- `internal/server/auth_oidc_handler.go` — providers/start/callback + per-IP
+  rate limiter; `auth_handler.go` — `sessionCookie()` SameSite=Lax, logout
+  revocation + signature change, `establishSession`.
+- `cmd/specgraph/serve.go` — build interactive login providers (secret from env,
+  fatal discovery), build every-provider verifier set (as today), wire
+  `WebAuthStore` into the resolver + handlers, start the web-auth sweeper.
+- `web/src/lib/auth.svelte.ts`, `web/src/lib/components/LoginModal.svelte`,
+  `web/src/routes/+layout.svelte`.
+- `site/docs/guides/oidc-login.md` (new), `site/docs/architecture.md` (update).
+- Unit + httptest + integration tests; follow-up issue for native generic-OAuth2.
+
+## Resolved review findings
+
+### Round 1
+
+- **B1** secret resolution didn't exist → `client_secret_env` at build time;
+  fatal when unresolved.
+- **B2** backward-compat vs validation → `interactive` opt-in; token-only configs
+  need no secret.
+- **B3** nonce silently unverified → `VerifyWithNonce` + `OIDCClaims.Nonce`.
+- **B4** JIT-disabled login loop → callback resolves identity before seating.
+- **M1** 4 KB cookie → server-side session; opaque id in cookie.
+- **M2** audience collision → interactive `audience` must be empty/`client_id`,
+  validated.
+- **M3** SameSite=Strict → session cookie `Lax` (+ stated invariant).
+- **M4** unauthenticated tx cookie → server-side flow state; cookie is an opaque
+  id.
+- **M5** concurrent logins → accepted/surfaced (`auth_error=expired`),
+  documented.
+- **M6** logout/RP-logout → logout revokes the server session; RP-logout out of
+  scope, documented.
+- **M-a/M-b/M-d** → documented in the guide.
+- **M-c** `x/oauth2` indirect→direct → `go mod tidy` promotes; v0.36 has PKCE
+  helpers.
+
+### Round 2
+
+- **BL-1** non-fatal-discovery contradiction → reverted to fatal-at-startup,
+  rationale documented; resilient registry recorded as out-of-scope follow-up.
+- **MA-1** ephemeral tx-cookie key broke multi-replica → server-side
+  `oidc_login_flows` table; cookie carries only an opaque flow id.
+- **MA-2** interactive login spent the JIT budget → `WithInteractiveLogin`
+  bypasses the rate limiter (allowlist + claim mapping still enforced).
+- **MA-3** session transient path unspecified → `resolveSession` mirrors
+  `resolveAPIKey` (DB error → `ErrTransient`, not 401).
+- **MI-1** sweeper not reusable → new `StartWebAuthSweeper`.
+- **MI-2** logout store access + API-key guard → signature change +
+  `spgr_ws_`-only revoke.
+- **MI-3** nil `WebAuth` → guarded to `ErrUnauthenticated`.
+- **MI-4** missing goose Down → added.
+- **MI-5** dead `last_used_at` / no idle TTL → column dropped; absolute TTL only.
+- **MI-6** session accumulation / no global logout → documented v1 limitation.
+- **MI-7** double verification → accepted (JWKS cached; negligible), noted.
+- **MI-8** Strict→Lax global relaxation → documented "no GET mutates state"
+  invariant.
+
+### Round 3
+
+- **MAJOR-1** unauthenticated DB-write DoS on `start` (introduced by MA-1) →
+  per-IP token-bucket rate limit on `start`/`callback` (429 + `Retry-After`),
+  flow TTL shortened to ~5m, sweeper on a ~1m interval; `/providers` is
+  in-memory.
+- **MINOR-1** residual interactive JIT-creation DoS → documented; email-domain
+  allowlist named as the mitigating control; bypass marker is unexported and
+  callback-only (no forgery).
+- **MINOR-2** provider removed mid-flow → callback maps to `auth_error=exchange`
+  (logged); contract row + test added.
+- **MINOR-3** flow secrets plaintext-at-rest → documented as deliberate (useless
+  without the browser-delivered `code`).
+- **MINOR-4** tx cookie not cleared on callback → callback emits a `Max-Age=-1`
+  delete.
+- **MINOR-5** session-fixation implicit → stated `establishSession` name/path
+  invariant so a callback `Set-Cookie` always overwrites a stale cookie.
+
+## Open questions
+
+None outstanding.

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/crypto v0.51.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sys v0.45.0
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.37.0
@@ -192,7 +193,6 @@ require (
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/api v0.280.0 // indirect

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -67,3 +67,21 @@ func ProjectFromContext(ctx context.Context) (string, bool) {
 	}
 	return slug, true
 }
+
+type interactiveLoginKey struct{}
+
+// WithInteractiveLogin marks the context as originating from the interactive
+// OIDC login callback. Consumed by jitResolve to bypass the per-issuer JIT
+// rate limiter (the limiter targets unsolicited bearer-JWT JIT; an interactive
+// login is user-driven and IdP+PKCE+nonce authenticated). Set ONLY by the
+// callback handler — bearer entry points never set it.
+func WithInteractiveLogin(ctx context.Context) context.Context {
+	return context.WithValue(ctx, interactiveLoginKey{}, true)
+}
+
+// InteractiveLoginFromContext reports whether the context was marked by
+// WithInteractiveLogin.
+func InteractiveLoginFromContext(ctx context.Context) bool {
+	v, _ := ctx.Value(interactiveLoginKey{}).(bool)
+	return v
+}

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -82,6 +82,6 @@ func WithInteractiveLogin(ctx context.Context) context.Context {
 // InteractiveLoginFromContext reports whether the context was marked by
 // WithInteractiveLogin.
 func InteractiveLoginFromContext(ctx context.Context) bool {
-	v, _ := ctx.Value(interactiveLoginKey{}).(bool)
-	return v
+	v, ok := ctx.Value(interactiveLoginKey{}).(bool)
+	return ok && v
 }

--- a/internal/auth/context_test.go
+++ b/internal/auth/context_test.go
@@ -40,3 +40,14 @@ func TestBearerToken_Empty(t *testing.T) {
 		t.Error("BearerTokenFromContext returned true for empty token")
 	}
 }
+
+func TestInteractiveLoginContext(t *testing.T) {
+	ctx := context.Background()
+	if InteractiveLoginFromContext(ctx) {
+		t.Fatal("plain context must not be marked interactive")
+	}
+	ctx = WithInteractiveLogin(ctx)
+	if !InteractiveLoginFromContext(ctx) {
+		t.Fatal("marked context must report interactive")
+	}
+}

--- a/internal/auth/identitystore.go
+++ b/internal/auth/identitystore.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
@@ -35,6 +36,7 @@ type LastUsedTracker interface {
 // + per-issuer OIDCVerifiers; enforces JIT rate-limit and allowlist.
 type pgIdentityStore struct {
 	users     storage.UsersBackend
+	webAuth   storage.WebAuthStore
 	verifiers map[string]*OIDCVerifier // issuer -> verifier
 	tracker   LastUsedTracker
 
@@ -54,6 +56,10 @@ type IdentityStoreConfig struct {
 	Users     storage.UsersBackend
 	Verifiers []*OIDCVerifier
 	Tracker   LastUsedTracker
+
+	// WebAuth persists/looks up interactive-login web sessions. Optional: when
+	// nil, spgr_ws_-prefixed tokens resolve to ErrUnauthenticated.
+	WebAuth storage.WebAuthStore
 
 	// KnownRoles is the set of role names valid for assignment. Validated
 	// against at construction time: any JITDefaultRole or
@@ -133,6 +139,7 @@ func NewIdentityStore(cfg IdentityStoreConfig) (Resolver, error) { //nolint:gocr
 	}
 	return &pgIdentityStore{
 		users:              cfg.Users,
+		webAuth:            cfg.WebAuth,
 		verifiers:          verifiers,
 		tracker:            cfg.Tracker,
 		jitEnabled:         cfg.JITEnabled,
@@ -154,6 +161,9 @@ func (s *pgIdentityStore) Resolve(ctx context.Context, token string) (*Identity,
 	if isJWTShaped(token) {
 		return s.resolveJWT(ctx, token)
 	}
+	if strings.HasPrefix(token, sessionTokenPrefix) {
+		return s.resolveSession(ctx, token)
+	}
 	return s.resolveAPIKey(ctx, token)
 }
 
@@ -165,11 +175,14 @@ func (s *pgIdentityStore) Resolve(ctx context.Context, token string) (*Identity,
 // The spgr_sk_ prefix is excluded in addition to the dot-count check so a
 // (hypothetical) API key whose secret happens to contain two dots is never
 // misrouted to the OIDC/JWT path: an spgr_sk_-prefixed token always goes to
-// the API-key resolver regardless of its dot count. Any future API-key
-// prefix that could contain dots MUST be added to this guard, or such keys
-// risk being treated as JWTs.
+// the API-key resolver regardless of its dot count. The spgr_ws_ session
+// prefix is excluded for the same reason. Any future credential prefix that
+// could contain dots MUST be added to this guard, or such tokens risk being
+// treated as JWTs.
 func isJWTShaped(token string) bool {
-	return strings.Count(token, ".") == 2 && !strings.HasPrefix(token, "spgr_sk_")
+	return strings.Count(token, ".") == 2 &&
+		!strings.HasPrefix(token, apiKeyPrefix) &&
+		!strings.HasPrefix(token, sessionTokenPrefix)
 }
 
 const (
@@ -177,6 +190,8 @@ const (
 	apiKeyPrefixLen = 8          // characters
 	apiKeySecretLen = 32         // characters
 )
+
+const sessionTokenPrefix = "spgr_ws_" //nolint:gosec // G101: token-format prefix, not a credential
 
 // parseAPIKey splits a token of the form spgr_sk_<prefix>_<secret> into
 // its components. Returns ("", "", false) for any malformed input.
@@ -323,6 +338,47 @@ func (s *pgIdentityStore) resolveAPIKey(ctx context.Context, token string) (*Ide
 	}, nil
 }
 
+// resolveSession resolves an opaque web-session token (spgr_ws_...). Mirrors
+// resolveAPIKey's error discipline: not-found/revoked/expired/soft-deleted →
+// ErrUnauthenticated; any other backend error → ErrTransient.
+func (s *pgIdentityStore) resolveSession(ctx context.Context, token string) (*Identity, error) {
+	if s.webAuth == nil {
+		return nil, ErrUnauthenticated
+	}
+	sum := sha256.Sum256([]byte(token))
+	sess, err := s.webAuth.LookupSessionByHash(ctx, sum[:])
+	if err != nil {
+		if errors.Is(err, storage.ErrSessionNotFound) {
+			return nil, ErrUnauthenticated
+		}
+		return nil, fmt.Errorf("%w: %w", ErrTransient, err)
+	}
+	if !sess.IsActive(s.now()) {
+		return nil, ErrUnauthenticated
+	}
+	user, err := s.users.GetUserByID(ctx, sess.UserID)
+	if err != nil {
+		if errors.Is(err, storage.ErrUserNotFound) {
+			return nil, ErrUnauthenticated
+		}
+		return nil, fmt.Errorf("%w: %w", ErrTransient, err)
+	}
+	if user.DeletedAt != nil {
+		slog.LogAttrs(ctx, slog.LevelWarn, "auth: session resolved to soft-deleted user",
+			slog.String("user_id", user.ID), slog.String("subject", sess.OIDCSubject))
+		return nil, ErrUnauthenticated
+	}
+	return &Identity{
+		UserID:        user.ID,
+		Subject:       "oidc:" + sess.OIDCSubject,
+		DisplayName:   user.DisplayName,
+		Email:         user.Email,
+		Role:          Role(user.Role),
+		EffectiveRole: Role(user.Role),
+		Source:        "oidc",
+	}, nil
+}
+
 // peekIssuer extracts the iss claim from an unverified JWT payload. Used
 // only to route to the correct OIDCVerifier; the verifier subsequently
 // validates signature+audience+expiry.
@@ -441,11 +497,17 @@ func (s *pgIdentityStore) jitResolve(ctx context.Context, claims *OIDCClaims) (*
 	// failure still spends a token. This is deliberate — it dampens retry
 	// storms during DB degradation rather than letting failed attempts retry
 	// against the backend for free.
-	limiter := s.rateLimiterFor(claims.Issuer)
-	if !limiter.Allow() {
-		slog.LogAttrs(ctx, slog.LevelWarn, "auth: JIT rate-limit exceeded",
-			slog.String("issuer", claims.Issuer), slog.String("subject", claims.Subject))
-		return nil, ErrUnauthenticated
+	//
+	// Skipped for interactive logins (user-driven, IdP+PKCE+nonce verified);
+	// the limiter targets unsolicited bearer-JWT JIT. The email-domain
+	// allowlist (step 1, above) still applies.
+	if !InteractiveLoginFromContext(ctx) {
+		limiter := s.rateLimiterFor(claims.Issuer)
+		if !limiter.Allow() {
+			slog.LogAttrs(ctx, slog.LevelWarn, "auth: JIT rate-limit exceeded",
+				slog.String("issuer", claims.Issuer), slog.String("subject", claims.Subject))
+			return nil, ErrUnauthenticated
+		}
 	}
 
 	// (3) ClaimsMapping: derive role from token claims at JIT time only.

--- a/internal/auth/identitystore_session_test.go
+++ b/internal/auth/identitystore_session_test.go
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// compile-time assertion: fakeWebAuth must implement storage.WebAuthStore.
+var _ storage.WebAuthStore = (*fakeWebAuth)(nil)
+
+// fakeWebAuth is a hand-rolled stub for storage.WebAuthStore used by the
+// session-resolution tests. Only LookupSessionByHash carries behavior; the
+// other methods are unused by the Resolver and return zero values.
+type fakeWebAuth struct {
+	lookupSessionByHash func(ctx context.Context, tokenHash []byte) (*storage.Session, error)
+}
+
+func (f *fakeWebAuth) LookupSessionByHash(ctx context.Context, tokenHash []byte) (*storage.Session, error) {
+	if f.lookupSessionByHash == nil {
+		return nil, storage.ErrSessionNotFound
+	}
+	return f.lookupSessionByHash(ctx, tokenHash)
+}
+
+func (f *fakeWebAuth) CreateSession(_ context.Context, _ *storage.Session) (*storage.Session, error) {
+	return nil, nil
+}
+func (f *fakeWebAuth) RevokeSession(_ context.Context, _ []byte) error { return nil }
+func (f *fakeWebAuth) DeleteExpiredSessions(_ context.Context) (int64, error) {
+	return 0, nil
+}
+func (f *fakeWebAuth) CreateLoginFlow(_ context.Context, _ *storage.LoginFlow) (string, error) {
+	return "", nil
+}
+func (f *fakeWebAuth) ConsumeLoginFlow(_ context.Context, _ string) (*storage.LoginFlow, error) {
+	return nil, nil
+}
+func (f *fakeWebAuth) DeleteExpiredLoginFlows(_ context.Context) (int64, error) {
+	return 0, nil
+}
+
+// --- Task 9: opaque web-session resolution (spgr_ws_...) ---
+
+// TestResolveSession resolves a seeded active session whose UserID maps to an
+// active user, asserting the returned Identity mirrors the OIDC shape.
+func TestResolveSession(t *testing.T) {
+	const token = "spgr_ws_TOKEN"
+	wantHash := sha256.Sum256([]byte(token))
+
+	web := &fakeWebAuth{
+		lookupSessionByHash: func(_ context.Context, tokenHash []byte) (*storage.Session, error) {
+			require.True(t, bytes.Equal(wantHash[:], tokenHash), "lookup must use sha256(token)")
+			return &storage.Session{
+				ID:          "s1",
+				TokenHash:   tokenHash,
+				UserID:      "u1",
+				Issuer:      "https://issuer.example/",
+				OIDCSubject: "subject-123",
+				ExpiresAt:   time.Now().Add(time.Hour),
+			}, nil
+		},
+	}
+	stub := &usersBackendStub{
+		getUserByID: func(_ context.Context, id string) (*storage.User, error) {
+			require.Equal(t, "u1", id)
+			u := activeUser(id, "writer", storage.KindHuman)
+			u.Email = "alice@example.com"
+			return u, nil
+		},
+	}
+	store, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, WebAuth: web, Tracker: &noopTracker{},
+	})
+	require.NoError(t, err)
+
+	id, err := store.Resolve(context.Background(), token)
+	require.NoError(t, err)
+	require.Equal(t, "u1", id.UserID)
+	require.Equal(t, "oidc:subject-123", id.Subject)
+	require.Equal(t, "oidc", id.Source)
+	require.Equal(t, auth.Role("writer"), id.Role)
+	require.Equal(t, auth.Role("writer"), id.EffectiveRole)
+	require.Equal(t, "alice@example.com", id.Email)
+}
+
+// TestResolveSession_Errors covers the error discipline of resolveSession.
+func TestResolveSession_Errors(t *testing.T) {
+	const token = "spgr_ws_TOKEN"
+
+	t.Run("missing session → Unauthenticated", func(t *testing.T) {
+		web := &fakeWebAuth{
+			lookupSessionByHash: func(_ context.Context, _ []byte) (*storage.Session, error) {
+				return nil, storage.ErrSessionNotFound
+			},
+		}
+		store, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+			Users: &usersBackendStub{}, WebAuth: web, Tracker: &noopTracker{},
+		})
+		require.NoError(t, err)
+		_, err = store.Resolve(context.Background(), token)
+		require.ErrorIs(t, err, auth.ErrUnauthenticated)
+	})
+
+	t.Run("backend error → Transient", func(t *testing.T) {
+		web := &fakeWebAuth{
+			lookupSessionByHash: func(_ context.Context, _ []byte) (*storage.Session, error) {
+				return nil, errors.New("connection refused")
+			},
+		}
+		store, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+			Users: &usersBackendStub{}, WebAuth: web, Tracker: &noopTracker{},
+		})
+		require.NoError(t, err)
+		_, err = store.Resolve(context.Background(), token)
+		require.ErrorIs(t, err, auth.ErrTransient)
+	})
+
+	t.Run("WebAuth nil → Unauthenticated (no panic)", func(t *testing.T) {
+		store, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+			Users: &usersBackendStub{}, Tracker: &noopTracker{},
+			// WebAuth left nil.
+		})
+		require.NoError(t, err)
+		_, err = store.Resolve(context.Background(), token)
+		require.ErrorIs(t, err, auth.ErrUnauthenticated)
+	})
+
+	t.Run("inactive (expired) session → Unauthenticated", func(t *testing.T) {
+		web := &fakeWebAuth{
+			lookupSessionByHash: func(_ context.Context, _ []byte) (*storage.Session, error) {
+				return &storage.Session{
+					ID: "s1", UserID: "u1", OIDCSubject: "sub",
+					ExpiresAt: time.Now().Add(-time.Hour), // expired
+				}, nil
+			},
+		}
+		store, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+			Users: &usersBackendStub{}, WebAuth: web, Tracker: &noopTracker{},
+		})
+		require.NoError(t, err)
+		_, err = store.Resolve(context.Background(), token)
+		require.ErrorIs(t, err, auth.ErrUnauthenticated)
+	})
+
+	t.Run("revoked session → Unauthenticated", func(t *testing.T) {
+		revoked := time.Now().Add(-time.Minute)
+		web := &fakeWebAuth{
+			lookupSessionByHash: func(_ context.Context, _ []byte) (*storage.Session, error) {
+				return &storage.Session{
+					ID: "s1", UserID: "u1", OIDCSubject: "sub",
+					ExpiresAt: time.Now().Add(time.Hour), // not expired
+					RevokedAt: &revoked,                  // but revoked
+				}, nil
+			},
+		}
+		store, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+			Users: &usersBackendStub{}, WebAuth: web, Tracker: &noopTracker{},
+		})
+		require.NoError(t, err)
+		_, err = store.Resolve(context.Background(), token)
+		require.ErrorIs(t, err, auth.ErrUnauthenticated)
+	})
+
+	t.Run("soft-deleted user → Unauthenticated", func(t *testing.T) {
+		web := &fakeWebAuth{
+			lookupSessionByHash: func(_ context.Context, _ []byte) (*storage.Session, error) {
+				return &storage.Session{
+					ID: "s1", UserID: "u1", OIDCSubject: "sub",
+					ExpiresAt: time.Now().Add(time.Hour),
+				}, nil
+			},
+		}
+		deleted := time.Now().Add(-time.Hour)
+		stub := &usersBackendStub{
+			getUserByID: func(_ context.Context, id string) (*storage.User, error) {
+				u := activeUser(id, "reader", storage.KindHuman)
+				u.DeletedAt = &deleted
+				return u, nil
+			},
+		}
+		store, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+			Users: stub, WebAuth: web, Tracker: &noopTracker{},
+		})
+		require.NoError(t, err)
+		_, err = store.Resolve(context.Background(), token)
+		require.ErrorIs(t, err, auth.ErrUnauthenticated)
+	})
+}
+
+// --- Task 9 (d): interactive-login bypasses the per-issuer JIT rate limiter ---
+
+// TestJITResolve_InteractiveBypassesLimiter proves that an interactive-login
+// context skips the per-issuer JIT rate limiter while a bearer (non-interactive)
+// context still consumes it. With JITRateBurstPerHour=1:
+//   - a non-interactive JIT after the bucket is drained → ErrUnauthenticated
+//   - an interactive JIT after the bucket is drained → still succeeds
+//
+// The email-domain allowlist still applies to interactive logins, so an
+// out-of-domain interactive token is rejected (only the rate counter is
+// bypassed, not the allowlist).
+func TestJITResolve_InteractiveBypassesLimiter(t *testing.T) {
+	p := newOIDCTestIssuer(t)
+	v, err := auth.NewOIDCVerifier(context.Background(), config.OIDCProviderConfig{
+		ID: "test", Issuer: p.server.URL, ClientID: "aud-1",
+	})
+	require.NoError(t, err)
+
+	stub := &usersBackendStub{
+		lookupOIDCBinding: func(_ context.Context, _, _ string) (*storage.OIDCBinding, error) {
+			return nil, storage.ErrOIDCBindingNotFound
+		},
+		jitCreateHuman: func(_ context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error) {
+			u.ID = "u"
+			b.ID = "b"
+			b.UserID = "u"
+			return u, b, nil
+		},
+	}
+	store, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users: stub, Verifiers: []*auth.OIDCVerifier{v}, Tracker: &noopTracker{},
+		JITEnabled:              true,
+		JITDefaultRole:          auth.RoleReader,
+		JITRateBurstPerHour:     1, // single token per issuer
+		JITEmailDomainAllowlist: []string{"example.com"},
+	})
+	require.NoError(t, err)
+
+	mint := func(sub, email string) string {
+		return p.mintToken(t, map[string]any{
+			"iss": p.server.URL, "sub": sub, "aud": "aud-1",
+			"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+			"email": email,
+		})
+	}
+
+	// Drain the issuer's single rate-limit token via a non-interactive JIT.
+	_, err = store.Resolve(context.Background(), mint("drain", "drain@example.com"))
+	require.NoError(t, err, "first non-interactive JIT consumes the only token")
+
+	// (i) Non-interactive JIT with the bucket exhausted → rejected.
+	_, err = store.Resolve(context.Background(), mint("bearer", "bearer@example.com"))
+	require.ErrorIs(t, err, auth.ErrUnauthenticated,
+		"non-interactive JIT must be rate-limited once the bucket is drained")
+
+	// (ii) Interactive JIT with the bucket exhausted → still succeeds (bypass).
+	ictx := auth.WithInteractiveLogin(context.Background())
+	_, err = store.Resolve(ictx, mint("inter-1", "inter1@example.com"))
+	require.NoError(t, err, "interactive JIT must bypass the exhausted limiter")
+	// A second interactive JIT also succeeds — proving no per-token decrement.
+	_, err = store.Resolve(ictx, mint("inter-2", "inter2@example.com"))
+	require.NoError(t, err, "interactive JIT must not decrement the limiter")
+
+	// The allowlist still gates interactive logins — out-of-domain rejected.
+	_, err = store.Resolve(ictx, mint("inter-bad", "mallory@evil.com"))
+	require.ErrorIs(t, err, auth.ErrUnauthenticated,
+		"interactive login must still honor the email-domain allowlist")
+}

--- a/internal/auth/identitystore_session_test.go
+++ b/internal/auth/identitystore_session_test.go
@@ -57,7 +57,7 @@ func (f *fakeWebAuth) DeleteExpiredLoginFlows(_ context.Context) (int64, error) 
 // TestResolveSession resolves a seeded active session whose UserID maps to an
 // active user, asserting the returned Identity mirrors the OIDC shape.
 func TestResolveSession(t *testing.T) {
-	const token = "spgr_ws_TOKEN"
+	const token = "spgr_ws_TOKEN" //nolint:gosec // G101: test token literal, not a real credential
 	wantHash := sha256.Sum256([]byte(token))
 
 	web := &fakeWebAuth{
@@ -98,7 +98,7 @@ func TestResolveSession(t *testing.T) {
 
 // TestResolveSession_Errors covers the error discipline of resolveSession.
 func TestResolveSession_Errors(t *testing.T) {
-	const token = "spgr_ws_TOKEN"
+	const token = "spgr_ws_TOKEN" //nolint:gosec // G101: test token literal, not a real credential
 
 	t.Run("missing session → Unauthenticated", func(t *testing.T) {
 		web := &fakeWebAuth{

--- a/internal/auth/loginprovider.go
+++ b/internal/auth/loginprovider.go
@@ -106,7 +106,7 @@ var defaultScopes = []string{"openid", "email", "profile"}
 // keep the signature stable for the serve.go call site.
 func BuildLoginProviders(ctx context.Context, providers []config.OIDCProviderConfig, _ string) ([]LoginProvider, error) {
 	var out []LoginProvider
-	for _, pc := range providers {
+	for _, pc := range providers { //nolint:gocritic // rangeValCopy: provider list is small and startup-only
 		if !pc.Interactive {
 			continue
 		}

--- a/internal/auth/loginprovider.go
+++ b/internal/auth/loginprovider.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+
+	"github.com/specgraph/specgraph/internal/config"
+)
+
+// LoginProvider drives the interactive OAuth2 Authorization Code flow for one
+// provider. The oidc implementation verifies the returned id_token (incl.
+// nonce) and returns the raw token for the resolver to materialize identity.
+type LoginProvider interface {
+	ID() string
+	DisplayName() string
+	AuthCodeURL(state, nonce, codeChallenge, redirectURI string) string
+	// Exchange swaps the authorization code for a nonce-verified raw id_token.
+	Exchange(ctx context.Context, code, codeVerifier, nonce, redirectURI string) (idToken string, err error)
+}
+
+type oidcLoginProvider struct {
+	id          string
+	displayName string
+	authURL     string
+	tokenURL    string
+	clientID    string
+	secret      string
+	scopes      []string
+	verifier    *OIDCVerifier
+}
+
+func (p *oidcLoginProvider) ID() string          { return p.id }
+func (p *oidcLoginProvider) DisplayName() string { return p.displayName }
+
+func (p *oidcLoginProvider) AuthCodeURL(state, nonce, codeChallenge, redirectURI string) string {
+	cfg := p.oauth2Config(redirectURI)
+	return cfg.AuthCodeURL(state,
+		oidc.Nonce(nonce),
+		oauth2.SetAuthURLParam("code_challenge", codeChallenge),
+		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+	)
+}
+
+func (p *oidcLoginProvider) Exchange(ctx context.Context, code, codeVerifier, nonce, redirectURI string) (string, error) {
+	cfg := p.oauth2Config(redirectURI)
+	tok, err := cfg.Exchange(ctx, code, oauth2.SetAuthURLParam("code_verifier", codeVerifier))
+	if err != nil {
+		return "", fmt.Errorf("oidc exchange: %w", err)
+	}
+	rawID, ok := tok.Extra("id_token").(string)
+	if !ok || rawID == "" {
+		return "", errors.New("oidc exchange: no id_token in response")
+	}
+	if _, err := p.verifier.VerifyWithNonce(ctx, rawID, nonce); err != nil {
+		return "", err
+	}
+	return rawID, nil
+}
+
+func (p *oidcLoginProvider) oauth2Config(redirectURI string) oauth2.Config {
+	return oauth2.Config{
+		ClientID:     p.clientID,
+		ClientSecret: p.secret,
+		Endpoint:     oauth2.Endpoint{AuthURL: p.authURL, TokenURL: p.tokenURL},
+		RedirectURL:  redirectURI,
+		Scopes:       p.scopes,
+	}
+}
+
+// resolveClientSecret returns the provider's client secret from
+// ClientSecretEnv (preferred) or the plaintext ClientSecret fallback.
+func resolveClientSecret(pc config.OIDCProviderConfig) (string, error) { //nolint:gocritic // hugeParam: pc is read-only; matches NewOIDCVerifier convention
+	if pc.ClientSecretEnv != "" {
+		v := os.Getenv(pc.ClientSecretEnv)
+		if v == "" {
+			return "", fmt.Errorf("client secret env var %q is unset", pc.ClientSecretEnv)
+		}
+		return v, nil
+	}
+	if pc.ClientSecret != "" {
+		return pc.ClientSecret, nil
+	}
+	return "", errors.New("no client secret (set client_secret_env or client_secret)")
+}
+
+// defaultScopes is applied when a provider configures none.
+var defaultScopes = []string{"openid", "email", "profile"}
+
+// BuildLoginProviders discovers and constructs a LoginProvider for each
+// interactive OIDC provider. Non-interactive providers are skipped. All
+// failures (unknown kind, missing secret, bad audience, discovery failure)
+// are fatal — the caller treats a non-nil error as a startup abort.
+//
+// The trailing string param is currently unused (reserved for a base URL hint);
+// keep the signature stable for the serve.go call site.
+func BuildLoginProviders(ctx context.Context, providers []config.OIDCProviderConfig, _ string) ([]LoginProvider, error) {
+	var out []LoginProvider
+	for _, pc := range providers {
+		if !pc.Interactive {
+			continue
+		}
+		kind := pc.Kind
+		if kind == "" {
+			kind = "oidc"
+		}
+		if kind != "oidc" {
+			return nil, fmt.Errorf("OIDC provider %s: unsupported kind %q (only \"oidc\")", pc.ID, kind)
+		}
+		if pc.Audience != "" && pc.Audience != pc.ClientID {
+			return nil, fmt.Errorf("OIDC provider %s: interactive audience must be empty or equal client_id", pc.ID)
+		}
+		secret, err := resolveClientSecret(pc)
+		if err != nil {
+			return nil, fmt.Errorf("OIDC provider %s: %w", pc.ID, err)
+		}
+		// Single bounded discovery: NewOIDCVerifier discovers the issuer and
+		// exposes Endpoint(), so we don't round-trip .well-known twice. The
+		// timeout guards against a hung IdP blocking startup.
+		dctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		verifier, err := NewOIDCVerifier(dctx, pc)
+		cancel()
+		if err != nil {
+			return nil, fmt.Errorf("OIDC provider %s discovery: %w", pc.ID, err)
+		}
+		scopes := pc.Scopes
+		if len(scopes) == 0 {
+			scopes = defaultScopes
+		}
+		scopes = ensureOpenID(scopes)
+		display := pc.DisplayName
+		if display == "" {
+			display = pc.ID
+		}
+		ep := verifier.Endpoint()
+		out = append(out, &oidcLoginProvider{
+			id:          pc.ID,
+			displayName: display,
+			authURL:     ep.AuthURL,
+			tokenURL:    ep.TokenURL,
+			clientID:    pc.ClientID,
+			secret:      secret,
+			scopes:      scopes,
+			verifier:    verifier,
+		})
+	}
+	return out, nil
+}
+
+// ensureOpenID guarantees the openid scope is present.
+func ensureOpenID(scopes []string) []string {
+	for _, s := range scopes {
+		if s == "openid" {
+			return scopes
+		}
+	}
+	return append([]string{"openid"}, scopes...)
+}
+
+// RedirectURI builds the OIDC callback URL from the request, honoring an
+// explicit base override (auth.oidc.base_url) when set.
+func RedirectURI(baseURL string, tls bool, host, fwdProto, fwdHost string) string {
+	if baseURL != "" {
+		return strings.TrimRight(baseURL, "/") + "/api/auth/oidc/callback"
+	}
+	scheme := "http"
+	if tls || fwdProto == "https" {
+		scheme = "https"
+	}
+	h := host
+	if fwdHost != "" {
+		h = fwdHost
+	}
+	u := url.URL{Scheme: scheme, Host: h, Path: "/api/auth/oidc/callback"}
+	return u.String()
+}

--- a/internal/auth/loginprovider_test.go
+++ b/internal/auth/loginprovider_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/config"
+)
+
+func TestBuildLoginProviders_SkipsNonInteractive(t *testing.T) {
+	provs, err := BuildLoginProviders(nil, []config.OIDCProviderConfig{
+		{ID: "verify-only", Issuer: "https://x", ClientID: "c"}, // interactive=false
+	}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(provs) != 0 {
+		t.Fatalf("non-interactive provider must not yield a login provider, got %d", len(provs))
+	}
+}
+
+func TestBuildLoginProviders_MissingSecret(t *testing.T) {
+	_, err := BuildLoginProviders(nil, []config.OIDCProviderConfig{
+		{ID: "entra", Interactive: true, Issuer: "https://x", ClientID: "c"},
+	}, "")
+	if err == nil || !strings.Contains(err.Error(), "client secret") {
+		t.Fatalf("expected missing-secret error, got %v", err)
+	}
+}
+
+func TestBuildLoginProviders_AudienceMismatch(t *testing.T) {
+	t.Setenv("TEST_SECRET", "shh")
+	_, err := BuildLoginProviders(nil, []config.OIDCProviderConfig{
+		{ID: "entra", Interactive: true, Issuer: "https://x", ClientID: "c",
+			Audience: "different", ClientSecretEnv: "TEST_SECRET"},
+	}, "")
+	if err == nil || !strings.Contains(err.Error(), "audience") {
+		t.Fatalf("expected audience error, got %v", err)
+	}
+}
+
+func TestResolveClientSecret(t *testing.T) {
+	t.Setenv("MY_SECRET", "value")
+	got, err := resolveClientSecret(config.OIDCProviderConfig{ClientSecretEnv: "MY_SECRET"})
+	if err != nil || got != "value" {
+		t.Fatalf("env resolution: got %q err %v", got, err)
+	}
+	got, err = resolveClientSecret(config.OIDCProviderConfig{ClientSecret: "plain"})
+	if err != nil || got != "plain" {
+		t.Fatalf("plaintext fallback: got %q err %v", got, err)
+	}
+	if _, err := resolveClientSecret(config.OIDCProviderConfig{ClientSecretEnv: "UNSET_VAR_XYZ"}); err == nil {
+		t.Fatal("unset env var must error")
+	}
+}
+
+func TestOIDCLoginProvider_AuthCodeURL(t *testing.T) {
+	p := &oidcLoginProvider{
+		id:          "entra",
+		displayName: "Entra",
+		authURL:     "https://idp/authorize",
+		clientID:    "client-1",
+		scopes:      []string{"openid", "email"},
+	}
+	got := p.AuthCodeURL("STATE", "NONCE", "CHALLENGE", "https://app/api/auth/oidc/callback")
+	for _, want := range []string{
+		"https://idp/authorize?", "client_id=client-1", "state=STATE",
+		"nonce=NONCE", "code_challenge=CHALLENGE", "code_challenge_method=S256",
+		"scope=openid+email", "response_type=code",
+		"redirect_uri=https%3A%2F%2Fapp%2Fapi%2Fauth%2Foidc%2Fcallback",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("AuthCodeURL missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestRedirectURI(t *testing.T) {
+	if got := RedirectURI("https://app.example.com", false, "ignored", "", ""); got != "https://app.example.com/api/auth/oidc/callback" {
+		t.Fatalf("override: %q", got)
+	}
+	if got := RedirectURI("", false, "internal:9090", "https", "app.example.com"); got != "https://app.example.com/api/auth/oidc/callback" {
+		t.Fatalf("derived: %q", got)
+	}
+	if got := RedirectURI("", false, "localhost:9090", "", ""); got != "http://localhost:9090/api/auth/oidc/callback" {
+		t.Fatalf("http: %q", got)
+	}
+}

--- a/internal/auth/loginprovider_test.go
+++ b/internal/auth/loginprovider_test.go
@@ -4,6 +4,7 @@
 package auth
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -11,7 +12,7 @@ import (
 )
 
 func TestBuildLoginProviders_SkipsNonInteractive(t *testing.T) {
-	provs, err := BuildLoginProviders(nil, []config.OIDCProviderConfig{
+	provs, err := BuildLoginProviders(context.Background(), []config.OIDCProviderConfig{
 		{ID: "verify-only", Issuer: "https://x", ClientID: "c"}, // interactive=false
 	}, "")
 	if err != nil {
@@ -23,7 +24,7 @@ func TestBuildLoginProviders_SkipsNonInteractive(t *testing.T) {
 }
 
 func TestBuildLoginProviders_MissingSecret(t *testing.T) {
-	_, err := BuildLoginProviders(nil, []config.OIDCProviderConfig{
+	_, err := BuildLoginProviders(context.Background(), []config.OIDCProviderConfig{
 		{ID: "entra", Interactive: true, Issuer: "https://x", ClientID: "c"},
 	}, "")
 	if err == nil || !strings.Contains(err.Error(), "client secret") {
@@ -33,7 +34,7 @@ func TestBuildLoginProviders_MissingSecret(t *testing.T) {
 
 func TestBuildLoginProviders_AudienceMismatch(t *testing.T) {
 	t.Setenv("TEST_SECRET", "shh")
-	_, err := BuildLoginProviders(nil, []config.OIDCProviderConfig{
+	_, err := BuildLoginProviders(context.Background(), []config.OIDCProviderConfig{
 		{ID: "entra", Interactive: true, Issuer: "https://x", ClientID: "c",
 			Audience: "different", ClientSecretEnv: "TEST_SECRET"},
 	}, "")
@@ -52,7 +53,7 @@ func TestResolveClientSecret(t *testing.T) {
 	if err != nil || got != "plain" {
 		t.Fatalf("plaintext fallback: got %q err %v", got, err)
 	}
-	if _, err := resolveClientSecret(config.OIDCProviderConfig{ClientSecretEnv: "UNSET_VAR_XYZ"}); err == nil {
+	if _, err := resolveClientSecret(config.OIDCProviderConfig{ClientSecretEnv: "UNSET_VAR_XYZ"}); err == nil { //nolint:gosec // G101: env var name, not a credential
 		t.Fatal("unset env var must error")
 	}
 }

--- a/internal/auth/oidc_verifier.go
+++ b/internal/auth/oidc_verifier.go
@@ -5,7 +5,9 @@ package auth
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -21,6 +23,7 @@ type OIDCClaims struct {
 	Issuer  string
 	Subject string
 	Email   string
+	Nonce   string
 	Raw     map[string]json.RawMessage
 }
 
@@ -96,5 +99,30 @@ func (v *OIDCVerifier) Verify(ctx context.Context, rawToken string) (*OIDCClaims
 			break
 		}
 	}
+	c.Nonce = idToken.Nonce
 	return c, nil
+}
+
+// nonceMatches reports whether got equals want in constant time. An empty
+// want is never a match (a login flow always sets a non-empty nonce).
+func nonceMatches(got, want string) bool {
+	if want == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+}
+
+// VerifyWithNonce validates the token like Verify and additionally requires
+// the id_token's nonce claim to equal expectedNonce. Used by the interactive
+// login callback; the bearer-token path uses Verify (no nonce).
+func (v *OIDCVerifier) VerifyWithNonce(ctx context.Context, rawToken, expectedNonce string) (*OIDCClaims, error) {
+	claims, err := v.Verify(ctx, rawToken)
+	if err != nil {
+		return nil, err
+	}
+	if !nonceMatches(claims.Nonce, expectedNonce) {
+		slog.LogAttrs(ctx, slog.LevelWarn, "auth: OIDC nonce mismatch", slog.String("provider", v.providerID))
+		return nil, errors.New("oidc verify: nonce mismatch")
+	}
+	return claims, nil
 }

--- a/internal/auth/oidc_verifier.go
+++ b/internal/auth/oidc_verifier.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
 
 	"github.com/specgraph/specgraph/internal/config"
 )
@@ -34,6 +35,7 @@ type OIDCClaims struct {
 type OIDCVerifier struct {
 	providerID string
 	issuer     string
+	provider   *oidc.Provider
 	verifier   *oidc.IDTokenVerifier
 }
 
@@ -52,12 +54,18 @@ func NewOIDCVerifier(ctx context.Context, cfg config.OIDCProviderConfig) (*OIDCV
 	return &OIDCVerifier{
 		providerID: cfg.ID,
 		issuer:     cfg.Issuer,
+		provider:   provider,
 		verifier:   verifier,
 	}, nil
 }
 
 // Issuer returns the OIDC issuer URL.
 func (v *OIDCVerifier) Issuer() string { return v.issuer }
+
+// Endpoint returns the provider's OAuth2 authorization and token endpoints
+// (from discovery), so callers building an interactive login flow do not need
+// a second discovery round-trip.
+func (v *OIDCVerifier) Endpoint() oauth2.Endpoint { return v.provider.Endpoint() }
 
 // ProviderID returns the configured provider ID (used in logs).
 func (v *OIDCVerifier) ProviderID() string { return v.providerID }

--- a/internal/auth/oidc_verifier_nonce_test.go
+++ b/internal/auth/oidc_verifier_nonce_test.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import "testing"
+
+func TestNonceMatches(t *testing.T) {
+	if !nonceMatches("abc", "abc") {
+		t.Fatal("equal nonces should match")
+	}
+	if nonceMatches("abc", "xyz") {
+		t.Fatal("different nonces must not match")
+	}
+	if nonceMatches("", "abc") {
+		t.Fatal("empty received nonce must not match a non-empty expected nonce")
+	}
+	if nonceMatches("", "") {
+		t.Fatal("both-empty must not match (the empty-want guard's purpose)")
+	}
+}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -143,6 +143,10 @@ type ServerSection struct {
 	Postgres PostgresConfig `yaml:"postgres" koanf:"postgres"`
 	Docker   bool           `yaml:"docker" koanf:"docker"`
 	Probes   ProbesConfig   `yaml:"probes,omitempty" koanf:"probes"`
+	// TrustedProxy, when true, lets request-IP extraction trust
+	// X-Forwarded-For/X-Real-Ip (e.g. behind a load balancer) for the OIDC
+	// per-IP rate limiter. Default false → use RemoteAddr.
+	TrustedProxy bool `yaml:"trusted_proxy" koanf:"trusted_proxy"`
 }
 
 // ProbesConfig configures the plain-HTTP Kubernetes/Knative probe listener.
@@ -202,6 +206,13 @@ type Route struct {
 type OIDCConfig struct {
 	Providers []OIDCProviderConfig `yaml:"providers" koanf:"providers"`
 	JITCreate JITCreateConfig      `yaml:"jit_create" koanf:"jit_create"`
+	// BaseURL overrides the request-derived origin used to build the OIDC
+	// redirect_uri. Required behind a proxy that rewrites Host. Empty = derive
+	// from the request.
+	BaseURL string `yaml:"base_url" koanf:"base_url"`
+	// SessionTTL is the absolute lifetime of a web session minted by the
+	// interactive login flow. Zero = default (12h, applied in applyPostLoad).
+	SessionTTL time.Duration `yaml:"session_ttl" koanf:"session_ttl"`
 }
 
 // JITCreateConfig parametrizes just-in-time Human creation on first
@@ -215,9 +226,9 @@ type JITCreateConfig struct {
 
 // AuthConfig configures authentication and authorization.
 type AuthConfig struct {
-	Mode          string               `yaml:"mode" koanf:"mode"`                   // deprecated; ignored after Authn plan
-	DefaultRole   string               `yaml:"default_role" koanf:"default_role"`   // deprecated; ignored after Authn plan
-	APIKeys       []APIKeyConfig       `yaml:"api_keys" koanf:"api_keys"`           // ignored after Authn plan (storage owns)
+	Mode          string               `yaml:"mode" koanf:"mode"`                     // deprecated; ignored after Authn plan
+	DefaultRole   string               `yaml:"default_role" koanf:"default_role"`     // deprecated; ignored after Authn plan
+	APIKeys       []APIKeyConfig       `yaml:"api_keys" koanf:"api_keys"`             // ignored after Authn plan (storage owns)
 	OIDCProviders []OIDCProviderConfig `yaml:"oidc_providers" koanf:"oidc_providers"` // deprecated; superseded by OIDC.Providers
 	Roles         []string             `yaml:"roles" koanf:"roles"`
 	Policies      PolicyConfig         `yaml:"policies" koanf:"policies"`
@@ -241,11 +252,17 @@ type APIKeyConfig struct {
 
 // OIDCProviderConfig defines a single OIDC identity provider.
 type OIDCProviderConfig struct {
-	ID            string         `yaml:"id" koanf:"id"`
-	Issuer        string         `yaml:"issuer" koanf:"issuer"`
-	ClientID      string         `yaml:"client_id" koanf:"client_id"`
-	Audience      string         `yaml:"audience" koanf:"audience"`
-	ClaimsMapping []ClaimMapping `yaml:"claims_mapping" koanf:"claims_mapping"`
+	ID              string         `yaml:"id" koanf:"id"`
+	Kind            string         `yaml:"kind" koanf:"kind"`               // "oidc" (default); reserved for "oauth2"
+	Interactive     bool           `yaml:"interactive" koanf:"interactive"` // opt-in to the UI login flow
+	DisplayName     string         `yaml:"display_name" koanf:"display_name"`
+	Issuer          string         `yaml:"issuer" koanf:"issuer"`
+	ClientID        string         `yaml:"client_id" koanf:"client_id"`
+	ClientSecret    string         `yaml:"client_secret" koanf:"client_secret"`         // dev-only plaintext fallback
+	ClientSecretEnv string         `yaml:"client_secret_env" koanf:"client_secret_env"` // preferred: env var name
+	Audience        string         `yaml:"audience" koanf:"audience"`
+	Scopes          []string       `yaml:"scopes" koanf:"scopes"`
+	ClaimsMapping   []ClaimMapping `yaml:"claims_mapping" koanf:"claims_mapping"`
 }
 
 // ClaimMapping maps a JWT claim value to a SpecGraph role.
@@ -285,7 +302,8 @@ func decoderConf(out *GlobalConfig) koanf.UnmarshalConf {
 }
 
 // applyPostLoad runs transforms that must happen after unmarshal: the OIDC
-// providers migration and postgres backend coercion.
+// providers migration, postgres backend coercion, and the OIDC session-TTL
+// default.
 func applyPostLoad(cfg *GlobalConfig) {
 	if len(cfg.Auth.OIDCProviders) > 0 && len(cfg.Auth.OIDC.Providers) == 0 {
 		cfg.Auth.OIDC.Providers = cfg.Auth.OIDCProviders
@@ -297,6 +315,9 @@ func applyPostLoad(cfg *GlobalConfig) {
 	// backend (e.g. "memory") is never overridden.
 	if cfg.Server.Postgres.URL != "" && cfg.Server.Backend == "" {
 		cfg.Server.Backend = "postgres"
+	}
+	if cfg.Auth.OIDC.SessionTTL <= 0 {
+		cfg.Auth.OIDC.SessionTTL = 12 * time.Hour
 	}
 }
 

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -228,6 +228,46 @@ auth:
 	require.Len(t, cfg.Auth.OIDC.Providers, 1)
 }
 
+func TestLoadGlobal_OIDCInteractiveFields(t *testing.T) {
+	yamlBody := []byte(`
+auth:
+  oidc:
+    base_url: https://specgraph.example.com
+    session_ttl: 8h
+    providers:
+      - id: entra
+        kind: oidc
+        interactive: true
+        display_name: Microsoft Entra
+        issuer: https://login.microsoftonline.com/tenant/v2.0
+        client_id: app-id
+        client_secret_env: SPECGRAPH_OIDC_ENTRA_SECRET
+        scopes: [openid, profile, email]
+`)
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, yamlBody, 0o600))
+
+	cfg, err := config.LoadGlobal(path)
+	require.NoError(t, err)
+	require.Equal(t, "https://specgraph.example.com", cfg.Auth.OIDC.BaseURL)
+	require.Equal(t, 8*time.Hour, cfg.Auth.OIDC.SessionTTL)
+	require.Len(t, cfg.Auth.OIDC.Providers, 1)
+	p := cfg.Auth.OIDC.Providers[0]
+	require.Equal(t, "oidc", p.Kind)
+	require.True(t, p.Interactive)
+	require.Equal(t, "Microsoft Entra", p.DisplayName)
+	require.Equal(t, "SPECGRAPH_OIDC_ENTRA_SECRET", p.ClientSecretEnv)
+	require.Equal(t, []string{"openid", "profile", "email"}, p.Scopes)
+}
+
+func TestLoadGlobal_SessionTTLDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("server:\n  backend: memory\n"), 0o600))
+	cfg, err := config.LoadGlobal(path)
+	require.NoError(t, err)
+	require.Equal(t, 12*time.Hour, cfg.Auth.OIDC.SessionTTL)
+}
+
 func TestLoadGlobal_LegacyOIDCProvidersStillWorks(t *testing.T) {
 	yamlBody := []byte(`
 auth:

--- a/internal/server/auth_handler.go
+++ b/internal/server/auth_handler.go
@@ -4,20 +4,24 @@
 package server
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 
 	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 const sessionCookieName = "specgraph_session"
 
 // RegisterAuthHandlers registers login, logout, and whoami endpoints.
 // authMW is applied to protected routes (whoami). It must not be nil.
-// resolver is the Resolver used to validate credentials at the login endpoint.
-func RegisterAuthHandlers(mux *http.ServeMux, resolver auth.Resolver, authMW func(http.Handler) http.Handler) {
+// resolver validates credentials at login. webAuth (may be nil) is used to
+// revoke the server session on logout.
+func RegisterAuthHandlers(mux *http.ServeMux, resolver auth.Resolver, webAuth storage.WebAuthStore, authMW func(http.Handler) http.Handler) {
 	if authMW == nil {
 		panic("RegisterAuthHandlers: authMW must not be nil")
 	}
@@ -35,7 +39,7 @@ func RegisterAuthHandlers(mux *http.ServeMux, resolver auth.Resolver, authMW fun
 			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
 			return
 		}
-		handleLogout(w, r)
+		handleLogout(w, r, webAuth)
 	})
 
 	// whoami: GET only, translate session cookie → Authorization header, then apply authMW.
@@ -80,9 +84,18 @@ func handleLogin(w http.ResponseWriter, r *http.Request, resolver auth.Resolver)
 	json.NewEncoder(w).Encode(newIdentityResponse(id)) //nolint:errcheck // best-effort write to http.ResponseWriter
 }
 
-// handleLogout clears the session cookie.
-func handleLogout(w http.ResponseWriter, r *http.Request) {
-	c := sessionCookie("", r) //nolint:gosec // G124: cookie comes from sessionCookie() which sets HttpOnly, SameSite, and dynamic Secure
+// handleLogout revokes the server session (if the cookie holds a spgr_ws_
+// token) and clears the session cookie. A legacy API-key cookie value is
+// never hashed/looked-up.
+func handleLogout(w http.ResponseWriter, r *http.Request, webAuth storage.WebAuthStore) {
+	if c, err := r.Cookie(sessionCookieName); err == nil && webAuth != nil &&
+		strings.HasPrefix(c.Value, "spgr_ws_") {
+		sum := sha256.Sum256([]byte(c.Value))
+		if revErr := webAuth.RevokeSession(r.Context(), sum[:]); revErr != nil {
+			slog.LogAttrs(r.Context(), slog.LevelWarn, "logout: revoke session", slog.Any("error", revErr))
+		}
+	}
+	c := sessionCookie("", r) //nolint:gosec // G124: sessionCookie sets HttpOnly/SameSite/dynamic Secure
 	c.MaxAge = -1
 	http.SetCookie(w, c)
 	w.WriteHeader(http.StatusNoContent)
@@ -123,16 +136,29 @@ func writeJSONError(w http.ResponseWriter, code int, msg string) {
 	json.NewEncoder(w).Encode(map[string]string{"error": msg}) //nolint:errcheck // best-effort write to http.ResponseWriter
 }
 
+// establishSession sets the session cookie to the given token value. It is the
+// single seam that seats a web session (OIDC flow uses it). MUST reuse
+// sessionCookie()'s exact name and Path so a callback's Set-Cookie
+// deterministically overwrites any pre-existing session cookie and logout's
+// clear always deletes it.
+func establishSession(w http.ResponseWriter, r *http.Request, token string) {
+	http.SetCookie(w, sessionCookie(token, r))
+}
+
 // sessionCookie returns a configured session cookie with the given value.
 // Secure is set dynamically: true when the request arrived over TLS or via a
 // reverse proxy signaling HTTPS via X-Forwarded-Proto, false otherwise (local HTTP dev).
+// SameSite=Lax so the cookie is sent on the post-IdP redirect top-level
+// navigation; safe because no GET endpoint mutates state. This relaxation is
+// intentionally global: it applies to the legacy API-key session cookie too,
+// which is acceptable under the same "no GET mutates state" invariant.
 func sessionCookie(value string, r *http.Request) *http.Cookie {
 	return &http.Cookie{ //nolint:gosec // G124: Secure is dynamic via r.TLS / X-Forwarded-Proto for dev/prod parity; HttpOnly+SameSite are set below // nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
 		Name:     sessionCookieName,
 		Value:    value,
 		Path:     "/",
 		HttpOnly: true,
-		SameSite: http.SameSiteStrictMode,
+		SameSite: http.SameSiteLaxMode,
 		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
 	}
 }

--- a/internal/server/auth_handler_test.go
+++ b/internal/server/auth_handler_test.go
@@ -259,7 +259,7 @@ func TestLogout_RevokesSession(t *testing.T) {
 	RegisterAuthHandlers(mux, &mockResolver{}, wa, noopMW)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
-	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "spgr_ws_abc"})
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "spgr_ws_abc"}) //nolint:gosec // G124: test request cookie
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -283,7 +283,7 @@ func TestLogout_NonSessionCookie_NoRevoke(t *testing.T) {
 
 	// A legacy API-key cookie value must never be hashed/revoked.
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
-	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "spgr_sk_legacy"})
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "spgr_sk_legacy"}) //nolint:gosec // G124: test request cookie
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 

--- a/internal/server/auth_handler_test.go
+++ b/internal/server/auth_handler_test.go
@@ -4,7 +4,9 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // mockResolver implements auth.Resolver for tests.
@@ -45,7 +48,7 @@ func identityMW(id *auth.Identity) func(http.Handler) http.Handler {
 
 func newTestMux(resolver auth.Resolver, authMW func(http.Handler) http.Handler) *http.ServeMux {
 	mux := http.NewServeMux()
-	RegisterAuthHandlers(mux, resolver, authMW)
+	RegisterAuthHandlers(mux, resolver, nil, authMW)
 	return mux
 }
 
@@ -209,5 +212,85 @@ func TestHandleWhoami_NoIdentity(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+// logoutFakeWA is a minimal storage.WebAuthStore for logout-revocation tests.
+// Only RevokeSession has a meaningful body; the rest return zero values.
+type logoutFakeWA struct {
+	onRevoke   func()
+	gotRevoked []byte // the token hash passed to the most recent RevokeSession
+}
+
+var _ storage.WebAuthStore = (*logoutFakeWA)(nil)
+
+func (f *logoutFakeWA) RevokeSession(_ context.Context, tokenHash []byte) error {
+	f.gotRevoked = tokenHash
+	if f.onRevoke != nil {
+		f.onRevoke()
+	}
+	return nil
+}
+
+func (f *logoutFakeWA) CreateSession(_ context.Context, _ *storage.Session) (*storage.Session, error) {
+	return nil, nil
+}
+
+func (f *logoutFakeWA) LookupSessionByHash(_ context.Context, _ []byte) (*storage.Session, error) {
+	return nil, nil
+}
+
+func (f *logoutFakeWA) DeleteExpiredSessions(_ context.Context) (int64, error) { return 0, nil }
+
+func (f *logoutFakeWA) CreateLoginFlow(_ context.Context, _ *storage.LoginFlow) (string, error) {
+	return "", nil
+}
+
+func (f *logoutFakeWA) ConsumeLoginFlow(_ context.Context, _ string) (*storage.LoginFlow, error) {
+	return nil, nil
+}
+
+func (f *logoutFakeWA) DeleteExpiredLoginFlows(_ context.Context) (int64, error) { return 0, nil }
+
+func TestLogout_RevokesSession(t *testing.T) {
+	revoked := false
+	wa := &logoutFakeWA{onRevoke: func() { revoked = true }}
+	mux := http.NewServeMux()
+	RegisterAuthHandlers(mux, &mockResolver{}, wa, noopMW)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "spgr_ws_abc"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d", rec.Code)
+	}
+	if !revoked {
+		t.Fatal("expected RevokeSession to be called")
+	}
+	want := sha256.Sum256([]byte("spgr_ws_abc"))
+	if !bytes.Equal(wa.gotRevoked, want[:]) {
+		t.Fatalf("RevokeSession got wrong hash: %x want %x", wa.gotRevoked, want[:])
+	}
+}
+
+func TestLogout_NonSessionCookie_NoRevoke(t *testing.T) {
+	revoked := false
+	wa := &logoutFakeWA{onRevoke: func() { revoked = true }}
+	mux := http.NewServeMux()
+	RegisterAuthHandlers(mux, &mockResolver{}, wa, noopMW)
+
+	// A legacy API-key cookie value must never be hashed/revoked.
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "spgr_sk_legacy"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d", rec.Code)
+	}
+	if revoked {
+		t.Fatal("expected RevokeSession NOT to be called for non-spgr_ws_ cookie")
 	}
 }

--- a/internal/server/auth_oidc_handler.go
+++ b/internal/server/auth_oidc_handler.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -44,7 +45,7 @@ type oidcLoginHandler struct {
 // RegisterOIDCLoginHandlers wires /api/auth/oidc/{providers,start,callback}.
 // Endpoints are public (no RequireAuth); start/callback are per-IP rate
 // limited. No-op when no interactive providers are configured.
-func RegisterOIDCLoginHandlers(mux *http.ServeMux, cfg OIDCLoginConfig) {
+func RegisterOIDCLoginHandlers(mux *http.ServeMux, cfg OIDCLoginConfig) { //nolint:gocritic // hugeParam: cfg is one-shot startup wiring, not a hot path
 	if len(cfg.Providers) == 0 {
 		return
 	}
@@ -124,6 +125,7 @@ func (h *oidcLoginHandler) handleStart(w http.ResponseWriter, r *http.Request) {
 
 	redirectURI := auth.RedirectURI(h.baseURL, r.TLS != nil, r.Host,
 		r.Header.Get("X-Forwarded-Proto"), r.Header.Get("X-Forwarded-Host"))
+	//nolint:gosec // G710: redirect target is the configured IdP authorize URL (from discovery) + opaque params, not user-controlled
 	http.Redirect(w, r, p.AuthCodeURL(state, nonce, challenge, redirectURI), http.StatusFound)
 }
 
@@ -204,7 +206,7 @@ func (h *oidcLoginHandler) handleCallback(w http.ResponseWriter, r *http.Request
 }
 
 func (h *oidcLoginHandler) txCookie(value string, r *http.Request) *http.Cookie {
-	return &http.Cookie{
+	return &http.Cookie{ //nolint:gosec // G124: Secure is dynamic via r.TLS / X-Forwarded-Proto for dev/prod parity; HttpOnly+SameSite are set here
 		Name:     txCookieName,
 		Value:    value,
 		Path:     "/api/auth/oidc",
@@ -216,7 +218,7 @@ func (h *oidcLoginHandler) txCookie(value string, r *http.Request) *http.Cookie 
 }
 
 func (h *oidcLoginHandler) deleteTxCookie(r *http.Request) *http.Cookie {
-	c := h.txCookie("", r)
+	c := h.txCookie("", r) //nolint:gosec // G124: cookie comes from txCookie() which sets HttpOnly/SameSite/dynamic Secure
 	c.MaxAge = -1
 	return c
 }
@@ -233,7 +235,7 @@ func subjectOnly(subject string) string {
 func randToken() (string, error) {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
-		return "", err
+		return "", fmt.Errorf("read random bytes: %w", err)
 	}
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
@@ -242,7 +244,7 @@ func randToken() (string, error) {
 func randSessionToken() (string, error) {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
-		return "", err
+		return "", fmt.Errorf("read random bytes: %w", err)
 	}
 	return "spgr_ws_" + base64.RawURLEncoding.EncodeToString(b), nil
 }

--- a/internal/server/auth_oidc_handler.go
+++ b/internal/server/auth_oidc_handler.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+const txCookieName = "specgraph_oidc_tx"
+
+// OIDCLoginConfig parametrizes the interactive login handlers.
+type OIDCLoginConfig struct {
+	Providers  []auth.LoginProvider
+	Resolver   auth.Resolver
+	WebAuth    storage.WebAuthStore
+	BaseURL    string
+	SessionTTL time.Duration
+	FlowTTL    time.Duration // default 5m
+	Limiter    *ipRateLimiter
+}
+
+type oidcLoginHandler struct {
+	byID       map[string]auth.LoginProvider
+	resolver   auth.Resolver
+	webAuth    storage.WebAuthStore
+	baseURL    string
+	sessionTTL time.Duration
+	flowTTL    time.Duration
+}
+
+// RegisterOIDCLoginHandlers wires /api/auth/oidc/{providers,start,callback}.
+// Endpoints are public (no RequireAuth); start/callback are per-IP rate
+// limited. No-op when no interactive providers are configured.
+func RegisterOIDCLoginHandlers(mux *http.ServeMux, cfg OIDCLoginConfig) {
+	if len(cfg.Providers) == 0 {
+		return
+	}
+	flowTTL := cfg.FlowTTL
+	if flowTTL <= 0 {
+		flowTTL = 5 * time.Minute
+	}
+	h := &oidcLoginHandler{
+		byID:       map[string]auth.LoginProvider{},
+		resolver:   cfg.Resolver,
+		webAuth:    cfg.WebAuth,
+		baseURL:    cfg.BaseURL,
+		sessionTTL: cfg.SessionTTL,
+		flowTTL:    flowTTL,
+	}
+	for _, p := range cfg.Providers {
+		h.byID[p.ID()] = p
+	}
+
+	limit := cfg.Limiter.wrap
+	mux.HandleFunc("/api/auth/oidc/providers", h.handleProviders)
+	mux.Handle("/api/auth/oidc/callback", limit(http.HandlerFunc(h.handleCallback)))
+	mux.Handle("/api/auth/oidc/{provider}/start", limit(http.HandlerFunc(h.handleStart)))
+}
+
+type providerInfo struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+}
+
+func (h *oidcLoginHandler) handleProviders(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	infos := make([]providerInfo, 0, len(h.byID))
+	for _, p := range h.byID {
+		infos = append(infos, providerInfo{ID: p.ID(), DisplayName: p.DisplayName()})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"providers": infos}) //nolint:errcheck // best-effort write
+}
+
+func (h *oidcLoginHandler) handleStart(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	p, ok := h.byID[r.PathValue("provider")]
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "unknown provider")
+		return
+	}
+	state, err := randToken()
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal")
+		return
+	}
+	nonce, err := randToken()
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal")
+		return
+	}
+	verifier := oauth2.GenerateVerifier()
+	challenge := oauth2.S256ChallengeFromVerifier(verifier)
+
+	flowID, err := h.webAuth.CreateLoginFlow(r.Context(), &storage.LoginFlow{
+		State: state, Nonce: nonce, CodeVerifier: verifier, ProviderID: p.ID(),
+		ExpiresAt: time.Now().Add(h.flowTTL),
+	})
+	if err != nil {
+		slog.LogAttrs(r.Context(), slog.LevelError, "oidc: create login flow", slog.Any("error", err))
+		writeJSONError(w, http.StatusServiceUnavailable, "temporary")
+		return
+	}
+	http.SetCookie(w, h.txCookie(flowID, r))
+
+	redirectURI := auth.RedirectURI(h.baseURL, r.TLS != nil, r.Host,
+		r.Header.Get("X-Forwarded-Proto"), r.Header.Get("X-Forwarded-Host"))
+	http.Redirect(w, r, p.AuthCodeURL(state, nonce, challenge, redirectURI), http.StatusFound)
+}
+
+func (h *oidcLoginHandler) handleCallback(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	// Always delete the tx cookie on the response.
+	http.SetCookie(w, h.deleteTxCookie(r))
+
+	fail := func(reason string) { http.Redirect(w, r, "/?auth_error="+reason, http.StatusFound) }
+
+	c, err := r.Cookie(txCookieName)
+	if err != nil || c.Value == "" {
+		fail("expired")
+		return
+	}
+	if errParam := r.URL.Query().Get("error"); errParam != "" {
+		fail("denied")
+		return
+	}
+	flow, err := h.webAuth.ConsumeLoginFlow(r.Context(), c.Value)
+	if err != nil {
+		// Not-found/expired/bad-id → expired; a genuine DB error → temporary.
+		if errors.Is(err, storage.ErrLoginFlowNotFound) {
+			fail("expired")
+		} else {
+			fail("temporary")
+		}
+		return
+	}
+	if r.URL.Query().Get("state") != flow.State {
+		fail("state")
+		return
+	}
+	p, ok := h.byID[flow.ProviderID]
+	if !ok {
+		slog.LogAttrs(r.Context(), slog.LevelWarn, "oidc: provider removed mid-flow", slog.String("provider", flow.ProviderID))
+		fail("exchange")
+		return
+	}
+	redirectURI := auth.RedirectURI(h.baseURL, r.TLS != nil, r.Host,
+		r.Header.Get("X-Forwarded-Proto"), r.Header.Get("X-Forwarded-Host"))
+	idToken, err := p.Exchange(r.Context(), r.URL.Query().Get("code"), flow.CodeVerifier, flow.Nonce, redirectURI)
+	if err != nil {
+		slog.LogAttrs(r.Context(), slog.LevelWarn, "oidc: exchange failed", slog.String("provider", p.ID()), slog.Any("error", err))
+		fail("exchange")
+		return
+	}
+	// Resolve identity (triggers binding lookup / JIT), limiter bypassed.
+	id, err := h.resolver.Resolve(auth.WithInteractiveLogin(r.Context()), idToken)
+	if err != nil {
+		if errors.Is(err, auth.ErrTransient) {
+			fail("temporary")
+			return
+		}
+		fail("unauthorized")
+		return
+	}
+	// Mint the server session.
+	token, err := randSessionToken()
+	if err != nil {
+		fail("temporary")
+		return
+	}
+	sum := sha256.Sum256([]byte(token))
+	if _, err := h.webAuth.CreateSession(r.Context(), &storage.Session{
+		TokenHash: sum[:], UserID: id.UserID, OIDCSubject: subjectOnly(id.Subject),
+		ExpiresAt: time.Now().Add(h.sessionTTL),
+	}); err != nil {
+		slog.LogAttrs(r.Context(), slog.LevelError, "oidc: create session", slog.Any("error", err))
+		fail("temporary")
+		return
+	}
+	establishSession(w, r, token)
+	http.Redirect(w, r, "/", http.StatusFound)
+}
+
+func (h *oidcLoginHandler) txCookie(value string, r *http.Request) *http.Cookie {
+	return &http.Cookie{
+		Name:     txCookieName,
+		Value:    value,
+		Path:     "/api/auth/oidc",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+		MaxAge:   300,
+	}
+}
+
+func (h *oidcLoginHandler) deleteTxCookie(r *http.Request) *http.Cookie {
+	c := h.txCookie("", r)
+	c.MaxAge = -1
+	return c
+}
+
+// subjectOnly strips the "oidc:" prefix the resolver adds to Identity.Subject.
+func subjectOnly(subject string) string {
+	const p = "oidc:"
+	if len(subject) > len(p) && subject[:len(p)] == p {
+		return subject[len(p):]
+	}
+	return subject
+}
+
+func randToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// randSessionToken returns the opaque spgr_ws_ session token.
+func randSessionToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return "spgr_ws_" + base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/internal/server/auth_oidc_handler.go
+++ b/internal/server/auth_oidc_handler.go
@@ -6,6 +6,7 @@ package server
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -158,7 +159,7 @@ func (h *oidcLoginHandler) handleCallback(w http.ResponseWriter, r *http.Request
 		}
 		return
 	}
-	if r.URL.Query().Get("state") != flow.State {
+	if subtle.ConstantTimeCompare([]byte(r.URL.Query().Get("state")), []byte(flow.State)) != 1 {
 		fail("state")
 		return
 	}

--- a/internal/server/auth_oidc_handler_test.go
+++ b/internal/server/auth_oidc_handler_test.go
@@ -145,7 +145,7 @@ func TestOIDCCallback_HappyPath(t *testing.T) {
 	mux := newTestOIDCMux([]auth.LoginProvider{&fakeProvider{id: "entra", idToken: "tok"}}, wa, res)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?state=S&code=abc", nil)
-	req.AddCookie(&http.Cookie{Name: txCookieName, Value: "flow-1"})
+	req.AddCookie(&http.Cookie{Name: txCookieName, Value: "flow-1"}) //nolint:gosec // G124: test request cookie
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -200,7 +200,7 @@ func TestOIDCCallback_Failures(t *testing.T) {
 
 			req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?"+tc.query, nil)
 			if tc.withTx {
-				req.AddCookie(&http.Cookie{Name: txCookieName, Value: tc.txValue})
+				req.AddCookie(&http.Cookie{Name: txCookieName, Value: tc.txValue}) //nolint:gosec // G124: test request cookie
 			}
 			rec := httptest.NewRecorder()
 			mux.ServeHTTP(rec, req)
@@ -227,7 +227,7 @@ func TestOIDCCallback_ConsumeTransient(t *testing.T) {
 	mux := newTestOIDCMux([]auth.LoginProvider{&fakeProvider{id: "entra", idToken: "tok"}}, wa, res)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?state=S&code=abc", nil)
-	req.AddCookie(&http.Cookie{Name: txCookieName, Value: "flow-1"})
+	req.AddCookie(&http.Cookie{Name: txCookieName, Value: "flow-1"}) //nolint:gosec // G124: test request cookie
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -246,7 +246,7 @@ func TestOIDCCallback_Unauthorized(t *testing.T) {
 	mux := newTestOIDCMux([]auth.LoginProvider{&fakeProvider{id: "entra", idToken: "tok"}}, wa, res)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?state=S&code=abc", nil)
-	req.AddCookie(&http.Cookie{Name: txCookieName, Value: "flow-1"})
+	req.AddCookie(&http.Cookie{Name: txCookieName, Value: "flow-1"}) //nolint:gosec // G124: test request cookie
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -288,7 +288,7 @@ func callbackWithFlow(t *testing.T, prov auth.LoginProvider, res auth.Resolver, 
 	}
 	mux := newTestOIDCMux([]auth.LoginProvider{prov}, wa, res)
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?state=S&code=abc", nil)
-	req.AddCookie(&http.Cookie{Name: txCookieName, Value: "flow-1"})
+	req.AddCookie(&http.Cookie{Name: txCookieName, Value: "flow-1"}) //nolint:gosec // G124: test request cookie
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 	return rec

--- a/internal/server/auth_oidc_handler_test.go
+++ b/internal/server/auth_oidc_handler_test.go
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+type fakeProvider struct {
+	id          string
+	exchangeErr error
+	idToken     string
+}
+
+func (f *fakeProvider) ID() string          { return f.id }
+func (f *fakeProvider) DisplayName() string { return "Fake" }
+func (f *fakeProvider) AuthCodeURL(state, _, _, _ string) string {
+	return "https://idp/authorize?state=" + state
+}
+func (f *fakeProvider) Exchange(_ context.Context, _, _, _, _ string) (string, error) {
+	return f.idToken, f.exchangeErr
+}
+
+type fakeWA struct {
+	flows      map[string]*storage.LoginFlow
+	sessions   map[string]*storage.Session
+	createErr  error
+	consumeErr error // when set, ConsumeLoginFlow returns it (for the existing flow id)
+}
+
+func (f *fakeWA) CreateSession(_ context.Context, s *storage.Session) (*storage.Session, error) {
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	if f.sessions == nil {
+		f.sessions = map[string]*storage.Session{}
+	}
+	s.ID = "s1"
+	f.sessions[string(s.TokenHash)] = s
+	return s, nil
+}
+func (f *fakeWA) LookupSessionByHash(context.Context, []byte) (*storage.Session, error) {
+	return nil, storage.ErrSessionNotFound
+}
+func (f *fakeWA) RevokeSession(context.Context, []byte) error          { return nil }
+func (f *fakeWA) DeleteExpiredSessions(context.Context) (int64, error) { return 0, nil }
+func (f *fakeWA) CreateLoginFlow(_ context.Context, fl *storage.LoginFlow) (string, error) {
+	if f.flows == nil {
+		f.flows = map[string]*storage.LoginFlow{}
+	}
+	fl.ID = "flow-1"
+	f.flows[fl.ID] = fl
+	return fl.ID, nil
+}
+func (f *fakeWA) ConsumeLoginFlow(_ context.Context, id string) (*storage.LoginFlow, error) {
+	if f.consumeErr != nil {
+		return nil, f.consumeErr
+	}
+	fl, ok := f.flows[id]
+	if !ok {
+		return nil, storage.ErrLoginFlowNotFound
+	}
+	delete(f.flows, id)
+	return fl, nil
+}
+func (f *fakeWA) DeleteExpiredLoginFlows(context.Context) (int64, error) { return 0, nil }
+
+type fakeResolver struct {
+	id  *auth.Identity
+	err error
+}
+
+func (f *fakeResolver) Resolve(context.Context, string) (*auth.Identity, error) {
+	return f.id, f.err
+}
+func (f *fakeResolver) HasAuth(context.Context) (bool, error) { return true, nil }
+
+func newTestOIDCMux(provs []auth.LoginProvider, wa storage.WebAuthStore, res auth.Resolver) *http.ServeMux {
+	mux := http.NewServeMux()
+	RegisterOIDCLoginHandlers(mux, OIDCLoginConfig{
+		Providers: provs, Resolver: res, WebAuth: wa,
+		SessionTTL: time.Hour, FlowTTL: time.Minute,
+		Limiter: newIPRateLimiter(1000, 1000, false),
+	})
+	return mux
+}
+
+func TestOIDCStart_RedirectsAndSetsCookie(t *testing.T) {
+	wa := &fakeWA{}
+	mux := newTestOIDCMux([]auth.LoginProvider{&fakeProvider{id: "entra"}}, wa, &fakeResolver{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/entra/start", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+	}
+	if loc := rec.Header().Get("Location"); !strings.HasPrefix(loc, "https://idp/authorize") {
+		t.Fatalf("Location = %q, want prefix https://idp/authorize", loc)
+	}
+	if len(wa.flows) != 1 {
+		t.Fatalf("flows created = %d, want 1", len(wa.flows))
+	}
+	var found bool
+	for _, sc := range rec.Header().Values("Set-Cookie") {
+		if strings.Contains(sc, txCookieName) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("Set-Cookie missing %q: %v", txCookieName, rec.Header().Values("Set-Cookie"))
+	}
+}
+
+func TestOIDCStart_UnknownProvider404(t *testing.T) {
+	mux := newTestOIDCMux([]auth.LoginProvider{&fakeProvider{id: "entra"}}, &fakeWA{}, &fakeResolver{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/nope/start", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestOIDCCallback_HappyPath(t *testing.T) {
+	wa := &fakeWA{
+		flows: map[string]*storage.LoginFlow{
+			"flow-1": {ID: "flow-1", State: "S", ProviderID: "entra", Nonce: "n", CodeVerifier: "v"},
+		},
+	}
+	res := &fakeResolver{id: &auth.Identity{UserID: "u1", Subject: "oidc:sub-1"}}
+	mux := newTestOIDCMux([]auth.LoginProvider{&fakeProvider{id: "entra", idToken: "tok"}}, wa, res)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?state=S&code=abc", nil)
+	req.AddCookie(&http.Cookie{Name: txCookieName, Value: "flow-1"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/" {
+		t.Fatalf("Location = %q, want /", loc)
+	}
+	if len(wa.sessions) != 1 {
+		t.Fatalf("sessions created = %d, want 1", len(wa.sessions))
+	}
+	var sessionVal string
+	for _, ck := range rec.Result().Cookies() {
+		if ck.Name == sessionCookieName {
+			sessionVal = ck.Value
+		}
+	}
+	if !strings.HasPrefix(sessionVal, "spgr_ws_") {
+		t.Fatalf("session cookie value = %q, want prefix spgr_ws_", sessionVal)
+	}
+	// Verify subject prefix stripped for storage.
+	for _, s := range wa.sessions {
+		if s.OIDCSubject != "sub-1" {
+			t.Fatalf("OIDCSubject = %q, want sub-1", s.OIDCSubject)
+		}
+	}
+}
+
+func TestOIDCCallback_Failures(t *testing.T) {
+	tests := []struct {
+		name      string
+		withTx    bool
+		txValue   string
+		query     string
+		wantError string
+	}{
+		{name: "missing-tx", withTx: false, query: "state=S&code=abc", wantError: "expired"},
+		{name: "unknown-flow", withTx: true, txValue: "no-such", query: "state=S&code=abc", wantError: "expired"},
+		{name: "idp-error", withTx: true, txValue: "flow-1", query: "error=access_denied", wantError: "denied"},
+		{name: "state-mismatch", withTx: true, txValue: "flow-1", query: "state=WRONG&code=abc", wantError: "state"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wa := &fakeWA{
+				flows: map[string]*storage.LoginFlow{
+					"flow-1": {ID: "flow-1", State: "S", ProviderID: "entra", Nonce: "n", CodeVerifier: "v"},
+				},
+			}
+			res := &fakeResolver{id: &auth.Identity{UserID: "u1", Subject: "oidc:sub-1"}}
+			mux := newTestOIDCMux([]auth.LoginProvider{&fakeProvider{id: "entra", idToken: "tok"}}, wa, res)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?"+tc.query, nil)
+			if tc.withTx {
+				req.AddCookie(&http.Cookie{Name: txCookieName, Value: tc.txValue})
+			}
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusFound {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+			}
+			loc := rec.Header().Get("Location")
+			if !strings.Contains(loc, "auth_error="+tc.wantError) {
+				t.Fatalf("Location = %q, want auth_error=%s", loc, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestOIDCCallback_ConsumeTransient(t *testing.T) {
+	wa := &fakeWA{
+		flows: map[string]*storage.LoginFlow{
+			"flow-1": {ID: "flow-1", State: "S", ProviderID: "entra"},
+		},
+		consumeErr: errors.New("db down"),
+	}
+	res := &fakeResolver{id: &auth.Identity{UserID: "u1", Subject: "oidc:sub-1"}}
+	mux := newTestOIDCMux([]auth.LoginProvider{&fakeProvider{id: "entra", idToken: "tok"}}, wa, res)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?state=S&code=abc", nil)
+	req.AddCookie(&http.Cookie{Name: txCookieName, Value: "flow-1"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if loc := rec.Header().Get("Location"); !strings.Contains(loc, "auth_error=temporary") {
+		t.Fatalf("Location = %q, want auth_error=temporary", loc)
+	}
+}
+
+func TestOIDCCallback_Unauthorized(t *testing.T) {
+	wa := &fakeWA{
+		flows: map[string]*storage.LoginFlow{
+			"flow-1": {ID: "flow-1", State: "S", ProviderID: "entra", Nonce: "n", CodeVerifier: "v"},
+		},
+	}
+	res := &fakeResolver{err: auth.ErrUnauthenticated}
+	mux := newTestOIDCMux([]auth.LoginProvider{&fakeProvider{id: "entra", idToken: "tok"}}, wa, res)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?state=S&code=abc", nil)
+	req.AddCookie(&http.Cookie{Name: txCookieName, Value: "flow-1"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if loc := rec.Header().Get("Location"); !strings.Contains(loc, "auth_error=unauthorized") {
+		t.Fatalf("Location = %q, want auth_error=unauthorized", loc)
+	}
+	if len(wa.sessions) != 0 {
+		t.Fatalf("sessions created = %d, want 0", len(wa.sessions))
+	}
+}
+
+func TestOIDCCallback_DeletesTxCookie(t *testing.T) {
+	wa := &fakeWA{}
+	mux := newTestOIDCMux([]auth.LoginProvider{&fakeProvider{id: "entra"}}, wa, &fakeResolver{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?state=S", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	var found bool
+	for _, ck := range rec.Result().Cookies() {
+		if ck.Name == txCookieName && ck.MaxAge < 0 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected %q cookie with MaxAge<0 (deletion): %v", txCookieName, rec.Result().Cookies())
+	}
+}
+
+// callbackWithFlow drives a callback against a freshly-seeded flow-1 and
+// returns the auth_error reason from the redirect Location (empty for success).
+func callbackWithFlow(t *testing.T, prov auth.LoginProvider, res auth.Resolver, wa *fakeWA) *httptest.ResponseRecorder {
+	t.Helper()
+	if wa.flows == nil {
+		wa.flows = map[string]*storage.LoginFlow{
+			"flow-1": {ID: "flow-1", State: "S", ProviderID: "entra", Nonce: "n", CodeVerifier: "v"},
+		}
+	}
+	mux := newTestOIDCMux([]auth.LoginProvider{prov}, wa, res)
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?state=S&code=abc", nil)
+	req.AddCookie(&http.Cookie{Name: txCookieName, Value: "flow-1"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestOIDCCallback_ResolverTransient(t *testing.T) {
+	wa := &fakeWA{}
+	res := &fakeResolver{err: auth.ErrTransient}
+	rec := callbackWithFlow(t, &fakeProvider{id: "entra", idToken: "tok"}, res, wa)
+	if loc := rec.Header().Get("Location"); !strings.Contains(loc, "auth_error=temporary") {
+		t.Fatalf("Location = %q, want auth_error=temporary", loc)
+	}
+	if len(wa.sessions) != 0 {
+		t.Fatalf("no session must be minted on transient resolve, got %d", len(wa.sessions))
+	}
+}
+
+func TestOIDCCallback_ExchangeFailure(t *testing.T) {
+	wa := &fakeWA{}
+	prov := &fakeProvider{id: "entra", exchangeErr: errors.New("token endpoint 500")}
+	rec := callbackWithFlow(t, prov, &fakeResolver{}, wa)
+	if loc := rec.Header().Get("Location"); !strings.Contains(loc, "auth_error=exchange") {
+		t.Fatalf("Location = %q, want auth_error=exchange", loc)
+	}
+	if len(wa.sessions) != 0 {
+		t.Fatalf("no session must be minted on exchange failure, got %d", len(wa.sessions))
+	}
+}
+
+func TestOIDCCallback_ProviderRemovedMidFlow(t *testing.T) {
+	// The flow references "ghost", but only "entra" is registered.
+	wa := &fakeWA{
+		flows: map[string]*storage.LoginFlow{
+			"flow-1": {ID: "flow-1", State: "S", ProviderID: "ghost", Nonce: "n", CodeVerifier: "v"},
+		},
+	}
+	rec := callbackWithFlow(t, &fakeProvider{id: "entra", idToken: "tok"}, &fakeResolver{}, wa)
+	if loc := rec.Header().Get("Location"); !strings.Contains(loc, "auth_error=exchange") {
+		t.Fatalf("Location = %q, want auth_error=exchange", loc)
+	}
+}

--- a/internal/server/ratelimit.go
+++ b/internal/server/ratelimit.go
@@ -35,6 +35,12 @@ func newIPRateLimiter(perSec float64, burst int, trustedProxy bool) *ipRateLimit
 	}
 }
 
+// NewIPRateLimiterForOIDC returns the rate limiter used for the public OIDC
+// start/callback endpoints: 10 requests/min, burst 20, per client IP.
+func NewIPRateLimiterForOIDC(trustedProxy bool) *ipRateLimiter {
+	return newIPRateLimiter(10.0/60.0, 20, trustedProxy)
+}
+
 func (l *ipRateLimiter) limiterFor(ip string) *rate.Limiter {
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/internal/server/ratelimit.go
+++ b/internal/server/ratelimit.go
@@ -37,7 +37,7 @@ func newIPRateLimiter(perSec float64, burst int, trustedProxy bool) *ipRateLimit
 
 // NewIPRateLimiterForOIDC returns the rate limiter used for the public OIDC
 // start/callback endpoints: 10 requests/min, burst 20, per client IP.
-func NewIPRateLimiterForOIDC(trustedProxy bool) *ipRateLimiter {
+func NewIPRateLimiterForOIDC(trustedProxy bool) *ipRateLimiter { //nolint:revive // unexported-return: the limiter is internal server wiring passed into OIDCLoginConfig
 	return newIPRateLimiter(10.0/60.0, 20, trustedProxy)
 }
 

--- a/internal/server/ratelimit.go
+++ b/internal/server/ratelimit.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+
+	"golang.org/x/time/rate"
+)
+
+// ipRateLimiter is a per-client-IP token-bucket limiter. Buckets are created
+// lazily and kept in memory for the process lifetime (bounded by distinct IPs;
+// acceptable for the public OIDC start/callback endpoints). Used to bound the
+// unauthenticated DB writes performed by /api/auth/oidc/start.
+type ipRateLimiter struct {
+	mu           sync.Mutex
+	buckets      map[string]*rate.Limiter
+	r            rate.Limit
+	burst        int
+	trustedProxy bool
+}
+
+// newIPRateLimiter returns a limiter allowing r events/sec with the given
+// burst, per client IP. trustedProxy selects X-Forwarded-For extraction.
+func newIPRateLimiter(perSec float64, burst int, trustedProxy bool) *ipRateLimiter {
+	return &ipRateLimiter{
+		buckets:      map[string]*rate.Limiter{},
+		r:            rate.Limit(perSec),
+		burst:        burst,
+		trustedProxy: trustedProxy,
+	}
+}
+
+func (l *ipRateLimiter) limiterFor(ip string) *rate.Limiter {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	lim, ok := l.buckets[ip]
+	if !ok {
+		lim = rate.NewLimiter(l.r, l.burst)
+		l.buckets[ip] = lim
+	}
+	return lim
+}
+
+// wrap returns middleware that rejects over-limit requests with 429.
+func (l *ipRateLimiter) wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip := clientIP(r, l.trustedProxy)
+		if !l.limiterFor(ip).Allow() {
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, `{"error":"rate limited"}`, http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// clientIP returns the client IP. When trustedProxy is true it uses the
+// leftmost X-Forwarded-For entry (then X-Real-Ip); otherwise the TCP peer.
+func clientIP(r *http.Request, trustedProxy bool) string {
+	if trustedProxy {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			if first, _, ok := strings.Cut(xff, ","); ok {
+				return strings.TrimSpace(first)
+			}
+			return strings.TrimSpace(xff)
+		}
+		if xr := r.Header.Get("X-Real-Ip"); xr != "" {
+			return strings.TrimSpace(xr)
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/internal/server/ratelimit_test.go
+++ b/internal/server/ratelimit_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPerIPRateLimiter(t *testing.T) {
+	rl := newIPRateLimiter(1, 1, false) // 1/sec, burst 1
+	h := rl.wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, req)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first request should pass, got %d", rec1.Code)
+	}
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req)
+	if rec2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request should be 429, got %d", rec2.Code)
+	}
+	if rec2.Header().Get("Retry-After") == "" {
+		t.Fatal("429 must set Retry-After")
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req2.RemoteAddr = "10.0.0.2:1234"
+	rec3 := httptest.NewRecorder()
+	h.ServeHTTP(rec3, req2)
+	if rec3.Code != http.StatusOK {
+		t.Fatalf("new IP should pass, got %d", rec3.Code)
+	}
+}
+
+func TestClientIP_TrustedProxy(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.RemoteAddr = "10.0.0.9:5555"
+	req.Header.Set("X-Forwarded-For", "203.0.113.7, 10.0.0.9")
+
+	if ip := clientIP(req, false); ip != "10.0.0.9" {
+		t.Fatalf("untrusted: want RemoteAddr host, got %q", ip)
+	}
+	if ip := clientIP(req, true); ip != "203.0.113.7" {
+		t.Fatalf("trusted: want leftmost XFF, got %q", ip)
+	}
+}

--- a/internal/server/sweeper.go
+++ b/internal/server/sweeper.go
@@ -14,6 +14,38 @@ type ClaimSweeper interface {
 	ReleaseExpiredClaims(ctx context.Context) (int, error)
 }
 
+// WebAuthSweeper releases expired web sessions and login flows.
+type WebAuthSweeper interface {
+	DeleteExpiredSessions(ctx context.Context) (int64, error)
+	DeleteExpiredLoginFlows(ctx context.Context) (int64, error)
+}
+
+// StartWebAuthSweeper launches a goroutine that periodically GCs expired web
+// sessions and OIDC login flows. Stops when ctx is cancelled.
+func StartWebAuthSweeper(ctx context.Context, store WebAuthSweeper, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if n, err := store.DeleteExpiredSessions(ctx); err != nil {
+					slog.LogAttrs(ctx, slog.LevelError, "sweep expired sessions", slog.Any("error", err))
+				} else if n > 0 {
+					slog.LogAttrs(ctx, slog.LevelDebug, "swept expired sessions", slog.Int64("count", n))
+				}
+				if n, err := store.DeleteExpiredLoginFlows(ctx); err != nil {
+					slog.LogAttrs(ctx, slog.LevelError, "sweep expired login flows", slog.Any("error", err))
+				} else if n > 0 {
+					slog.LogAttrs(ctx, slog.LevelDebug, "swept expired login flows", slog.Int64("count", n))
+				}
+			}
+		}
+	}()
+}
+
 // StartSweeper launches a background goroutine that periodically releases expired claims.
 // It stops when the context is cancelled.
 func StartSweeper(ctx context.Context, store ClaimSweeper, interval time.Duration) {

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -158,3 +158,9 @@ var ErrBootstrapExists = errors.New("bootstrap user already exists")
 
 // ErrAPIKeyPrefixExists is returned when an API key prefix collides with an existing key.
 var ErrAPIKeyPrefixExists = errors.New("api key prefix collision")
+
+// ErrSessionNotFound is returned when a web session does not exist (or is expired/revoked at lookup).
+var ErrSessionNotFound = errors.New("web session not found")
+
+// ErrLoginFlowNotFound is returned when an OIDC login-flow row does not exist or has expired.
+var ErrLoginFlowNotFound = errors.New("oidc login flow not found")

--- a/internal/storage/postgres/auth.go
+++ b/internal/storage/postgres/auth.go
@@ -26,6 +26,9 @@ var authMigrations embed.FS
 // Mirrors the convention used by *Store for ConstitutionBackend etc.
 var _ storage.UsersBackend = (*AuthStore)(nil)
 
+// Compile-time assertion that *AuthStore implements WebAuthStore.
+var _ storage.WebAuthStore = (*AuthStore)(nil)
+
 // AuthStore is the Postgres implementation of UsersBackend. It is a sibling
 // to *Store: shares the database pool, holds no project scope, owns the
 // identity tables exclusively.

--- a/internal/storage/postgres/auth_migrations/002_web_auth.sql
+++ b/internal/storage/postgres/auth_migrations/002_web_auth.sql
@@ -1,0 +1,38 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 Sean Brandt
+
+-- +goose Up
+
+CREATE TABLE web_sessions (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    token_hash    bytea NOT NULL UNIQUE,
+    user_id       uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    issuer        text NOT NULL DEFAULT '' CHECK (length(issuer) <= 512),
+    oidc_subject  text NOT NULL DEFAULT '' CHECK (length(oidc_subject) <= 255),
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    expires_at    timestamptz NOT NULL,
+    revoked_at    timestamptz
+);
+
+CREATE INDEX web_sessions_user   ON web_sessions(user_id);
+CREATE INDEX web_sessions_expiry ON web_sessions(expires_at) WHERE revoked_at IS NULL;
+
+CREATE TABLE oidc_login_flows (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    state         text NOT NULL CHECK (length(state) <= 512),
+    nonce         text NOT NULL CHECK (length(nonce) <= 512),
+    code_verifier text NOT NULL CHECK (length(code_verifier) <= 256),
+    provider_id   text NOT NULL CHECK (length(provider_id) <= 128),
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    expires_at    timestamptz NOT NULL
+);
+
+CREATE INDEX oidc_login_flows_expiry ON oidc_login_flows(expires_at);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS oidc_login_flows_expiry;
+DROP TABLE IF EXISTS oidc_login_flows;
+DROP INDEX IF EXISTS web_sessions_expiry;
+DROP INDEX IF EXISTS web_sessions_user;
+DROP TABLE IF EXISTS web_sessions;

--- a/internal/storage/postgres/web_auth.go
+++ b/internal/storage/postgres/web_auth.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// CreateSession inserts a web session row, returning the generated id and
+// created_at.
+func (s *AuthStore) CreateSession(ctx context.Context, sess *storage.Session) (*storage.Session, error) {
+	if len(sess.TokenHash) == 0 {
+		return nil, errors.New("CreateSession: TokenHash required")
+	}
+	if sess.UserID == "" {
+		return nil, errors.New("CreateSession: UserID required")
+	}
+	if sess.ExpiresAt.IsZero() {
+		return nil, errors.New("CreateSession: ExpiresAt required")
+	}
+	const q = `
+		INSERT INTO web_sessions (token_hash, user_id, issuer, oidc_subject, expires_at)
+		SELECT $1, $2::uuid, $3, $4, $5
+		WHERE EXISTS (SELECT 1 FROM users WHERE id = $2::uuid AND deleted_at IS NULL)
+		RETURNING id, created_at`
+	var id string
+	var createdAt time.Time
+	err := s.pool.QueryRow(ctx, q, sess.TokenHash, sess.UserID, sess.Issuer, sess.OIDCSubject, sess.ExpiresAt).
+		Scan(&id, &createdAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("create session: %w", storage.ErrUserNotFound)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("create session: %w", err)
+	}
+	sess.ID = id
+	sess.CreatedAt = createdAt
+	return sess, nil
+}
+
+// LookupSessionByHash returns the session for the given token hash.
+func (s *AuthStore) LookupSessionByHash(ctx context.Context, tokenHash []byte) (*storage.Session, error) {
+	const q = `
+		SELECT id, token_hash, user_id, issuer, oidc_subject, created_at, expires_at, revoked_at
+		FROM web_sessions
+		WHERE token_hash = $1`
+	row := s.pool.QueryRow(ctx, q, tokenHash)
+	var sess storage.Session
+	err := row.Scan(&sess.ID, &sess.TokenHash, &sess.UserID, &sess.Issuer,
+		&sess.OIDCSubject, &sess.CreatedAt, &sess.ExpiresAt, &sess.RevokedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, storage.ErrSessionNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan session: %w", err)
+	}
+	return &sess, nil
+}
+
+// RevokeSession marks the session revoked by token hash. Idempotent.
+func (s *AuthStore) RevokeSession(ctx context.Context, tokenHash []byte) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE web_sessions SET revoked_at = $1
+		WHERE token_hash = $2 AND revoked_at IS NULL`, s.now(), tokenHash)
+	if err != nil {
+		return fmt.Errorf("revoke session: %w", err)
+	}
+	return nil
+}
+
+// DeleteExpiredSessions removes expired rows. Revoked rows are left to expire
+// naturally so a revoked id never silently reappears as "not found vs revoked".
+func (s *AuthStore) DeleteExpiredSessions(ctx context.Context) (int64, error) {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM web_sessions WHERE expires_at <= $1`, s.now())
+	if err != nil {
+		return 0, fmt.Errorf("delete expired sessions: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// CreateLoginFlow inserts a flow row and returns its opaque id.
+func (s *AuthStore) CreateLoginFlow(ctx context.Context, f *storage.LoginFlow) (string, error) {
+	if f.State == "" || f.Nonce == "" || f.CodeVerifier == "" || f.ProviderID == "" {
+		return "", errors.New("CreateLoginFlow: state, nonce, code_verifier, provider_id required")
+	}
+	if f.ExpiresAt.IsZero() {
+		return "", errors.New("CreateLoginFlow: ExpiresAt required")
+	}
+	const q = `
+		INSERT INTO oidc_login_flows (state, nonce, code_verifier, provider_id, expires_at)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id`
+	var id string
+	if err := s.pool.QueryRow(ctx, q, f.State, f.Nonce, f.CodeVerifier, f.ProviderID, f.ExpiresAt).Scan(&id); err != nil {
+		return "", fmt.Errorf("create login flow: %w", err)
+	}
+	return id, nil
+}
+
+// ConsumeLoginFlow atomically deletes and returns the (unexpired) flow.
+func (s *AuthStore) ConsumeLoginFlow(ctx context.Context, flowID string) (*storage.LoginFlow, error) {
+	const q = `
+		DELETE FROM oidc_login_flows
+		WHERE id = $1::uuid AND expires_at > $2
+		RETURNING id, state, nonce, code_verifier, provider_id, created_at, expires_at`
+	row := s.pool.QueryRow(ctx, q, flowID, s.now())
+	var f storage.LoginFlow
+	err := row.Scan(&f.ID, &f.State, &f.Nonce, &f.CodeVerifier, &f.ProviderID, &f.CreatedAt, &f.ExpiresAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, storage.ErrLoginFlowNotFound
+	}
+	// A malformed flowID (not a uuid) yields a 22P02 invalid_text_representation
+	// cast error; map only that to not-found so the handler renders
+	// auth_error=expired. Genuine DB errors (outage, pool exhaustion) propagate
+	// so the caller can treat them as transient — mirroring LookupSessionByHash.
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "22P02" {
+		return nil, storage.ErrLoginFlowNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("consume login flow: %w", err)
+	}
+	return &f, nil
+}
+
+// DeleteExpiredLoginFlows removes expired flow rows.
+func (s *AuthStore) DeleteExpiredLoginFlows(ctx context.Context) (int64, error) {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM oidc_login_flows WHERE expires_at <= $1`, s.now())
+	if err != nil {
+		return 0, fmt.Errorf("delete expired login flows: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}

--- a/internal/storage/postgres/web_auth_test.go
+++ b/internal/storage/postgres/web_auth_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+func TestWebAuth_SessionLifecycle(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	var userID string
+	require.NoError(t, pool.QueryRow(ctx,
+		`INSERT INTO users (kind, display_name, email, role) VALUES ('human','U','u@example.com','reader') RETURNING id`).Scan(&userID))
+
+	hash := []byte("0123456789abcdef0123456789abcdef") // 32 bytes stand-in
+	sess, err := auth.CreateSession(ctx, &storage.Session{
+		TokenHash: hash, UserID: userID, Issuer: "iss", OIDCSubject: "sub",
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, sess.ID)
+
+	got, err := auth.LookupSessionByHash(ctx, hash)
+	require.NoError(t, err)
+	require.Equal(t, userID, got.UserID)
+	require.True(t, got.IsActive(time.Now()))
+
+	require.NoError(t, auth.RevokeSession(ctx, hash))
+	got, err = auth.LookupSessionByHash(ctx, hash)
+	require.NoError(t, err)
+	require.False(t, got.IsActive(time.Now()))
+
+	_, err = auth.LookupSessionByHash(ctx, []byte("nope"))
+	require.ErrorIs(t, err, storage.ErrSessionNotFound)
+}
+
+func TestWebAuth_CreateSessionUnknownUser(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	_, err := auth.CreateSession(ctx, &storage.Session{
+		TokenHash: []byte("x"), UserID: "00000000-0000-0000-0000-000000000000",
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+}
+
+func TestWebAuth_DeleteExpiredSessions(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	var userID string
+	require.NoError(t, pool.QueryRow(ctx,
+		`INSERT INTO users (kind, display_name, email, role) VALUES ('human','U','u@example.com','reader') RETURNING id`).Scan(&userID))
+
+	_, err := auth.CreateSession(ctx, &storage.Session{
+		TokenHash: []byte("expired-hash"), UserID: userID,
+		ExpiresAt: time.Now().Add(-time.Minute),
+	})
+	require.NoError(t, err)
+	n, err := auth.DeleteExpiredSessions(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, n, int64(1))
+}
+
+func TestWebAuth_LoginFlowConsumeSingleUse(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	id, err := auth.CreateLoginFlow(ctx, &storage.LoginFlow{
+		State: "st", Nonce: "no", CodeVerifier: "cv", ProviderID: "entra",
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, id)
+
+	f, err := auth.ConsumeLoginFlow(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "st", f.State)
+	require.Equal(t, "entra", f.ProviderID)
+
+	_, err = auth.ConsumeLoginFlow(ctx, id)
+	require.ErrorIs(t, err, storage.ErrLoginFlowNotFound)
+
+	_, err = auth.ConsumeLoginFlow(ctx, "not-a-uuid")
+	require.ErrorIs(t, err, storage.ErrLoginFlowNotFound)
+}
+
+func TestWebAuth_LoginFlowExpired(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	id, err := auth.CreateLoginFlow(ctx, &storage.LoginFlow{
+		State: "st", Nonce: "no", CodeVerifier: "cv", ProviderID: "entra",
+		ExpiresAt: time.Now().Add(-time.Minute),
+	})
+	require.NoError(t, err)
+	_, err = auth.ConsumeLoginFlow(ctx, id)
+	require.ErrorIs(t, err, storage.ErrLoginFlowNotFound)
+}

--- a/internal/storage/web_auth.go
+++ b/internal/storage/web_auth.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package storage
+
+import "context"
+
+// WebAuthStore persists interactive-login web sessions and short-lived OAuth2
+// login-flow handshake state. Kept separate from UsersBackend so existing
+// UsersBackend implementations/fakes are unaffected. Implemented by
+// *postgres.AuthStore.
+type WebAuthStore interface {
+	// --- sessions ---
+
+	// CreateSession inserts a new session row. s.ExpiresAt must be set.
+	CreateSession(ctx context.Context, s *Session) (*Session, error)
+
+	// LookupSessionByHash returns the session with the given token hash.
+	// Returns ErrSessionNotFound on miss. Does NOT filter expired/revoked —
+	// the caller (resolver) gates on Session.IsActive.
+	LookupSessionByHash(ctx context.Context, tokenHash []byte) (*Session, error)
+
+	// RevokeSession marks the session revoked by token hash. Idempotent.
+	RevokeSession(ctx context.Context, tokenHash []byte) error
+
+	// DeleteExpiredSessions removes expired/long-revoked rows; returns count.
+	DeleteExpiredSessions(ctx context.Context) (int64, error)
+
+	// --- login-flow state ---
+
+	// CreateLoginFlow inserts a flow row and returns its opaque id (the PK).
+	CreateLoginFlow(ctx context.Context, f *LoginFlow) (flowID string, err error)
+
+	// ConsumeLoginFlow atomically deletes and returns the flow for flowID.
+	// Returns ErrLoginFlowNotFound if the id is unknown or already expired.
+	ConsumeLoginFlow(ctx context.Context, flowID string) (*LoginFlow, error)
+
+	// DeleteExpiredLoginFlows removes expired flow rows; returns count.
+	DeleteExpiredLoginFlows(ctx context.Context) (int64, error)
+}

--- a/internal/storage/web_auth_domain.go
+++ b/internal/storage/web_auth_domain.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package storage
+
+import "time"
+
+// Session is a SpecGraph-issued opaque web session minted by the interactive
+// OIDC login flow. The raw token is never stored — only its SHA-256 hash.
+type Session struct {
+	ID          string
+	TokenHash   []byte // SHA-256 of the opaque session token
+	UserID      string
+	Issuer      string // OIDC issuer (audit)
+	OIDCSubject string // audit
+	CreatedAt   time.Time
+	ExpiresAt   time.Time
+	RevokedAt   *time.Time // nil = active
+}
+
+// IsActive reports whether the session is neither revoked nor expired as of now.
+func (s *Session) IsActive(now time.Time) bool {
+	if s.RevokedAt != nil {
+		return false
+	}
+	return s.ExpiresAt.After(now)
+}
+
+// LoginFlow is server-side OAuth2 handshake state for one interactive login
+// attempt. The opaque flow id (ID) is carried in the short-lived tx cookie;
+// state/nonce/code_verifier never leave the server.
+type LoginFlow struct {
+	ID           string // opaque flow id (tx cookie value)
+	State        string // CSRF token, constant-time compared at callback
+	Nonce        string
+	CodeVerifier string // PKCE
+	ProviderID   string
+	CreatedAt    time.Time
+	ExpiresAt    time.Time
+}

--- a/site/docs/architecture.md
+++ b/site/docs/architecture.md
@@ -187,6 +187,15 @@ validates requests before they reach service handlers.
   extracts and validates credentials from request headers or cookies before
   forwarding to handlers.
 
+Beyond bearer-token verification, SpecGraph also offers an **interactive
+browser login** for human operators. Providers marked `interactive: true` run
+a server-side OAuth2 Authorization Code flow with PKCE: SpecGraph drives the
+handshake against the IdP, validates the returned ID token, and mints an
+opaque server-side session (the browser cookie holds only the session id, so
+the flow needs no sticky sessions across replicas). See the
+[Interactive OIDC Login guide](guides/oidc-login.md) for provider setup and
+configuration.
+
 Authentication is optional — the server runs without it for local
 development. Enable it in the server configuration.
 

--- a/site/docs/guides/index.md
+++ b/site/docs/guides/index.md
@@ -23,6 +23,16 @@ jump to whichever workflow you need.
 
     [:octicons-arrow-right-24: Sync & Integration](sync.md)
 
+- :material-login: **Interactive OIDC Login**
+
+    ---
+
+    Enable browser-based "Sign in with &lt;provider&gt;" login (Authorization
+    Code + PKCE → opaque server session) with Microsoft Entra ID, Okta, and
+    GitHub-via-broker configuration examples.
+
+    [:octicons-arrow-right-24: Interactive OIDC Login](oidc-login.md)
+
 - :material-heart-pulse: **Health Probes (Kubernetes / Knative)**
 
     ---

--- a/site/docs/guides/oidc-login.md
+++ b/site/docs/guides/oidc-login.md
@@ -1,0 +1,286 @@
+# Interactive OIDC Login
+
+SpecGraph can present a browser-based **"Sign in with &lt;provider&gt;"** flow so
+that human operators authenticate through your identity provider (IdP) instead
+of pasting a bearer token. This guide covers enabling interactive login,
+configuring real providers (Microsoft Entra ID, Okta, GitHub via a broker), and
+troubleshooting the common failure modes.
+
+## Overview
+
+Interactive login runs a **server-side OAuth2 Authorization Code flow with
+PKCE**. SpecGraph drives the handshake against the provider, validates the
+returned ID token, and mints a **SpecGraph-issued opaque server-side session**.
+
+- The session lives server-side; the browser cookie holds only an opaque
+  session id. All handshake state (PKCE verifier, nonce, requested provider)
+  is kept server-side, so the flow is **multi-replica safe** — no sticky
+  sessions and no session affinity are required at your load balancer.
+- Session lifetime is controlled by `auth.oidc.session_ttl` (default `12h`).
+
+This is **distinct from the existing bearer-token OIDC verification** used by
+the CLI and API. That path validates an ID token presented in the
+`Authorization` header against the provider's JWKS. Interactive login is
+**opt-in per provider** — set `interactive: true` on the provider you want to
+expose as a sign-in button. A provider can serve bearer-token verification,
+interactive login, or both.
+
+The interactive flow uses three endpoints:
+
+- `GET /api/auth/oidc/providers` — lists the providers with `interactive: true`
+  (used to render the sign-in buttons).
+- `GET /api/auth/oidc/{provider}/start` — begins the Authorization Code + PKCE
+  handshake and redirects the browser to the IdP.
+- `GET /api/auth/oidc/callback` — the IdP redirect target; exchanges the code,
+  validates the token, and establishes the session.
+
+## Common Configuration
+
+The following settings apply to every interactive provider regardless of the
+IdP behind it.
+
+### Redirect URI
+
+The redirect URI is **always** `https://<host>/api/auth/oidc/callback`. Register
+**exactly** this URI at the IdP — an exact match, with no wildcards. All
+providers share this single callback path.
+
+### `base_url` behind a reverse proxy
+
+!!! warning "Required behind a host-rewriting proxy or load balancer"
+    `auth.oidc.base_url` is **REQUIRED** whenever SpecGraph sits behind a
+    reverse proxy or load balancer that rewrites the `Host` header.
+
+Without `base_url`, SpecGraph derives the redirect URI from request headers
+(`X-Forwarded-Host` / `X-Forwarded-Proto`). Behind an untrusted or
+host-rewriting proxy, that derivation can produce a **wrong redirect URI** — the
+handshake will then fail the IdP's exact-match check, or (worse) be steered to
+an attacker-influenced host. Setting `base_url` makes the redirect URI
+deterministic and independent of inbound headers. It is the **recommended
+production setting**.
+
+```yaml
+auth:
+  oidc:
+    base_url: https://specgraph.example.com
+```
+
+### Trusted proxy and rate limiting
+
+The login start and callback endpoints are protected by a **per-IP rate
+limiter**. When SpecGraph sits behind a trusted load balancer, set
+`server.trusted_proxy: true` so the limiter keys on the **real client IP** from
+`X-Forwarded-For` rather than the proxy's IP. Without this, all clients share
+the proxy IP and a single user can exhaust the limit for everyone.
+
+```yaml
+server:
+  trusted_proxy: true
+```
+
+!!! danger "Only enable `trusted_proxy` behind a trusted proxy"
+    `X-Forwarded-For` is client-spoofable when the request reaches SpecGraph
+    directly. Enable `trusted_proxy` **only** when a trusted load balancer
+    terminates and rewrites the header.
+
+### Client secrets
+
+Provide the OAuth client secret via the environment, never in committed config:
+
+```yaml
+providers:
+  - id: entra
+    client_secret_env: SPECGRAPH_OIDC_ENTRA_SECRET
+```
+
+`client_secret_env` names an environment variable that SpecGraph reads at
+startup. Do **not** commit a plaintext `client_secret` to your config file. If
+the named environment variable is unset, SpecGraph treats it as a **fatal
+startup error** and refuses to boot — failing closed rather than running a
+provider with no secret.
+
+### JIT provisioning and the email allowlist
+
+Interactive logins **bypass the per-issuer JIT (just-in-time) rate limiter**.
+That limiter exists to throttle bearer-token first-contact provisioning;
+interactive logins are user-driven and already gated by the IdP, PKCE, and a
+server-side nonce, so they are not subject to it.
+
+Because that throttle does not apply, **any internet-facing deployment with JIT
+enabled must bound who can self-provision** using
+`auth.oidc.jit_create.email_domain_allowlist`:
+
+```yaml
+auth:
+  oidc:
+    jit_create:
+      enabled: true
+      default_role: reader
+      email_domain_allowlist: [example.com]
+```
+
+Only verified-email users whose domain is on the allowlist will have an account
+created on first sign-in. Everyone else is rejected (see Troubleshooting).
+
+### Logout caveat
+
+Logout revokes the **SpecGraph server session** — the opaque session id is
+invalidated and the cookie cleared. It does **not** terminate the **IdP SSO
+session**. A subsequent click on "Sign in" may **silently re-authenticate** the
+same user if the IdP still considers them logged in.
+
+!!! note "Shared-machine caveat"
+    On shared or kiosk machines, SpecGraph logout alone does not sign the user
+    out of the IdP. Operators on shared hardware should also sign out at the
+    IdP (or close the browser session) to prevent silent re-authentication.
+
+## Microsoft Entra ID
+
+A complete provider block for Microsoft Entra ID (formerly Azure AD):
+
+```yaml
+auth:
+  oidc:
+    base_url: https://specgraph.example.com
+    session_ttl: 12h
+    providers:
+      - id: entra
+        interactive: true
+        display_name: Microsoft Entra
+        issuer: https://login.microsoftonline.com/<tenant-id>/v2.0
+        client_id: <application-client-id>
+        client_secret_env: SPECGRAPH_OIDC_ENTRA_SECRET
+        scopes: [openid, profile, email]
+        claims_mapping:
+          - { claim: groups, value: <group-object-id>, role: admin }
+    jit_create:
+      enabled: true
+      default_role: reader
+      email_domain_allowlist: [example.com]
+```
+
+### Entra notes
+
+- **Use a tenant-specific issuer:**
+  `https://login.microsoftonline.com/<tenant-id>/v2.0` — **not** `common` or
+  `organizations`. SpecGraph routes providers by exact `iss` match. The
+  multi-tenant endpoints return a **templated** issuer
+  (`.../{tenantid}/v2.0`) that will not match the concrete `iss` value in an
+  issued token, so sign-in fails. Substitute your real tenant GUID.
+- **Emit the `groups` claim.** For `groups` → role mapping to work, the app
+  registration must be configured to include the `groups` claim in the ID
+  token: **App registration → Token configuration → Add groups claim**. Be
+  aware of **"groups overage"** — users who belong to many groups get a claim
+  pointing at the Graph API instead of the inline group list, which breaks
+  direct claim matching. Prefer mapping on a small number of curated security
+  groups, or assign app roles instead.
+- **App registration setup:**
+    1. Add the redirect URI
+       `https://specgraph.example.com/api/auth/oidc/callback` under the **Web**
+       platform.
+    2. Create a **client secret** and place its value in the
+       `SPECGRAPH_OIDC_ENTRA_SECRET` environment variable.
+    3. Copy the **Application (client) ID** into `client_id` and the **Directory
+       (tenant) ID** into the issuer URL.
+
+## Okta
+
+Register an OIDC **Web** application in Okta, then configure the provider:
+
+```yaml
+auth:
+  oidc:
+    base_url: https://specgraph.example.com
+    session_ttl: 12h
+    providers:
+      - id: okta
+        interactive: true
+        display_name: Okta
+        issuer: https://<org>.okta.com/oauth2/default
+        client_id: <okta-client-id>
+        client_secret_env: SPECGRAPH_OIDC_OKTA_SECRET
+        scopes: [openid, profile, email]
+        claims_mapping:
+          - { claim: groups, value: specgraph-admins, role: admin }
+    jit_create:
+      enabled: true
+      default_role: reader
+      email_domain_allowlist: [example.com]
+```
+
+### Okta notes
+
+- **Application type:** create an **OIDC → Web Application** in the Okta admin
+  console (it must hold a client secret for the Authorization Code flow).
+- **Issuer:** use your authorization server's issuer. The built-in default
+  server is `https://<org>.okta.com/oauth2/default`. If you use a **custom** or
+  **org** authorization server, use its issuer URL instead — and confirm it
+  matches the `iss` in issued tokens exactly.
+- **Redirect URI:** add `https://specgraph.example.com/api/auth/oidc/callback`
+  to the application's **Sign-in redirect URIs** (exact match, no wildcards).
+- **Groups claim:** to use `groups` → role mapping, add a **groups claim** to
+  the authorization server (**Security → API → Authorization Servers → Claims**)
+  that emits group names (e.g. a filter matching `specgraph-*`) in the ID
+  token, and ensure the `groups` scope/claim is returned.
+
+## GitHub (via an OIDC broker)
+
+!!! danger "GitHub is not an OIDC provider for user sign-in"
+    GitHub **cannot** be used directly with SpecGraph's OIDC login. GitHub
+    OAuth issues an **opaque access token and no `id_token`**, and there is no
+    user-facing `.well-known/openid-configuration` discovery document. SpecGraph
+    requires a verifiable ID token, so GitHub-direct does not work.
+
+### Supported path: federate through a broker
+
+Put an OIDC broker that **does** issue ID tokens in front of GitHub, configure
+GitHub as an **upstream identity provider** in that broker, and point SpecGraph
+at the broker. To SpecGraph, the broker looks like any other OIDC provider.
+
+Brokers that work this way include:
+
+- **Microsoft Entra External ID**
+- **Auth0**
+- **Keycloak**
+- **Dex**
+
+The flow is: browser → SpecGraph → broker → GitHub (and back). SpecGraph only
+ever talks to the broker, which mints a standard ID token:
+
+```yaml
+auth:
+  oidc:
+    base_url: https://specgraph.example.com
+    session_ttl: 12h
+    providers:
+      - id: github-via-broker
+        interactive: true
+        display_name: Sign in with GitHub
+        issuer: https://broker.example.com/realms/specgraph
+        client_id: <broker-client-id>
+        client_secret_env: SPECGRAPH_OIDC_BROKER_SECRET
+        scopes: [openid, profile, email]
+```
+
+Configure GitHub as the upstream IdP **inside the broker** (the broker holds the
+GitHub OAuth app's client id/secret and the GitHub callback). SpecGraph's
+redirect URI is still `https://specgraph.example.com/api/auth/oidc/callback`,
+registered at the **broker**, not at GitHub.
+
+!!! note "Deferred follow-up"
+    Native GitHub-direct support — a generic OAuth2 + `userinfo` provider that
+    does not require an ID token — is a deferred follow-up and is not yet
+    available.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `redirect_uri` mismatch at the IdP | The registered URI does not match what SpecGraph sent | Register the exact URI `https://<host>/api/auth/oidc/callback`; set `auth.oidc.base_url` so the sent URI is deterministic. |
+| `iss` mismatch / "no provider for issuer" | Using the Entra `common`/`organizations` endpoint, or a mismatched Okta authorization server | Use a **tenant-specific** Entra issuer (`.../<tenant-id>/v2.0`); for Okta, match the exact authorization-server issuer. |
+| Login loop or `auth_error=unauthorized` after a successful IdP sign-in | JIT provisioning disabled, or the user's email domain is not allowlisted | Enable `auth.oidc.jit_create`, or add the user's domain to `email_domain_allowlist`. |
+| Wrong redirect URI / rate limiting keyed on the proxy IP | Running behind a reverse proxy without proxy settings | Set `auth.oidc.base_url` and `server.trusted_proxy: true`. |
+
+For deeper diagnosis, check the server logs around the callback request — the
+validated `iss`, the resolved redirect URI, and the JIT decision are recorded
+there.

--- a/site/zensical.toml
+++ b/site/zensical.toml
@@ -14,7 +14,7 @@ nav = [
   "how-it-works.md",
   "quickstart.md",
   { "Concepts" = ["concepts/index.md", "concepts/ground-truth.md", "concepts/spec-graph.md", "concepts/decisions.md", "concepts/authoring.md", "concepts/passes.md", "concepts/slices.md", "concepts/drift.md", "concepts/lifecycle.md", "concepts/linting.md", "concepts/example-spec.md"] },
-  { "Guides" = ["guides/index.md", "guides/cli-cookbook.md", "guides/sync.md", "guides/health-probes.md", "guides/observability.md"] },
+  { "Guides" = ["guides/index.md", "guides/cli-cookbook.md", "guides/sync.md", "guides/oidc-login.md", "guides/health-probes.md", "guides/observability.md"] },
   "cli-reference.md",
   "architecture.md",
   "ecosystem.md",

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@bufbuild/protoc-gen-es": "2.12.0",
@@ -16,7 +17,8 @@
     "@types/node": "^25.9.1",
     "svelte": "^5.56.2",
     "typescript": "^6.0.3",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^3.0.0"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.12.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -26,13 +26,13 @@ importers:
         version: 2.12.0(@bufbuild/protobuf@2.12.0)
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
-        version: 3.0.10(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.1)))(svelte@5.56.2)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)))
+        version: 3.0.10(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)))(svelte@5.56.2)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)))
       '@sveltejs/kit':
         specifier: ^2.63.0
-        version: 2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.1)))(svelte@5.56.2)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1))
+        version: 2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)))(svelte@5.56.2)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
-        version: 7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.1))
+        version: 7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7))
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
@@ -44,7 +44,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(@types/node@25.9.1)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.27.7)
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.6(@types/node@25.9.1)(lightningcss@1.32.0)
 
 packages:
 
@@ -89,6 +92,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -216,6 +375,144 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.61.1':
+    resolution: {integrity: sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    resolution: {integrity: sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.61.1':
+    resolution: {integrity: sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    resolution: {integrity: sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    resolution: {integrity: sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    resolution: {integrity: sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    resolution: {integrity: sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    resolution: {integrity: sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    resolution: {integrity: sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==}
+    cpu: [x64]
+    os: [win32]
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -255,8 +552,14 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -272,6 +575,35 @@ packages:
     peerDependencies:
       typescript: '*'
 
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
+
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
+
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
+
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
+
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
+
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -281,9 +613,25 @@ packages:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -302,6 +650,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -313,6 +665,14 @@ packages:
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
@@ -323,6 +683,13 @@ packages:
     peerDependenciesMeta:
       '@typescript-eslint/types':
         optional: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -340,6 +707,9 @@ packages:
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -422,6 +792,9 @@ packages:
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -441,6 +814,13 @@ packages:
     resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
     engines: {node: '>=12.20.0'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -457,8 +837,16 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rollup@4.61.1:
+    resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -468,13 +856,40 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   svelte@5.56.2:
     resolution: {integrity: sha512-1lDf8TLqpxyAt3xgybfytWPJQbaUD6TiDgpiCLH0BKrKEwzecB9pjuNVnEJMpzH018xUzo6oxheK2HT0oa2RoQ==}
     engines: {node: '>=18'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -495,6 +910,51 @@ packages:
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -546,6 +1006,39 @@ packages:
     peerDependenciesMeta:
       vite:
         optional: true
+
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
@@ -599,6 +1092,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -682,21 +1253,96 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    optional: true
+
   '@standard-schema/spec@1.1.0': {}
 
   '@sveltejs/acorn-typescript@1.0.10(acorn@8.16.0)':
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.1)))(svelte@5.56.2)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)))(svelte@5.56.2)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)))':
     dependencies:
-      '@sveltejs/kit': 2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.1)))(svelte@5.56.2)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1))
+      '@sveltejs/kit': 2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)))(svelte@5.56.2)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7))
 
-  '@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.1)))(svelte@5.56.2)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1))':
+  '@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)))(svelte@5.56.2)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.1))
+      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.6.0
@@ -708,25 +1354,32 @@ snapshots:
       set-cookie-parser: 3.1.0
       sirv: 3.0.2
       svelte: 5.56.2
-      vite: 8.0.16(@types/node@25.9.1)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.27.7)
     optionalDependencies:
       typescript: 6.0.3
 
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.1))':
+  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.2
       svelte: 5.56.2
-      vite: 8.0.16(@types/node@25.9.1)
-      vitefu: 1.1.3(vite@8.0.16(@types/node@25.9.1))
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.27.7)
+      vitefu: 1.1.3(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7))
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/cookie@0.6.0': {}
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
@@ -743,11 +1396,67 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@3.2.6':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@25.9.1)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.5(@types/node@25.9.1)(lightningcss@1.32.0)
+
+  '@vitest/pretty-format@3.2.6':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.6':
+    dependencies:
+      '@vitest/utils': 3.2.6
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.6':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   acorn@8.16.0: {}
 
   aria-query@5.3.1: {}
 
+  assertion-error@2.0.1: {}
+
   axobject-query@4.1.0: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
 
   clsx@2.1.1: {}
 
@@ -757,17 +1466,56 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   deepmerge@4.3.1: {}
 
   detect-libc@2.1.2: {}
 
   devalue@5.8.1: {}
 
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   esm-env@1.2.2: {}
 
   esrap@2.2.11:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.3.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -779,6 +1527,8 @@ snapshots:
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
+
+  js-tokens@9.0.1: {}
 
   kleur@4.1.5: {}
 
@@ -833,6 +1583,8 @@ snapshots:
 
   locate-character@3.0.0: {}
 
+  loupe@3.2.1: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -844,6 +1596,10 @@ snapshots:
   nanoid@3.3.12: {}
 
   obug@2.1.2: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -876,7 +1632,40 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.3
       '@rolldown/binding-win32-x64-msvc': 1.0.3
 
+  rollup@4.61.1:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.61.1
+      '@rollup/rollup-android-arm64': 4.61.1
+      '@rollup/rollup-darwin-arm64': 4.61.1
+      '@rollup/rollup-darwin-x64': 4.61.1
+      '@rollup/rollup-freebsd-arm64': 4.61.1
+      '@rollup/rollup-freebsd-x64': 4.61.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.61.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.61.1
+      '@rollup/rollup-linux-arm64-gnu': 4.61.1
+      '@rollup/rollup-linux-arm64-musl': 4.61.1
+      '@rollup/rollup-linux-loong64-gnu': 4.61.1
+      '@rollup/rollup-linux-loong64-musl': 4.61.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.61.1
+      '@rollup/rollup-linux-ppc64-musl': 4.61.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.61.1
+      '@rollup/rollup-linux-riscv64-musl': 4.61.1
+      '@rollup/rollup-linux-s390x-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-musl': 4.61.1
+      '@rollup/rollup-openbsd-x64': 4.61.1
+      '@rollup/rollup-openharmony-arm64': 4.61.1
+      '@rollup/rollup-win32-arm64-msvc': 4.61.1
+      '@rollup/rollup-win32-ia32-msvc': 4.61.1
+      '@rollup/rollup-win32-x64-gnu': 4.61.1
+      '@rollup/rollup-win32-x64-msvc': 4.61.1
+      fsevents: 2.3.3
+
   set-cookie-parser@3.1.0: {}
+
+  siginfo@2.0.0: {}
 
   sirv@3.0.2:
     dependencies:
@@ -885,6 +1674,14 @@ snapshots:
       totalist: 3.0.1
 
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   svelte@5.56.2:
     dependencies:
@@ -907,10 +1704,20 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   totalist@3.0.1: {}
 
@@ -923,7 +1730,41 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  vite@8.0.16(@types/node@25.9.1):
+  vite-node@3.2.4(@types/node@25.9.1)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.5(@types/node@25.9.1)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.5(@types/node@25.9.1)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.61.1
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.1
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+
+  vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -932,10 +1773,57 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.1
+      esbuild: 0.27.7
       fsevents: 2.3.3
 
-  vitefu@1.1.3(vite@8.0.16(@types/node@25.9.1)):
+  vitefu@1.1.3(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)):
     optionalDependencies:
-      vite: 8.0.16(@types/node@25.9.1)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.27.7)
+
+  vitest@3.2.6(@types/node@25.9.1)(lightningcss@1.32.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@25.9.1)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.5(@types/node@25.9.1)(lightningcss@1.32.0)
+      vite-node: 3.2.4(@types/node@25.9.1)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   zimmerframe@1.1.4: {}

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+allowBuilds:
+  esbuild: true
 # Exclude svelte@5.56.2 from the pnpm minimumReleaseAge supply-chain policy.
 # The version is newer than the policy's age cutoff but is a trusted upstream
 # release; without this exclude `pnpm install --frozen-lockfile` fails in CI

--- a/web/src/lib/components/LoginModal.svelte
+++ b/web/src/lib/components/LoginModal.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
   import { login } from '$lib/auth.svelte';
+  import { fetchProviders, authErrorMessage, type OidcProvider } from '$lib/oidc.svelte';
+  import { onMount } from 'svelte';
 
   let key = $state('');
   let error = $state('');
   let loading = $state(false);
+  let providers = $state<OidcProvider[]>([]);
 
-  let { onSuccess } = $props();
+  let { onSuccess, authError = null }: { onSuccess: () => Promise<void>; authError?: string | null } = $props();
+
+  onMount(async () => {
+    providers = await fetchProviders();
+    if (authError) error = authErrorMessage(authError);
+  });
 
   async function handleSubmit(e: Event) {
     e.preventDefault();
@@ -30,6 +38,14 @@
 <div class="overlay">
   <form class="login-card" onsubmit={handleSubmit}>
     <h2>SpecGraph</h2>
+    {#if providers.length > 0}
+      <div class="providers">
+        {#each providers as p}
+          <a class="oidc-btn" href={`/api/auth/oidc/${p.id}/start`}>Sign in with {p.displayName}</a>
+        {/each}
+      </div>
+      <div class="divider"><span>or</span></div>
+    {/if}
     <p>Enter your API key to continue.</p>
     <input
       type="password"
@@ -89,4 +105,14 @@
   }
   button:hover:not(:disabled) { background: #2d2d4e; }
   button:disabled { opacity: 0.5; cursor: not-allowed; }
+  .providers { display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 0.75rem; }
+  .oidc-btn {
+    display: block; text-align: center; text-decoration: none;
+    padding: 0.5rem; border: 1px solid #1a1a2e; border-radius: 4px;
+    color: #1a1a2e; font-size: 0.9rem;
+  }
+  .oidc-btn:hover { background: #f1f5f9; }
+  .divider { display: flex; align-items: center; text-align: center; color: #94a3b8; font-size: 0.8rem; margin: 0.25rem 0 0.75rem; }
+  .divider::before, .divider::after { content: ''; flex: 1; border-bottom: 1px solid #e2e8f0; }
+  .divider span { padding: 0 0.5rem; }
 </style>

--- a/web/src/lib/oidc.svelte.ts
+++ b/web/src/lib/oidc.svelte.ts
@@ -1,0 +1,33 @@
+export interface OidcProvider {
+  id: string;
+  displayName: string;
+}
+
+// fetchProviders returns the configured interactive OIDC providers (empty on
+// error or when none are configured).
+export async function fetchProviders(): Promise<OidcProvider[]> {
+  try {
+    const resp = await fetch('/api/auth/oidc/providers');
+    if (!resp.ok) return [];
+    const data = await resp.json();
+    return (data.providers ?? []).map((p: { id: string; display_name: string }) => ({
+      id: p.id,
+      displayName: p.display_name,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+// authErrorMessage maps a backend auth_error reason token to a friendly message.
+export function authErrorMessage(reason: string | null): string {
+  switch (reason) {
+    case 'denied': return 'Sign-in was cancelled or denied by the provider.';
+    case 'unauthorized': return 'Your account is not permitted to sign in. Contact an administrator.';
+    case 'expired': return 'The sign-in attempt expired. Please try again.';
+    case 'state': return 'The sign-in could not be verified. Please try again.';
+    case 'exchange': return 'Sign-in failed during authentication. Please try again.';
+    case 'temporary': return 'The server is temporarily unavailable. Please try again shortly.';
+    default: return 'Sign-in failed. Please try again.';
+  }
+}

--- a/web/src/lib/oidc.test.ts
+++ b/web/src/lib/oidc.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { authErrorMessage } from './oidc.svelte';
+
+describe('authErrorMessage', () => {
+  it('maps known reasons', () => {
+    expect(authErrorMessage('denied')).toContain('cancelled');
+    expect(authErrorMessage('unauthorized')).toContain('not permitted');
+    expect(authErrorMessage('temporary')).toContain('temporarily');
+  });
+  it('falls back for unknown reasons', () => {
+    expect(authErrorMessage('weird')).toBe('Sign-in failed. Please try again.');
+    expect(authErrorMessage(null)).toBe('Sign-in failed. Please try again.');
+  });
+});

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -7,9 +7,18 @@
 
   let { children } = $props();
   let ready = $state(false);
+  let authError = $state(null);
 
   onMount(async () => {
     await checkAuth();
+    const params = new URLSearchParams(window.location.search);
+    const ae = params.get('auth_error');
+    if (ae) {
+      authError = ae;
+      params.delete('auth_error');
+      const qs = params.toString();
+      history.replaceState({}, '', window.location.pathname + (qs ? '?' + qs : ''));
+    }
     if (auth.authenticated) {
       await loadProjects();
     }
@@ -24,7 +33,7 @@
 {#if !ready}
   <main><p class="loading">Connecting...</p></main>
 {:else if !auth.authenticated}
-  <LoginModal onSuccess={handleLoginSuccess} />
+  <LoginModal onSuccess={handleLoginSuccess} {authError} />
 {:else}
   <nav>
     <a href="/" class:active={$page.url.pathname === '/'}>Dashboard</a>


### PR DESCRIPTION
## Summary

Adds a **"Sign in with <provider>"** Authorization Code + PKCE flow to the SpecGraph web dashboard. Previously the UI authenticated only via pasted API key; OIDC was server-side bearer-verification only. This adds the interactive browser login.

- **Server-side opaque session** (not a cookie-JWT): on callback we mint a `spgr_ws_` token, store only its SHA-256 hash in a new `web_sessions` table, and resolve it per request. Handshake state (`state`/`nonce`/PKCE verifier) lives server-side in `oidc_login_flows` (multi-replica safe — no sticky sessions; the tx cookie carries only an opaque flow id).
- **Endpoints**: `GET /api/auth/oidc/providers`, `GET /api/auth/oidc/{provider}/start`, `GET /api/auth/oidc/callback` (start/callback per-IP rate limited).
- **Providers**: Entra ID and Okta native (interactive opt-in via `interactive: true`); GitHub documented via an OIDC broker (GitHub-direct isn't OIDC — opaque token, no `id_token`). Native generic-OAuth2 is a deferred follow-up (spgr-1rq9).
- **Security**: nonce verification (`VerifyWithNonce`), PKCE S256, single-use server-side `state` (constant-time compared), `SameSite=Lax` session cookie, per-IP rate limit on the unauthenticated start/callback, generic `auth_error` taxonomy (no internal detail leaked), logout revokes the server session. Interactive logins bypass the per-issuer JIT rate limiter (user-driven + IdP/PKCE/nonce authenticated) while still honoring the email-domain allowlist.
- **Config**: `auth.oidc.{base_url, session_ttl}`, provider fields `interactive`/`display_name`/`client_secret_env`/`scopes`, and `server.trusted_proxy`. Secrets come from `client_secret_env` (never plaintext).
- **Frontend**: provider buttons in the login modal + `?auth_error=` surfacing.
- **Docs**: new operator guide `site/docs/guides/oidc-login.md` (Entra/Okta/GitHub-broker, grounded config) + architecture.md update.

Design spec and implementation plan are included under `docs/superpowers/`.

## Test Plan

- [x] `task check` (fmt, license, lint, build, unit tests) — green
- [x] WebAuth storage integration tests (`go test -tags integration ./internal/storage/postgres/ -run TestWebAuth`) — green
- [x] Unit coverage: resolver session path + transient/unauth discipline, JIT-bypass matrix, nonce verify, provider build/validation, per-IP rate limit, full handler flow (happy path, every failure reason, single-use replay, tx-cookie deletion), logout revocation, frontend auth_error mapping
- [ ] Manual smoke against a real IdP (Entra/Okta): button → IdP → callback → logged in; `?auth_error=denied` shows a friendly message

## Follow-ups

- spgr-1rq9 — native generic OAuth2 + userinfo provider (GitHub-direct)
- spgr-bbp2 — populate `web_sessions.issuer` for audit / future RP-logout