### PR TITLE
feat: browser-based OIDC login for the CLI (specgraph login/logout)

### DIFF
--- a/cmd/specgraph/docs.go
+++ b/cmd/specgraph/docs.go
@@ -55,7 +55,7 @@ var commandGroups = []commandGroup{
 	{Name: "Sync", Commands: []string{"sync"}},
 	{Name: "Export & Backup", Commands: []string{"export", "import", "verify"}},
 	{Name: "Server & Config", Commands: []string{"up", "down", "install", "uninstall", "serve", "status", "health", "doctor", "init", "prime", "read-mcp-resource"}},
-	{Name: "Identity & Auth", Commands: []string{"login", "auth"}},
+	{Name: "Identity & Auth", Commands: []string{"login", "logout", "auth"}},
 }
 
 func runDocsCli(_ *cobra.Command, args []string) error {

--- a/cmd/specgraph/docs.go
+++ b/cmd/specgraph/docs.go
@@ -55,7 +55,7 @@ var commandGroups = []commandGroup{
 	{Name: "Sync", Commands: []string{"sync"}},
 	{Name: "Export & Backup", Commands: []string{"export", "import", "verify"}},
 	{Name: "Server & Config", Commands: []string{"up", "down", "install", "uninstall", "serve", "status", "health", "doctor", "init", "prime", "read-mcp-resource"}},
-	{Name: "Identity & Auth", Commands: []string{"auth"}},
+	{Name: "Identity & Auth", Commands: []string{"login", "auth"}},
 }
 
 func runDocsCli(_ *cobra.Command, args []string) error {

--- a/cmd/specgraph/login.go
+++ b/cmd/specgraph/login.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/browser"
+	"github.com/specgraph/specgraph/internal/credentials"
+	"github.com/specgraph/specgraph/internal/xdg"
+)
+
+var (
+	loginProviderFlag string
+	loginServerFlag   string
+	loginNoBrowser    bool
+)
+
+var loginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Log in via OIDC in the browser and store a session token",
+	RunE:  runLogin,
+}
+
+func runLogin(cmd *cobra.Command, _ []string) error {
+	w := cmd.OutOrStdout()
+
+	serverURL := loginServerFlag
+	if serverURL == "" {
+		resolved, _, err := resolveBaseURL()
+		if err != nil {
+			return fmt.Errorf("resolve server URL: %w", err)
+		}
+		serverURL = resolved
+	}
+	serverURL = strings.TrimRight(serverURL, "/")
+
+	if err := guardHTTPS(serverURL); err != nil {
+		return err
+	}
+	if err := guardRemote(); err != nil {
+		return err
+	}
+
+	provider, err := pickProvider(cmd.Context(), serverURL, loginProviderFlag)
+	if err != nil {
+		return err
+	}
+
+	verifier := oauth2.GenerateVerifier()
+	challenge := oauth2.S256ChallengeFromVerifier(verifier)
+	cliState := oauth2.GenerateVerifier() // reuse as a high-entropy opaque token
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("start loopback listener: %w", err)
+	}
+	defer func() { _ = ln.Close() }() //nolint:errcheck // best-effort cleanup
+	tcpAddr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		return fmt.Errorf("loopback listener address is not TCP: %T", ln.Addr())
+	}
+	port := tcpAddr.Port
+	cbURL := fmt.Sprintf("http://127.0.0.1:%d/callback", port)
+
+	authURL := fmt.Sprintf("%s/api/auth/oidc/%s/start?%s", serverURL, url.PathEscape(provider),
+		url.Values{"cli_callback": {cbURL}, "cli_state": {cliState}, "cli_challenge": {challenge}}.Encode())
+
+	codeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	srv := &http.Server{Handler: loopbackHandler(port, cliState, codeCh, errCh), ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = srv.Serve(ln) }()  //nolint:errcheck // Serve always returns a non-nil error on Close
+	defer func() { _ = srv.Close() }() //nolint:errcheck // best-effort cleanup
+
+	if loginNoBrowser {
+		fmt.Fprintf(w, "Open this URL to log in:\n\n  %s\n\n", authURL) //nolint:errcheck // writes to user stream
+	} else if openErr := browser.Open(authURL); openErr != nil {
+		fmt.Fprintf(w, "Could not open a browser. Open this URL to log in:\n\n  %s\n\n", authURL) //nolint:errcheck // writes to user stream
+	}
+	fmt.Fprintln(w, "Waiting for the browser to complete login…") //nolint:errcheck // writes to user stream
+
+	var code string
+	select {
+	case code = <-codeCh:
+	case err = <-errCh:
+		return err
+	case <-time.After(3 * time.Minute):
+		return errors.New("login timed out, please retry")
+	// Inert until the root wires signal-based cancellation; harmless to keep.
+	case <-cmd.Context().Done():
+		return cmd.Context().Err()
+	}
+
+	token, subject, err := exchangeCode(cmd.Context(), serverURL, code, verifier)
+	if err != nil {
+		return err
+	}
+
+	if err := writeCredentials(w, serverURL, token, subject); err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "Logged in as %s on %s\n", subject, serverURL) //nolint:errcheck // writes to user stream
+	return nil
+}
+
+// loopbackHandler validates the Host header + cli_state and forwards the code.
+func loopbackHandler(port int, cliState string, codeCh chan<- string, errCh chan<- error) http.Handler {
+	wantHost := fmt.Sprintf("127.0.0.1:%d", port)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Host != wantHost {
+			http.Error(w, "bad host", http.StatusBadRequest)
+			return
+		}
+		q := r.URL.Query()
+		if subtle.ConstantTimeCompare([]byte(q.Get("cli_state")), []byte(cliState)) != 1 {
+			http.Error(w, "state mismatch", http.StatusBadRequest)
+			errCh <- errors.New("loopback state mismatch — aborting")
+			return
+		}
+		code := q.Get("code")
+		if code == "" {
+			http.Error(w, "missing code", http.StatusBadRequest)
+			errCh <- errors.New("loopback callback missing code")
+			return
+		}
+		fmt.Fprintln(w, "Login complete. You can close this tab and return to the terminal.") //nolint:errcheck // writes to user stream
+		codeCh <- code
+	})
+}
+
+func guardHTTPS(serverURL string) error {
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return fmt.Errorf("parse server URL: %w", err)
+	}
+	if u.Scheme == "https" || auth.IsLiteralLoopbackHost(u.Hostname()) {
+		return nil
+	}
+	return fmt.Errorf("refusing to log in over plain http to a non-loopback server (%s); use https", serverURL)
+}
+
+func guardRemote() error {
+	if loginNoBrowser {
+		return nil
+	}
+	if os.Getenv("SSH_CONNECTION") != "" || os.Getenv("SSH_TTY") != "" {
+		return errors.New("browser-based login isn't available over SSH/headless sessions; create an API key instead: specgraph auth api-key create")
+	}
+	return nil
+}
+
+type providersResponse struct {
+	Providers []struct {
+		ID          string `json:"id"`
+		DisplayName string `json:"display_name"`
+	} `json:"providers"`
+}
+
+func pickProvider(ctx context.Context, serverURL, want string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, serverURL+"/api/auth/oidc/providers", http.NoBody)
+	if err != nil {
+		return "", fmt.Errorf("build providers request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("list providers: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // best-effort cleanup
+	var pr providersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return "", fmt.Errorf("decode providers: %w", err)
+	}
+	if len(pr.Providers) == 0 {
+		return "", errors.New("server has no interactive OIDC providers; use specgraph auth api-key create")
+	}
+	if want != "" {
+		for _, p := range pr.Providers {
+			if p.ID == want {
+				return p.ID, nil
+			}
+		}
+		return "", fmt.Errorf("provider %q not found on server", want)
+	}
+	if len(pr.Providers) == 1 {
+		return pr.Providers[0].ID, nil
+	}
+	return "", errors.New("multiple OIDC providers configured; pass --provider <id>")
+}
+
+func exchangeCode(ctx context.Context, serverURL, code, verifier string) (token, subject string, err error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	body, err := json.Marshal(map[string]string{"code": code, "cli_verifier": verifier})
+	if err != nil {
+		return "", "", fmt.Errorf("marshal exchange request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL+"/api/auth/cli/exchange", bytes.NewReader(body))
+	if err != nil {
+		return "", "", fmt.Errorf("build exchange request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("exchange code: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // best-effort cleanup
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusBadRequest {
+			return "", "", errors.New("login expired, please retry")
+		}
+		return "", "", fmt.Errorf("exchange failed: server returned %d", resp.StatusCode)
+	}
+	var er struct {
+		Token       string `json:"token"`
+		OIDCSubject string `json:"oidc_subject"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+		return "", "", fmt.Errorf("decode exchange response: %w", err)
+	}
+	return er.Token, er.OIDCSubject, nil
+}
+
+func writeCredentials(w io.Writer, serverURL, token, subject string) error {
+	credPath := xdg.CredentialsFile()
+	f, err := credentials.Load(credPath)
+	if err != nil {
+		return fmt.Errorf("load credentials: %w", err)
+	}
+	if existing := f.TokenFor(serverURL); existing != "" && !strings.HasPrefix(existing, "spgr_ws_") {
+		fmt.Fprintf(w, "warning: replacing a non-session credential for %s\n", serverURL) //nolint:errcheck // writes to user stream
+	}
+	f.Upsert(serverURL, credentials.ServerCreds{Token: token, Label: "oidc:" + subject})
+	if err := f.Save(credPath); err != nil {
+		return fmt.Errorf("save credentials: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	loginCmd.Flags().StringVar(&loginProviderFlag, "provider", "", "OIDC provider id (skips the picker)")
+	loginCmd.Flags().StringVar(&loginServerFlag, "server", "", "server base URL (overrides resolved)")
+	loginCmd.Flags().BoolVar(&loginNoBrowser, "no-browser", false, "print the URL instead of opening a browser")
+	rootCmd.AddCommand(loginCmd)
+}

--- a/cmd/specgraph/login.go
+++ b/cmd/specgraph/login.go
@@ -128,6 +128,12 @@ func loopbackHandler(port int, cliState string, codeCh chan<- string, errCh chan
 			http.Error(w, "bad host", http.StatusBadRequest)
 			return
 		}
+		// Ignore stray requests (favicon, prefetch, loopback port scans) without
+		// aborting the login — only /callback drives the flow.
+		if r.URL.Path != "/callback" {
+			http.NotFound(w, r)
+			return
+		}
 		q := r.URL.Query()
 		if subtle.ConstantTimeCompare([]byte(q.Get("cli_state")), []byte(cliState)) != 1 {
 			http.Error(w, "state mismatch", http.StatusBadRequest)
@@ -156,10 +162,11 @@ func guardHTTPS(serverURL string) error {
 	return fmt.Errorf("refusing to log in over plain http to a non-loopback server (%s); use https", serverURL)
 }
 
+// guardRemote rejects SSH/headless sessions where the loopback redirect cannot
+// reach the CLI host. Applies regardless of --no-browser: over SSH a loopback
+// login can never complete (the browser runs on a different machine), so we
+// fail fast with actionable guidance instead of hanging until the timeout.
 func guardRemote() error {
-	if loginNoBrowser {
-		return nil
-	}
 	if os.Getenv("SSH_CONNECTION") != "" || os.Getenv("SSH_TTY") != "" {
 		return errors.New("browser-based login isn't available over SSH/headless sessions; create an API key instead: specgraph auth api-key create")
 	}

--- a/cmd/specgraph/login_test.go
+++ b/cmd/specgraph/login_test.go
@@ -56,6 +56,32 @@ func TestLoopbackHandler_Success(t *testing.T) {
 	}
 }
 
+func TestLoopbackHandler_IgnoresOtherPaths(t *testing.T) {
+	t.Parallel()
+	codeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	h := loopbackHandler(5000, "secret", codeCh, errCh)
+	req := httptest.NewRequest(http.MethodGet, "/favicon.ico", nil)
+	req.Host = "127.0.0.1:5000"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	select {
+	case <-errCh:
+		t.Fatal("a non-callback request must not abort the login")
+	default:
+	}
+}
+
+func TestGuardRemote_SSHRejected(t *testing.T) {
+	t.Setenv("SSH_CONNECTION", "10.0.0.1 22 10.0.0.2 22")
+	if err := guardRemote(); err == nil {
+		t.Fatal("expected guardRemote to reject an SSH session")
+	}
+}
+
 func TestPickProvider(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/cmd/specgraph/login_test.go
+++ b/cmd/specgraph/login_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGuardHTTPS(t *testing.T) {
+	t.Parallel()
+	if err := guardHTTPS("http://127.0.0.1:9090"); err != nil {
+		t.Errorf("loopback http should pass: %v", err)
+	}
+	if err := guardHTTPS("https://api.example.com"); err != nil {
+		t.Errorf("https should pass: %v", err)
+	}
+	if err := guardHTTPS("http://api.example.com"); err == nil {
+		t.Error("remote http should fail")
+	}
+}
+
+func TestLoopbackHandler_StateMismatch(t *testing.T) {
+	t.Parallel()
+	codeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	h := loopbackHandler(5000, "secret", codeCh, errCh)
+	req := httptest.NewRequest(http.MethodGet, "/callback?cli_state=wrong&code=abc", nil)
+	req.Host = "127.0.0.1:5000"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	select {
+	case <-errCh:
+	default:
+		t.Fatal("expected an error on the channel")
+	}
+}
+
+func TestLoopbackHandler_Success(t *testing.T) {
+	t.Parallel()
+	codeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	h := loopbackHandler(5000, "secret", codeCh, errCh)
+	req := httptest.NewRequest(http.MethodGet, "/callback?cli_state=secret&code=thecode", nil)
+	req.Host = "127.0.0.1:5000"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if got := <-codeCh; got != "thecode" {
+		t.Fatalf("code = %q", got)
+	}
+}
+
+func TestPickProvider(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"providers":[{"id":"entra","display_name":"Entra"}]}`))
+	}))
+	defer srv.Close()
+	id, err := pickProvider(t.Context(), srv.URL, "")
+	if err != nil || id != "entra" {
+		t.Fatalf("id=%q err=%v", id, err)
+	}
+}
+
+func TestExchangeCode_BadRequest(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	_, _, err := exchangeCode(t.Context(), srv.URL, "c", "v")
+	if err == nil || !strings.Contains(err.Error(), "expired") {
+		t.Fatalf("want expired error, got %v", err)
+	}
+}

--- a/cmd/specgraph/logout.go
+++ b/cmd/specgraph/logout.go
@@ -64,6 +64,10 @@ func runLogout(cmd *cobra.Command, _ []string) error {
 }
 
 func revokeSession(ctx context.Context, serverURL, token string) error {
+	// Never send the session token over plaintext to a non-loopback server.
+	if err := guardHTTPS(serverURL); err != nil {
+		return fmt.Errorf("refusing insecure revoke transport: %w", err)
+	}
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL+"/api/auth/logout", http.NoBody)

--- a/cmd/specgraph/logout.go
+++ b/cmd/specgraph/logout.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/specgraph/specgraph/internal/credentials"
+	"github.com/specgraph/specgraph/internal/xdg"
+)
+
+var logoutServerFlag string
+
+var logoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Revoke the stored session and remove local credentials",
+	RunE:  runLogout,
+}
+
+func runLogout(cmd *cobra.Command, _ []string) error {
+	w := cmd.OutOrStdout()
+	serverURL := logoutServerFlag
+	if serverURL == "" {
+		resolved, _, err := resolveBaseURL()
+		if err != nil {
+			return fmt.Errorf("resolve server URL: %w", err)
+		}
+		serverURL = resolved
+	}
+	serverURL = strings.TrimRight(serverURL, "/")
+
+	credPath := xdg.CredentialsFile()
+	f, err := credentials.Load(credPath)
+	if err != nil {
+		return fmt.Errorf("load credentials: %w", err)
+	}
+	token := f.TokenFor(serverURL)
+	if token == "" {
+		fmt.Fprintf(w, "No stored credential for %s\n", serverURL) //nolint:errcheck // writes to user stream
+		return nil
+	}
+
+	if strings.HasPrefix(token, "spgr_ws_") {
+		if err := revokeSession(cmd.Context(), serverURL, token); err != nil {
+			fmt.Fprintf(w, "warning: server revoke failed: %v\n", err) //nolint:errcheck // writes to user stream
+		}
+	} else {
+		fmt.Fprintf(w, "warning: removing a non-session credential (API key) for %s\n", serverURL) //nolint:errcheck // writes to user stream
+	}
+
+	delete(f.Servers, strings.TrimRight(serverURL, "/"))
+	if err := f.Save(credPath); err != nil {
+		return fmt.Errorf("save credentials: %w", err)
+	}
+	fmt.Fprintf(w, "Logged out of %s\n", serverURL) //nolint:errcheck // writes to user stream
+	return nil
+}
+
+func revokeSession(ctx context.Context, serverURL, token string) error {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL+"/api/auth/logout", http.NoBody)
+	if err != nil {
+		return fmt.Errorf("build revoke request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("revoke request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // best-effort close
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func init() {
+	logoutCmd.Flags().StringVar(&logoutServerFlag, "server", "", "server base URL (overrides resolved)")
+	rootCmd.AddCommand(logoutCmd)
+}

--- a/cmd/specgraph/logout_test.go
+++ b/cmd/specgraph/logout_test.go
@@ -35,3 +35,11 @@ func TestRevokeSession_ServerError(t *testing.T) {
 		t.Fatal("expected error on 500")
 	}
 }
+
+func TestRevokeSession_RefusesPlaintextRemote(t *testing.T) {
+	t.Parallel()
+	// A non-loopback plaintext URL must be refused before the token is sent.
+	if err := revokeSession(t.Context(), "http://api.example.com", "spgr_ws_abc"); err == nil {
+		t.Fatal("expected revokeSession to refuse plaintext remote transport")
+	}
+}

--- a/cmd/specgraph/logout_test.go
+++ b/cmd/specgraph/logout_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRevokeSession(t *testing.T) {
+	t.Parallel()
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	if err := revokeSession(t.Context(), srv.URL, "spgr_ws_abc"); err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer spgr_ws_abc" {
+		t.Fatalf("auth header = %q", gotAuth)
+	}
+}
+
+func TestRevokeSession_ServerError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	if err := revokeSession(t.Context(), srv.URL, "spgr_ws_abc"); err == nil {
+		t.Fatal("expected error on 500")
+	}
+}

--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -213,13 +213,14 @@ func buildAppHandler(_ context.Context, cfg *config.GlobalConfig, deps *appDeps,
 	server.RegisterAPIHandlers(mux, store, auth.RequireAuth(resolver))
 	server.RegisterAuthHandlers(mux, resolver, res.authStore, auth.RequireAuth(resolver))
 	server.RegisterOIDCLoginHandlers(mux, server.OIDCLoginConfig{
-		Providers:  deps.loginProviders,
-		Resolver:   resolver,
-		WebAuth:    res.authStore,
-		BaseURL:    cfg.Auth.OIDC.BaseURL,
-		SessionTTL: cfg.Auth.OIDC.SessionTTL,
-		FlowTTL:    5 * time.Minute,
-		Limiter:    server.NewIPRateLimiterForOIDC(cfg.Server.TrustedProxy),
+		Providers:       deps.loginProviders,
+		Resolver:        resolver,
+		WebAuth:         res.authStore,
+		BaseURL:         cfg.Auth.OIDC.BaseURL,
+		SessionTTL:      cfg.Auth.OIDC.SessionTTL,
+		FlowTTL:         5 * time.Minute,
+		Limiter:         server.NewIPRateLimiterForOIDC(cfg.Server.TrustedProxy),
+		CLILoginEnabled: cfg.Auth.OIDC.CLILoginEnabled,
 	})
 
 	loopbackClient := newHTTPClient("")

--- a/docs/plans/2026-06-15-cli-oidc-login-design.md
+++ b/docs/plans/2026-06-15-cli-oidc-login-design.md
@@ -1,0 +1,470 @@
+# CLI OIDC Login Design
+
+**Date:** 2026-06-15
+**Status:** Proposed (revised after three adversarial-review passes; pass 3 verdict: ready to implement)
+**Part of:** Identity, RBAC & Audit epic. Companion designs: Identity Authn, Identity Storage, Bootstrap & UX.
+
+## Problem
+
+OIDC login exists for the web dashboard but not the CLI. The browser flow
+(`internal/server/auth_oidc_handler.go`) ends by minting an opaque `spgr_ws_`
+session token, seating it in an **HttpOnly** cookie, and redirecting to `/`. A
+CLI cannot read that cookie, so today the only way to authenticate the CLI is a
+long-lived API key (`SPECGRAPH_API_KEY` env var or an entry in the credentials
+file, resolved in `cmd/specgraph/client.go`).
+
+We want a `gh auth login`-style experience: run `specgraph login`, complete the
+existing OIDC flow in the browser, and have the CLI capture a token and store it
+in the credentials file (`internal/credentials/`) — whose header already reads
+*"Managed by `specgraph login`"*.
+
+A `spgr_ws_` session token already resolves as a valid CLI bearer token (the
+resolver accepts it at `internal/auth/identitystore.go`), so the only missing
+piece is a server-side affordance to hand the token back to the CLI instead of
+seating a cookie.
+
+## Scope
+
+- A top-level `specgraph login` command that performs a **browser-based OIDC
+  login via a loopback redirect** against the configured server and writes the
+  resulting session token to the credentials file.
+- A top-level `specgraph logout` command that revokes the session server-side
+  and removes the local credentials entry.
+- The minimal server-side changes to broker the flow to a CLI loopback listener.
+
+**Out of scope (v1):**
+
+- **Any remote/headless login path.** SSH / remote-dev / container shells cannot
+  use the loopback redirect (the browser runs on a different host). v1 detects
+  this and hard-errors with guidance to use `specgraph auth api-key create`. A
+  paste-the-code fallback was considered and **rejected** — it is phishable
+  (login-CSRF / account takeover, see "Why no paste/manual code" below). A proper
+  RFC 8628 device flow is the correct future answer and is deferred.
+- Device authorization grant (RFC 8628), refresh-token handling (re-run
+  `specgraph login` when the session expires), a separate native/public IdP
+  client registration, and any change to the web dashboard flow.
+
+### Why no paste/manual code
+
+A "server displays a one-time code, user pastes it into the CLI" fallback does
+**not** match loopback security, even with PKCE. PKCE proves possession of the
+verifier but never binds the *authenticating user* to the CLI process. An
+attacker can run `specgraph login` on their own machine (keeping verifier `V`,
+challenge `S256(V)`), phish the victim with the resulting authorize URL, let the
+victim authenticate as themselves (server mints a code bound to the *victim's*
+identity and displays it to the victim), then social-engineer the victim into
+returning the code and exchange `{code, V}` for a session **for the victim's
+account, delivered to the attacker**. The loopback path is immune because the
+code is delivered only to an attacker-uncontrolled `127.0.0.1` listener. v1 does
+not ship a manual-code path.
+
+## Threat model summary
+
+The IdP only ever sees the **server** callback (`auth.RedirectURI` →
+`/api/auth/oidc/callback`, `loginprovider.go:172`); it never validates the
+loopback URL. The server itself performs the final 302 to the CLI's
+`cli_callback`. Therefore the server-side loopback validation is the **sole**
+gate preventing the server from being weaponized as an open redirect that
+discloses a bearer-capable artifact. Two independent secrets protect the result,
+and crucially the code is only ever delivered to an attacker-uncontrolled
+loopback listener:
+
+- **`cli_state`** — CSRF protection on the loopback leg (CLI-verified, constant
+  time).
+- **`cli_verifier` (PKCE)** — proof-of-possession on the exchange leg
+  (server-verified, constant time). The one-time `cli_code` is useless without
+  the verifier, which never leaves the CLI process.
+
+These are distinct from, and additional to, the unchanged IdP-leg
+`state`/`nonce`/PKCE.
+
+## Architectural shape
+
+Server-brokered loopback with a one-time code **bound by PKCE**. The CLI never
+talks to the IdP directly; the server keeps its existing relationship with the
+IdP (client secret, PKCE, nonce) and only learns to deliver the result to a
+loopback URL when the flow originated from the CLI.
+
+```text
+specgraph login
+  │ 1. resolveBaseURL() → server + project ; enforce loopback-or-https (see Security)
+  │    refuse if SSH/headless/no-browser (see Remote sessions) → point to api-key
+  │ 2. GET <server>/api/auth/oidc/providers → pick provider (--provider or prompt)
+  │ 3. gen cli_state (CSRF) + cli_verifier (PKCE) ; cli_challenge = S256(cli_verifier)
+  │    start loopback listener bound to literal 127.0.0.1:<rand>/callback
+  │ 4. open browser → <server>/api/auth/oidc/{provider}/start
+  │        ?cli_callback=http://127.0.0.1:<port>/callback
+  │        &cli_state=<state>&cli_challenge=<challenge>
+  ▼
+server handleStart  – validate cli_callback (strict loopback, see Security);
+  │                    require cli_challenge ; reject if cli_login_enabled=false (403);
+  │                    persist cli_callback + cli_state + cli_challenge on the
+  │                    LoginFlow row ; run normal IdP redirect
+  ▼ (IdP auth — unchanged: PKCE + nonce, client secret stays server-side)
+server handleCallback – code exchange + identity resolve (unchanged) … then:
+  │   if the flow carries a cli_callback → DO NOT mint a session / set a cookie.
+  │   Instead: gen one-time cli_code (32-byte random), store
+  │     {code_hash → user_id, oidc_subject, cli_challenge, TTL 60s},
+  │   redirect 302 to <validated cli_callback> with cli_state + code (via url.Values)
+  ▼
+CLI loopback handler – validate Host header is 127.0.0.1:<port> ; constant-time
+  │   compare cli_state ; then POST {code, cli_verifier} → /api/auth/cli/exchange
+  ▼
+server handleExchange – AuthStore.ExchangeCLICode (single transaction):
+  │   SELECT … FOR UPDATE the code (single-use); verify S256(cli_verifier) ==
+  │   stored cli_challenge (constant time); INSERT spgr_ws_ session; DELETE code.
+  │   Any error rolls back → code stays retryable within TTL. Return {token, expires_at}.
+  ▼
+CLI – credentials.Upsert(server, {token, label}) + Save(); render browser success page;
+      print "Logged in as <subject> on <server>" ; shut down the loopback listener
+```
+
+The web path is unchanged: a flow with no `cli_callback` mints the session and
+sets the cookie exactly as today.
+
+### Remote sessions (SSH / headless)
+
+Before opening anything, the CLI checks for an environment where the loopback
+redirect cannot work: `SSH_CONNECTION`/`SSH_TTY` set, no usable browser, or
+`--no-browser` on a non-loopback server. In those cases it does **not** start a
+doomed loopback listener; it exits with a clear message: *"Browser-based login
+isn't available over SSH/headless sessions. Create an API key instead:
+`specgraph auth api-key create`."*
+
+## Resolution / validation semantics
+
+- **`cli_callback` validation (server, `handleStart`).** Parse with `url.Parse`
+  and require *all* of: scheme exactly `http`; `u.Hostname()` exactly the string
+  `127.0.0.1` or `::1` (literal IPs only — `url.Hostname()` strips the brackets
+  from `[::1]`, so the compare is against `::1`; **`localhost` is rejected** to
+  avoid resolver/DNS rebinding per RFC 8252 §8.3); no userinfo (`u.User == nil`);
+  path exactly `/callback`; empty `RawQuery` and empty `Fragment`. Anything else
+  → 400. The 302 `Location` is then built by re-parsing the validated callback
+  and setting `cli_state`/`code` via `url.Values` — never by string
+  concatenation. The **port is intentionally unvalidated**: the redirect targets
+  a port on the *requesting browser's own* `127.0.0.1`, so even a hypothetical
+  validation slip discloses the code only to the user's own loopback, and the
+  code is useless without the PKCE verifier.
+- **`cli_challenge` is required** whenever `cli_callback` is present. A CLI flow
+  without a challenge is rejected — there is no unbound-code path.
+- **`cli_state`** is an opaque high-entropy CSRF token round-tripped on the
+  loopback leg, compared in constant time by the CLI; empty/short values are
+  rejected.
+- **One-time `cli_code`** is a 32-byte random token (same generator as the web
+  session/state tokens, `randToken` at `auth_oidc_handler.go:236`), single-use,
+  60s TTL, stored hashed. It maps to the **resolved identity** (`user_id`,
+  `oidc_subject`) plus the `cli_challenge` — never to a token, so nothing
+  bearer-capable is persisted at rest.
+- **Exchange (server)** verifies `S256(cli_verifier) == stored cli_challenge`
+  using `crypto/subtle.ConstantTimeCompare` before minting. The `spgr_ws_`
+  session is minted only here; only its SHA-256 hash is stored, exactly as in the
+  web callback.
+- A flow that resolves identity but is never exchanged (user closes the browser)
+  leaves only a short-lived code row that expires and is swept; no session is
+  created.
+
+## Storage
+
+`internal/storage/` domain types and the postgres implementation
+(`internal/storage/postgres/`), behind the existing `WebAuthStore` interface,
+implemented by `*postgres.AuthStore`.
+
+- Extend `LoginFlow` with `CLICallback`, `CLIState`, and `CLIChallenge` columns,
+  declared **`NOT NULL DEFAULT ''`** (not nullable). The domain `LoginFlow`
+  fields stay `string` (`web_auth_domain.go`), and `ConsumeLoginFlow` scans into
+  them (`web_auth.go:116`); pgx v5 cannot scan SQL `NULL` into a Go `string`, so
+  nullable columns would regress **every** web login. `NOT NULL DEFAULT ''`
+  matches the "web flow leaves them empty" intent and keeps the scan working.
+  `CreateLoginFlow`'s INSERT and `ConsumeLoginFlow`'s `RETURNING`/`Scan` are both
+  extended for the three columns.
+- New goose migration: `cli_login_codes(code_hash bytea pk, user_id, oidc_subject,
+  cli_challenge text, expires_at, created_at)`. Codes stored hashed; single-use
+  via the exchange transaction.
+- New `WebAuthStore` methods. To match the existing session convention
+  (`CreateSession` takes a pre-hashed `TokenHash` — `web_auth.go:20`), the
+  **caller hashes**; the raw code never crosses the storage boundary. The PKCE
+  comparison is passed as a **precomputed challenge string** (the server computes
+  `S256(cli_verifier)` and passes the result), not a behavioral closure — this
+  keeps the storage boundary to domain values only (per the constitution) and
+  keeps S256 in the server layer:
+  - `CreateCLICode(ctx, codeHash []byte, userID, subject, challenge string, expiresAt time.Time) error`
+  - `ExchangeCLICode(ctx, codeHash []byte, sess *Session, gotChallenge string) (*Session, error)`
+    — returns the minted session (incl. `OIDCSubject`); see Atomic exchange.
+  - `DeleteExpiredCLICodes(ctx) (int64, error)` — for the existing sweep loop.
+
+### Atomic exchange (ADR-004)
+
+`AuthStore` does **not** participate in `*Store.RunInTransaction` —
+`RunInTransaction` is defined on `*Store` (`tx.go:42`) and threads a `pgx.Tx`
+through context, but `AuthStore` runs statements directly against its own pool
+(`web_auth.go:37…`). The two are distinct objects (`serve.go:142` vs `:218`), so
+a `*Store` transaction cannot make `AuthStore` calls atomic.
+
+Therefore the consume-then-mint write path is encapsulated in a single
+`AuthStore.ExchangeCLICode` method that opens **its own** `pool.Begin`
+transaction (`AuthStore` holds a `*pgxpool.Pool`, `auth.go:48`) and, in one
+round-trip-bounded unit, runs all statements **directly on the `pgx.Tx`** — it
+must NOT call the existing `CreateSession` (that method runs on `s.pool`, outside
+the new tx, and would silently defeat atomicity). `AuthStore` has no
+tx-from-context routing like `*Store`, so the SQL is inlined on the tx handle:
+
+1. `SELECT user_id, oidc_subject, cli_challenge FROM cli_login_codes
+   WHERE code_hash = $1 AND expires_at > now() FOR UPDATE`
+   → `ErrCLICodeNotFound` if absent/expired (also enforces single-use under the
+   row lock; READ COMMITTED makes a concurrent exchange block then re-read the
+   DELETEd row).
+2. `subtle.ConstantTimeCompare([]byte(gotChallenge), []byte(storedChallenge))` —
+   the `gotChallenge` argument is `S256(cli_verifier)` precomputed by the handler,
+   so no crypto runs in storage. A mismatch rolls back (the code is **not**
+   burned — it stays retryable for the rest of its TTL; see brute-force note).
+3. `INSERT INTO web_sessions (… SELECT … WHERE EXISTS user not soft-deleted)
+   RETURNING …` → `ErrUserNotFound` if the user was deleted mid-flow.
+4. `DELETE FROM cli_login_codes WHERE code_hash = $1`.
+5. Commit. The returned `*Session` carries `OIDCSubject` for the handler's
+   response.
+
+Any error rolls back the whole unit: a transient `INSERT` failure leaves the
+code un-consumed and retryable within its TTL; a terminal `ErrUserNotFound`
+propagates so the handler can return a terminal status (see Error handling).
+
+**Brute-force barrier.** Because a wrong verifier does not consume the code, the
+verifier's only protections are its entropy (256-bit, `oauth2.GenerateVerifier`),
+the 60s code TTL, and the per-IP rate limiter. That margin is ample; burning the
+code on mismatch would be marginally stricter but is not required.
+
+## Server changes
+
+`internal/server/auth_oidc_handler.go`:
+
+- `handleStart`: read optional `cli_callback`, `cli_state`, `cli_challenge` query
+  params; apply the strict validation above; if `cli_login_enabled=false` and a
+  `cli_callback` is present, **fail fast with 403 `cli_login_disabled`** (do NOT
+  silently degrade to the web flow); otherwise persist all three on the
+  `LoginFlow`.
+- `handleCallback`: after identity resolution, branch on the flow's
+  `cli_callback`. The loopback branch **re-runs the strict `cli_callback`
+  validation** (defense-in-depth — never trust the stored value into a redirect),
+  mints a one-time code, and 302s to the validated loopback with `cli_state` +
+  `code` built via `url.Values`; the web branch (no `cli_callback`) is untouched.
+- New `POST /api/auth/cli/exchange`: body `{code, cli_verifier}`. Hashes the code,
+  precomputes `S256(cli_verifier)`, calls `AuthStore.ExchangeCLICode`, and returns
+  JSON `{token, expires_at, oidc_subject}` — `oidc_subject` (carried on the code
+  row and the returned session) lets the CLI write the `oidc:<subject>`
+  credentials label and print "Logged in as <subject>" without an extra round
+  trip. Public endpoint, per-IP rate limited via the existing
+  `NewIPRateLimiterForOIDC` limiter. When `cli_login_enabled=false` the route is
+  not registered (404). Response carries `Cache-Control: no-store`.
+
+`internal/server/auth_handler.go`:
+
+- Extend `handleLogout` to also revoke when the token arrives via an
+  `Authorization: Bearer` header — but only when it carries the `spgr_ws_` prefix
+  (mirror the cookie path's guard at `auth_handler.go:92`), so an API key sent as
+  bearer is never hashed and looked up as a session. `RevokeSession` is already
+  idempotent for expired/revoked tokens (`web_auth.go:70`).
+
+`cmd/specgraph/serve.go`: wire the new `/api/auth/cli/exchange` route into the
+existing `RegisterOIDCLoginHandlers` config (conditional on `cli_login_enabled`).
+
+### Config gate
+
+Add `auth.oidc.cli_login_enabled` as a plain `bool` defaulted to `true` in
+`globalDefaults()` (the same pattern as `Log.Requests`; koanf merges only
+file-present keys over defaults, so an absent key keeps `true` and an explicit
+`false` wins — no `*bool` ambiguity needed). It is wired onto `OIDCLoginConfig`
+and read in `handleStart` / route registration. When `false`: `handleStart`
+rejects CLI flows with 403, the exchange route is not registered, and the CLI
+surfaces "CLI login is disabled on this server; use `specgraph auth api-key
+create`." (`RegisterOIDCLoginHandlers` already no-ops when zero providers exist,
+so a static `true` default is harmless with no providers.)
+
+## CLI changes
+
+`cmd/specgraph/`:
+
+- New `login.go` — top-level `specgraph login`:
+  - Flags: `--provider` (skip the picker), `--server` (override resolved base
+    URL), `--no-browser` (print the loopback authorize URL instead of opening a
+    browser; still loopback-bound, for local-but-no-default-browser cases).
+  - **Remote/headless guard:** if `SSH_CONNECTION`/`SSH_TTY` is set or no usable
+    browser is found (and not a local `--no-browser`), hard-error to api-key
+    guidance (see "Remote sessions").
+  - **HTTPS guard:** refuse to run the exchange (and to write creds) when the
+    server base URL is non-loopback and not `https://`. "Loopback" here uses the
+    same **strict literal-IP** check as `cli_callback` (127.0.0.1 / ::1), shared
+    as a small helper — **not** the existing `isLoopbackAddr` (`serve.go:655`),
+    which accepts `localhost` and all of `127.0.0.0/8` and would silently weaken
+    the guard.
+  - Generates `cli_state` + PKCE `cli_verifier`/`cli_challenge`, starts a loopback
+    listener bound to literal `127.0.0.1`, opens the browser, validates the
+    callback (`Host` header + constant-time `cli_state`), exchanges
+    `{code, cli_verifier}`, writes the token via `credentials.Upsert` + `Save`,
+    then shuts down the listener (and on a hard timeout).
+  - **Non-TTY + multiple providers + no `--provider`:** hard-error with guidance
+    rather than blocking on an unanswerable prompt.
+  - **Credentials write:** label set to `oidc:<subject>` (subject from the
+    exchange response). To decide whether to warn about overwriting, read the
+    existing entry via `credentials.Load` + `TokenFor` directly — **not**
+    `resolveAPIKey` (`client.go:102`), which masks the file entry behind
+    `SPECGRAPH_API_KEY` and would misfire the warning. If the existing entry is
+    **not** a session token (e.g. a hand-placed `spgr_sk_` API key), warn before
+    overwriting.
+  - On success, prints "Logged in as <subject> on <server>" using the subject
+    from the exchange response (no extra `Whoami` round trip required).
+- New `logout.go` — top-level `specgraph logout`:
+  - Reads the stored token. If it is a `spgr_ws_` session, POSTs it as a bearer
+    to `/api/auth/logout` to revoke server-side. Then removes the credentials
+    entry for the server (preserving other servers). If the stored token is an
+    API key, only the local entry is removed (with a warning) and no revoke is
+    attempted.
+- New `internal/browser` package — cross-platform opener (`open` on darwin,
+  `xdg-open` on linux, `rundll32 url.dll,FileProtocolHandler` on windows) with a
+  clean fallback to printing the URL.
+
+## Concurrency
+
+Concurrent `specgraph login` invocations share the browser's single cookie jar,
+and the existing `tx` cookie has a fixed name scoped to `/api/auth/oidc`
+(`auth_oidc_handler.go:24,213`); a second `handleStart` would overwrite the
+first's cookie. v1 treats CLI login as **one-at-a-time**: the CLI listener
+enforces a hard timeout (default 3 min) and exits with a clear "login timed out,
+please retry" rather than hanging. A per-flow `tx` cookie name (suffixed with the
+flow id) is noted as the robust follow-up but is out of scope for v1.
+
+## Error handling
+
+- `cli_callback`/`cli_challenge` validation failure → server 400; CLI surfaces a
+  clear message.
+- `cli_login_enabled=false` → `handleStart` 403 `cli_login_disabled`; CLI prints
+  api-key guidance (no hang).
+- `cli_state` mismatch or bad `Host` header on the loopback leg → CLI aborts
+  without writing creds.
+- Expired/replayed `cli_code` or PKCE mismatch → exchange returns 400; CLI
+  reports "login expired, please retry".
+- User soft-deleted between callback and exchange (`ErrUserNotFound` from the
+  mint) → **terminal** 403 `account_unavailable` with a distinct message; the CLI
+  does **not** retry. (The un-consumed code simply expires.)
+- Transient backend failure during exchange → 503; the transaction rolled back,
+  so the code is NOT consumed and the CLI may retry within the TTL.
+- Browser cannot be opened on a local session → fall back to printing the URL.
+- Remote/SSH/headless → hard-error to api-key guidance before opening anything.
+- Non-loopback server over plain `http://` → CLI refuses with the HTTPS-guard
+  message before opening anything.
+- Server has no interactive OIDC providers (or CLI login disabled) → CLI exits
+  with a message pointing to `specgraph auth api-key create`.
+
+## Testing
+
+- **Server unit:** `cli_callback` validation table (literal v4 `127.0.0.1` and v6
+  `::1` pass; `localhost`, `127.0.0.1.evil.com`, `user@127.0.0.1`, `https`, wrong
+  path, non-empty query/fragment, missing challenge all rejected); CLI-loopback
+  branch in `handleCallback` builds the redirect via `url.Values`;
+  `cli_login_enabled=false` → 403 and no exchange route; `ExchangeCLICode`
+  happy/expired/replayed/PKCE-mismatch/`ErrUserNotFound` paths; rollback leaves
+  the code retryable on transient mint failure; logout-via-bearer revocation only
+  for `spgr_ws_` prefixes.
+- **CLI unit:** loopback handler `cli_state` + `Host` validation; PKCE
+  verifier/challenge generation; credentials write + label + overwrite warning;
+  HTTPS guard; SSH/headless → hard-error; non-TTY multi-provider hard-error;
+  listener timeout; logout removes the entry and revokes only sessions.
+- **Storage integration (postgres/testcontainers):** `ExchangeCLICode` atomicity
+  — concurrent exchange of the same code yields exactly one session (FOR UPDATE);
+  expired code rejected; `ErrUserNotFound` rolls back and leaves no session;
+  `LoginFlow` CLI fields round-trip; **a web-flow login still succeeds with the
+  new `NOT NULL DEFAULT ''` columns** (regression guard against the nullable-scan
+  trap); sweep deletes expired codes.
+- **Regression:** assert the access log records only `r.URL.Path`, never the
+  query string (so `cli_code`/`cli_state` never hit server logs), and the
+  outbound 302 `Location` to the loopback is not logged by any middleware.
+- **Wiring:** `serve.go` registers the exchange route iff enabled and it is
+  reachable.
+
+## Trade-offs
+
+- **No remote/headless login in v1.** SSH/remote users use API keys; a secure
+  remote path (RFC 8628 device flow) is deferred. This is a deliberate cut to
+  avoid shipping a phishable paste flow.
+- Session lifetime is bounded by `auth.oidc.session_ttl`; there is no refresh, so
+  the CLI re-authenticates with `specgraph login` when the token expires. Matches
+  the web session's posture.
+- The server brokers the flow, so a separate public/native IdP client is not
+  required and the client secret never reaches the CLI. The cost is one new
+  endpoint, one branch, one small table, and a dedicated transactional
+  `ExchangeCLICode` method.
+- One-login-at-a-time (concurrency) is an accepted v1 limitation with a hard
+  timeout.
+
+## Appendix: adversarial review disposition
+
+Two review passes (2026-06-15) raised twelve findings. Disposition:
+
+**Pass 1**
+
+- **#1 No proof-of-possession (Critical)** — fixed: CLI↔server PKCE bound to the
+  code, verified at exchange.
+- **#2 Loopback validation under-specified (Critical)** — fixed: strict
+  `url.Parse` validation, literal IPs only, `localhost` rejected, scheme/path
+  pinned, no userinfo, query/fragment rejected; plus `cli_login_enabled` gate.
+- **#3 SSH/headless breaks (High)** — addressed by **cutting** remote login from
+  v1 with a clear hard-error (paste fallback rejected, see #C1).
+- **#4 No transaction on consume+mint (High)** — fixed: dedicated transactional
+  `AuthStore.ExchangeCLICode` (see "Atomic exchange").
+- **#5 Hashing inconsistency (Medium)** — fixed: caller hashes; store takes
+  `codeHash []byte`.
+- **#6 Concurrent-login cookie collision (Medium)** — accepted v1 limitation:
+  one-at-a-time with a hard timeout; per-flow cookie noted as follow-up.
+- **#7 No HTTPS enforcement (Medium)** — fixed: CLI HTTPS guard (literal-IP
+  loopback definition).
+- **#8 Loopback listener hardening (Medium)** — fixed: literal `127.0.0.1` bind,
+  `Host` check, constant-time `cli_state`, shutdown after first hit / timeout.
+- **#9 Rate-limit NAT + code entropy (Low)** — code entropy stated (32-byte
+  random); shared per-IP limiter accepted as-is for v1.
+- **#10 Non-TTY multi-provider (Low)** — fixed: hard-error with guidance.
+
+**Pass 2**
+
+- **#C1 Paste flow phishable / account takeover (Critical)** — fixed by
+  **removing** the paste path entirely; v1 is loopback-only (see "Why no
+  paste/manual code").
+- **#H2 `RunInTransaction` not implemented on `AuthStore` (High)** — fixed:
+  `ExchangeCLICode` opens its own `pool.Begin` transaction; the prior
+  cross-`Store` plan is dropped (see "Atomic exchange").
+- **#M3 Soft-deleted user mid-flow (Medium)** — fixed: terminal 403
+  `account_unavailable`, no retry.
+- **#M4 `[::1]` vs `::1` (Medium)** — fixed: compare `u.Hostname()` to `::1`
+  (brackets stripped); added to the test table.
+- **#M5 `cli_login_enabled=false` silent degradation (Medium)** — fixed:
+  fail-fast 403 and unregistered exchange route, not a degraded web flow.
+- **#M6 Paste page cache/referrer (Medium)** — moot (paste removed); the exchange
+  response carries `Cache-Control: no-store`.
+- **#L7 Query/fragment on `cli_callback` (Low)** — fixed: rejected; redirect built
+  via `url.Values`.
+- **#L8 Constant-time PKCE compare (Low)** — fixed: `subtle.ConstantTimeCompare`.
+- **#L9 Logout bearer prefix guard (Low)** — fixed: revoke only `spgr_ws_`
+  bearers.
+- **#L10 HTTPS-guard `localhost` inconsistency (Low)** — fixed: literal-IP
+  definition shared with `cli_callback`.
+- **#L11 Credentials overwrite/label (Low)** — fixed: label `oidc:<subject>`;
+  warn before overwriting a non-session entry.
+
+**Pass 3** (verdict: ready for writing-plans, no security blocker)
+
+- **#N1 Nullable CLI columns would regress every web login (Medium)** — fixed:
+  columns are `NOT NULL DEFAULT ''` so pgx scans into the `string` domain fields;
+  added a web-login regression test.
+- **#4 Subject not in exchange response (Medium)** — fixed: exchange returns
+  `oidc_subject`, so the `oidc:<subject>` label and success line need no extra
+  round trip; resolves the prior `{token, expires_at}` inconsistency.
+- **`ExchangeCLICode` must inline SQL, not call `CreateSession` (caveat)** — made
+  explicit: `CreateSession` runs on the pool, outside the tx, and would defeat
+  atomicity; the exchange runs all statements on the `pgx.Tx`.
+- **#N2 `verify` closure crossed the storage boundary (Low)** — fixed: pass a
+  precomputed `gotChallenge string`; storage does only a constant-time compare.
+- **#N3 Code not burned on PKCE mismatch (Low)** — documented: brute-force
+  resistance rests on verifier entropy + 60s TTL + rate limiter.
+- **#N4 Re-validate `cli_callback` at callback time (Low)** — added as
+  defense-in-depth before building the redirect.
+- **Strict-loopback helper, not `isLoopbackAddr` (Low)** — called out: the HTTPS
+  guard shares the literal 127.0.0.1/::1 check, not `serve.go`'s permissive one.
+- **`cli_login_enabled` default (Low)** — pinned: plain `bool` defaulted `true`
+  in `globalDefaults()`, mirroring `Log.Requests`; no `*bool`.

--- a/docs/plans/2026-06-15-cli-oidc-login-implementation-plan.md
+++ b/docs/plans/2026-06-15-cli-oidc-login-implementation-plan.md
@@ -1,0 +1,1633 @@
+# CLI OIDC Login Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a top-level `specgraph login` (and `specgraph logout`) that performs a browser-based OIDC login via a loopback redirect and stores the resulting `spgr_ws_` session token in the CLI credentials file.
+
+**Architecture:** Server-brokered loopback with a PKCE-bound one-time code. The CLI opens the browser to the existing `/api/auth/oidc/{provider}/start` with extra `cli_callback`/`cli_state`/`cli_challenge` params; the server runs its normal IdP flow, then (for CLI flows) redirects a one-time code to the CLI's `127.0.0.1` listener instead of setting a cookie. The CLI exchanges `{code, cli_verifier}` at a new `POST /api/auth/cli/exchange`, which mints the session atomically inside a single `AuthStore` transaction. v1 is loopback-only; SSH/headless hard-errors to API keys.
+
+**Tech Stack:** Go, ConnectRPC + plain `net/http` handlers, pgx v5 / goose migrations (`internal/storage/postgres`), cobra CLI, `golang.org/x/oauth2` (PKCE helpers), testcontainers for postgres integration tests.
+
+**Spec:** `docs/plans/2026-06-15-cli-oidc-login-design.md`
+
+**Repo conventions (read before starting):**
+
+- This is a **jj-colocated** repo. Commit with `jj commit -m "<msg>"` (never `git push`). Every commit needs a `Signed-off-by:` trailer — append it inside the `-m` body as shown in each Commit step.
+- All `.go` files need the SPDX header (first two lines). New Go packages need a `// Package <name> ...` doc comment or `revive` fails.
+- `gen/` is generated; this plan touches **no** proto, so no `task proto` runs.
+- Run `task check` before the final commit of each task batch (fmt → license → lint → build → unit tests). Postgres integration tests (`//go:build integration`) run via `task test:integration` (requires Docker) — only Task 3 adds those.
+
+---
+
+## File Structure
+
+**New files:**
+
+- `internal/storage/postgres/auth_migrations/003_cli_login.sql` — migration: 3 columns on `oidc_login_flows`, new `cli_login_codes` table.
+- `internal/auth/loopback.go` — `IsLiteralLoopbackHost(host string) bool`, shared strict literal-loopback check (server validation + CLI HTTPS guard).
+- `internal/auth/loopback_test.go` — unit tests for the host check.
+- `internal/browser/browser.go` — cross-platform `Open(url string) error`.
+- `internal/browser/browser_test.go` — opener command-resolution test.
+- `cmd/specgraph/login.go` — `specgraph login`.
+- `cmd/specgraph/login_test.go` — login unit tests.
+- `cmd/specgraph/logout.go` — `specgraph logout`.
+- `cmd/specgraph/logout_test.go` — logout unit tests.
+
+**Modified files:**
+
+- `internal/storage/errors.go` — add `ErrCLICodeNotFound`, `ErrCLIChallengeMismatch`.
+- `internal/storage/web_auth_domain.go` — add CLI fields to `LoginFlow`.
+- `internal/storage/web_auth.go` — extend `WebAuthStore` interface (3 new methods).
+- `internal/storage/postgres/web_auth.go` — extend `CreateLoginFlow`/`ConsumeLoginFlow`; add `CreateCLICode`/`ExchangeCLICode`/`DeleteExpiredCLICodes`.
+- `internal/storage/postgres/web_auth_test.go` — integration tests for the new storage paths.
+- `internal/config/global.go` — add `OIDCConfig.CLILoginEnabled bool`; default `true` in `globalDefaults()`.
+- `internal/server/auth_oidc_handler.go` — `OIDCLoginConfig.CLILoginEnabled`; handler field; `handleStart` CLI params; `handleCallback` CLI branch; `handleExchange` + route.
+- `internal/server/auth_oidc_handler_test.go` — handler unit tests for the CLI paths.
+- `internal/server/auth_handler.go` — `handleLogout` accepts `spgr_ws_` bearer.
+- `internal/server/auth_handler_test.go` — logout-via-bearer test.
+- `cmd/specgraph/serve.go` — pass `CLILoginEnabled` into `OIDCLoginConfig`.
+
+---
+
+## Task 1: Storage domain — errors and `LoginFlow` CLI fields
+
+**Files:**
+
+- Modify: `internal/storage/errors.go`
+- Modify: `internal/storage/web_auth_domain.go`
+
+- [ ] **Step 1: Add the two sentinel errors**
+
+In `internal/storage/errors.go`, after the existing `ErrLoginFlowNotFound` declaration (around line 166), add:
+
+```go
+// ErrCLICodeNotFound is returned when a CLI one-time login code does not exist
+// or has expired.
+var ErrCLICodeNotFound = errors.New("cli login code not found")
+
+// ErrCLIChallengeMismatch is returned when the PKCE verifier presented at the
+// CLI exchange does not match the challenge stored with the code.
+var ErrCLIChallengeMismatch = errors.New("cli login challenge mismatch")
+```
+
+- [ ] **Step 2: Add CLI fields to the `LoginFlow` domain struct**
+
+In `internal/storage/web_auth_domain.go`, extend the `LoginFlow` struct (after the `ProviderID` field):
+
+```go
+type LoginFlow struct {
+	ID           string // opaque flow id (tx cookie value)
+	State        string // CSRF token, constant-time compared at callback
+	Nonce        string
+	CodeVerifier string // PKCE
+	ProviderID   string
+	// CLI-login fields. Empty for the web flow; set when the flow originated
+	// from `specgraph login`. CLICallback is a validated loopback URL,
+	// CLIState a CSRF token round-tripped to the CLI, CLIChallenge the PKCE
+	// S256 challenge bound to the one-time code.
+	CLICallback  string
+	CLIState     string
+	CLIChallenge string
+	CreatedAt    time.Time
+	ExpiresAt    time.Time
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `go build ./internal/storage/...`
+Expected: success (no callers reference the new fields yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "feat(storage): CLI login domain errors and LoginFlow fields
+
+Signed-off-by: Sean Brandt <seanb4t@users.noreply.github.com>"
+```
+
+---
+
+## Task 2: Migration — `oidc_login_flows` columns + `cli_login_codes` table
+
+**Files:**
+
+- Create: `internal/storage/postgres/auth_migrations/003_cli_login.sql`
+
+- [ ] **Step 1: Write the migration**
+
+Create `internal/storage/postgres/auth_migrations/003_cli_login.sql`:
+
+```sql
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 Sean Brandt
+
+-- +goose Up
+
+ALTER TABLE oidc_login_flows
+    ADD COLUMN cli_callback  text NOT NULL DEFAULT '' CHECK (length(cli_callback) <= 512),
+    ADD COLUMN cli_state     text NOT NULL DEFAULT '' CHECK (length(cli_state) <= 512),
+    ADD COLUMN cli_challenge text NOT NULL DEFAULT '' CHECK (length(cli_challenge) <= 256);
+
+CREATE TABLE cli_login_codes (
+    code_hash     bytea PRIMARY KEY,
+    user_id       uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    oidc_subject  text NOT NULL DEFAULT '' CHECK (length(oidc_subject) <= 255),
+    cli_challenge text NOT NULL CHECK (length(cli_challenge) <= 256),
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    expires_at    timestamptz NOT NULL
+);
+
+CREATE INDEX cli_login_codes_expiry ON cli_login_codes(expires_at);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS cli_login_codes_expiry;
+DROP TABLE IF EXISTS cli_login_codes;
+ALTER TABLE oidc_login_flows
+    DROP COLUMN IF EXISTS cli_challenge,
+    DROP COLUMN IF EXISTS cli_state,
+    DROP COLUMN IF EXISTS cli_callback;
+```
+
+- [ ] **Step 2: Verify license header lint passes**
+
+Run: `task license:check`
+Expected: PASS (the `-- SPDX` header satisfies addlicense for `.sql`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj commit -m "feat(storage): migration for CLI login codes and flow columns
+
+Signed-off-by: Sean Brandt <seanb4t@users.noreply.github.com>"
+```
+
+---
+
+## Task 3: Storage methods — extend flow methods + add CLI-code methods
+
+**Files:**
+
+- Modify: `internal/storage/web_auth.go` (interface)
+- Modify: `internal/storage/postgres/web_auth.go` (implementation)
+- Test: `internal/storage/postgres/web_auth_test.go` (integration, `//go:build integration`)
+
+- [ ] **Step 1: Extend the `WebAuthStore` interface**
+
+In `internal/storage/web_auth.go`, add to the `// --- login-flow state ---` section (after `DeleteExpiredLoginFlows`):
+
+```go
+	// --- CLI one-time login codes ---
+
+	// CreateCLICode inserts a one-time CLI login code. codeHash is the SHA-256
+	// of the opaque code; the raw code never reaches storage.
+	CreateCLICode(ctx context.Context, codeHash []byte, userID, subject, challenge string, expiresAt time.Time) error
+
+	// ExchangeCLICode atomically consumes an unexpired code and mints a session
+	// in one transaction. gotChallenge is S256(verifier) precomputed by the
+	// caller; it is constant-time compared against the stored challenge.
+	// sess must carry TokenHash and ExpiresAt; UserID/OIDCSubject/ID/CreatedAt
+	// are filled from the consumed code and the inserted row.
+	// Returns ErrCLICodeNotFound (unknown/expired), ErrCLIChallengeMismatch
+	// (PKCE mismatch), or ErrUserNotFound (user soft-deleted mid-flow).
+	ExchangeCLICode(ctx context.Context, codeHash []byte, sess *Session, gotChallenge string) (*Session, error)
+
+	// DeleteExpiredCLICodes removes expired code rows; returns count.
+	DeleteExpiredCLICodes(ctx context.Context) (int64, error)
+```
+
+Add `"time"` to the imports if not already present (it is not — add it).
+
+- [ ] **Step 2: Extend `CreateLoginFlow` and `ConsumeLoginFlow` for the CLI columns**
+
+In `internal/storage/postgres/web_auth.go`, replace the `CreateLoginFlow` query and args:
+
+```go
+	const q = `
+		INSERT INTO oidc_login_flows (state, nonce, code_verifier, provider_id, cli_callback, cli_state, cli_challenge, expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		RETURNING id`
+	var id string
+	if err := s.pool.QueryRow(ctx, q, f.State, f.Nonce, f.CodeVerifier, f.ProviderID, f.CLICallback, f.CLIState, f.CLIChallenge, f.ExpiresAt).Scan(&id); err != nil {
+		return "", fmt.Errorf("create login flow: %w", err)
+	}
+	return id, nil
+```
+
+And replace the `ConsumeLoginFlow` query + scan:
+
+```go
+	const q = `
+		DELETE FROM oidc_login_flows
+		WHERE id = $1::uuid AND expires_at > $2
+		RETURNING id, state, nonce, code_verifier, provider_id, cli_callback, cli_state, cli_challenge, created_at, expires_at`
+	row := s.pool.QueryRow(ctx, q, flowID, s.now())
+	var f storage.LoginFlow
+	err := row.Scan(&f.ID, &f.State, &f.Nonce, &f.CodeVerifier, &f.ProviderID, &f.CLICallback, &f.CLIState, &f.CLIChallenge, &f.CreatedAt, &f.ExpiresAt)
+```
+
+(Leave the rest of `ConsumeLoginFlow`'s error handling unchanged.)
+
+- [ ] **Step 3: Add the three new methods**
+
+Append to `internal/storage/postgres/web_auth.go`:
+
+```go
+// CreateCLICode inserts a one-time CLI login code (code stored hashed).
+func (s *AuthStore) CreateCLICode(ctx context.Context, codeHash []byte, userID, subject, challenge string, expiresAt time.Time) error {
+	if len(codeHash) == 0 {
+		return errors.New("CreateCLICode: codeHash required")
+	}
+	if userID == "" || challenge == "" {
+		return errors.New("CreateCLICode: userID and challenge required")
+	}
+	if expiresAt.IsZero() {
+		return errors.New("CreateCLICode: expiresAt required")
+	}
+	const q = `
+		INSERT INTO cli_login_codes (code_hash, user_id, oidc_subject, cli_challenge, expires_at)
+		SELECT $1, $2::uuid, $3, $4, $5
+		WHERE EXISTS (SELECT 1 FROM users WHERE id = $2::uuid AND deleted_at IS NULL)`
+	tag, err := s.pool.Exec(ctx, q, codeHash, userID, subject, challenge, expiresAt)
+	if err != nil {
+		return fmt.Errorf("create cli code: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("create cli code: %w", storage.ErrUserNotFound)
+	}
+	return nil
+}
+
+// ExchangeCLICode consumes a code and mints a session atomically. All
+// statements run on the transaction handle; it MUST NOT call CreateSession
+// (which runs on the pool and would break atomicity).
+func (s *AuthStore) ExchangeCLICode(ctx context.Context, codeHash []byte, sess *storage.Session, gotChallenge string) (*storage.Session, error) {
+	if len(sess.TokenHash) == 0 || sess.ExpiresAt.IsZero() {
+		return nil, errors.New("ExchangeCLICode: sess.TokenHash and ExpiresAt required")
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("exchange cli code: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }() //nolint:errcheck // no-op after a successful Commit
+
+	var userID, subject, storedChallenge string
+	selErr := tx.QueryRow(ctx, `
+		SELECT user_id::text, oidc_subject, cli_challenge
+		FROM cli_login_codes
+		WHERE code_hash = $1 AND expires_at > $2
+		FOR UPDATE`, codeHash, s.now()).Scan(&userID, &subject, &storedChallenge)
+	if errors.Is(selErr, pgx.ErrNoRows) {
+		return nil, storage.ErrCLICodeNotFound
+	}
+	if selErr != nil {
+		return nil, fmt.Errorf("exchange cli code: select: %w", selErr)
+	}
+
+	if subtle.ConstantTimeCompare([]byte(gotChallenge), []byte(storedChallenge)) != 1 {
+		return nil, storage.ErrCLIChallengeMismatch // rollback via defer; code NOT consumed
+	}
+
+	var id string
+	var createdAt time.Time
+	insErr := tx.QueryRow(ctx, `
+		INSERT INTO web_sessions (token_hash, user_id, oidc_subject, expires_at)
+		SELECT $1, $2::uuid, $3, $4
+		WHERE EXISTS (SELECT 1 FROM users WHERE id = $2::uuid AND deleted_at IS NULL)
+		RETURNING id, created_at`, sess.TokenHash, userID, subject, sess.ExpiresAt).Scan(&id, &createdAt)
+	if errors.Is(insErr, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("exchange cli code: %w", storage.ErrUserNotFound)
+	}
+	if insErr != nil {
+		return nil, fmt.Errorf("exchange cli code: insert: %w", insErr)
+	}
+
+	if _, delErr := tx.Exec(ctx, `DELETE FROM cli_login_codes WHERE code_hash = $1`, codeHash); delErr != nil {
+		return nil, fmt.Errorf("exchange cli code: delete: %w", delErr)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("exchange cli code: commit: %w", err)
+	}
+
+	sess.ID = id
+	sess.UserID = userID
+	sess.OIDCSubject = subject
+	sess.CreatedAt = createdAt
+	return sess, nil
+}
+
+// DeleteExpiredCLICodes removes expired code rows.
+func (s *AuthStore) DeleteExpiredCLICodes(ctx context.Context) (int64, error) {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM cli_login_codes WHERE expires_at <= $1`, s.now())
+	if err != nil {
+		return 0, fmt.Errorf("delete expired cli codes: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+```
+
+Add `"crypto/subtle"` to the imports of `internal/storage/postgres/web_auth.go`.
+
+- [ ] **Step 4: Write the failing integration tests**
+
+Append to `internal/storage/postgres/web_auth_test.go` (this file already has `//go:build integration` and a helper that seeds a user and returns an `*AuthStore`; mirror the existing tests' setup — inspect the top of the file for the exact helper name, e.g. `newTestAuthStore(t)` returning the store and a seeded `userID`):
+
+```go
+func TestExchangeCLICode_RoundTrip(t *testing.T) {
+	t.Parallel()
+	auth, userID := newAuthStoreWithUser(t)
+	ctx := context.Background()
+
+	codeHash := sha256.Sum256([]byte("rawcode"))
+	challenge := "CHALLENGE"
+	require.NoError(t, auth.CreateCLICode(ctx, codeHash[:], userID, "oidc:subj", challenge, time.Now().Add(time.Minute)))
+
+	tokenHash := sha256.Sum256([]byte("spgr_ws_token"))
+	sess, err := auth.ExchangeCLICode(ctx, codeHash[:], &storage.Session{
+		TokenHash: tokenHash[:], ExpiresAt: time.Now().Add(time.Hour),
+	}, challenge)
+	require.NoError(t, err)
+	require.Equal(t, userID, sess.UserID)
+	require.Equal(t, "oidc:subj", sess.OIDCSubject)
+
+	// Single-use: second exchange fails.
+	_, err = auth.ExchangeCLICode(ctx, codeHash[:], &storage.Session{
+		TokenHash: tokenHash[:], ExpiresAt: time.Now().Add(time.Hour),
+	}, challenge)
+	require.ErrorIs(t, err, storage.ErrCLICodeNotFound)
+}
+
+func TestExchangeCLICode_ChallengeMismatchLeavesCode(t *testing.T) {
+	t.Parallel()
+	auth, userID := newAuthStoreWithUser(t)
+	ctx := context.Background()
+
+	codeHash := sha256.Sum256([]byte("rawcode2"))
+	require.NoError(t, auth.CreateCLICode(ctx, codeHash[:], userID, "", "GOOD", time.Now().Add(time.Minute)))
+
+	tokenHash := sha256.Sum256([]byte("tok"))
+	_, err := auth.ExchangeCLICode(ctx, codeHash[:], &storage.Session{TokenHash: tokenHash[:], ExpiresAt: time.Now().Add(time.Hour)}, "BAD")
+	require.ErrorIs(t, err, storage.ErrCLIChallengeMismatch)
+
+	// Code is NOT consumed; a correct verifier still works.
+	sess, err := auth.ExchangeCLICode(ctx, codeHash[:], &storage.Session{TokenHash: tokenHash[:], ExpiresAt: time.Now().Add(time.Hour)}, "GOOD")
+	require.NoError(t, err)
+	require.Equal(t, userID, sess.UserID)
+}
+
+func TestExchangeCLICode_Expired(t *testing.T) {
+	t.Parallel()
+	auth, userID := newAuthStoreWithUser(t)
+	ctx := context.Background()
+	codeHash := sha256.Sum256([]byte("rawcode3"))
+	require.NoError(t, auth.CreateCLICode(ctx, codeHash[:], userID, "", "C", time.Now().Add(-time.Second)))
+	_, err := auth.ExchangeCLICode(ctx, codeHash[:], &storage.Session{TokenHash: codeHash[:], ExpiresAt: time.Now().Add(time.Hour)}, "C")
+	require.ErrorIs(t, err, storage.ErrCLICodeNotFound)
+}
+
+func TestLoginFlow_CLIFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+	auth, _ := newAuthStoreWithUser(t)
+	ctx := context.Background()
+	id, err := auth.CreateLoginFlow(ctx, &storage.LoginFlow{
+		State: "s", Nonce: "n", CodeVerifier: "v", ProviderID: "p",
+		CLICallback: "http://127.0.0.1:5000/callback", CLIState: "cs", CLIChallenge: "cc",
+		ExpiresAt: time.Now().Add(time.Minute),
+	})
+	require.NoError(t, err)
+	got, err := auth.ConsumeLoginFlow(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "http://127.0.0.1:5000/callback", got.CLICallback)
+	require.Equal(t, "cs", got.CLIState)
+	require.Equal(t, "cc", got.CLIChallenge)
+}
+
+// TestLoginFlow_WebStillWorks guards against the nullable-scan regression:
+// the new NOT NULL DEFAULT '' columns must let a web-only flow round-trip.
+func TestLoginFlow_WebStillWorks(t *testing.T) {
+	t.Parallel()
+	auth, _ := newAuthStoreWithUser(t)
+	ctx := context.Background()
+	id, err := auth.CreateLoginFlow(ctx, &storage.LoginFlow{
+		State: "s", Nonce: "n", CodeVerifier: "v", ProviderID: "p",
+		ExpiresAt: time.Now().Add(time.Minute),
+	})
+	require.NoError(t, err)
+	got, err := auth.ConsumeLoginFlow(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "", got.CLICallback)
+}
+```
+
+If the existing test file uses a different seed helper than `newAuthStoreWithUser`, reuse that one verbatim (check the top of `web_auth_test.go` — e.g. the helper used by `TestWebAuth_CreateSession`). Add `"crypto/sha256"` to the test imports if absent.
+
+- [ ] **Step 5: Run the integration tests (requires Docker)**
+
+Run: `task test:integration -- -run 'TestExchangeCLICode|TestLoginFlow' ./internal/storage/postgres/`
+Expected: PASS for all five tests. (If `task test:integration` does not accept `-run`, run `go test -tags integration -run 'TestExchangeCLICode|TestLoginFlow' ./internal/storage/postgres/`.)
+
+- [ ] **Step 6: Build the whole module**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj commit -m "feat(storage): CLI login code create/exchange and flow columns
+
+Signed-off-by: Sean Brandt <seanb4t@users.noreply.github.com>"
+```
+
+---
+
+## Task 4: Shared strict literal-loopback host check
+
+**Files:**
+
+- Create: `internal/auth/loopback.go`
+- Test: `internal/auth/loopback_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/auth/loopback_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/auth"
+)
+
+func TestIsLiteralLoopbackHost(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"127.0.0.1":           true,
+		"::1":                 true,
+		"localhost":           false,
+		"127.0.0.1.evil.com":  false,
+		"127.0.0.1.":          false,
+		"0.0.0.0":             false,
+		"2130706433":          false,
+		"::ffff:127.0.0.1":    false,
+		"":                    false,
+		"127.0.0.2":           false,
+	}
+	for host, want := range cases {
+		if got := auth.IsLiteralLoopbackHost(host); got != want {
+			t.Errorf("IsLiteralLoopbackHost(%q) = %v, want %v", host, got, want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/auth/ -run TestIsLiteralLoopbackHost`
+Expected: FAIL (undefined: `auth.IsLiteralLoopbackHost`).
+
+- [ ] **Step 3: Implement**
+
+Create `internal/auth/loopback.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+// IsLiteralLoopbackHost reports whether host is exactly the IPv4 or IPv6
+// loopback literal. It deliberately rejects "localhost" (resolver/DNS-rebinding
+// risk, RFC 8252 §8.3) and any non-canonical form. Callers pass the result of
+// net/url's url.Hostname(), which strips the brackets from "[::1]" → "::1".
+func IsLiteralLoopbackHost(host string) bool {
+	return host == "127.0.0.1" || host == "::1"
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./internal/auth/ -run TestIsLiteralLoopbackHost`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj commit -m "feat(auth): strict literal-loopback host check
+
+Signed-off-by: Sean Brandt <seanb4t@users.noreply.github.com>"
+```
+
+---
+
+## Task 5: Server handlers — CLI start params, callback branch, exchange endpoint
+
+**Files:**
+
+- Modify: `internal/server/auth_oidc_handler.go`
+- Test: `internal/server/auth_oidc_handler_test.go`
+
+- [ ] **Step 1: Add `CLILoginEnabled` to config + handler and a `cli_callback` validator**
+
+In `internal/server/auth_oidc_handler.go`, add `CLILoginEnabled bool` to `OIDCLoginConfig` (after `Limiter`) and to `oidcLoginHandler` (after `flowTTL`). In `RegisterOIDCLoginHandlers`, set `cliLoginEnabled: cfg.CLILoginEnabled` on the handler, and register the exchange route only when enabled:
+
+```go
+	mux.HandleFunc("/api/auth/oidc/providers", h.handleProviders)
+	mux.Handle("/api/auth/oidc/callback", limit(http.HandlerFunc(h.handleCallback)))
+	mux.Handle("/api/auth/oidc/{provider}/start", limit(http.HandlerFunc(h.handleStart)))
+	if cfg.CLILoginEnabled {
+		mux.Handle("/api/auth/cli/exchange", limit(http.HandlerFunc(h.handleCLIExchange)))
+	}
+```
+
+Add this validator function (and the imports `net/url`, `strings`, `crypto/sha256`, `encoding/json`, `time` — most are already present; add `net/url` and `strings`):
+
+```go
+// validateCLICallback enforces a strict loopback redirect target. Returns the
+// parsed URL (query/fragment-free, path "/callback") or false.
+func validateCLICallback(raw string) (*url.URL, bool) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "http" || u.User != nil ||
+		u.RawQuery != "" || u.Fragment != "" || u.Path != "/callback" ||
+		!auth.IsLiteralLoopbackHost(u.Hostname()) {
+		return nil, false
+	}
+	return u, true
+}
+```
+
+- [ ] **Step 2: Read CLI params in `handleStart`**
+
+In `handleStart`, after resolving the provider `p` and before generating `state`, add:
+
+```go
+	cliCallback := r.URL.Query().Get("cli_callback")
+	cliState := r.URL.Query().Get("cli_state")
+	cliChallenge := r.URL.Query().Get("cli_challenge")
+	if cliCallback != "" {
+		if !h.cliLoginEnabled {
+			writeJSONError(w, http.StatusForbidden, "cli_login_disabled")
+			return
+		}
+		if _, ok := validateCLICallback(cliCallback); !ok {
+			writeJSONError(w, http.StatusBadRequest, "invalid cli_callback")
+			return
+		}
+		if cliChallenge == "" || cliState == "" {
+			writeJSONError(w, http.StatusBadRequest, "cli_challenge and cli_state required")
+			return
+		}
+	}
+```
+
+Then persist them on the flow — extend the `CreateLoginFlow` call's `&storage.LoginFlow{...}` literal to include:
+
+```go
+		CLICallback: cliCallback, CLIState: cliState, CLIChallenge: cliChallenge,
+```
+
+- [ ] **Step 3: Branch in `handleCallback`**
+
+In `handleCallback`, replace the tail (from `// Mint the server session.` through the final `http.Redirect(w, r, "/", http.StatusFound)`) with:
+
+```go
+	// CLI flow: deliver a one-time code to the validated loopback, no cookie.
+	if flow.CLICallback != "" {
+		cb, ok := validateCLICallback(flow.CLICallback) // re-validate; never trust stored value into a redirect
+		if !ok {
+			fail("exchange")
+			return
+		}
+		code, err := randToken()
+		if err != nil {
+			fail("temporary")
+			return
+		}
+		sum := sha256.Sum256([]byte(code))
+		if err := h.webAuth.CreateCLICode(r.Context(), sum[:], id.UserID, subjectOnly(id.Subject), flow.CLIChallenge, time.Now().Add(60*time.Second)); err != nil {
+			if errors.Is(err, storage.ErrUserNotFound) {
+				fail("unauthorized")
+				return
+			}
+			fail("temporary")
+			return
+		}
+		q := url.Values{"cli_state": {flow.CLIState}, "code": {code}}
+		cb.RawQuery = q.Encode()
+		http.Redirect(w, r, cb.String(), http.StatusFound) //nolint:gosec // G710: target validated to literal loopback via validateCLICallback
+		return
+	}
+
+	// Web flow: mint the server session (unchanged).
+	token, err := randSessionToken()
+	if err != nil {
+		fail("temporary")
+		return
+	}
+	sum := sha256.Sum256([]byte(token))
+	if _, err := h.webAuth.CreateSession(r.Context(), &storage.Session{
+		TokenHash: sum[:], UserID: id.UserID, OIDCSubject: subjectOnly(id.Subject),
+		ExpiresAt: time.Now().Add(h.sessionTTL),
+	}); err != nil {
+		slog.LogAttrs(r.Context(), slog.LevelError, "oidc: create session", slog.Any("error", err))
+		fail("temporary")
+		return
+	}
+	establishSession(w, r, token)
+	http.Redirect(w, r, "/", http.StatusFound)
+```
+
+- [ ] **Step 4: Add the exchange handler**
+
+Append to `internal/server/auth_oidc_handler.go`:
+
+```go
+type cliExchangeRequest struct {
+	Code        string `json:"code"`
+	CLIVerifier string `json:"cli_verifier"`
+}
+
+type cliExchangeResponse struct {
+	Token       string    `json:"token"`
+	ExpiresAt   time.Time `json:"expires_at"`
+	OIDCSubject string    `json:"oidc_subject"`
+}
+
+func (h *oidcLoginHandler) handleCLIExchange(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req cliExchangeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Code == "" || req.CLIVerifier == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing code or verifier")
+		return
+	}
+	token, err := randSessionToken()
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "temporary")
+		return
+	}
+	tokenHash := sha256.Sum256([]byte(token))
+	codeHash := sha256.Sum256([]byte(req.Code))
+	gotChallenge := oauth2.S256ChallengeFromVerifier(req.CLIVerifier)
+	expiresAt := time.Now().Add(h.sessionTTL)
+
+	sess, err := h.webAuth.ExchangeCLICode(r.Context(), codeHash[:], &storage.Session{
+		TokenHash: tokenHash[:], ExpiresAt: expiresAt,
+	}, gotChallenge)
+	if err != nil {
+		switch {
+		case errors.Is(err, storage.ErrCLICodeNotFound), errors.Is(err, storage.ErrCLIChallengeMismatch):
+			writeJSONError(w, http.StatusBadRequest, "invalid or expired code")
+		case errors.Is(err, storage.ErrUserNotFound):
+			writeJSONError(w, http.StatusForbidden, "account_unavailable")
+		default:
+			slog.LogAttrs(r.Context(), slog.LevelError, "oidc: cli exchange", slog.Any("error", err))
+			writeJSONError(w, http.StatusServiceUnavailable, "temporary")
+		}
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	json.NewEncoder(w).Encode(cliExchangeResponse{ //nolint:errcheck // best-effort write
+		Token: token, ExpiresAt: sess.ExpiresAt, OIDCSubject: sess.OIDCSubject,
+	})
+}
+```
+
+Ensure imports include `golang.org/x/oauth2` (already imported) and `github.com/specgraph/specgraph/internal/auth` (already imported).
+
+- [ ] **Step 5: Write handler unit tests**
+
+The existing `auth_oidc_handler_test.go` has a `fakeWA` implementing `storage.WebAuthStore` and a `newTestOIDCMux` helper. Add `CreateCLICode`/`ExchangeCLICode`/`DeleteExpiredCLICodes` methods to `fakeWA` (record args / return configurable values), then add:
+
+```go
+func TestValidateCLICallback(t *testing.T) {
+	t.Parallel()
+	ok := []string{"http://127.0.0.1:5000/callback", "http://[::1]:5000/callback"}
+	for _, s := range ok {
+		if _, valid := validateCLICallback(s); !valid {
+			t.Errorf("want valid: %s", s)
+		}
+	}
+	bad := []string{
+		"https://127.0.0.1:5000/callback", "http://localhost:5000/callback",
+		"http://127.0.0.1.evil.com/callback", "http://user@127.0.0.1/callback",
+		"http://127.0.0.1/other", "http://127.0.0.1/callback?x=1", "http://127.0.0.1/callback#y",
+	}
+	for _, s := range bad {
+		if _, valid := validateCLICallback(s); valid {
+			t.Errorf("want invalid: %s", s)
+		}
+	}
+}
+
+func TestHandleStart_CLIDisabled(t *testing.T) {
+	t.Parallel()
+	// Build a mux with CLILoginEnabled=false (extend newTestOIDCMux or inline
+	// RegisterOIDCLoginHandlers with the flag false) and one provider "entra".
+	mux := newTestOIDCMuxCLI(t, false)
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/entra/start?cli_callback=http://127.0.0.1:5000/callback&cli_state=s&cli_challenge=c", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestHandleCLIExchange_Success(t *testing.T) {
+	t.Parallel()
+	wa := &fakeWA{exchangeSubject: "subj"} // fakeWA.ExchangeCLICode returns the passed sess with OIDCSubject set
+	mux := newTestOIDCMuxWith(t, true, wa)
+	body := `{"code":"abc","cli_verifier":"verifier"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/cli/exchange", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var resp cliExchangeResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(resp.Token, "spgr_ws_") || resp.OIDCSubject != "subj" {
+		t.Fatalf("bad response: %+v", resp)
+	}
+}
+
+func TestHandleCLIExchange_BadCode(t *testing.T) {
+	t.Parallel()
+	wa := &fakeWA{exchangeErr: storage.ErrCLICodeNotFound}
+	mux := newTestOIDCMuxWith(t, true, wa)
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/cli/exchange", strings.NewReader(`{"code":"x","cli_verifier":"y"}`))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+```
+
+Add the small test helpers `newTestOIDCMuxCLI(t, enabled)` and `newTestOIDCMuxWith(t, enabled, wa)` next to the existing `newTestOIDCMux`, passing `CLILoginEnabled: enabled` into `RegisterOIDCLoginHandlers`. Give `fakeWA` the fields `exchangeSubject string` and `exchangeErr error`; its `ExchangeCLICode` returns `exchangeErr` if set, else sets `sess.OIDCSubject = exchangeSubject` and returns `sess, nil`.
+
+- [ ] **Step 6: Run the handler tests**
+
+Run: `go test ./internal/server/ -run 'TestValidateCLICallback|TestHandleStart_CLIDisabled|TestHandleCLIExchange'`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj commit -m "feat(server): CLI loopback login start/callback/exchange handlers
+
+Signed-off-by: Sean Brandt <seanb4t@users.noreply.github.com>"
+```
+
+---
+
+## Task 6: Logout-via-bearer
+
+**Files:**
+
+- Modify: `internal/server/auth_handler.go`
+- Test: `internal/server/auth_handler_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `internal/server/auth_handler_test.go`, add (the file already has a `logoutFakeWA` recording `RevokeSession` calls):
+
+```go
+func TestHandleLogout_BearerSession(t *testing.T) {
+	t.Parallel()
+	wa := &logoutFakeWA{}
+	mux := http.NewServeMux()
+	RegisterAuthHandlers(mux, stubResolver{}, wa, func(h http.Handler) http.Handler { return h })
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	req.Header.Set("Authorization", "Bearer spgr_ws_abc")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+	want := sha256.Sum256([]byte("spgr_ws_abc"))
+	if !wa.revokedWith(want[:]) {
+		t.Fatal("expected RevokeSession for the bearer session token")
+	}
+}
+
+func TestHandleLogout_BearerAPIKeyIgnored(t *testing.T) {
+	t.Parallel()
+	wa := &logoutFakeWA{}
+	mux := http.NewServeMux()
+	RegisterAuthHandlers(mux, stubResolver{}, wa, func(h http.Handler) http.Handler { return h })
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	req.Header.Set("Authorization", "Bearer spgr_sk_key")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if wa.revokeCalled {
+		t.Fatal("RevokeSession must NOT be called for a non-spgr_ws_ bearer")
+	}
+}
+```
+
+If `logoutFakeWA` lacks `revokedWith`/`revokeCalled`, add them (record the hash passed to `RevokeSession`). Reuse the existing `stubResolver` in that test file; if none exists, pass the package's existing fake resolver.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/server/ -run TestHandleLogout_Bearer`
+Expected: FAIL (bearer path not handled).
+
+- [ ] **Step 3: Implement**
+
+In `internal/server/auth_handler.go`, replace the body of `handleLogout` with:
+
+```go
+func handleLogout(w http.ResponseWriter, r *http.Request, webAuth storage.WebAuthStore) {
+	if webAuth != nil {
+		if tok := bearerSessionToken(r); tok != "" {
+			sum := sha256.Sum256([]byte(tok))
+			if revErr := webAuth.RevokeSession(r.Context(), sum[:]); revErr != nil {
+				slog.LogAttrs(r.Context(), slog.LevelWarn, "logout: revoke session", slog.Any("error", revErr))
+			}
+		}
+	}
+	c := sessionCookie("", r) //nolint:gosec // G124: sessionCookie sets HttpOnly/SameSite/dynamic Secure
+	c.MaxAge = -1
+	http.SetCookie(w, c)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// bearerSessionToken returns a spgr_ws_ session token from the cookie or an
+// Authorization: Bearer header. Non-session values (e.g. API keys) yield "".
+func bearerSessionToken(r *http.Request) string {
+	if c, err := r.Cookie(sessionCookieName); err == nil && strings.HasPrefix(c.Value, "spgr_ws_") {
+		return c.Value
+	}
+	const prefix = "Bearer "
+	h := r.Header.Get("Authorization")
+	if strings.HasPrefix(h, prefix) {
+		if tok := strings.TrimSpace(h[len(prefix):]); strings.HasPrefix(tok, "spgr_ws_") {
+			return tok
+		}
+	}
+	return ""
+}
+```
+
+(`strings` and `crypto/sha256` are already imported in this file.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./internal/server/ -run TestHandleLogout`
+Expected: PASS (including the pre-existing cookie logout test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj commit -m "feat(server): logout accepts spgr_ws_ bearer token
+
+Signed-off-by: Sean Brandt <seanb4t@users.noreply.github.com>"
+```
+
+---
+
+## Task 7: Config flag + serve wiring
+
+**Files:**
+
+- Modify: `internal/config/global.go`
+- Modify: `cmd/specgraph/serve.go`
+
+- [ ] **Step 1: Add the config field**
+
+In `internal/config/global.go`, add to `OIDCConfig` (after `SessionTTL`):
+
+```go
+	// CLILoginEnabled gates the `specgraph login` broker (loopback redirect +
+	// /api/auth/cli/exchange). Defaults to true (set in globalDefaults).
+	CLILoginEnabled bool `yaml:"cli_login_enabled" koanf:"cli_login_enabled"`
+```
+
+- [ ] **Step 2: Default it to true**
+
+In `globalDefaults()`, add an `Auth` section to the returned struct literal (it currently has none) so the default merges like `Log.Requests`:
+
+```go
+		Auth: AuthConfig{
+			OIDC: OIDCConfig{CLILoginEnabled: true},
+		},
+```
+
+- [ ] **Step 3: Wire it into serve.go**
+
+In `cmd/specgraph/serve.go`, add to the `server.OIDCLoginConfig{...}` literal (around line 215):
+
+```go
+		CLILoginEnabled: cfg.Auth.OIDC.CLILoginEnabled,
+```
+
+- [ ] **Step 4: Add a default-value test**
+
+In the config package's existing loader test file (e.g. `internal/config/loader_internal_test.go` or `global_test.go` — match where `Log.Requests` default is asserted), add:
+
+```go
+func TestDefault_CLILoginEnabled(t *testing.T) {
+	t.Parallel()
+	cfg := globalDefaults()
+	if !cfg.Auth.OIDC.CLILoginEnabled {
+		t.Fatal("CLILoginEnabled should default to true")
+	}
+}
+```
+
+(If asserting via the public load path instead, load a minimal config with no `auth:` block and assert `cfg.Auth.OIDC.CLILoginEnabled == true`, then load one with `auth.oidc.cli_login_enabled: false` and assert it is `false`.)
+
+- [ ] **Step 5: Build + test**
+
+Run: `go build ./... && go test ./internal/config/ -run TestDefault_CLILoginEnabled`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj commit -m "feat(config): cli_login_enabled flag, default true
+
+Signed-off-by: Sean Brandt <seanb4t@users.noreply.github.com>"
+```
+
+---
+
+## Task 8: Cross-platform browser opener
+
+**Files:**
+
+- Create: `internal/browser/browser.go`
+- Test: `internal/browser/browser_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/browser/browser_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package browser
+
+import "testing"
+
+func TestOpenCommand(t *testing.T) {
+	t.Parallel()
+	name, args := openCommand("darwin", "https://example.com")
+	if name != "open" || len(args) != 1 || args[0] != "https://example.com" {
+		t.Fatalf("darwin: got %s %v", name, args)
+	}
+	name, _ = openCommand("linux", "https://example.com")
+	if name != "xdg-open" {
+		t.Fatalf("linux: got %s", name)
+	}
+	name, args = openCommand("windows", "https://example.com")
+	if name != "rundll32" || args[0] != "url.dll,FileProtocolHandler" {
+		t.Fatalf("windows: got %s %v", name, args)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/browser/`
+Expected: FAIL (package/function missing).
+
+- [ ] **Step 3: Implement**
+
+Create `internal/browser/browser.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+// Package browser opens a URL in the user's default browser.
+package browser
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// openCommand returns the platform command + args to open url.
+func openCommand(goos, url string) (string, []string) {
+	switch goos {
+	case "windows":
+		return "rundll32", []string{"url.dll,FileProtocolHandler", url}
+	case "darwin":
+		return "open", []string{url}
+	default:
+		return "xdg-open", []string{url}
+	}
+}
+
+// Open launches the default browser at url. It returns an error if the platform
+// opener cannot be started; callers should fall back to printing the URL.
+func Open(url string) error {
+	name, args := openCommand(runtime.GOOS, url)
+	if err := exec.Command(name, args...).Start(); err != nil {
+		return fmt.Errorf("open browser: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./internal/browser/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj commit -m "feat(browser): cross-platform URL opener
+
+Signed-off-by: Sean Brandt <seanb4t@users.noreply.github.com>"
+```
+
+---
+
+## Task 9: `specgraph login`
+
+**Files:**
+
+- Create: `cmd/specgraph/login.go`
+- Test: `cmd/specgraph/login_test.go`
+
+- [ ] **Step 1: Implement the command**
+
+Create `cmd/specgraph/login.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+
+	"github.com/specgraph/specgraph/internal/auth"
+	"github.com/specgraph/specgraph/internal/browser"
+	"github.com/specgraph/specgraph/internal/credentials"
+	"github.com/specgraph/specgraph/internal/xdg"
+)
+
+var (
+	loginProviderFlag string
+	loginServerFlag   string
+	loginNoBrowser    bool
+)
+
+var loginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Log in via OIDC in the browser and store a session token",
+	RunE:  runLogin,
+}
+
+func runLogin(cmd *cobra.Command, _ []string) error {
+	w := cmd.OutOrStdout()
+
+	serverURL := loginServerFlag
+	if serverURL == "" {
+		resolved, _, err := resolveBaseURL()
+		if err != nil {
+			return fmt.Errorf("resolve server URL: %w", err)
+		}
+		serverURL = resolved
+	}
+	serverURL = strings.TrimRight(serverURL, "/")
+
+	if err := guardHTTPS(serverURL); err != nil {
+		return err
+	}
+	if err := guardRemote(); err != nil {
+		return err
+	}
+
+	provider, err := pickProvider(cmd.Context(), serverURL, loginProviderFlag)
+	if err != nil {
+		return err
+	}
+
+	// PKCE + CSRF secrets (CLI↔server leg).
+	verifier := oauth2.GenerateVerifier()
+	challenge := oauth2.S256ChallengeFromVerifier(verifier)
+	cliState := oauth2.GenerateVerifier() // reuse as a high-entropy opaque token
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("start loopback listener: %w", err)
+	}
+	defer func() { _ = ln.Close() }()
+	port := ln.Addr().(*net.TCPAddr).Port
+	cbURL := fmt.Sprintf("http://127.0.0.1:%d/callback", port)
+
+	authURL := fmt.Sprintf("%s/api/auth/oidc/%s/start?%s", serverURL, url.PathEscape(provider),
+		url.Values{"cli_callback": {cbURL}, "cli_state": {cliState}, "cli_challenge": {challenge}}.Encode())
+
+	codeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	srv := &http.Server{Handler: loopbackHandler(port, cliState, codeCh, errCh), ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = srv.Serve(ln) }()
+	defer func() { _ = srv.Close() }()
+
+	if loginNoBrowser {
+		fmt.Fprintf(w, "Open this URL to log in:\n\n  %s\n\n", authURL) //nolint:errcheck
+	} else if err := browser.Open(authURL); err != nil {
+		fmt.Fprintf(w, "Could not open a browser. Open this URL to log in:\n\n  %s\n\n", authURL) //nolint:errcheck
+	}
+	fmt.Fprintln(w, "Waiting for the browser to complete login…") //nolint:errcheck
+
+	var code string
+	select {
+	case code = <-codeCh:
+	case err = <-errCh:
+		return err
+	case <-time.After(3 * time.Minute):
+		return errors.New("login timed out, please retry")
+	case <-cmd.Context().Done():
+		return cmd.Context().Err()
+	}
+
+	token, subject, err := exchangeCode(cmd.Context(), serverURL, code, verifier)
+	if err != nil {
+		return err
+	}
+
+	if err := writeCredentials(w, serverURL, token, subject); err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "Logged in as %s on %s\n", subject, serverURL) //nolint:errcheck
+	return nil
+}
+
+// loopbackHandler validates the Host header + cli_state and forwards the code.
+func loopbackHandler(port int, cliState string, codeCh chan<- string, errCh chan<- error) http.Handler {
+	wantHost := fmt.Sprintf("127.0.0.1:%d", port)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Host != wantHost {
+			http.Error(w, "bad host", http.StatusBadRequest)
+			return
+		}
+		q := r.URL.Query()
+		if subtle.ConstantTimeCompare([]byte(q.Get("cli_state")), []byte(cliState)) != 1 {
+			http.Error(w, "state mismatch", http.StatusBadRequest)
+			errCh <- errors.New("loopback state mismatch — aborting")
+			return
+		}
+		code := q.Get("code")
+		if code == "" {
+			http.Error(w, "missing code", http.StatusBadRequest)
+			errCh <- errors.New("loopback callback missing code")
+			return
+		}
+		fmt.Fprintln(w, "Login complete. You can close this tab and return to the terminal.") //nolint:errcheck
+		codeCh <- code
+	})
+}
+
+func guardHTTPS(serverURL string) error {
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return fmt.Errorf("parse server URL: %w", err)
+	}
+	if u.Scheme == "https" || auth.IsLiteralLoopbackHost(u.Hostname()) {
+		return nil
+	}
+	return fmt.Errorf("refusing to log in over plain http to a non-loopback server (%s); use https", serverURL)
+}
+
+func guardRemote() error {
+	if loginNoBrowser {
+		return nil
+	}
+	if os.Getenv("SSH_CONNECTION") != "" || os.Getenv("SSH_TTY") != "" {
+		return errors.New("browser-based login isn't available over SSH/headless sessions; create an API key instead: specgraph auth api-key create")
+	}
+	return nil
+}
+
+type providersResponse struct {
+	Providers []struct {
+		ID          string `json:"id"`
+		DisplayName string `json:"display_name"`
+	} `json:"providers"`
+}
+
+func pickProvider(ctx context.Context, serverURL, want string) (string, error) {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, serverURL+"/api/auth/oidc/providers", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("list providers: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var pr providersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return "", fmt.Errorf("decode providers: %w", err)
+	}
+	if len(pr.Providers) == 0 {
+		return "", errors.New("server has no interactive OIDC providers; use specgraph auth api-key create")
+	}
+	if want != "" {
+		for _, p := range pr.Providers {
+			if p.ID == want {
+				return p.ID, nil
+			}
+		}
+		return "", fmt.Errorf("provider %q not found on server", want)
+	}
+	if len(pr.Providers) == 1 {
+		return pr.Providers[0].ID, nil
+	}
+	return "", errors.New("multiple OIDC providers configured; pass --provider <id>")
+}
+
+func exchangeCode(ctx context.Context, serverURL, code, verifier string) (token, subject string, err error) {
+	body, _ := json.Marshal(map[string]string{"code": code, "cli_verifier": verifier})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, serverURL+"/api/auth/cli/exchange", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("exchange code: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusBadRequest {
+			return "", "", errors.New("login expired, please retry")
+		}
+		return "", "", fmt.Errorf("exchange failed: server returned %d", resp.StatusCode)
+	}
+	var er struct {
+		Token       string `json:"token"`
+		OIDCSubject string `json:"oidc_subject"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+		return "", "", fmt.Errorf("decode exchange response: %w", err)
+	}
+	return er.Token, er.OIDCSubject, nil
+}
+
+func writeCredentials(w interface{ Write([]byte) (int, error) }, serverURL, token, subject string) error {
+	credPath := xdg.CredentialsFile()
+	f, err := credentials.Load(credPath)
+	if err != nil {
+		return fmt.Errorf("load credentials: %w", err)
+	}
+	if existing := f.TokenFor(serverURL); existing != "" && !strings.HasPrefix(existing, "spgr_ws_") {
+		fmt.Fprintf(w, "warning: replacing a non-session credential for %s\n", serverURL) //nolint:errcheck
+	}
+	f.Upsert(serverURL, credentials.ServerCreds{Token: token, Label: "oidc:" + subject})
+	if err := f.Save(credPath); err != nil {
+		return fmt.Errorf("save credentials: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	loginCmd.Flags().StringVar(&loginProviderFlag, "provider", "", "OIDC provider id (skips the picker)")
+	loginCmd.Flags().StringVar(&loginServerFlag, "server", "", "server base URL (overrides resolved)")
+	loginCmd.Flags().BoolVar(&loginNoBrowser, "no-browser", false, "print the URL instead of opening a browser")
+	rootCmd.AddCommand(loginCmd)
+}
+```
+
+- [ ] **Step 2: Write unit tests for the pure helpers**
+
+Create `cmd/specgraph/login_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGuardHTTPS(t *testing.T) {
+	t.Parallel()
+	if err := guardHTTPS("http://127.0.0.1:9090"); err != nil {
+		t.Errorf("loopback http should pass: %v", err)
+	}
+	if err := guardHTTPS("https://api.example.com"); err != nil {
+		t.Errorf("https should pass: %v", err)
+	}
+	if err := guardHTTPS("http://api.example.com"); err == nil {
+		t.Error("remote http should fail")
+	}
+}
+
+func TestLoopbackHandler_StateMismatch(t *testing.T) {
+	t.Parallel()
+	codeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	h := loopbackHandler(5000, "secret", codeCh, errCh)
+	req := httptest.NewRequest(http.MethodGet, "/callback?cli_state=wrong&code=abc", nil)
+	req.Host = "127.0.0.1:5000"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	select {
+	case <-errCh:
+	default:
+		t.Fatal("expected an error on the channel")
+	}
+}
+
+func TestLoopbackHandler_Success(t *testing.T) {
+	t.Parallel()
+	codeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	h := loopbackHandler(5000, "secret", codeCh, errCh)
+	req := httptest.NewRequest(http.MethodGet, "/callback?cli_state=secret&code=thecode", nil)
+	req.Host = "127.0.0.1:5000"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if got := <-codeCh; got != "thecode" {
+		t.Fatalf("code = %q", got)
+	}
+}
+
+func TestPickProvider(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`{"providers":[{"id":"entra","display_name":"Entra"}]}`)) //nolint:errcheck
+	}))
+	defer srv.Close()
+	id, err := pickProvider(t.Context(), srv.URL, "")
+	if err != nil || id != "entra" {
+		t.Fatalf("id=%q err=%v", id, err)
+	}
+}
+
+func TestExchangeCode_BadRequest(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	_, _, err := exchangeCode(t.Context(), srv.URL, "c", "v")
+	if err == nil || !strings.Contains(err.Error(), "expired") {
+		t.Fatalf("want expired error, got %v", err)
+	}
+}
+```
+
+(If the Go toolchain version predates `t.Context()`, use `context.Background()` and add the import.)
+
+- [ ] **Step 3: Run the tests**
+
+Run: `go test ./cmd/specgraph/ -run 'TestGuardHTTPS|TestLoopbackHandler|TestPickProvider|TestExchangeCode'`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "feat(cli): specgraph login (browser OIDC loopback)
+
+Signed-off-by: Sean Brandt <seanb4t@users.noreply.github.com>"
+```
+
+---
+
+## Task 10: `specgraph logout`
+
+**Files:**
+
+- Create: `cmd/specgraph/logout.go`
+- Test: `cmd/specgraph/logout_test.go`
+
+- [ ] **Step 1: Implement the command**
+
+Create `cmd/specgraph/logout.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/specgraph/specgraph/internal/credentials"
+	"github.com/specgraph/specgraph/internal/xdg"
+)
+
+var logoutServerFlag string
+
+var logoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Revoke the stored session and remove local credentials",
+	RunE:  runLogout,
+}
+
+func runLogout(cmd *cobra.Command, _ []string) error {
+	w := cmd.OutOrStdout()
+	serverURL := logoutServerFlag
+	if serverURL == "" {
+		resolved, _, err := resolveBaseURL()
+		if err != nil {
+			return fmt.Errorf("resolve server URL: %w", err)
+		}
+		serverURL = resolved
+	}
+	serverURL = strings.TrimRight(serverURL, "/")
+
+	credPath := xdg.CredentialsFile()
+	f, err := credentials.Load(credPath)
+	if err != nil {
+		return fmt.Errorf("load credentials: %w", err)
+	}
+	token := f.TokenFor(serverURL)
+	if token == "" {
+		fmt.Fprintf(w, "No stored credential for %s\n", serverURL) //nolint:errcheck
+		return nil
+	}
+
+	if strings.HasPrefix(token, "spgr_ws_") {
+		if err := revokeSession(cmd.Context(), serverURL, token); err != nil {
+			fmt.Fprintf(w, "warning: server revoke failed: %v\n", err) //nolint:errcheck
+		}
+	} else {
+		fmt.Fprintf(w, "warning: removing a non-session credential (API key) for %s\n", serverURL) //nolint:errcheck
+	}
+
+	delete(f.Servers, strings.TrimRight(serverURL, "/"))
+	if err := f.Save(credPath); err != nil {
+		return fmt.Errorf("save credentials: %w", err)
+	}
+	fmt.Fprintf(w, "Logged out of %s\n", serverURL) //nolint:errcheck
+	return nil
+}
+
+func revokeSession(ctx context.Context, serverURL, token string) error {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, serverURL+"/api/auth/logout", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("revoke request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func init() {
+	logoutCmd.Flags().StringVar(&logoutServerFlag, "server", "", "server base URL (overrides resolved)")
+	rootCmd.AddCommand(logoutCmd)
+}
+```
+
+> Note: `credentials.File.Servers` is an exported map, so `delete(f.Servers, key)` is valid. The key normalization (`TrimRight` of trailing slashes) mirrors `credentials.normalize`; since `serverURL` is already trimmed above, the delete key matches the `Upsert` key written by login.
+
+- [ ] **Step 2: Write the test**
+
+Create `cmd/specgraph/logout_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRevokeSession(t *testing.T) {
+	t.Parallel()
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	if err := revokeSession(t.Context(), srv.URL, "spgr_ws_abc"); err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer spgr_ws_abc" {
+		t.Fatalf("auth header = %q", gotAuth)
+	}
+}
+
+func TestRevokeSession_ServerError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	if err := revokeSession(t.Context(), srv.URL, "spgr_ws_abc"); err == nil {
+		t.Fatal("expected error on 500")
+	}
+}
+```
+
+- [ ] **Step 3: Run the test**
+
+Run: `go test ./cmd/specgraph/ -run TestRevokeSession`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "feat(cli): specgraph logout
+
+Signed-off-by: Sean Brandt <seanb4t@users.noreply.github.com>"
+```
+
+---
+
+## Task 11: Full gate + docs touch-up
+
+**Files:**
+
+- Modify: `cmd/specgraph/docs_test.go` (only if it asserts a fixed command list — add `login`/`logout`)
+
+- [ ] **Step 1: Run the full check gate**
+
+Run: `task check`
+Expected: PASS (fmt, license, lint incl. `revive` package comments + `wrapcheck`, build, unit tests). Fix any lint findings inline (common: `wrapcheck` wants `fmt.Errorf("...: %w", err)` wrapping on returned errors — already applied in the code above; `errcheck` is silenced with `//nolint` on best-effort writes).
+
+- [ ] **Step 2: Run the postgres integration suite (Docker)**
+
+Run: `task test:integration`
+Expected: PASS (includes Task 3's `cli_login_codes` tests).
+
+- [ ] **Step 3: Manual smoke (optional, requires a configured interactive provider)**
+
+Run a local server with one interactive OIDC provider, then:
+
+```bash
+specgraph login --provider <id>
+specgraph auth whoami      # shows the OIDC identity
+specgraph logout
+```
+
+Expected: browser opens, login completes, `whoami` resolves via the `spgr_ws_` session, `logout` revokes and clears the entry.
+
+- [ ] **Step 4: Final commit**
+
+```bash
+jj commit -m "test: full gate for CLI OIDC login
+
+Signed-off-by: Sean Brandt <seanb4t@users.noreply.github.com>"
+```
+
+---
+
+## Self-Review notes (already reconciled against the spec)
+
+- **PKCE binding:** CLI generates `verifier`/`challenge` (Task 9); server stores `challenge` with the code (Task 5) and verifies `S256(verifier)` at exchange (Task 5 → Task 3 `ExchangeCLICode`). ✓
+- **Strict loopback validation:** `validateCLICallback` (Task 5) uses `IsLiteralLoopbackHost` (Task 4); re-validated at callback. ✓
+- **Atomic exchange:** `ExchangeCLICode` runs all statements on one `pgx.Tx`, never calls `CreateSession` (Task 3). ✓
+- **Soft-deleted mid-flow:** `INSERT … WHERE EXISTS (not deleted)` → `ErrUserNotFound` → terminal 403 (Tasks 3, 5). ✓
+- **Config gate:** `cli_login_enabled` default true, fail-fast 403, unregistered exchange route (Tasks 5, 7). ✓
+- **HTTPS guard + creds label + overwrite warning:** `guardHTTPS`, `oidc:<subject>` label via exchange response, `credentials.Load` (not `resolveAPIKey`) for the warning (Task 9). ✓
+- **Logout-via-bearer with prefix guard:** `bearerSessionToken` (Task 6); CLI logout only revokes `spgr_ws_` (Task 10). ✓
+- **Remote/headless hard-error; non-TTY multi-provider hard-error:** `guardRemote`, `pickProvider` (Task 9). ✓
+- **Method/type name consistency:** `ExchangeCLICode`, `CreateCLICode`, `IsLiteralLoopbackHost`, `validateCLICallback`, `handleCLIExchange`, `cliExchangeResponse`, `bearerSessionToken` are used identically across tasks. ✓

--- a/internal/auth/identitystore_session_test.go
+++ b/internal/auth/identitystore_session_test.go
@@ -51,6 +51,15 @@ func (f *fakeWebAuth) ConsumeLoginFlow(_ context.Context, _ string) (*storage.Lo
 func (f *fakeWebAuth) DeleteExpiredLoginFlows(_ context.Context) (int64, error) {
 	return 0, nil
 }
+func (f *fakeWebAuth) CreateCLICode(_ context.Context, _ []byte, _, _, _ string, _ time.Time) error {
+	return nil
+}
+func (f *fakeWebAuth) ExchangeCLICode(_ context.Context, _ []byte, _ *storage.Session, _ string) (*storage.Session, error) {
+	return nil, nil
+}
+func (f *fakeWebAuth) DeleteExpiredCLICodes(_ context.Context) (int64, error) {
+	return 0, nil
+}
 
 // --- Task 9: opaque web-session resolution (spgr_ws_...) ---
 

--- a/internal/auth/loopback.go
+++ b/internal/auth/loopback.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+// IsLiteralLoopbackHost reports whether host is exactly the IPv4 or IPv6
+// loopback literal. It deliberately rejects "localhost" (resolver/DNS-rebinding
+// risk, RFC 8252 §8.3) and any non-canonical form. Callers pass the result of
+// net/url's url.Hostname(), which strips the brackets from "[::1]" → "::1".
+func IsLiteralLoopbackHost(host string) bool {
+	return host == "127.0.0.1" || host == "::1"
+}

--- a/internal/auth/loopback_test.go
+++ b/internal/auth/loopback_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/specgraph/specgraph/internal/auth"
+)
+
+func TestIsLiteralLoopbackHost(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"127.0.0.1":          true,
+		"::1":                true,
+		"localhost":          false,
+		"127.0.0.1.evil.com": false,
+		"127.0.0.1.":         false,
+		"0.0.0.0":            false,
+		"2130706433":         false,
+		"::ffff:127.0.0.1":   false,
+		"":                   false,
+		"127.0.0.2":          false,
+	}
+	for host, want := range cases {
+		if got := auth.IsLiteralLoopbackHost(host); got != want {
+			t.Errorf("IsLiteralLoopbackHost(%q) = %v, want %v", host, got, want)
+		}
+	}
+}

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+// Package browser opens a URL in the user's default browser.
+package browser
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// openCommand returns the platform command + args to open url.
+func openCommand(goos, url string) (name string, args []string) {
+	switch goos {
+	case "windows":
+		return "rundll32", []string{"url.dll,FileProtocolHandler", url}
+	case "darwin":
+		return "open", []string{url}
+	default:
+		return "xdg-open", []string{url}
+	}
+}
+
+// Open launches the default browser at url. It returns an error if the platform
+// opener cannot be started; callers should fall back to printing the URL.
+func Open(url string) error {
+	name, args := openCommand(runtime.GOOS, url)
+	if err := exec.Command(name, args...).Start(); err != nil {
+		return fmt.Errorf("open browser: %w", err)
+	}
+	return nil
+}

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -26,8 +26,12 @@ func openCommand(goos, url string) (name string, args []string) {
 // opener cannot be started; callers should fall back to printing the URL.
 func Open(url string) error {
 	name, args := openCommand(runtime.GOOS, url)
-	if err := exec.Command(name, args...).Start(); err != nil {
+	cmd := exec.Command(name, args...)
+	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("open browser: %w", err)
 	}
+	// Reap the opener once it exits so it doesn't linger as a zombie for the
+	// lifetime of the (potentially minutes-long) login wait.
+	go func() { _ = cmd.Wait() }() //nolint:errcheck // best-effort reap
 	return nil
 }

--- a/internal/browser/browser_test.go
+++ b/internal/browser/browser_test.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package browser
+
+import "testing"
+
+func TestOpenCommand(t *testing.T) {
+	t.Parallel()
+	name, args := openCommand("darwin", "https://example.com")
+	if name != "open" || len(args) != 1 || args[0] != "https://example.com" {
+		t.Fatalf("darwin: got %s %v", name, args)
+	}
+	name, _ = openCommand("linux", "https://example.com")
+	if name != "xdg-open" {
+		t.Fatalf("linux: got %s", name)
+	}
+	name, args = openCommand("windows", "https://example.com")
+	if name != "rundll32" || args[0] != "url.dll,FileProtocolHandler" {
+		t.Fatalf("windows: got %s %v", name, args)
+	}
+}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -213,6 +213,9 @@ type OIDCConfig struct {
 	// SessionTTL is the absolute lifetime of a web session minted by the
 	// interactive login flow. Zero = default (12h, applied in applyPostLoad).
 	SessionTTL time.Duration `yaml:"session_ttl" koanf:"session_ttl"`
+	// CLILoginEnabled gates the `specgraph login` broker (loopback redirect +
+	// /api/auth/cli/exchange). Defaults to true (set in globalDefaults).
+	CLILoginEnabled bool `yaml:"cli_login_enabled" koanf:"cli_login_enabled"`
 }
 
 // JITCreateConfig parametrizes just-in-time Human creation on first
@@ -420,6 +423,9 @@ func globalDefaults() *GlobalConfig {
 		},
 		Client: ClientConfig{
 			DefaultServer: "http://127.0.0.1:9090",
+		},
+		Auth: AuthConfig{
+			OIDC: OIDCConfig{CLILoginEnabled: true},
 		},
 		Log: LogConfig{
 			Level:    "info",

--- a/internal/config/loader_internal_test.go
+++ b/internal/config/loader_internal_test.go
@@ -64,3 +64,19 @@ func TestLoadGlobal_LogRequestsExplicitFalseOverrides(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, cfg.Log.Requests, "explicit log.requests:false must override the true default")
 }
+
+func TestDefault_CLILoginEnabled(t *testing.T) {
+	assert.True(t, globalDefaults().Auth.OIDC.CLILoginEnabled,
+		"CLILoginEnabled should default to true")
+}
+
+func TestLoadGlobal_CLILoginEnabledExplicitFalseOverrides(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("auth:\n  oidc:\n    cli_login_enabled: false\n"), 0o600))
+
+	cfg, err := LoadGlobalExplicit(path)
+	require.NoError(t, err)
+	assert.False(t, cfg.Auth.OIDC.CLILoginEnabled,
+		"explicit auth.oidc.cli_login_enabled:false must override the true default")
+}

--- a/internal/server/auth_handler.go
+++ b/internal/server/auth_handler.go
@@ -88,17 +88,34 @@ func handleLogin(w http.ResponseWriter, r *http.Request, resolver auth.Resolver)
 // token) and clears the session cookie. A legacy API-key cookie value is
 // never hashed/looked-up.
 func handleLogout(w http.ResponseWriter, r *http.Request, webAuth storage.WebAuthStore) {
-	if c, err := r.Cookie(sessionCookieName); err == nil && webAuth != nil &&
-		strings.HasPrefix(c.Value, "spgr_ws_") {
-		sum := sha256.Sum256([]byte(c.Value))
-		if revErr := webAuth.RevokeSession(r.Context(), sum[:]); revErr != nil {
-			slog.LogAttrs(r.Context(), slog.LevelWarn, "logout: revoke session", slog.Any("error", revErr))
+	if webAuth != nil {
+		if tok := bearerSessionToken(r); tok != "" {
+			sum := sha256.Sum256([]byte(tok))
+			if revErr := webAuth.RevokeSession(r.Context(), sum[:]); revErr != nil {
+				slog.LogAttrs(r.Context(), slog.LevelWarn, "logout: revoke session", slog.Any("error", revErr))
+			}
 		}
 	}
 	c := sessionCookie("", r) //nolint:gosec // G124: sessionCookie sets HttpOnly/SameSite/dynamic Secure
 	c.MaxAge = -1
 	http.SetCookie(w, c)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// bearerSessionToken returns a spgr_ws_ session token from the cookie or an
+// Authorization: Bearer header. Non-session values (e.g. API keys) yield "".
+func bearerSessionToken(r *http.Request) string {
+	if c, err := r.Cookie(sessionCookieName); err == nil && strings.HasPrefix(c.Value, "spgr_ws_") {
+		return c.Value
+	}
+	const prefix = "Bearer "
+	h := r.Header.Get("Authorization")
+	if strings.HasPrefix(h, prefix) {
+		if tok := strings.TrimSpace(h[len(prefix):]); strings.HasPrefix(tok, "spgr_ws_") {
+			return tok
+		}
+	}
+	return ""
 }
 
 // handleWhoami returns the identity from the request context (set by authMW).

--- a/internal/server/auth_handler.go
+++ b/internal/server/auth_handler.go
@@ -103,15 +103,16 @@ func handleLogout(w http.ResponseWriter, r *http.Request, webAuth storage.WebAut
 }
 
 // bearerSessionToken returns a spgr_ws_ session token from the cookie or an
-// Authorization: Bearer header. Non-session values (e.g. API keys) yield "".
+// Authorization: Bearer header. The auth scheme is matched case-insensitively
+// (RFC 7235), consistent with auth.extractBearerToken. Non-session values
+// (e.g. API keys) yield "".
 func bearerSessionToken(r *http.Request) string {
 	if c, err := r.Cookie(sessionCookieName); err == nil && strings.HasPrefix(c.Value, "spgr_ws_") {
 		return c.Value
 	}
-	const prefix = "Bearer "
-	h := r.Header.Get("Authorization")
-	if strings.HasPrefix(h, prefix) {
-		if tok := strings.TrimSpace(h[len(prefix):]); strings.HasPrefix(tok, "spgr_ws_") {
+	scheme, tok, ok := strings.Cut(r.Header.Get("Authorization"), " ")
+	if ok && strings.EqualFold(scheme, "Bearer") {
+		if tok = strings.TrimSpace(tok); strings.HasPrefix(tok, "spgr_ws_") {
 			return tok
 		}
 	}

--- a/internal/server/auth_handler_test.go
+++ b/internal/server/auth_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/specgraph/specgraph/internal/auth"
 	"github.com/specgraph/specgraph/internal/storage"
@@ -251,6 +252,13 @@ func (f *logoutFakeWA) ConsumeLoginFlow(_ context.Context, _ string) (*storage.L
 }
 
 func (f *logoutFakeWA) DeleteExpiredLoginFlows(_ context.Context) (int64, error) { return 0, nil }
+func (f *logoutFakeWA) CreateCLICode(_ context.Context, _ []byte, _, _, _ string, _ time.Time) error {
+	return nil
+}
+func (f *logoutFakeWA) ExchangeCLICode(_ context.Context, _ []byte, _ *storage.Session, _ string) (*storage.Session, error) {
+	return nil, nil
+}
+func (f *logoutFakeWA) DeleteExpiredCLICodes(_ context.Context) (int64, error) { return 0, nil }
 
 func TestLogout_RevokesSession(t *testing.T) {
 	revoked := false

--- a/internal/server/auth_handler_test.go
+++ b/internal/server/auth_handler_test.go
@@ -339,7 +339,28 @@ func TestHandleLogout_BearerAPIKeyIgnored(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer spgr_sk_key")
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
 	if wa.revokeCalled {
 		t.Fatal("RevokeSession must NOT be called for a non-spgr_ws_ bearer")
+	}
+}
+
+func TestHandleLogout_BearerLowercaseScheme(t *testing.T) {
+	t.Parallel()
+	wa := &logoutFakeWA{}
+	mux := http.NewServeMux()
+	RegisterAuthHandlers(mux, &mockResolver{}, wa, noopMW)
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	req.Header.Set("Authorization", "bearer spgr_ws_abc") // lowercase scheme (RFC 7235)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+	want := sha256.Sum256([]byte("spgr_ws_abc"))
+	if !wa.revokedWith(want[:]) {
+		t.Fatal("expected RevokeSession for a lowercase-scheme bearer session token")
 	}
 }

--- a/internal/server/auth_handler_test.go
+++ b/internal/server/auth_handler_test.go
@@ -219,18 +219,25 @@ func TestHandleWhoami_NoIdentity(t *testing.T) {
 // logoutFakeWA is a minimal storage.WebAuthStore for logout-revocation tests.
 // Only RevokeSession has a meaningful body; the rest return zero values.
 type logoutFakeWA struct {
-	onRevoke   func()
-	gotRevoked []byte // the token hash passed to the most recent RevokeSession
+	onRevoke     func()
+	gotRevoked   []byte // the token hash passed to the most recent RevokeSession
+	revokeCalled bool   // true once RevokeSession has been invoked
 }
 
 var _ storage.WebAuthStore = (*logoutFakeWA)(nil)
 
 func (f *logoutFakeWA) RevokeSession(_ context.Context, tokenHash []byte) error {
 	f.gotRevoked = tokenHash
+	f.revokeCalled = true
 	if f.onRevoke != nil {
 		f.onRevoke()
 	}
 	return nil
+}
+
+// revokedWith reports whether the most recent RevokeSession received hash.
+func (f *logoutFakeWA) revokedWith(hash []byte) bool {
+	return bytes.Equal(f.gotRevoked, hash)
 }
 
 func (f *logoutFakeWA) CreateSession(_ context.Context, _ *storage.Session) (*storage.Session, error) {
@@ -300,5 +307,39 @@ func TestLogout_NonSessionCookie_NoRevoke(t *testing.T) {
 	}
 	if revoked {
 		t.Fatal("expected RevokeSession NOT to be called for non-spgr_ws_ cookie")
+	}
+}
+
+func TestHandleLogout_BearerSession(t *testing.T) {
+	t.Parallel()
+	wa := &logoutFakeWA{}
+	mux := http.NewServeMux()
+	RegisterAuthHandlers(mux, &mockResolver{}, wa, noopMW)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	req.Header.Set("Authorization", "Bearer spgr_ws_abc")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+	want := sha256.Sum256([]byte("spgr_ws_abc"))
+	if !wa.revokedWith(want[:]) {
+		t.Fatal("expected RevokeSession for the bearer session token")
+	}
+}
+
+func TestHandleLogout_BearerAPIKeyIgnored(t *testing.T) {
+	t.Parallel()
+	wa := &logoutFakeWA{}
+	mux := http.NewServeMux()
+	RegisterAuthHandlers(mux, &mockResolver{}, wa, noopMW)
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	req.Header.Set("Authorization", "Bearer spgr_sk_key")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if wa.revokeCalled {
+		t.Fatal("RevokeSession must NOT be called for a non-spgr_ws_ bearer")
 	}
 }

--- a/internal/server/auth_oidc_handler.go
+++ b/internal/server/auth_oidc_handler.go
@@ -340,7 +340,8 @@ func (h *oidcLoginHandler) handleCLIExchange(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	var req cliExchangeRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Code == "" || req.CLIVerifier == "" {
+	// Bound the public endpoint's request body; {code, cli_verifier} is tiny.
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<10)).Decode(&req); err != nil || req.Code == "" || req.CLIVerifier == "" {
 		writeJSONError(w, http.StatusBadRequest, "missing code or verifier")
 		return
 	}

--- a/internal/server/auth_oidc_handler.go
+++ b/internal/server/auth_oidc_handler.go
@@ -126,6 +126,12 @@ func (h *oidcLoginHandler) handleStart(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusBadRequest, "cli_challenge and cli_state required")
 			return
 		}
+		// Bound lengths to the storage CHECK constraints so oversized params
+		// surface as 400 rather than a generic 503 from the failed INSERT.
+		if len(cliCallback) > 512 || len(cliState) > 512 || len(cliChallenge) > 256 {
+			writeJSONError(w, http.StatusBadRequest, "cli parameter too long")
+			return
+		}
 	}
 	state, err := randToken()
 	if err != nil {

--- a/internal/server/auth_oidc_handler.go
+++ b/internal/server/auth_oidc_handler.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -23,24 +24,29 @@ import (
 
 const txCookieName = "specgraph_oidc_tx"
 
+// cliCodeTTL bounds the lifetime of a one-time CLI login code (machine leg).
+const cliCodeTTL = 60 * time.Second
+
 // OIDCLoginConfig parametrizes the interactive login handlers.
 type OIDCLoginConfig struct {
-	Providers  []auth.LoginProvider
-	Resolver   auth.Resolver
-	WebAuth    storage.WebAuthStore
-	BaseURL    string
-	SessionTTL time.Duration
-	FlowTTL    time.Duration // default 5m
-	Limiter    *ipRateLimiter
+	Providers       []auth.LoginProvider
+	Resolver        auth.Resolver
+	WebAuth         storage.WebAuthStore
+	BaseURL         string
+	SessionTTL      time.Duration
+	FlowTTL         time.Duration // default 5m
+	Limiter         *ipRateLimiter
+	CLILoginEnabled bool
 }
 
 type oidcLoginHandler struct {
-	byID       map[string]auth.LoginProvider
-	resolver   auth.Resolver
-	webAuth    storage.WebAuthStore
-	baseURL    string
-	sessionTTL time.Duration
-	flowTTL    time.Duration
+	byID            map[string]auth.LoginProvider
+	resolver        auth.Resolver
+	webAuth         storage.WebAuthStore
+	baseURL         string
+	sessionTTL      time.Duration
+	flowTTL         time.Duration
+	cliLoginEnabled bool
 }
 
 // RegisterOIDCLoginHandlers wires /api/auth/oidc/{providers,start,callback}.
@@ -55,12 +61,13 @@ func RegisterOIDCLoginHandlers(mux *http.ServeMux, cfg OIDCLoginConfig) { //noli
 		flowTTL = 5 * time.Minute
 	}
 	h := &oidcLoginHandler{
-		byID:       map[string]auth.LoginProvider{},
-		resolver:   cfg.Resolver,
-		webAuth:    cfg.WebAuth,
-		baseURL:    cfg.BaseURL,
-		sessionTTL: cfg.SessionTTL,
-		flowTTL:    flowTTL,
+		byID:            map[string]auth.LoginProvider{},
+		resolver:        cfg.Resolver,
+		webAuth:         cfg.WebAuth,
+		baseURL:         cfg.BaseURL,
+		sessionTTL:      cfg.SessionTTL,
+		flowTTL:         flowTTL,
+		cliLoginEnabled: cfg.CLILoginEnabled,
 	}
 	for _, p := range cfg.Providers {
 		h.byID[p.ID()] = p
@@ -70,6 +77,9 @@ func RegisterOIDCLoginHandlers(mux *http.ServeMux, cfg OIDCLoginConfig) { //noli
 	mux.HandleFunc("/api/auth/oidc/providers", h.handleProviders)
 	mux.Handle("/api/auth/oidc/callback", limit(http.HandlerFunc(h.handleCallback)))
 	mux.Handle("/api/auth/oidc/{provider}/start", limit(http.HandlerFunc(h.handleStart)))
+	if cfg.CLILoginEnabled {
+		mux.Handle("/api/auth/cli/exchange", limit(http.HandlerFunc(h.handleCLIExchange)))
+	}
 }
 
 type providerInfo struct {
@@ -100,6 +110,23 @@ func (h *oidcLoginHandler) handleStart(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusNotFound, "unknown provider")
 		return
 	}
+	cliCallback := r.URL.Query().Get("cli_callback")
+	cliState := r.URL.Query().Get("cli_state")
+	cliChallenge := r.URL.Query().Get("cli_challenge")
+	if cliCallback != "" {
+		if !h.cliLoginEnabled {
+			writeJSONError(w, http.StatusForbidden, "cli_login_disabled")
+			return
+		}
+		if _, ok := validateCLICallback(cliCallback); !ok {
+			writeJSONError(w, http.StatusBadRequest, "invalid cli_callback")
+			return
+		}
+		if cliChallenge == "" || cliState == "" {
+			writeJSONError(w, http.StatusBadRequest, "cli_challenge and cli_state required")
+			return
+		}
+	}
 	state, err := randToken()
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "internal")
@@ -115,6 +142,7 @@ func (h *oidcLoginHandler) handleStart(w http.ResponseWriter, r *http.Request) {
 
 	flowID, err := h.webAuth.CreateLoginFlow(r.Context(), &storage.LoginFlow{
 		State: state, Nonce: nonce, CodeVerifier: verifier, ProviderID: p.ID(),
+		CLICallback: cliCallback, CLIState: cliState, CLIChallenge: cliChallenge,
 		ExpiresAt: time.Now().Add(h.flowTTL),
 	})
 	if err != nil {
@@ -187,7 +215,34 @@ func (h *oidcLoginHandler) handleCallback(w http.ResponseWriter, r *http.Request
 		fail("unauthorized")
 		return
 	}
-	// Mint the server session.
+	// CLI flow: deliver a one-time code to the validated loopback, no cookie.
+	if flow.CLICallback != "" {
+		cb, ok := validateCLICallback(flow.CLICallback) // re-validate; never trust stored value into a redirect
+		if !ok {
+			fail("exchange")
+			return
+		}
+		code, codeErr := randToken()
+		if codeErr != nil {
+			fail("temporary")
+			return
+		}
+		sum := sha256.Sum256([]byte(code))
+		if createErr := h.webAuth.CreateCLICode(r.Context(), sum[:], id.UserID, subjectOnly(id.Subject), flow.CLIChallenge, time.Now().Add(cliCodeTTL)); createErr != nil {
+			if errors.Is(createErr, storage.ErrUserNotFound) {
+				fail("unauthorized")
+				return
+			}
+			fail("temporary")
+			return
+		}
+		q := url.Values{"cli_state": {flow.CLIState}, "code": {code}}
+		cb.RawQuery = q.Encode()
+		http.Redirect(w, r, cb.String(), http.StatusFound) //nolint:gosec // G710: target validated to literal loopback via validateCLICallback
+		return
+	}
+
+	// Web flow: mint the server session (unchanged).
 	token, err := randSessionToken()
 	if err != nil {
 		fail("temporary")
@@ -224,6 +279,18 @@ func (h *oidcLoginHandler) deleteTxCookie(r *http.Request) *http.Cookie {
 	return c
 }
 
+// validateCLICallback enforces a strict loopback redirect target. Returns the
+// parsed URL (query/fragment-free, path "/callback") or false.
+func validateCLICallback(raw string) (*url.URL, bool) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "http" || u.User != nil ||
+		u.RawQuery != "" || u.Fragment != "" || u.Path != "/callback" ||
+		!auth.IsLiteralLoopbackHost(u.Hostname()) {
+		return nil, false
+	}
+	return u, true
+}
+
 // subjectOnly strips the "oidc:" prefix the resolver adds to Identity.Subject.
 func subjectOnly(subject string) string {
 	const p = "oidc:"
@@ -248,4 +315,57 @@ func randSessionToken() (string, error) {
 		return "", fmt.Errorf("read random bytes: %w", err)
 	}
 	return "spgr_ws_" + base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+type cliExchangeRequest struct {
+	Code        string `json:"code"`
+	CLIVerifier string `json:"cli_verifier"`
+}
+
+type cliExchangeResponse struct {
+	Token       string    `json:"token"`
+	ExpiresAt   time.Time `json:"expires_at"`
+	OIDCSubject string    `json:"oidc_subject"`
+}
+
+func (h *oidcLoginHandler) handleCLIExchange(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req cliExchangeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Code == "" || req.CLIVerifier == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing code or verifier")
+		return
+	}
+	token, err := randSessionToken()
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "temporary")
+		return
+	}
+	tokenHash := sha256.Sum256([]byte(token))
+	codeHash := sha256.Sum256([]byte(req.Code))
+	gotChallenge := oauth2.S256ChallengeFromVerifier(req.CLIVerifier)
+	expiresAt := time.Now().Add(h.sessionTTL)
+
+	sess, err := h.webAuth.ExchangeCLICode(r.Context(), codeHash[:], &storage.Session{
+		TokenHash: tokenHash[:], ExpiresAt: expiresAt,
+	}, gotChallenge)
+	if err != nil {
+		switch {
+		case errors.Is(err, storage.ErrCLICodeNotFound), errors.Is(err, storage.ErrCLIChallengeMismatch):
+			writeJSONError(w, http.StatusBadRequest, "invalid or expired code")
+		case errors.Is(err, storage.ErrUserNotFound):
+			writeJSONError(w, http.StatusForbidden, "account_unavailable")
+		default:
+			slog.LogAttrs(r.Context(), slog.LevelError, "oidc: cli exchange", slog.Any("error", err))
+			writeJSONError(w, http.StatusServiceUnavailable, "temporary")
+		}
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	json.NewEncoder(w).Encode(cliExchangeResponse{ //nolint:errcheck // best-effort write
+		Token: token, ExpiresAt: sess.ExpiresAt, OIDCSubject: sess.OIDCSubject,
+	})
 }

--- a/internal/server/auth_oidc_handler_test.go
+++ b/internal/server/auth_oidc_handler_test.go
@@ -442,6 +442,18 @@ func TestHandleStart_CLIDisabled(t *testing.T) {
 	}
 }
 
+func TestHandleStart_CLIParamTooLong(t *testing.T) {
+	t.Parallel()
+	mux := newTestOIDCMuxCLI(t, true)
+	long := strings.Repeat("a", 513)
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/entra/start?cli_callback=http://127.0.0.1:5000/callback&cli_state="+long+"&cli_challenge=c", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
 func TestHandleCLIExchange_Success(t *testing.T) {
 	t.Parallel()
 	wa := &fakeWA{exchangeSubject: "subj"}

--- a/internal/server/auth_oidc_handler_test.go
+++ b/internal/server/auth_oidc_handler_test.go
@@ -74,6 +74,13 @@ func (f *fakeWA) ConsumeLoginFlow(_ context.Context, id string) (*storage.LoginF
 	return fl, nil
 }
 func (f *fakeWA) DeleteExpiredLoginFlows(context.Context) (int64, error) { return 0, nil }
+func (f *fakeWA) CreateCLICode(context.Context, []byte, string, string, string, time.Time) error {
+	return nil
+}
+func (f *fakeWA) ExchangeCLICode(context.Context, []byte, *storage.Session, string) (*storage.Session, error) {
+	return nil, nil
+}
+func (f *fakeWA) DeleteExpiredCLICodes(context.Context) (int64, error) { return 0, nil }
 
 type fakeResolver struct {
 	id  *auth.Identity

--- a/internal/server/auth_oidc_handler_test.go
+++ b/internal/server/auth_oidc_handler_test.go
@@ -5,9 +5,11 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -36,6 +38,9 @@ type fakeWA struct {
 	sessions   map[string]*storage.Session
 	createErr  error
 	consumeErr error // when set, ConsumeLoginFlow returns it (for the existing flow id)
+
+	exchangeSubject string
+	exchangeErr     error
 }
 
 func (f *fakeWA) CreateSession(_ context.Context, s *storage.Session) (*storage.Session, error) {
@@ -77,8 +82,12 @@ func (f *fakeWA) DeleteExpiredLoginFlows(context.Context) (int64, error) { retur
 func (f *fakeWA) CreateCLICode(context.Context, []byte, string, string, string, time.Time) error {
 	return nil
 }
-func (f *fakeWA) ExchangeCLICode(context.Context, []byte, *storage.Session, string) (*storage.Session, error) {
-	return nil, nil
+func (f *fakeWA) ExchangeCLICode(_ context.Context, _ []byte, sess *storage.Session, _ string) (*storage.Session, error) {
+	if f.exchangeErr != nil {
+		return nil, f.exchangeErr
+	}
+	sess.OIDCSubject = f.exchangeSubject
+	return sess, nil
 }
 func (f *fakeWA) DeleteExpiredCLICodes(context.Context) (int64, error) { return 0, nil }
 
@@ -98,6 +107,24 @@ func newTestOIDCMux(provs []auth.LoginProvider, wa storage.WebAuthStore, res aut
 		Providers: provs, Resolver: res, WebAuth: wa,
 		SessionTTL: time.Hour, FlowTTL: time.Minute,
 		Limiter: newIPRateLimiter(1000, 1000, false),
+	})
+	return mux
+}
+
+func newTestOIDCMuxCLI(t *testing.T, enabled bool) *http.ServeMux {
+	t.Helper()
+	return newTestOIDCMuxWith(t, enabled, &fakeWA{})
+}
+
+func newTestOIDCMuxWith(t *testing.T, enabled bool, wa storage.WebAuthStore) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	RegisterOIDCLoginHandlers(mux, OIDCLoginConfig{
+		Providers: []auth.LoginProvider{&fakeProvider{id: "entra"}},
+		Resolver:  &fakeResolver{}, WebAuth: wa,
+		SessionTTL: time.Hour, FlowTTL: time.Minute,
+		Limiter:         newIPRateLimiter(1000, 1000, false),
+		CLILoginEnabled: enabled,
 	})
 	return mux
 }
@@ -179,6 +206,52 @@ func TestOIDCCallback_HappyPath(t *testing.T) {
 		if s.OIDCSubject != "sub-1" {
 			t.Fatalf("OIDCSubject = %q, want sub-1", s.OIDCSubject)
 		}
+	}
+}
+
+func TestHandleCallback_CLIRedirect(t *testing.T) {
+	wa := &fakeWA{
+		flows: map[string]*storage.LoginFlow{
+			"flow-1": {
+				ID: "flow-1", State: "S", ProviderID: "entra", Nonce: "n", CodeVerifier: "v",
+				CLICallback: "http://127.0.0.1:5000/callback", CLIState: "CLISTATE", CLIChallenge: "CHAL",
+			},
+		},
+	}
+	res := &fakeResolver{id: &auth.Identity{UserID: "u1", Subject: "oidc:sub-1"}}
+	mux := newTestOIDCMux([]auth.LoginProvider{&fakeProvider{id: "entra", idToken: "tok"}}, wa, res)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?state=S&code=abc", nil)
+	req.AddCookie(&http.Cookie{Name: txCookieName, Value: "flow-1"}) //nolint:gosec // G124: test request cookie
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusFound)
+	}
+	loc := rec.Header().Get("Location")
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("Location %q parse error: %v", loc, err)
+	}
+	if u.Scheme != "http" || u.Host != "127.0.0.1:5000" || u.Path != "/callback" {
+		t.Fatalf("Location = %q, want http://127.0.0.1:5000/callback", loc)
+	}
+	q := u.Query()
+	if got := q.Get("cli_state"); got != "CLISTATE" {
+		t.Fatalf("cli_state = %q, want CLISTATE", got)
+	}
+	if got := q.Get("code"); got == "" {
+		t.Fatalf("code is empty, want non-empty")
+	}
+	// No server session cookie must be established on the CLI leg.
+	for _, ck := range rec.Result().Cookies() {
+		if ck.Name == sessionCookieName && ck.Value != "" {
+			t.Fatalf("unexpected session cookie %q=%q on CLI redirect", ck.Name, ck.Value)
+		}
+	}
+	if len(wa.sessions) != 0 {
+		t.Fatalf("sessions created = %d, want 0 on CLI redirect", len(wa.sessions))
 	}
 }
 
@@ -335,5 +408,117 @@ func TestOIDCCallback_ProviderRemovedMidFlow(t *testing.T) {
 	rec := callbackWithFlow(t, &fakeProvider{id: "entra", idToken: "tok"}, &fakeResolver{}, wa)
 	if loc := rec.Header().Get("Location"); !strings.Contains(loc, "auth_error=exchange") {
 		t.Fatalf("Location = %q, want auth_error=exchange", loc)
+	}
+}
+
+func TestValidateCLICallback(t *testing.T) {
+	t.Parallel()
+	ok := []string{"http://127.0.0.1:5000/callback", "http://[::1]:5000/callback"}
+	for _, s := range ok {
+		if _, valid := validateCLICallback(s); !valid {
+			t.Errorf("want valid: %s", s)
+		}
+	}
+	bad := []string{
+		"https://127.0.0.1:5000/callback", "http://localhost:5000/callback",
+		"http://127.0.0.1.evil.com/callback", "http://user@127.0.0.1/callback",
+		"http://127.0.0.1/other", "http://127.0.0.1/callback?x=1", "http://127.0.0.1/callback#y",
+	}
+	for _, s := range bad {
+		if _, valid := validateCLICallback(s); valid {
+			t.Errorf("want invalid: %s", s)
+		}
+	}
+}
+
+func TestHandleStart_CLIDisabled(t *testing.T) {
+	t.Parallel()
+	mux := newTestOIDCMuxCLI(t, false)
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/entra/start?cli_callback=http://127.0.0.1:5000/callback&cli_state=s&cli_challenge=c", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestHandleCLIExchange_Success(t *testing.T) {
+	t.Parallel()
+	wa := &fakeWA{exchangeSubject: "subj"}
+	mux := newTestOIDCMuxWith(t, true, wa)
+	body := `{"code":"abc","cli_verifier":"verifier"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/cli/exchange", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", cc)
+	}
+	var resp cliExchangeResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(resp.Token, "spgr_ws_") || resp.OIDCSubject != "subj" {
+		t.Fatalf("bad response: %+v", resp)
+	}
+}
+
+func TestHandleCLIExchange_BadCode(t *testing.T) {
+	t.Parallel()
+	wa := &fakeWA{exchangeErr: storage.ErrCLICodeNotFound}
+	mux := newTestOIDCMuxWith(t, true, wa)
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/cli/exchange", strings.NewReader(`{"code":"x","cli_verifier":"y"}`))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandleCLIExchange_Method(t *testing.T) {
+	t.Parallel()
+	mux := newTestOIDCMuxWith(t, true, &fakeWA{})
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/cli/exchange", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}
+
+func TestHandleCLIExchange_MissingFields(t *testing.T) {
+	t.Parallel()
+	mux := newTestOIDCMuxWith(t, true, &fakeWA{})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/cli/exchange", strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandleCLIExchange_UserUnavailable(t *testing.T) {
+	t.Parallel()
+	wa := &fakeWA{exchangeErr: storage.ErrUserNotFound}
+	mux := newTestOIDCMuxWith(t, true, wa)
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/cli/exchange", strings.NewReader(`{"code":"x","cli_verifier":"y"}`))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestHandleCLIExchange_ChallengeMismatch(t *testing.T) {
+	t.Parallel()
+	wa := &fakeWA{exchangeErr: storage.ErrCLIChallengeMismatch}
+	mux := newTestOIDCMuxWith(t, true, wa)
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/cli/exchange", strings.NewReader(`{"code":"x","cli_verifier":"y"}`))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
 	}
 }

--- a/internal/server/sweeper.go
+++ b/internal/server/sweeper.go
@@ -14,10 +14,11 @@ type ClaimSweeper interface {
 	ReleaseExpiredClaims(ctx context.Context) (int, error)
 }
 
-// WebAuthSweeper releases expired web sessions and login flows.
+// WebAuthSweeper releases expired web sessions, login flows, and CLI codes.
 type WebAuthSweeper interface {
 	DeleteExpiredSessions(ctx context.Context) (int64, error)
 	DeleteExpiredLoginFlows(ctx context.Context) (int64, error)
+	DeleteExpiredCLICodes(ctx context.Context) (int64, error)
 }
 
 // StartWebAuthSweeper launches a goroutine that periodically GCs expired web
@@ -40,6 +41,11 @@ func StartWebAuthSweeper(ctx context.Context, store WebAuthSweeper, interval tim
 					slog.LogAttrs(ctx, slog.LevelError, "sweep expired login flows", slog.Any("error", err))
 				} else if n > 0 {
 					slog.LogAttrs(ctx, slog.LevelDebug, "swept expired login flows", slog.Int64("count", n))
+				}
+				if n, err := store.DeleteExpiredCLICodes(ctx); err != nil {
+					slog.LogAttrs(ctx, slog.LevelError, "sweep expired cli codes", slog.Any("error", err))
+				} else if n > 0 {
+					slog.LogAttrs(ctx, slog.LevelDebug, "swept expired cli codes", slog.Int64("count", n))
 				}
 			}
 		}

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -164,3 +164,11 @@ var ErrSessionNotFound = errors.New("web session not found")
 
 // ErrLoginFlowNotFound is returned when an OIDC login-flow row does not exist or has expired.
 var ErrLoginFlowNotFound = errors.New("oidc login flow not found")
+
+// ErrCLICodeNotFound is returned when a CLI one-time login code does not exist
+// or has expired.
+var ErrCLICodeNotFound = errors.New("cli login code not found")
+
+// ErrCLIChallengeMismatch is returned when the PKCE verifier presented at the
+// CLI exchange does not match the challenge stored with the code.
+var ErrCLIChallengeMismatch = errors.New("cli login challenge mismatch")

--- a/internal/storage/postgres/auth_migrations/003_cli_login.sql
+++ b/internal/storage/postgres/auth_migrations/003_cli_login.sql
@@ -1,0 +1,29 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright 2026 Sean Brandt
+
+-- +goose Up
+
+ALTER TABLE oidc_login_flows
+    ADD COLUMN cli_callback  text NOT NULL DEFAULT '' CHECK (length(cli_callback) <= 512),
+    ADD COLUMN cli_state     text NOT NULL DEFAULT '' CHECK (length(cli_state) <= 512),
+    ADD COLUMN cli_challenge text NOT NULL DEFAULT '' CHECK (length(cli_challenge) <= 256);
+
+CREATE TABLE cli_login_codes (
+    code_hash     bytea PRIMARY KEY,
+    user_id       uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    oidc_subject  text NOT NULL DEFAULT '' CHECK (length(oidc_subject) <= 255),
+    cli_challenge text NOT NULL CHECK (length(cli_challenge) <= 256),
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    expires_at    timestamptz NOT NULL
+);
+
+CREATE INDEX cli_login_codes_expiry ON cli_login_codes(expires_at);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS cli_login_codes_expiry;
+DROP TABLE IF EXISTS cli_login_codes;
+ALTER TABLE oidc_login_flows
+    DROP COLUMN IF EXISTS cli_challenge,
+    DROP COLUMN IF EXISTS cli_state,
+    DROP COLUMN IF EXISTS cli_callback;

--- a/internal/storage/postgres/auth_migrations/003_cli_login.sql
+++ b/internal/storage/postgres/auth_migrations/003_cli_login.sql
@@ -8,6 +8,14 @@ ALTER TABLE oidc_login_flows
     ADD COLUMN cli_state     text NOT NULL DEFAULT '' CHECK (length(cli_state) <= 512),
     ADD COLUMN cli_challenge text NOT NULL DEFAULT '' CHECK (length(cli_challenge) <= 256);
 
+-- A flow is either a web flow (all CLI fields empty) or a CLI flow (all set).
+-- Reject partial CLI state at the storage layer as defense-in-depth.
+ALTER TABLE oidc_login_flows
+    ADD CONSTRAINT oidc_login_flows_cli_all_or_none CHECK (
+        (cli_callback = '' AND cli_state = '' AND cli_challenge = '')
+        OR (cli_callback <> '' AND cli_state <> '' AND cli_challenge <> '')
+    );
+
 CREATE TABLE cli_login_codes (
     code_hash     bytea PRIMARY KEY,
     user_id       uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -24,6 +32,7 @@ CREATE INDEX cli_login_codes_expiry ON cli_login_codes(expires_at);
 DROP INDEX IF EXISTS cli_login_codes_expiry;
 DROP TABLE IF EXISTS cli_login_codes;
 ALTER TABLE oidc_login_flows
+    DROP CONSTRAINT IF EXISTS oidc_login_flows_cli_all_or_none,
     DROP COLUMN IF EXISTS cli_challenge,
     DROP COLUMN IF EXISTS cli_state,
     DROP COLUMN IF EXISTS cli_callback;

--- a/internal/storage/postgres/web_auth.go
+++ b/internal/storage/postgres/web_auth.go
@@ -171,6 +171,9 @@ func (s *AuthStore) CreateCLICode(ctx context.Context, codeHash []byte, userID, 
 // statements run on the transaction handle; it MUST NOT call CreateSession
 // (which runs on the pool and would break atomicity).
 func (s *AuthStore) ExchangeCLICode(ctx context.Context, codeHash []byte, sess *storage.Session, gotChallenge string) (*storage.Session, error) {
+	if sess == nil {
+		return nil, errors.New("ExchangeCLICode: sess required")
+	}
 	if len(sess.TokenHash) == 0 || sess.ExpiresAt.IsZero() {
 		return nil, errors.New("ExchangeCLICode: sess.TokenHash and ExpiresAt required")
 	}

--- a/internal/storage/postgres/web_auth.go
+++ b/internal/storage/postgres/web_auth.go
@@ -5,6 +5,7 @@ package postgres
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"time"
@@ -96,11 +97,11 @@ func (s *AuthStore) CreateLoginFlow(ctx context.Context, f *storage.LoginFlow) (
 		return "", errors.New("CreateLoginFlow: ExpiresAt required")
 	}
 	const q = `
-		INSERT INTO oidc_login_flows (state, nonce, code_verifier, provider_id, expires_at)
-		VALUES ($1, $2, $3, $4, $5)
+		INSERT INTO oidc_login_flows (state, nonce, code_verifier, provider_id, cli_callback, cli_state, cli_challenge, expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		RETURNING id`
 	var id string
-	if err := s.pool.QueryRow(ctx, q, f.State, f.Nonce, f.CodeVerifier, f.ProviderID, f.ExpiresAt).Scan(&id); err != nil {
+	if err := s.pool.QueryRow(ctx, q, f.State, f.Nonce, f.CodeVerifier, f.ProviderID, f.CLICallback, f.CLIState, f.CLIChallenge, f.ExpiresAt).Scan(&id); err != nil {
 		return "", fmt.Errorf("create login flow: %w", err)
 	}
 	return id, nil
@@ -111,10 +112,10 @@ func (s *AuthStore) ConsumeLoginFlow(ctx context.Context, flowID string) (*stora
 	const q = `
 		DELETE FROM oidc_login_flows
 		WHERE id = $1::uuid AND expires_at > $2
-		RETURNING id, state, nonce, code_verifier, provider_id, created_at, expires_at`
+		RETURNING id, state, nonce, code_verifier, provider_id, cli_callback, cli_state, cli_challenge, created_at, expires_at`
 	row := s.pool.QueryRow(ctx, q, flowID, s.now())
 	var f storage.LoginFlow
-	err := row.Scan(&f.ID, &f.State, &f.Nonce, &f.CodeVerifier, &f.ProviderID, &f.CreatedAt, &f.ExpiresAt)
+	err := row.Scan(&f.ID, &f.State, &f.Nonce, &f.CodeVerifier, &f.ProviderID, &f.CLICallback, &f.CLIState, &f.CLIChallenge, &f.CreatedAt, &f.ExpiresAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, storage.ErrLoginFlowNotFound
 	}
@@ -137,6 +138,101 @@ func (s *AuthStore) DeleteExpiredLoginFlows(ctx context.Context) (int64, error) 
 	tag, err := s.pool.Exec(ctx, `DELETE FROM oidc_login_flows WHERE expires_at <= $1`, s.now())
 	if err != nil {
 		return 0, fmt.Errorf("delete expired login flows: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// CreateCLICode inserts a one-time CLI login code (code stored hashed).
+func (s *AuthStore) CreateCLICode(ctx context.Context, codeHash []byte, userID, subject, challenge string, expiresAt time.Time) error {
+	if len(codeHash) == 0 {
+		return errors.New("CreateCLICode: codeHash required")
+	}
+	if userID == "" || challenge == "" {
+		return errors.New("CreateCLICode: userID and challenge required")
+	}
+	if expiresAt.IsZero() {
+		return errors.New("CreateCLICode: expiresAt required")
+	}
+	const q = `
+		INSERT INTO cli_login_codes (code_hash, user_id, oidc_subject, cli_challenge, expires_at)
+		SELECT $1, $2::uuid, $3, $4, $5
+		WHERE EXISTS (SELECT 1 FROM users WHERE id = $2::uuid AND deleted_at IS NULL)`
+	tag, err := s.pool.Exec(ctx, q, codeHash, userID, subject, challenge, expiresAt)
+	if err != nil {
+		return fmt.Errorf("create cli code: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("create cli code: %w", storage.ErrUserNotFound)
+	}
+	return nil
+}
+
+// ExchangeCLICode consumes a code and mints a session atomically. All
+// statements run on the transaction handle; it MUST NOT call CreateSession
+// (which runs on the pool and would break atomicity).
+func (s *AuthStore) ExchangeCLICode(ctx context.Context, codeHash []byte, sess *storage.Session, gotChallenge string) (*storage.Session, error) {
+	if len(sess.TokenHash) == 0 || sess.ExpiresAt.IsZero() {
+		return nil, errors.New("ExchangeCLICode: sess.TokenHash and ExpiresAt required")
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("exchange cli code: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }() //nolint:errcheck // no-op after a successful Commit
+
+	var userID, subject, storedChallenge string
+	selErr := tx.QueryRow(ctx, `
+		SELECT user_id::text, oidc_subject, cli_challenge
+		FROM cli_login_codes
+		WHERE code_hash = $1 AND expires_at > $2
+		FOR UPDATE`, codeHash, s.now()).Scan(&userID, &subject, &storedChallenge)
+	if errors.Is(selErr, pgx.ErrNoRows) {
+		return nil, storage.ErrCLICodeNotFound
+	}
+	if selErr != nil {
+		return nil, fmt.Errorf("exchange cli code: select: %w", selErr)
+	}
+
+	if subtle.ConstantTimeCompare([]byte(gotChallenge), []byte(storedChallenge)) != 1 {
+		return nil, storage.ErrCLIChallengeMismatch // rollback via defer; code NOT consumed
+	}
+
+	var id string
+	var createdAt time.Time
+	insErr := tx.QueryRow(ctx, `
+		INSERT INTO web_sessions (token_hash, user_id, oidc_subject, expires_at)
+		SELECT $1, $2::uuid, $3, $4
+		WHERE EXISTS (SELECT 1 FROM users WHERE id = $2::uuid AND deleted_at IS NULL)
+		RETURNING id, created_at`, sess.TokenHash, userID, subject, sess.ExpiresAt).Scan(&id, &createdAt)
+	if errors.Is(insErr, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("exchange cli code: %w", storage.ErrUserNotFound)
+	}
+	if insErr != nil {
+		return nil, fmt.Errorf("exchange cli code: insert: %w", insErr)
+	}
+
+	if _, delErr := tx.Exec(ctx, `DELETE FROM cli_login_codes WHERE code_hash = $1`, codeHash); delErr != nil {
+		return nil, fmt.Errorf("exchange cli code: delete: %w", delErr)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("exchange cli code: commit: %w", err)
+	}
+
+	sess.ID = id
+	sess.UserID = userID
+	sess.OIDCSubject = subject
+	sess.CreatedAt = createdAt
+	// CLI-minted sessions carry no issuer (the INSERT omits it, DB defaults to
+	// ''); zero it so the returned struct matches the persisted row.
+	sess.Issuer = ""
+	return sess, nil
+}
+
+// DeleteExpiredCLICodes removes expired code rows.
+func (s *AuthStore) DeleteExpiredCLICodes(ctx context.Context) (int64, error) {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM cli_login_codes WHERE expires_at <= $1`, s.now())
+	if err != nil {
+		return 0, fmt.Errorf("delete expired cli codes: %w", err)
 	}
 	return tag.RowsAffected(), nil
 }

--- a/internal/storage/postgres/web_auth_test.go
+++ b/internal/storage/postgres/web_auth_test.go
@@ -7,12 +7,14 @@ package postgres_test
 
 import (
 	"context"
+	"crypto/sha256"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/specgraph/specgraph/internal/storage"
+	"github.com/specgraph/specgraph/internal/storage/postgres"
 )
 
 func TestWebAuth_SessionLifecycle(t *testing.T) {
@@ -118,4 +120,102 @@ func TestWebAuth_LoginFlowExpired(t *testing.T) {
 	require.NoError(t, err)
 	_, err = auth.ConsumeLoginFlow(ctx, id)
 	require.ErrorIs(t, err, storage.ErrLoginFlowNotFound)
+}
+
+// newAuthStoreWithUser seeds a clean auth store with a single user and returns
+// the store plus that user's id. Mirrors the inline setup used by the older
+// tests (authTestSetup + sharedTestPool + truncateAuthTables + user insert);
+// because it truncates the shared pool it is NOT parallel-safe, so the CLI
+// tests below run sequentially like the rest of this file.
+func newAuthStoreWithUser(t *testing.T) (*postgres.AuthStore, string) {
+	t.Helper()
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+	var userID string
+	require.NoError(t, pool.QueryRow(ctx,
+		`INSERT INTO users (kind, display_name, email, role) VALUES ('human','U','u@example.com','reader') RETURNING id`).Scan(&userID))
+	return auth, userID
+}
+
+func TestExchangeCLICode_RoundTrip(t *testing.T) {
+	auth, userID := newAuthStoreWithUser(t)
+	ctx := context.Background()
+
+	codeHash := sha256.Sum256([]byte("rawcode"))
+	challenge := "CHALLENGE"
+	require.NoError(t, auth.CreateCLICode(ctx, codeHash[:], userID, "oidc:subj", challenge, time.Now().Add(time.Minute)))
+
+	tokenHash := sha256.Sum256([]byte("spgr_ws_token"))
+	sess, err := auth.ExchangeCLICode(ctx, codeHash[:], &storage.Session{
+		TokenHash: tokenHash[:], ExpiresAt: time.Now().Add(time.Hour),
+	}, challenge)
+	require.NoError(t, err)
+	require.Equal(t, userID, sess.UserID)
+	require.Equal(t, "oidc:subj", sess.OIDCSubject)
+
+	// Single-use: second exchange fails.
+	_, err = auth.ExchangeCLICode(ctx, codeHash[:], &storage.Session{
+		TokenHash: tokenHash[:], ExpiresAt: time.Now().Add(time.Hour),
+	}, challenge)
+	require.ErrorIs(t, err, storage.ErrCLICodeNotFound)
+}
+
+func TestExchangeCLICode_ChallengeMismatchLeavesCode(t *testing.T) {
+	auth, userID := newAuthStoreWithUser(t)
+	ctx := context.Background()
+
+	codeHash := sha256.Sum256([]byte("rawcode2"))
+	require.NoError(t, auth.CreateCLICode(ctx, codeHash[:], userID, "", "GOOD", time.Now().Add(time.Minute)))
+
+	tokenHash := sha256.Sum256([]byte("tok"))
+	_, err := auth.ExchangeCLICode(ctx, codeHash[:], &storage.Session{TokenHash: tokenHash[:], ExpiresAt: time.Now().Add(time.Hour)}, "BAD")
+	require.ErrorIs(t, err, storage.ErrCLIChallengeMismatch)
+
+	// Code is NOT consumed; a correct verifier still works.
+	sess, err := auth.ExchangeCLICode(ctx, codeHash[:], &storage.Session{TokenHash: tokenHash[:], ExpiresAt: time.Now().Add(time.Hour)}, "GOOD")
+	require.NoError(t, err)
+	require.Equal(t, userID, sess.UserID)
+}
+
+func TestExchangeCLICode_Expired(t *testing.T) {
+	auth, userID := newAuthStoreWithUser(t)
+	ctx := context.Background()
+	codeHash := sha256.Sum256([]byte("rawcode3"))
+	require.NoError(t, auth.CreateCLICode(ctx, codeHash[:], userID, "", "C", time.Now().Add(-time.Second)))
+	tokenHash := sha256.Sum256([]byte("tok"))
+	_, err := auth.ExchangeCLICode(ctx, codeHash[:], &storage.Session{TokenHash: tokenHash[:], ExpiresAt: time.Now().Add(time.Hour)}, "C")
+	require.ErrorIs(t, err, storage.ErrCLICodeNotFound)
+}
+
+func TestLoginFlow_CLIFieldsRoundTrip(t *testing.T) {
+	auth, _ := newAuthStoreWithUser(t)
+	ctx := context.Background()
+	id, err := auth.CreateLoginFlow(ctx, &storage.LoginFlow{
+		State: "s", Nonce: "n", CodeVerifier: "v", ProviderID: "p",
+		CLICallback: "http://127.0.0.1:5000/callback", CLIState: "cs", CLIChallenge: "cc",
+		ExpiresAt: time.Now().Add(time.Minute),
+	})
+	require.NoError(t, err)
+	got, err := auth.ConsumeLoginFlow(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "http://127.0.0.1:5000/callback", got.CLICallback)
+	require.Equal(t, "cs", got.CLIState)
+	require.Equal(t, "cc", got.CLIChallenge)
+}
+
+// TestLoginFlow_WebStillWorks guards against the nullable-scan regression:
+// the new NOT NULL DEFAULT '' columns must let a web-only flow round-trip.
+func TestLoginFlow_WebStillWorks(t *testing.T) {
+	auth, _ := newAuthStoreWithUser(t)
+	ctx := context.Background()
+	id, err := auth.CreateLoginFlow(ctx, &storage.LoginFlow{
+		State: "s", Nonce: "n", CodeVerifier: "v", ProviderID: "p",
+		ExpiresAt: time.Now().Add(time.Minute),
+	})
+	require.NoError(t, err)
+	got, err := auth.ConsumeLoginFlow(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "", got.CLICallback)
 }

--- a/internal/storage/postgres/web_auth_test.go
+++ b/internal/storage/postgres/web_auth_test.go
@@ -219,3 +219,22 @@ func TestLoginFlow_WebStillWorks(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "", got.CLICallback)
 }
+
+func TestDeleteExpiredCLICodes(t *testing.T) {
+	auth, userID := newAuthStoreWithUser(t)
+	ctx := context.Background()
+
+	expired := sha256.Sum256([]byte("expired-code"))
+	live := sha256.Sum256([]byte("live-code"))
+	require.NoError(t, auth.CreateCLICode(ctx, expired[:], userID, "", "c1", time.Now().Add(-time.Minute)))
+	require.NoError(t, auth.CreateCLICode(ctx, live[:], userID, "", "c2", time.Now().Add(time.Minute)))
+
+	n, err := auth.DeleteExpiredCLICodes(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+
+	// The live code still exchanges; the expired one is gone.
+	tokenHash := sha256.Sum256([]byte("tok"))
+	_, err = auth.ExchangeCLICode(ctx, live[:], &storage.Session{TokenHash: tokenHash[:], ExpiresAt: time.Now().Add(time.Hour)}, "c2")
+	require.NoError(t, err)
+}

--- a/internal/storage/web_auth.go
+++ b/internal/storage/web_auth.go
@@ -3,7 +3,10 @@
 
 package storage
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // WebAuthStore persists interactive-login web sessions and short-lived OAuth2
 // login-flow handshake state. Kept separate from UsersBackend so existing
@@ -37,4 +40,22 @@ type WebAuthStore interface {
 
 	// DeleteExpiredLoginFlows removes expired flow rows; returns count.
 	DeleteExpiredLoginFlows(ctx context.Context) (int64, error)
+
+	// --- CLI one-time login codes ---
+
+	// CreateCLICode inserts a one-time CLI login code. codeHash is the SHA-256
+	// of the opaque code; the raw code never reaches storage.
+	CreateCLICode(ctx context.Context, codeHash []byte, userID, subject, challenge string, expiresAt time.Time) error
+
+	// ExchangeCLICode atomically consumes an unexpired code and mints a session
+	// in one transaction. gotChallenge is S256(verifier) precomputed by the
+	// caller; it is constant-time compared against the stored challenge.
+	// sess must carry TokenHash and ExpiresAt; UserID/OIDCSubject/ID/CreatedAt
+	// are filled from the consumed code and the inserted row.
+	// Returns ErrCLICodeNotFound (unknown/expired), ErrCLIChallengeMismatch
+	// (PKCE mismatch), or ErrUserNotFound (user soft-deleted mid-flow).
+	ExchangeCLICode(ctx context.Context, codeHash []byte, sess *Session, gotChallenge string) (*Session, error)
+
+	// DeleteExpiredCLICodes removes expired code rows; returns count.
+	DeleteExpiredCLICodes(ctx context.Context) (int64, error)
 }

--- a/internal/storage/web_auth_domain.go
+++ b/internal/storage/web_auth_domain.go
@@ -35,6 +35,13 @@ type LoginFlow struct {
 	Nonce        string
 	CodeVerifier string // PKCE
 	ProviderID   string
+	// CLI-login fields. Empty for the web flow; set when the flow originated
+	// from `specgraph login`. CLICallback is a validated loopback URL,
+	// CLIState a CSRF token round-tripped to the CLI, CLIChallenge the PKCE
+	// S256 challenge bound to the one-time code.
+	CLICallback  string
+	CLIState     string
+	CLIChallenge string
 	CreatedAt    time.Time
 	ExpiresAt    time.Time
 }

--- a/site/docs/cli-reference.md
+++ b/site/docs/cli-reference.md
@@ -18,6 +18,7 @@
 - [Sync](#sync)
 - [Export & Backup](#export-backup)
 - [Server & Config](#server-config)
+- [Identity & Auth](#identity-auth)
 
 ---
 
@@ -940,6 +941,9 @@ specgraph serve [flags]
 ```
       --cors-origin string   Enable CORS for this origin (dev mode only)
       --listen string        Address to listen on (overrides config; env: SPECGRAPH_SERVER_LISTEN)
+      --log-format string    Log format: json, text (overrides config; env: SPECGRAPH_LOG_FORMAT)
+      --log-level string     Log level: debug, info, warn, error (overrides config; env: SPECGRAPH_LOG_LEVEL)
+      --log-output string    Log output stream: stdout, stderr (overrides config; env: SPECGRAPH_LOG_OUTPUT)
       --pg-url string        PostgreSQL connection URL (overrides config; env: SPECGRAPH_SERVER_POSTGRES_URL)
 ```
 
@@ -1009,9 +1013,10 @@ specgraph init [project-slug] [flags]
 **Flags:**
 
 ```
-      --check   Exit non-zero if any managed file would be modified (no writes)
-      --quiet   Suppress per-file action lines
-      --yes     non-interactive (accepted for backward compat; init is always non-interactive)
+      --check            Exit non-zero if any managed file would be modified (no writes)
+      --quiet            Suppress per-file action lines
+      --skip-bootstrap   skip local admin bootstrap (managed files only)
+      --yes              non-interactive (accepted for backward compat; init is always non-interactive)
 ```
 
 ### specgraph prime
@@ -1037,5 +1042,243 @@ Reads the requested MCP resource via streamable-HTTP transport from the configur
 
 ```
 specgraph read-mcp-resource <uri>
+```
+
+## Identity & Auth
+
+### specgraph login
+
+Log in via OIDC in the browser and store a session token
+
+```
+specgraph login [flags]
+```
+
+**Flags:**
+
+```
+      --no-browser        print the URL instead of opening a browser
+      --provider string   OIDC provider id (skips the picker)
+      --server string     server base URL (overrides resolved)
+```
+
+### specgraph logout
+
+Revoke the stored session and remove local credentials
+
+```
+specgraph logout [flags]
+```
+
+**Flags:**
+
+```
+      --server string   server base URL (overrides resolved)
+```
+
+### specgraph auth
+
+Manage identity: users, service accounts, API keys, and OIDC bindings
+
+```
+specgraph auth
+```
+
+#### specgraph auth api-key
+
+Manage API keys
+
+```
+specgraph auth api-key
+```
+
+##### specgraph auth api-key create
+
+Create an API key (prints the secret once)
+
+```
+specgraph auth api-key create [flags]
+```
+
+**Flags:**
+
+```
+      --expires-at string       expiry as RFC3339 (e.g. 2026-01-02T15:04:05Z); omit for no expiry
+      --json                    output as JSON
+      --label string            human-friendly label
+      --role-downgrade string   cap the key's effective role
+      --user string             user ID to own the key (required)
+```
+
+##### specgraph auth api-key list
+
+List API keys
+
+```
+specgraph auth api-key list [flags]
+```
+
+**Flags:**
+
+```
+      --include-revoked   include revoked keys
+      --json              output as JSON
+      --user string       filter by user ID (omit to list all keys, admin only)
+```
+
+##### specgraph auth api-key revoke
+
+Revoke an API key
+
+```
+specgraph auth api-key revoke <key-id>
+```
+
+##### specgraph auth api-key rotate
+
+Rotate an API key: mints a new secret and revokes the old key. Owner, label, and role-downgrade are preserved from the old key. Use --expires-at to set the new secret's validity window (omit to keep the old expiry).
+
+```
+specgraph auth api-key rotate <key-id> [flags]
+```
+
+**Flags:**
+
+```
+      --expires-at string   new secret's expiry as RFC3339; omit to keep the old key's expiry
+      --json                output as JSON
+```
+
+#### specgraph auth oidc
+
+Manage OIDC bindings
+
+```
+specgraph auth oidc
+```
+
+##### specgraph auth oidc list
+
+List a user's OIDC bindings
+
+```
+specgraph auth oidc list [flags]
+```
+
+**Flags:**
+
+```
+      --json          output as JSON
+      --user string   user ID (required)
+```
+
+##### specgraph auth oidc unbind
+
+Remove an OIDC binding
+
+```
+specgraph auth oidc unbind <binding-id> [flags]
+```
+
+**Flags:**
+
+```
+      --force         allow removing the user's only credential
+      --user string   owner of the binding (required)
+```
+
+#### specgraph auth user
+
+Manage users
+
+```
+specgraph auth user
+```
+
+##### specgraph auth user delete
+
+Soft-delete a user (revokes their keys)
+
+```
+specgraph auth user delete <user-id> [flags]
+```
+
+**Flags:**
+
+```
+      --force   allow deleting the bootstrap admin
+```
+
+##### specgraph auth user list
+
+List users
+
+```
+specgraph auth user list [flags]
+```
+
+**Flags:**
+
+```
+      --include-deleted   include soft-deleted users
+      --json              output as JSON
+      --kind string       filter by kind: human|service_account
+      --role string       filter by role
+```
+
+##### specgraph auth user purge
+
+Permanently delete a user (irreversible)
+
+```
+specgraph auth user purge <user-id> [flags]
+```
+
+**Flags:**
+
+```
+      --force   allow purging the bootstrap admin
+```
+
+##### specgraph auth user set-role
+
+Change a user's role
+
+```
+specgraph auth user set-role <user-id> <role> [flags]
+```
+
+**Flags:**
+
+```
+      --json   output as JSON
+```
+
+##### specgraph auth user show
+
+Show a single user
+
+```
+specgraph auth user show <user-id> [flags]
+```
+
+**Flags:**
+
+```
+      --json   output as JSON
+```
+
+#### specgraph auth whoami
+
+Show the identity of the current credential
+
+```
+specgraph auth whoami [flags]
+```
+
+**Flags:**
+
+```
+      --json   output as JSON
 ```
 


### PR DESCRIPTION
## Summary

Adds a `gh`-style `specgraph login` (and `specgraph logout`) that performs browser-based OIDC login against the server and stores the resulting `spgr_ws_` session token in the CLI credentials file. Previously the CLI could only authenticate via long-lived API keys.

**Flow (server-brokered loopback, PKCE-bound one-time code):**
1. `specgraph login` opens the browser to `/api/auth/oidc/{provider}/start` with a loopback `cli_callback`, a CSRF `cli_state`, and a PKCE `cli_challenge`; it runs a `127.0.0.1` listener.
2. The server runs its existing IdP flow (client secret stays server-side), then redirects a **one-time code** to the loopback — no cookie, no token in the URL.
3. The CLI exchanges `{code, cli_verifier}` at `POST /api/auth/cli/exchange`; the server verifies PKCE and mints the session **atomically** (`SELECT … FOR UPDATE` → constant-time compare → INSERT session → DELETE code), returning `{token, expires_at, oidc_subject}`.
4. The token is written to the credentials file (label `oidc:<subject>`). `specgraph logout` revokes it server-side and removes the local entry.

v1 is **loopback-only**: SSH/headless hard-errors to `specgraph auth api-key create` (a paste-the-code fallback was deliberately rejected as phishable). Gated by `auth.oidc.cli_login_enabled` (default true).

## Key changes
- **Storage:** migration `003_cli_login.sql` (`cli_login_codes` table + flow columns); `CreateCLICode`/`ExchangeCLICode`/`DeleteExpiredCLICodes`; expired-code sweeping.
- **Server:** `/start` CLI params + strict literal-loopback validation, `handleCallback` CLI branch, `POST /api/auth/cli/exchange`, logout-via-`spgr_ws_`-bearer.
- **Config:** `auth.oidc.cli_login_enabled` gate.
- **CLI:** `specgraph login`/`logout`, `internal/browser` opener, `internal/auth` literal-loopback helper.
- **Docs:** regenerated `site/docs/cli-reference.md` (adds login/logout and syncs the auth tree).

## Security notes
- PKCE binds the one-time code to the CLI process; a stolen code is useless without the verifier.
- Strict literal-loopback redirect validation (rejects `localhost`/DNS-rebinding), re-validated at callback; redirect built via `url.Values`.
- Exchange is a single atomic transaction; challenge mismatch rolls back without consuming the code; soft-deleted user → terminal 403.
- Session token never printed; exchange response carries `Cache-Control: no-store`; logout revokes only `spgr_ws_` bearers.
- Design went through three adversarial-review passes; see `docs/plans/2026-06-15-cli-oidc-login-design.md`.

## Test Plan
- [x] `task check` (fmt, license, lint, build, unit tests) — passes
- [x] `task test:integration` (postgres/testcontainers, incl. 5 new `cli_login_codes` tests) — passes
- [x] Unit coverage: loopback validation table, callback CLI-redirect branch, exchange happy/expired/replayed/PKCE-mismatch/user-unavailable, logout bearer prefix guard, CLI guards/loopback handler/provider pick/exchange
- [ ] Manual smoke against a configured interactive OIDC provider: `specgraph login` → `specgraph auth whoami` → `specgraph logout`