### PR TITLE
feat(auth): OIDC app-roles + login-sync (closes #996)

### DIFF
--- a/cmd/specgraph/serve.go
+++ b/cmd/specgraph/serve.go
@@ -170,6 +170,7 @@ func buildAppHandler(_ context.Context, cfg *config.GlobalConfig, deps *appDeps,
 		JITClaimsMapping:        buildClaimsMappingByIssuer(cfg.Auth.OIDC.Providers),
 		JITRateBurstPerHour:     cfg.Auth.OIDC.JITCreate.RateLimitPerHour,
 		JITEmailDomainAllowlist: cfg.Auth.OIDC.JITCreate.EmailDomainAllowlist,
+		LoginSyncEnabled:        cfg.Auth.OIDC.SyncOnLogin,
 	})
 	if err != nil {
 		cleanup() // drain the tracker goroutine we just started

--- a/docs/plans/2026-06-15-oidc-app-roles-login-sync-design.md
+++ b/docs/plans/2026-06-15-oidc-app-roles-login-sync-design.md
@@ -1,0 +1,579 @@
+# OIDC App-Roles + Login-Sync — Design
+
+- **Status:** Draft (design)
+- **Date:** 2026-06-15
+- **Tracking:** GitHub #996 (OIDC `claims_mapping`: groups overage pattern not handled)
+- **Follow-up (out of scope):** `spgr-g7st` — self-service / auto MCP API-key
+  provisioning; `spgr-c2lb` — enforce app-role revocation on standing API/MCP
+  keys (force re-sync)
+- **Reviewed:** adversarial review 2026-06-15 — findings folded in below
+  (security premise sound; default-on demotion risk accepted with eyes open,
+  see Operational Warning)
+
+## Problem
+
+`claims_mapping` rules that target the `groups` claim silently never match for
+users whose group membership exceeds the IdP's inline cap (Entra "groups
+overage"). In that case the token omits `groups` entirely and substitutes the
+`_claim_names` / `_claim_sources` indirection, so a rule like
+`{claim: groups, value: <id>, role: admin}` never fires and the user falls
+through to `default_role` (GitHub #996).
+
+A second, related limitation surfaced during design: `claims_mapping` is
+evaluated **only at JIT (just-in-time) user creation** (`identitystore.go:513-523`).
+On every subsequent sign-in the stored binding resolves the DB-persisted role
+and `claims_mapping` is ignored. So even when group mapping *does* work, changing
+a user's IdP assignment never updates their SpecGraph role.
+
+## Decision: pivot to app roles, not group resolution
+
+Rather than fetch the overflowed group list from the directory API (rejected —
+see Alternatives), we lean on **app roles**, the Microsoft-recommended workaround
+the issue itself names. App roles ride **inline in the token as a `roles` array
+claim** and are **never subject to overage** — assigning an app role to a large
+group still emits the flattened role values in `roles`. Operators target the
+`roles` claim with the existing `claims_mapping` mechanism, which already matches
+string-array claims (`matchClaimValue`, `identitystore.go:579-593`).
+
+No Graph API calls, no client-credentials grant, no overage detection, no
+`GroupResolver`.
+
+### Example operator config (already valid today)
+
+````yaml
+auth:
+  oidc:
+    sync_on_login: true   # NEW (default true)
+    providers:
+      - id: entra
+        issuer: "https://login.microsoftonline.com/<tenant>/v2.0"
+        client_id: "<client-id>"
+        audience: "<client-id>"
+        client_secret: "<secret>"
+        interactive: true
+        display_name: "Entra"
+        claims_mapping:
+          - claim: "roles"
+            value: "specgraph.admin"
+            role: "admin"
+          - claim: "roles"
+            value: "specgraph.user"
+            role: "writer"
+````
+
+`value` matches the app role's **Value** field in the Entra app registration
+(e.g. `specgraph.admin`), not its display name. `admin`/`writer` are built-in
+roles (`auth.go:12-14`) validated at startup against `KnownRoles`
+(`identitystore.go:115-126`).
+
+## Scope
+
+On each **interactive login** — the OIDC browser callback **and** the CLI login
+broker, both of which flow through `resolver.Resolve(WithInteractiveLogin(ctx), …)`
+(`auth_oidc_handler.go:215`) — for an OIDC user whose binding already exists,
+SpecGraph will:
+
+1. **Re-enforce the email-domain allowlist** (M-1) — `applyLoginSync` re-checks
+   `jitEmailAllowlist` (the same gate `jitResolve` applies at creation,
+   `identitystore.go:481-493`). On a domain miss, the login is **denied**
+   (`ErrUnauthenticated`); a domain removed from the allowlist revokes access on
+   next interactive login rather than only blocking new users.
+   **Absent-email exception (R4 MEDIUM-5):** unlike `jitResolve` (which denies an
+   empty email under a non-empty allowlist, `identitystore.go:483-487`), for an
+   **existing** binding `applyLoginSync` **skips** the allowlist re-check when the
+   token carries no email claim — the user already passed at bind time
+   (`email_at_bind`, `auth_migrations/001_initial.sql`). Only a **present** email
+   whose domain is now disallowed denies. This preserves revoke-on-domain-removal
+   without locking out established users when a provider intermittently omits
+   `email`/`preferred_username`.
+2. **Refresh metadata** — update `DisplayName` and `Email` from the verified
+   token claims, with guards (see Metadata refresh below).
+3. **Re-evaluate role (single-issuer)** — re-derive the role from **only the
+   issuer the user just authenticated with** and update the stored role. The
+   role reflects **what the live token grants**. A user with multiple bindings
+   gets the role derived from their most-recent interactive login's issuer
+   (per-last-login). See Role re-eval.
+
+Per-request bearer JWTs and API-key requests (the MCP path, machine/CLI clients)
+are **not** interactive logins and therefore trigger **no** sync. First-time
+users still go through the unchanged `jitResolve` path.
+
+### Metadata refresh (H3 — `OIDCClaims` has no name field today)
+
+`OIDCClaims` currently exposes only `Issuer/Subject/Email/Nonce/Raw`
+(`oidc_verifier.go:23-29`) — there is **no parsed display name**, and
+`jitResolve` sets `DisplayName = claims.Subject` (the opaque `sub`) with the
+note "operator can rename later" (`identitystore.go:528`). Naively refreshing
+`DisplayName` from claims would either have no source or overwrite an operator
+rename with the opaque subject on every login.
+
+Required changes:
+
+- Add a parsed `Name string` to `OIDCClaims`, sourced in `oidc_verifier.go` from
+  the `name` claim, falling back to `preferred_username` (the same fallback
+  order already used for email).
+- `applyLoginSync` updates `DisplayName` **only when** the stored value still
+  equals the OIDC subject (i.e. never renamed by an operator) **and** the new
+  `Name` is non-empty. Operator renames are preserved.
+- `Email` is refreshed from the verified `email`/`preferred_username` resolution
+  (`oidc_verifier.go:99-109`); skip the write when unchanged.
+
+**Caveats (L-2/L-3):**
+
+- The "stored == subject ⇒ never renamed" test is a **value-equality heuristic**,
+  not true provenance (same limitation as the deferred `role_source` column). It
+  false-positives if an operator renames a user to a value equal to the opaque
+  `sub`, and behaves oddly for IdPs where `sub == email`.
+- `Email` has **no rename guard** (only skip-if-unchanged). This is benign today
+  because no admin email-edit operation exists (`UsersBackend` exposes only
+  `UpdateUserRole`), but the asymmetry with `DisplayName` is intentional and
+  must be revisited if an email-edit feature lands.
+- When both `name` and `email` claims are absent, `Name` and `Email` both fall
+  back to `preferred_username`, so `DisplayName` becomes an email-shaped string.
+
+### Out of scope
+
+- Directory/Graph API group fetching and the `_claim_names`/`_claim_sources`
+  overage indirection (rejected approach).
+- Self-service or auto MCP API-key provisioning (`spgr-g7st`).
+- Enforcing app-role *revocation* on standing API/MCP keys without re-login
+  (`spgr-c2lb`) — see Operational Warning.
+- Re-evaluating role on non-interactive (per-request) credentials.
+
+## Architecture
+
+### Hook point
+
+A new method on `pgIdentityStore`:
+
+````go
+// applyLoginSync re-enforces the email allowlist, refreshes profile metadata,
+// and re-derives the role from the issuer just authenticated (single-issuer)
+// for an existing OIDC user on interactive login. Returns the user to surface
+// as the resolved Identity, or an error that DENIES the login.
+//
+// Error model is asymmetric by privilege direction:
+//   - Allowlist miss            -> deny (ErrUnauthenticated).
+//   - PROMOTION persist failure -> best-effort: log a warning, proceed at the
+//     OLD (lower) role. Fails closed; no privilege is granted unbacked by the DB.
+//   - DEMOTION persist failure  -> DENY the login (fail closed). Never return an
+//     Identity whose role exceeds what is currently persisted; emit an
+//     error-level security event. "Demotion" = any change that is NOT a provable
+//     built-in promotion (see Demotion classifier).
+//   - Metadata-only failure     -> best-effort: log a warning, proceed.
+func (s *pgIdentityStore) applyLoginSync(ctx context.Context, claims *OIDCClaims, user *storage.User) (*storage.User, error)
+````
+
+**Returned-Identity invariant (M-4):** mutate the returned `user` struct only
+from values that `UpdateUserOnLogin` persisted successfully. On any persist
+error, return the originally-loaded `user` unchanged (promotion path) or an
+error (demotion/allowlist path). The Identity's role MUST never exceed the
+persisted role.
+
+The store gains a `loginSyncEnabled bool` field (wired from config — see Wiring
+below). `applyLoginSync` is called from `resolveJWT` in the
+**existing-binding** branch — after the soft-delete check (`identitystore.go:451-458`)
+and before the Identity is built (`identitystore.go:459`) — gated on:
+
+````go
+if s.loginSyncEnabled && InteractiveLoginFromContext(ctx) {
+    var err error
+    user, err = s.applyLoginSync(ctx, claims, user)
+    if err != nil {
+        return nil, err // deny: allowlist miss or failed demotion
+    }
+}
+````
+
+**Wiring (L-4):** add `LoginSyncEnabled bool` to the identity-store config
+struct and thread `cfg.Auth.OIDC.SyncOnLogin` into it at the store construction
+site in `serve.go` (alongside `JITClaimsMapping`/`JITDefaultRole`,
+`serve.go:162-173`).
+
+`InteractiveLoginFromContext` is the **sole gate** distinguishing a login event
+from a per-request bearer JWT. Its only production setter is the browser callback
+(`auth_oidc_handler.go:215`). Add a defensive comment at the `WithInteractiveLogin`
+definition forbidding new callers on any per-request/bearer path — one misplaced
+setter would let an ordinary MCP/RPC request mutate roles.
+
+### Role re-eval decision (single-issuer)
+
+A login carries exactly **one** issuer's token. The re-derived role is computed
+from **that issuer's** `claims_mapping` against the verified claims — the role
+reflects what the **live token** grants. We do **not** read or combine other
+bindings (the rejected most-privileged-across-bindings approach added a
+`derived_role` column, a cross-binding transaction the auth storage layer cannot
+provide, and a permanent stale-escalation hole; see Alternatives #5).
+
+Multi-binding note: a `User` may hold multiple bindings (`oidc_bindings` is
+unique only on `(issuer, subject)`; `ListOIDCBindings` returns many,
+`users.go:106-107`). With single-issuer, the role is re-derived from the issuer
+just logged in through. **Scope of the guarantee (R4 HIGH-2):** when that issuer
+**has `claims_mapping`**, the role equals what its mapping asserts for the live
+token (rules 2/3). When that issuer has **no** mappings (rule 1), the prior role
+is left **unchanged** — so a user who logs in through a mapping-less provider
+**retains** whatever role was last persisted (possibly derived months ago from a
+*different* provider). This is a deliberate, narrower form of role retention: it
+avoids the C1 mass-demotion for mapping-less providers, but it is **not** the
+stronger "your role always equals the credential you just presented" property —
+that holds only for issuers that have mappings. The "flap" between mapping-having
+issuers is still the safe direction (role = live token from that issuer).
+
+#### Pure, table-tested helper
+
+````go
+// resolveLoginRole computes the new role for an interactive login from the
+// issuer's mappings and the verified claims. Returns (newRole, changed).
+func resolveLoginRole(
+    mappings []config.ClaimMapping,   // this issuer's claims_mapping (nil/empty if none)
+    claims map[string]json.RawMessage,
+    currentRole string,
+    defaultRole string,
+) (role string, changed bool)
+````
+
+Rules — **evaluated in this exact order** (the ordering is the single
+correctness hinge; conflating "no mappings" with "no match" re-introduces the C1
+mass-demotion for every mapping-less provider):
+
+| # | Condition | Result |
+|---|---|---|
+| 1 | `len(mappings) == 0` (no `claims_mapping` for the issuer) | role **unchanged** — guard; never wipe roles for a provider without mappings |
+| 2 | mappings configured, a rule matches | that rule's role |
+| 3 | mappings configured, no rule matches | `default_role` (or `reader` if unset, matching `jitResolve`) |
+
+Rule-1-before-rule-3 ordering MUST be table-tested explicitly. Note
+`buildClaimsMappingByIssuer` only inserts a key when `len(ClaimsMapping) > 0`
+(`serve.go:775`), so "no provider entry" and "empty slice" both collapse to a
+nil/empty lookup → rule 1.
+
+This makes the IdP authoritative on interactive login over the **`roles` claim**,
+**for issuers that have `claims_mapping`**: losing your app-role assignment on a
+mapping-having issuer you log in through demotes you to `default_role` on next
+login via that issuer. (Logging in via a mapping-less issuer is rule 1 → no
+change; see the Scope-of-the-guarantee note above.)
+
+**Matching caveats (inherited from `matchClaimValue`, `identitystore.go:579-593`):**
+
+- Values are matched by **exact, case-sensitive string `==`**. App-role `Value`s
+  in the IdP MUST be strings; a numeric claim (e.g. `"roles":[1]`) never matches
+  → rule 3. Document this as a hard requirement.
+- `applyClaimsMapping` returns the **first** matching rule in config order
+  (`identitystore.go:564-575`), not the most-privileged. A user holding both
+  `specgraph.user` and `specgraph.admin` gets whichever rule is listed first —
+  order rules **most-privileged-first**. Document this.
+
+### Demotion classifier (custom roles fail closed — H4)
+
+The error model (above) treats demotions as fail-closed and promotions as
+best-effort. "Promotion" is defined **narrowly and provably**:
+
+````go
+// isPromotion reports true ONLY when both roles are built-ins and the new
+// built-in rank is strictly higher than the current. Everything else — a rank
+// decrease, equal, or ANY transition involving a custom/unranked role — is
+// treated as a potential demotion (fail closed).
+func isPromotion(current, next string) bool
+````
+
+Rationale: `roleRank` (`identitystore.go:246`) covers only built-ins
+(`reader=1, writer=2, admin=3`); the codebase deliberately treats custom roles as
+**incomparable** (`roleLessThan` returns false both ways, `clampedRole` fails
+closed to `reader`, `identitystore.go:260-292`). We do **not** invent a synthetic
+rank for custom roles. Instead, any change that is not a provable built-in
+promotion is conservatively classified as a demotion, so a custom-role user can
+never be left **more** privileged than the IdP currently grants on a persist
+failure. This matches `clampedRole`'s fail-closed philosophy.
+
+**`isPromotion` MUST NOT be consulted when the role did not change** — see the
+algorithm below, where classification is gated on `changed` first. `isPromotion`
+returns false for equal roles by construction, so consulting it on a
+role-unchanged login would mis-route a metadata-only write failure into the deny
+path.
+
+### Algorithm (explicit ordering — R4 HIGH-1)
+
+`applyLoginSync` MUST compose the helpers in this exact order. The three concerns
+(skip-if-unchanged, role classification, error bucket) are only correct together:
+
+````text
+1. Allowlist: if token has an email AND its domain ∉ allowlist  -> return ErrUnauthenticated (deny).
+   (absent email on an existing binding -> skip this check; see Scope step 1)
+2. Compute newRole, changed := resolveLoginRole(issuerMappings, claims, user.Role, defaultRole)
+   Compute newDisplayName (rename guard), newEmail (skip-if-empty).
+3. If (newDisplayName, newEmail, newRole) == (user.DisplayName, user.Email, user.Role):
+       -> NO write, NO classification, return user unchanged. (L3 no-op skip)
+4. Else call UpdateUserOnLogin(newDisplayName, newEmail, newRole). On success,
+   mutate the returned user from the persisted values; emit an audit line if
+   `changed`. Return user.
+5. On UpdateUserOnLogin error, classify by `changed` FIRST:
+       changed == false                 -> metadata-only: log warning, return ORIGINAL user (best-effort, login proceeds).
+       changed && isPromotion(old,new)  -> promotion:     log warning, return ORIGINAL (lower) user (best-effort).
+       changed && !isPromotion(old,new) -> demotion:      emit error-level audit line, return (nil, err) (DENY).
+````
+
+Key invariant: the returned Identity's role **never exceeds** the persisted role
+(M-4). The audit line (Operational Warning) fires on step 4 (successful change)
+and on the step-5 demotion-deny branch — **never** on a metadata-only failure, to
+avoid spurious "failed demotion" security events.
+
+### Storage
+
+`UpdateUserRole` exists (`users.go:49-51`) but there is no profile update. Add
+one method to `UsersBackend` and its Postgres impl:
+
+````go
+// UpdateUserOnLogin sets display_name, email, and role on an active user in a
+// single UPDATE (deleted_at IS NULL guard, like UpdateUserRole). Returns
+// ErrUserNotFound if no active row matched.
+UpdateUserOnLogin(ctx context.Context, userID, displayName, email, role string) error
+````
+
+Single-issuer means the entire mutation is **one `UPDATE` on the `users` row**
+(display_name, email, role are all columns there) — atomic as a single statement,
+**no transaction needed**, no new column, no `RunInTransaction` (which is in any
+case unreachable from `pgIdentityStore`: it lives on `*Store`/`tx.go:42`, while
+`AuthStore` uses `s.pool` directly and ignores `txFromContext`). This follows the
+existing `UpdateUserRole` shape (`postgres/users.go:225-237`).
+
+The surrounding logic is still **read-modify-write** (role computed from the user
+loaded earlier in `resolveJWT`, written here), so a concurrent admin
+`UpdateUserRole` racing the login is **last-writer-wins** — acceptable and
+documented (H2: when sync is on, the IdP is the sole authority over the
+`roles`-derived role, so login-sync winning is intended). The fail-closed
+demotion guarantee holds because the single `UPDATE` either commits the new
+(lower) role or returns an error that denies the login.
+
+**Startup role validation (H-2 — current guard is insufficient).** The doc
+previously assumed `claims_mapping` roles "are validated against `KnownRoles` at
+startup." That guard is **gated on `cfg.JITEnabled`** (`identitystore.go:115`),
+but `JITClaimsMapping` is wired unconditionally (`serve.go:170`) and login-sync
+consumes it independently of JIT. So with `jit_create.enabled: false` +
+`sync_on_login: true` + a typo'd role (`role: admln`), startup passes and the
+next login assigns `admln`, which authorizes nothing (default-deny,
+`known_roles.go`) → **silent lockout** — and exactly the manual-management
+audience told to set `jit_create.enabled: false`. **Required change:** validate
+`JITClaimsMapping` and `JITDefaultRole` against `KnownRoles` whenever
+`loginSyncEnabled || JITEnabled` (not `JITEnabled` alone). Update the
+`NewIdentityStore` guard at `identitystore.go:115`.
+
+**Write amplification (L3):** skip the `UPDATE` entirely when the computed
+`(displayName, email, role)` tuple equals the stored values, to avoid redundant
+row writes/WAL on every no-op login. (Note: the `users` table has **no
+`updated_at` column**, `auth_migrations/001_initial.sql`; the optimization is
+about avoiding redundant writes, not trigger churn.)
+
+## Config
+
+Add one field to `OIDCConfig` (`global.go:206-219`):
+
+````go
+// SyncOnLogin enables refreshing DisplayName/Email and re-evaluating the
+// role from token claims on each interactive login. Default true.
+SyncOnLogin bool `yaml:"sync_on_login" koanf:"sync_on_login"`
+````
+
+Default **true**, set **only in `globalDefaults()`** (the struct-defaults path,
+exactly as `CLILoginEnabled` is handled, `global.go:428`). It MUST NOT be
+defaulted in `applyPostLoad`: a bool whose desired default is `true` cannot be
+distinguished there from an operator's explicit `sync_on_login: false`, so an
+`applyPostLoad` guard would force-enable sync and make opt-out impossible.
+
+Operators who manage roles manually set it to `false` to retain the legacy
+JIT-only behavior.
+
+## Behavior across credential types (MCP / API keys)
+
+- **MCP harnesses** authenticate with static API keys (`spgr_sk_…`) via
+  `${SPECGRAPH_API_KEY}` (`managedfiles/manifest.go:42,63,93`). API-key requests
+  are not interactive logins → **no sync, no role change** on the MCP path. The
+  per-request invariant holds: nothing on `/mcp/` can mutate a role.
+- API-key requests resolve the **owner user's current DB role** every request
+  (`resolveAPIKey`). So a role change from a user's interactive login (web or
+  CLI) **propagates to their MCP key automatically** on its next call — no cache
+  to go stale.
+- **Boundary:** role changes reach MCP/API-key usage only **after** the human
+  re-authenticates interactively via an **OIDC** login (web callback or
+  `specgraph login`). A user who never interactively re-logs-in won't see
+  app-role changes take effect — including app-role *removal*, which is **not
+  enforced** on standing keys until re-login (follow-up `spgr-c2lb`). Note the
+  web dashboard also offers an **API-key paste** login (`auth_handler.go:81`)
+  that stores the raw key in a session cookie and resolves per-request as an API
+  key; that path is **non-interactive** and never drives sync. Only OIDC
+  interactive sessions do.
+
+## Operational Warning — default-on demotion (C1, accepted risk)
+
+`sync_on_login` defaults **true** and re-derives every existing OIDC user's role
+on their next interactive login. This is intentional, but carries a real
+lockout/mass-demotion hazard that operators MUST understand:
+
+- The premise of #996 is that existing `claims_mapping` rules target the broken
+  `groups` claim. **Until** rules are re-pointed at `roles` **and** each `value`
+  exactly matches the IdP app-role `Value` (case-sensitive), every OIDC user
+  hits rule 3 (no match) and is **demoted to `default_role` on next login**.
+- If admins were promoted via app roles that aren't yet assigned, or via manual
+  `auth user set-role` (see H2 below), they are demoted too. The **bootstrap
+  admin key is the only immune identity** (a SYSTEM admin with no OIDC binding,
+  `bootstrap.go`) — if it was discarded, a misconfig can leave the deployment
+  with **no admin**.
+
+Required mitigations in docs/runbook (behavior unchanged per maintainer
+decision):
+
+- **Migrate before first login:** re-target `claims_mapping` to `roles`, verify
+  every app-role `Value` string, and assign app roles to admins **before**
+  anyone logs in post-upgrade. Or set `sync_on_login: false` during migration
+  and flip it on after verifying.
+- **Keep the bootstrap admin key** recoverable until app-role mapping is
+  confirmed working. (The bootstrap admin is immune because it has no OIDC
+  binding and authenticates via `resolveAPIKey`, not `resolveJWT` — see
+  `bootstrap.go:44-48` for its `spgr_sk_`/admin shape.)
+- **Revoking via app-roles — do NOT delete the whole block (R4 MEDIUM-3).** To
+  *revoke* a provider's role grants, keep **≥1** mapping rule so rules 2/3 apply
+  (no-match → `default_role`). Deleting the **entire** `claims_mapping` block
+  flips the provider to **rule 1 = freeze**: nobody logging in via it is
+  re-evaluated and everyone keeps their last role. This is the inverse hazard of
+  the mass-demotion above — silent privilege *retention* after an operator
+  believes they revoked grants.
+- **No-match demotion floor (R4 LOW).** Rule 3's floor is
+  `jit_create.default_role` (or `reader` if unset), reused even when
+  `jit_create.enabled: false`. Operators running manual JIT-off setups who never
+  set `jit_create.default_role` will see no-match users demoted to `reader`.
+  Document that `jit_create.default_role` governs login-sync's floor regardless
+  of `jit_create.enabled`.
+- **Audit logging (M-3):** there is no audit subsystem today, only `slog`.
+  `applyLoginSync` MUST emit a dedicated structured line with an `audit=true`
+  attribute (subject, issuer, old → new role) on each role-change **decision** —
+  i.e. on a successful change (algorithm step 4) and on the **error-level**
+  demotion-deny branch (step 5, `changed && !isPromotion`). It MUST NOT fire on
+  metadata-only no-op failures (`changed == false`). The Operational-Warning
+  "demotions are visible" guarantee depends on the failed-demotion line existing.
+
+### H2 — IdP is the sole role authority when sync is on
+
+There is a single `role` column on `users` with no provenance (schema:
+`auth_migrations/001_initial.sql`). When `sync_on_login` is enabled, the IdP (via
+`claims_mapping`) is the **sole** authority for the `roles`-derived role of
+synced OIDC users: a manual `auth user set-role` promotion is **overwritten** on
+that user's next interactive login **through a provider that has `claims_mapping`**
+(rules 2/3). **Qualifier (R4 MEDIUM-4):** if the user logs in through a
+mapping-less provider, rule 1 leaves the manual grant **intact** — so manual
+durability is non-deterministic across providers. This is documented, not guarded
+— operators must not rely on manual grants for users covered by a provider's
+`claims_mapping`. (A `role_source` provenance column to make manual grants
+durable was considered and deferred.)
+
+**Scope of "authority" (M-1 honesty):** login-sync is authoritative over the
+**role derived from the `roles` claim only**. It is *not* a general access gate
+beyond what is enforced: the email-domain allowlist **is** re-enforced on each
+interactive login (deny on miss — see Scope step 1), but standing API/MCP keys
+are not revoked until re-login (`spgr-c2lb`).
+
+## Error handling (asymmetric by privilege direction — H-1)
+
+`applyLoginSync`'s failure behavior is determined by the **Algorithm** above; the
+buckets below restate its step-5 classification (always gated on `changed` first):
+
+- **Allowlist domain miss** → **deny** the login (`ErrUnauthenticated`). (Absent
+  email on an existing binding skips the check — see Scope step 1.)
+- **`changed && !isPromotion` (demotion) persist fails** → **deny** (fail closed).
+  Never return an Identity whose role exceeds the persisted role; emit an
+  error-level `audit=true` line.
+- **`changed && isPromotion` (promotion) persist fails** → **best-effort**: log a
+  warning, proceed at the OLD (lower) role. No privilege granted unbacked by DB.
+- **`changed == false` (role unchanged, metadata-only) persist fails** →
+  best-effort: log a warning, proceed; role is unaffected. **`isPromotion` is not
+  consulted here** — this bucket is reached only because classification is gated
+  on `changed`, which is what keeps it reachable (R4 HIGH-1).
+- Soft-deleted / inactive users are already rejected upstream in `resolveJWT`
+  before the sync hook; `UpdateUserOnLogin`'s `deleted_at IS NULL` guard is
+  defense-in-depth.
+
+The asymmetry is the point: a **sync hiccup must never leave a user more
+privileged than the IdP currently grants**, but it may transiently leave them
+*less* privileged (safe), and a role-unchanged login is never denied for a
+metadata write hiccup.
+
+## Testing
+
+- **`resolveLoginRole`** table tests, asserting **rule ordering**: `len==0`
+  (no mappings) → **unchanged even though no rule matches** (the C1 hinge);
+  configured + match → mapped role; configured + no-match → `default_role`;
+  `default_role` unset → `reader`; most-privileged-first rule ordering;
+  numeric/non-string claim → no match.
+- **`isPromotion` classifier (H4)**: built-in rank increase → true; built-in
+  decrease/equal → false; any transition involving a custom role (custom→builtin,
+  builtin→custom, custom→custom) → false (treated as demotion / fail-closed).
+- **Fail-closed demotion (H-1)**: demotion decided + `UpdateUserOnLogin` errors
+  → login **denied**, Identity NOT returned at the old elevated role, audit line
+  emitted. Promotion + persist error → login proceeds at old lower role.
+- **Metadata-only write failure does NOT deny (R4 HIGH-1)**: role unchanged
+  (rule 1, or rule 2 matching the same role) + email/name changed +
+  `UpdateUserOnLogin` errors → login **proceeds** (best-effort), NO deny, NO
+  "failed demotion" audit line. This is the regression-guard for the classifier
+  ordering bug.
+- **No-op skip**: unchanged `(displayName, email, role)` tuple → no `UPDATE`
+  issued at all (so no persist-failure path).
+- **Allowlist re-enforcement (M-1)**: existing-binding user whose email domain
+  was removed from the allowlist → login **denied**; same user with a token that
+  **omits** the email claim → login **allowed** (absent-email skip, R4 MEDIUM-5).
+- **Startup validation (H-2)**: `sync_on_login: true` + `jit_create.enabled:
+  false` + typo'd mapping role → `NewIdentityStore` returns an error at startup
+  (not a runtime lockout).
+- **Identity store**: interactive login updates role + metadata; a plain
+  bearer-JWT (non-interactive) request makes **no** change (preserves the
+  per-request invariant); API-key request makes no change.
+- **Multi-binding**: a user with bindings on two issuers gets the role of the
+  issuer they logged in through (per-last-login); logging in via a mapping-less
+  issuer (rule 1) **retains** the prior role (R4 HIGH-2 retention behavior).
+- **Metadata guards**: `DisplayName` updated only when stored value still equals
+  the subject (not after an operator rename); no-op tuple skips the write.
+- **Flag**: `sync_on_login: false` reproduces today's JIT-only behavior; default
+  unset → enabled (defaulted in `globalDefaults`, explicit `false` honored).
+- **Storage**: `UpdateUserOnLogin` updates the three columns in a single
+  statement, respects the active-row guard, returns `ErrUserNotFound` for
+  missing/deleted rows (Postgres integration test).
+
+## Documentation
+
+- `site/docs/guides/oidc-login.md`: recommend targeting the `roles` (app-role)
+  claim over `groups`; explain the groups-overage limitation and why app roles
+  avoid it; document `sync_on_login`, its demotion semantics, the migration
+  warning above, the IdP-sole-authority rule (H2), the string-`Value` and
+  most-privileged-first requirements, and that the issuer **must be
+  tenant-pinned** (not the multi-tenant `common`/`organizations` endpoint, which
+  could admit attacker-controlled `roles` from another tenant — L4).
+- Note the MCP boundary (role changes apply after the next interactive OIDC
+  login; key-paste sessions never sync) and the per-last-login behavior for
+  multi-binding users.
+
+## Alternatives considered
+
+1. **Directory/Graph group fetch (rejected).** Detect the overage pattern and
+   call `getMemberObjects` via app-only client credentials, behind a
+   `GroupResolver` seam. Rejected by the maintainer in favor of app roles:
+   adds network egress during auth, directory-API credentials, throttling and
+   error handling, and targets the deprecated `graph.windows.net` overage
+   endpoint. App roles solve the same need inline.
+2. **First-class `app_role_mapping` config (rejected).** A dedicated mapping
+   block separate from `claims_mapping`. Unnecessary — `claims_mapping` already
+   matches the `roles` array claim. YAGNI.
+3. **Generic distributed-claims fetcher (rejected).** Follow
+   `_claim_sources.endpoint` for any claim. Over-engineered; only `groups`
+   overage matters and it special-cases Graph anyway.
+4. **Sync on every JWT-bearing request (rejected).** Most current, but adds a DB
+   write to every machine/CLI/MCP request. Login-event scoping bounds the cost.
+5. **Most-privileged role across all bindings (designed, then rejected in
+   review round 3).** Persist each binding's last-derived role in a new
+   `oidc_bindings.derived_role` column and take the max on login. Rejected:
+   (a) the cross-binding transaction is **unreachable** from `pgIdentityStore`
+   (`RunInTransaction` is on `*Store`/`tx.go:42`; `AuthStore` uses `s.pool`
+   directly), so the writes would be non-atomic; (b) a stale `derived_role` from
+   a provider the user stopped using becomes **permanent privilege escalation**
+   with no live token backing it; (c) empty/`NULL` `derived_role` overloads
+   "no mapping" vs "not yet evaluated", causing spurious post-migration
+   demotion; (d) custom roles are **incomparable** (`roleRank`/`clampedRole`,
+   `identitystore.go:246-292`), so "most-privileged" has no coherent definition
+   for them. Single-issuer ("role = what the live token grants") is simpler and
+   strictly safer — the per-last-login "flap" is the secure failure direction.

--- a/docs/plans/2026-06-15-oidc-app-roles-login-sync-implementation-plan.md
+++ b/docs/plans/2026-06-15-oidc-app-roles-login-sync-implementation-plan.md
@@ -1,0 +1,993 @@
+# OIDC App-Roles + Login-Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On interactive OIDC login, refresh a user's `DisplayName`/`Email` and re-derive their role from the issuer's `claims_mapping` (so app-role assignments — the fix for the #996 groups-overage problem — take effect on every login, not just at JIT creation).
+
+**Architecture:** A new `applyLoginSync` method on `pgIdentityStore` runs in `resolveJWT`'s existing-binding branch, gated on `loginSyncEnabled && InteractiveLoginFromContext(ctx)`. It re-enforces the email allowlist, refreshes metadata with guards, and re-derives the role via a pure `resolveLoginRole` helper. Persistence is one atomic `UPDATE` on the `users` row (`UpdateUserOnLogin`). Failures are handled asymmetrically: demotions/allowlist-misses deny the login (fail closed), promotions/metadata-only failures are best-effort. A `sync_on_login` config flag (default true) gates the feature.
+
+**Tech Stack:** Go, `github.com/coreos/go-oidc/v3`, pgx v5 (Postgres), koanf config, testify, testcontainers (Postgres integration tests).
+
+**Design doc:** `docs/plans/2026-06-15-oidc-app-roles-login-sync-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `internal/auth/oidc_verifier.go` | Add parsed `Name` claim to `OIDCClaims` | Modify |
+| `internal/config/global.go` | Add `OIDCConfig.SyncOnLogin` field + default | Modify |
+| `internal/storage/users.go` | Add `UpdateUserOnLogin` to `UsersBackend` interface | Modify |
+| `internal/storage/postgres/users.go` | Implement `UpdateUserOnLogin` | Modify |
+| `internal/storage/postgres/users_test.go` | Integration test for `UpdateUserOnLogin` | Modify |
+| `internal/auth/usersbackend_stub_test.go` | Stub gains `UpdateUserOnLogin` (configurable) | Modify |
+| `internal/server/usersbackend_stub_test.go` | Stub gains `UpdateUserOnLogin` | Modify |
+| `internal/auth/loginsync.go` | `resolveLoginRole`, `isPromotion`, `applyLoginSync` | Create |
+| `internal/auth/loginsync_internal_test.go` | White-box (`package auth`) tests for the helpers + `applyLoginSync` (local fakes) | Create |
+| `internal/auth/oidc_verifier_internal_test.go` | White-box test for `nameFromClaims` | Create |
+| `internal/auth/identitystore.go` | New `loginSyncEnabled` field + config + startup validation + hook in `resolveJWT` | Modify |
+| `internal/auth/context.go` | Defensive comment on `WithInteractiveLogin` | Modify |
+| `cmd/specgraph/serve.go` | Wire `LoginSyncEnabled` from config | Modify |
+| `site/docs/guides/oidc-login.md` | Document app-roles, `sync_on_login`, warnings | Modify |
+
+Conventions: every `.go` file needs the SPDX header (`task license:add` fixes). New packages need a `// Package` doc comment (not needed here — all in existing `auth`/`config`/`postgres` packages). Run `task check` before pushing.
+
+---
+
+## Task 1: Add parsed `Name` to `OIDCClaims`
+
+**Files:**
+
+- Modify: `internal/auth/oidc_verifier.go` (struct ~23-29; `Verify` ~78-112)
+- Create: `internal/auth/oidc_verifier_internal_test.go` (white-box, `package auth`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/auth/oidc_verifier_internal_test.go` as a **white-box** test
+(`package auth`, mirroring the existing `internal/auth/clampedrole_internal_test.go`
+convention) so it can call the unexported `nameFromClaims`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNameFromClaims(t *testing.T) {
+	raw := func(s string) json.RawMessage { return json.RawMessage(`"` + s + `"`) }
+	cases := []struct {
+		name   string
+		claims map[string]json.RawMessage
+		want   string
+	}{
+		{"name preferred", map[string]json.RawMessage{"name": raw("Ada Lovelace"), "preferred_username": raw("ada@x.io")}, "Ada Lovelace"},
+		{"falls back to preferred_username", map[string]json.RawMessage{"preferred_username": raw("ada@x.io")}, "ada@x.io"},
+		{"both absent", map[string]json.RawMessage{}, ""},
+		{"empty name falls through", map[string]json.RawMessage{"name": raw(""), "preferred_username": raw("ada@x.io")}, "ada@x.io"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, nameFromClaims(tc.claims))
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/auth/ -run TestNameFromClaims`
+Expected: FAIL — `undefined: nameFromClaims`.
+
+- [ ] **Step 3: Add the `Name` field and `nameFromClaims` helper, populate in `Verify`**
+
+In `internal/auth/oidc_verifier.go`, add `Name` to the struct:
+
+```go
+type OIDCClaims struct {
+	Issuer  string
+	Subject string
+	Email   string
+	Name    string // parsed display name: "name" claim, falling back to "preferred_username"
+	Nonce   string
+	Raw     map[string]json.RawMessage
+}
+```
+
+Add the helper (place it near the bottom of the file, after `nonceMatches`):
+
+```go
+// nameFromClaims resolves a human-friendly display name from the claims,
+// preferring the standard "name" claim and falling back to
+// "preferred_username". Returns "" when neither is present or both are empty.
+func nameFromClaims(raw map[string]json.RawMessage) string {
+	for _, claim := range []string{"name", "preferred_username"} {
+		rawVal, ok := raw[claim]
+		if !ok {
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(rawVal, &s); err == nil && s != "" {
+			return s
+		}
+	}
+	return ""
+}
+```
+
+In `Verify`, after the email-resolution loop and before `c.Nonce = idToken.Nonce`, add:
+
+```go
+	c.Name = nameFromClaims(raw)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/auth/ -run TestNameFromClaims`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the package still builds**
+
+Run: `go build ./internal/auth/`
+Expected: no output (success).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/auth/oidc_verifier.go internal/auth/oidc_verifier_internal_test.go
+git commit -s -m "feat(auth): parse Name claim into OIDCClaims for login metadata sync"
+```
+
+---
+
+## Task 2: Add `sync_on_login` config field (default true)
+
+**Files:**
+
+- Modify: `internal/config/global.go` (`OIDCConfig` ~206-219; `globalDefaults` ~413-431)
+- Test: `internal/config/global_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/config/global_test.go`:
+
+```go
+func TestSyncOnLogin_DefaultsTrue_WhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("auth:\n  oidc:\n    providers: []\n"), 0o600))
+
+	cfg, err := config.LoadGlobalExplicit(path)
+	require.NoError(t, err)
+	require.True(t, cfg.Auth.OIDC.SyncOnLogin, "absent sync_on_login must default to true")
+}
+
+func TestSyncOnLogin_ExplicitFalse_Honored(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("auth:\n  oidc:\n    sync_on_login: false\n"), 0o600))
+
+	cfg, err := config.LoadGlobalExplicit(path)
+	require.NoError(t, err)
+	require.False(t, cfg.Auth.OIDC.SyncOnLogin, "explicit false must survive the default merge")
+}
+```
+
+Ensure `global_test.go` imports `os`, `path/filepath`, `testing`, `github.com/stretchr/testify/require`, and the `config` package (match the existing import style in that file; if it is `package config` white-box, drop the `config.` qualifier and use `LoadGlobalExplicit`/`cfg.Auth...` directly).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/config/ -run TestSyncOnLogin`
+Expected: FAIL — `cfg.Auth.OIDC.SyncOnLogin undefined`.
+
+- [ ] **Step 3: Add the field and default**
+
+In `internal/config/global.go`, add to `OIDCConfig` (after `CLILoginEnabled`):
+
+```go
+	// SyncOnLogin enables refreshing DisplayName/Email and re-evaluating the
+	// role from token claims on each interactive login. Default true (set in
+	// globalDefaults). MUST NOT be defaulted in applyPostLoad: a default-true
+	// bool cannot be distinguished there from an explicit `false`.
+	SyncOnLogin bool `yaml:"sync_on_login" koanf:"sync_on_login"`
+```
+
+In `globalDefaults()`, change the OIDC default to set both flags:
+
+```go
+		Auth: AuthConfig{
+			OIDC: OIDCConfig{CLILoginEnabled: true, SyncOnLogin: true},
+		},
+```
+
+Do **not** touch `applyPostLoad`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/config/ -run TestSyncOnLogin`
+Expected: PASS (both subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/global.go internal/config/global_test.go
+git commit -s -m "feat(config): add auth.oidc.sync_on_login flag (default true)"
+```
+
+---
+
+## Task 3: Add `UpdateUserOnLogin` storage method
+
+**Files:**
+
+- Modify: `internal/storage/users.go` (`UsersBackend` interface ~49-51)
+- Modify: `internal/storage/postgres/users.go` (after `UpdateUserRole` ~225-237)
+- Modify: `internal/storage/postgres/users_test.go` (integration)
+- Modify: `internal/auth/usersbackend_stub_test.go` and `internal/server/usersbackend_stub_test.go`
+
+- [ ] **Step 1: Add the interface method**
+
+In `internal/storage/users.go`, after the `UpdateUserRole` declaration:
+
+```go
+	// UpdateUserOnLogin sets display_name, email, AND role on an active user in
+	// a single UPDATE (deleted_at IS NULL guard, like UpdateUserRole). Used by
+	// the OIDC login-sync path. Returns ErrUserNotFound if no active row matched.
+	// Role validation is the caller's responsibility.
+	UpdateUserOnLogin(ctx context.Context, userID, displayName, email, role string) error
+```
+
+- [ ] **Step 2: Run build to verify it fails (interface not satisfied)**
+
+Run: `go build ./... 2>&1 | head`
+Expected: FAIL — `*AuthStore` (and the two test stubs) do not implement `storage.UsersBackend` (missing `UpdateUserOnLogin`).
+
+- [ ] **Step 3: Implement on `AuthStore`**
+
+In `internal/storage/postgres/users.go`, after `UpdateUserRole`:
+
+```go
+// UpdateUserOnLogin sets display_name, email, and role on an active user in a
+// single statement. Returns ErrUserNotFound if no active user has the given ID.
+func (s *AuthStore) UpdateUserOnLogin(ctx context.Context, userID, displayName, email, role string) error {
+	const q = `
+		UPDATE users SET display_name = $1, email = $2, role = $3
+		WHERE id = $4::uuid AND deleted_at IS NULL`
+	tag, err := s.pool.Exec(ctx, q, displayName, email, role, userID)
+	if err != nil {
+		return fmt.Errorf("update user on login: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return storage.ErrUserNotFound
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Add to the auth test stub**
+
+In `internal/auth/usersbackend_stub_test.go`, add a configurable hook field to the `usersBackendStub` struct (alongside `listUsers`):
+
+```go
+	updateUserOnLogin func(ctx context.Context, userID, displayName, email, role string) error
+```
+
+And the method (place near `UpdateUserRole`):
+
+```go
+func (s *usersBackendStub) UpdateUserOnLogin(ctx context.Context, userID, displayName, email, role string) error {
+	if s.updateUserOnLogin != nil {
+		return s.updateUserOnLogin(ctx, userID, displayName, email, role)
+	}
+	return errUnexpectedCall("UpdateUserOnLogin")
+}
+```
+
+- [ ] **Step 5: Add to the server test stub**
+
+In `internal/server/usersbackend_stub_test.go`, add the method mirroring its `UpdateUserRole` style (add an optional `updateUserOnLogin` func field if that stub uses field hooks; otherwise a no-op returning `nil`):
+
+```go
+func (s *usersBackendStub) UpdateUserOnLogin(ctx context.Context, userID, displayName, email, role string) error {
+	if s.updateUserOnLogin != nil {
+		return s.updateUserOnLogin(ctx, userID, displayName, email, role)
+	}
+	return nil
+}
+```
+
+If that stub does not use func-field hooks, drop the `if` and just `return nil`. Add the `updateUserOnLogin` field to its struct only if you used the hook form.
+
+- [ ] **Step 6: Verify build passes**
+
+Run: `go build ./... && go vet ./internal/storage/... ./internal/auth/... ./internal/server/...`
+Expected: no output (success).
+
+- [ ] **Step 7: Write the integration test**
+
+In `internal/storage/postgres/users_test.go` (build tag `//go:build integration`), add — model the setup on the existing `TestAuthStore_UpdateUserRole` (~269):
+
+```go
+func TestAuthStore_UpdateUserOnLogin(t *testing.T) {
+	ctx := context.Background()
+	auth := newTestAuthStore(t) // use whatever helper the existing tests use to get an *AuthStore
+	u, err := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "old-sub", Email: "old@x.io", Role: "reader",
+	}, nil)
+	require.NoError(t, err)
+
+	// Happy path: all three columns update.
+	require.NoError(t, auth.UpdateUserOnLogin(ctx, u.ID, "Ada", "ada@x.io", "admin"))
+	got, err := auth.GetUserByID(ctx, u.ID)
+	require.NoError(t, err)
+	require.Equal(t, "Ada", got.DisplayName)
+	require.Equal(t, "ada@x.io", got.Email)
+	require.Equal(t, "admin", got.Role)
+
+	// Unknown user -> ErrUserNotFound.
+	err = auth.UpdateUserOnLogin(ctx, "00000000-0000-0000-0000-aaaaaaaaaaaa", "x", "x@x.io", "reader")
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+
+	// Soft-deleted user -> ErrUserNotFound (active-row guard).
+	require.NoError(t, auth.SoftDeleteUser(ctx, u.ID))
+	err = auth.UpdateUserOnLogin(ctx, u.ID, "y", "y@x.io", "writer")
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+}
+```
+
+Match the actual helper name used by neighbouring tests for constructing the `*AuthStore` (search the file for how `TestAuthStore_UpdateUserRole` obtains `auth`). Use that exact pattern instead of `newTestAuthStore` if it differs.
+
+- [ ] **Step 8: Run the integration test (requires Docker)**
+
+Run: `go test -tags integration ./internal/storage/postgres/ -run TestAuthStore_UpdateUserOnLogin`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/storage/users.go internal/storage/postgres/users.go internal/storage/postgres/users_test.go internal/auth/usersbackend_stub_test.go internal/server/usersbackend_stub_test.go
+git commit -s -m "feat(storage): add UpdateUserOnLogin for OIDC login-sync"
+```
+
+---
+
+## Task 4: Pure helpers `resolveLoginRole` and `isPromotion`
+
+**Files:**
+
+- Create: `internal/auth/loginsync.go`
+- Create: `internal/auth/loginsync_internal_test.go` (white-box, `package auth`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/auth/loginsync_internal_test.go`. It is white-box (`package auth`)
+because it tests unexported `resolveLoginRole`/`isPromotion` (and, in Task 6,
+`applyLoginSync` on the unexported `pgIdentityStore`). It defines its **own**
+local fakes — the existing `usersBackendStub`/`noopTracker` live in `package
+auth_test` and are not visible here:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/storage"
+)
+
+// loginSyncFakeBackend satisfies storage.UsersBackend via an embedded (nil)
+// interface; only UpdateUserOnLogin is exercised by applyLoginSync. Any other
+// method call would nil-panic, which correctly flags an unexpected dependency.
+type loginSyncFakeBackend struct {
+	storage.UsersBackend
+	updateUserOnLogin func(ctx context.Context, userID, displayName, email, role string) error
+}
+
+func (f loginSyncFakeBackend) UpdateUserOnLogin(ctx context.Context, userID, displayName, email, role string) error {
+	return f.updateUserOnLogin(ctx, userID, displayName, email, role)
+}
+
+type loginSyncTracker struct{}
+
+func (loginSyncTracker) Touch(string) {}
+
+func rawArr(vals ...string) json.RawMessage {
+	b, _ := json.Marshal(vals)
+	return b
+}
+
+func TestResolveLoginRole(t *testing.T) {
+	adminRule := []config.ClaimMapping{{Claim: "roles", Value: "specgraph.admin", Role: "admin"}}
+	claimsAdmin := map[string]json.RawMessage{"roles": rawArr("specgraph.admin")}
+	claimsNone := map[string]json.RawMessage{"roles": rawArr("specgraph.other")}
+
+	cases := []struct {
+		name        string
+		mappings    []config.ClaimMapping
+		claims      map[string]json.RawMessage
+		current     string
+		defaultRole string
+		wantRole    string
+		wantChanged bool
+	}{
+		{"rule1 no mappings -> unchanged", nil, claimsNone, "admin", "reader", "admin", false},
+		{"rule1 empty slice -> unchanged", []config.ClaimMapping{}, claimsNone, "writer", "reader", "writer", false},
+		{"rule2 match", adminRule, claimsAdmin, "reader", "reader", "admin", true},
+		{"rule2 match no change -> changed=false", adminRule, claimsAdmin, "admin", "reader", "admin", false},
+		{"rule3 no match -> default_role", adminRule, claimsNone, "admin", "reader", "reader", true},
+		{"rule3 default unset -> reader", adminRule, claimsNone, "admin", "", "reader", true},
+		{"rule3 numeric claim never matches", adminRule, map[string]json.RawMessage{"roles": json.RawMessage(`[1]`)}, "admin", "reader", "reader", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			role, changed := resolveLoginRole(tc.mappings, tc.claims, tc.current, tc.defaultRole)
+			require.Equal(t, tc.wantRole, role)
+			require.Equal(t, tc.wantChanged, changed)
+		})
+	}
+}
+
+func TestIsPromotion(t *testing.T) {
+	cases := []struct {
+		current, next string
+		want          bool
+	}{
+		{"reader", "writer", true},
+		{"writer", "admin", true},
+		{"reader", "admin", true},
+		{"admin", "writer", false},     // demotion
+		{"writer", "writer", false},    // equal
+		{"reader", "auditor", false},   // builtin -> custom (incomparable)
+		{"auditor", "admin", false},    // custom -> builtin
+		{"auditor", "releaser", false}, // custom -> custom
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, isPromotion(tc.current, tc.next), "%s->%s", tc.current, tc.next)
+	}
+}
+```
+
+The `context`, `errors`, and `storage` imports are used by the Task-6 tests
+appended to this same file; including them now keeps the file compiling once
+Task 6 lands (they are unused until then — if `go vet` complains about unused
+imports between tasks, add the Task-6 tests in the same change, or temporarily
+drop the unused imports and re-add in Task 6).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/auth/ -run 'TestResolveLoginRole|TestIsPromotion'`
+Expected: FAIL — `undefined: resolveLoginRole`, `undefined: isPromotion`.
+
+- [ ] **Step 3: Implement the helpers**
+
+Create `internal/auth/loginsync.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"encoding/json"
+
+	"github.com/specgraph/specgraph/internal/config"
+)
+
+// resolveLoginRole computes the role for an interactive login from the issuer's
+// claims_mapping and the verified claims. Returns (newRole, changed).
+//
+// Rules, evaluated in this exact order (the ordering is the correctness hinge —
+// conflating "no mappings" with "no match" would mass-demote mapping-less
+// providers):
+//
+//	1. len(mappings) == 0           -> currentRole unchanged.
+//	2. a rule matches               -> that rule's role.
+//	3. mappings exist, none match   -> defaultRole (or "reader" if unset).
+func resolveLoginRole(mappings []config.ClaimMapping, claims map[string]json.RawMessage, currentRole, defaultRole string) (string, bool) {
+	if len(mappings) == 0 {
+		return currentRole, false // rule 1
+	}
+	if matched := applyClaimsMapping(claims, mappings); matched != "" {
+		return matched, matched != currentRole // rule 2
+	}
+	floor := defaultRole // rule 3
+	if floor == "" {
+		floor = string(RoleReader)
+	}
+	return floor, floor != currentRole
+}
+
+// isPromotion reports true ONLY when both roles are ranked built-ins and the
+// new built-in rank is strictly higher than the current. Every other change — a
+// rank decrease, equal roles, or ANY transition involving a custom/unranked
+// role — returns false, so the login-sync error model treats it as a potential
+// demotion and fails closed. This mirrors clampedRole's fail-closed philosophy
+// for incomparable custom roles.
+func isPromotion(current, next string) bool {
+	return roleLessThan(Role(current), Role(next))
+}
+```
+
+(`applyClaimsMapping` and `roleLessThan` already exist in `identitystore.go`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/auth/ -run 'TestResolveLoginRole|TestIsPromotion'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/auth/loginsync.go internal/auth/loginsync_internal_test.go
+git commit -s -m "feat(auth): add resolveLoginRole and isPromotion helpers"
+```
+
+---
+
+## Task 5: Wire `loginSyncEnabled` + extend startup validation
+
+**Files:**
+
+- Modify: `internal/auth/identitystore.go` (struct ~37-52; `IdentityStoreConfig` ~54-110; validation ~115; assembly ~140-156)
+- Modify: `cmd/specgraph/serve.go` (~162-173)
+- Test: `internal/auth/identitystore_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/auth/identitystore_test.go`:
+
+```go
+func TestNewIdentityStore_ValidatesMappingRoles_WhenLoginSyncOnAndJITOff(t *testing.T) {
+	_, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users:            &usersBackendStub{},
+		Tracker:          &noopTracker{},
+		JITEnabled:       false, // JIT off…
+		LoginSyncEnabled: true,  // …but login-sync on
+		KnownRoles:       map[auth.Role]bool{auth.RoleReader: true, auth.RoleWriter: true, auth.RoleAdmin: true},
+		JITClaimsMapping: map[string][]config.ClaimMapping{
+			"https://issuer": {{Claim: "roles", Value: "x", Role: "admln"}}, // typo
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown role")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/auth/ -run TestNewIdentityStore_ValidatesMappingRoles_WhenLoginSyncOnAndJITOff`
+Expected: FAIL — `unknown field LoginSyncEnabled` (compile error) or no error returned.
+
+- [ ] **Step 3: Add the field, config, validation gate, and assembly**
+
+In `internal/auth/identitystore.go`:
+
+Add to the `pgIdentityStore` struct (after `jitEmailAllowlist`):
+
+```go
+	loginSyncEnabled bool
+```
+
+Add to `IdentityStoreConfig` (after `JITEmailDomainAllowlist`):
+
+```go
+	// LoginSyncEnabled turns on metadata + role re-evaluation on interactive
+	// login (see loginsync.go). When true, claims-mapping roles are validated
+	// at startup even if JITEnabled is false.
+	LoginSyncEnabled bool
+```
+
+Change the validation gate condition from:
+
+```go
+	if cfg.JITEnabled && len(cfg.KnownRoles) > 0 {
+```
+
+to:
+
+```go
+	if (cfg.JITEnabled || cfg.LoginSyncEnabled) && len(cfg.KnownRoles) > 0 {
+```
+
+Add to the returned struct literal (after `jitEmailAllowlist: allowlist,`):
+
+```go
+		loginSyncEnabled:   cfg.LoginSyncEnabled,
+```
+
+In `cmd/specgraph/serve.go`, add to the `auth.IdentityStoreConfig{...}` literal (after `JITEmailDomainAllowlist`):
+
+```go
+		LoginSyncEnabled:        cfg.Auth.OIDC.SyncOnLogin,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/auth/ -run TestNewIdentityStore_ValidatesMappingRoles_WhenLoginSyncOnAndJITOff`
+Expected: PASS.
+
+- [ ] **Step 5: Verify everything builds**
+
+Run: `go build ./...`
+Expected: no output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/auth/identitystore.go cmd/specgraph/serve.go internal/auth/identitystore_test.go
+git commit -s -m "feat(auth): wire loginSyncEnabled and validate mapping roles when on"
+```
+
+---
+
+## Task 6: Implement `applyLoginSync` and hook into `resolveJWT`
+
+**Files:**
+
+- Modify: `internal/auth/loginsync.go` (add the method)
+- Modify: `internal/auth/identitystore.go` (`resolveJWT` existing-binding branch — after the soft-delete check, before the `return &Identity{` at ~459)
+- Test: `internal/auth/loginsync_internal_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/auth/loginsync_internal_test.go` (white-box, `package auth`;
+reuses the local `loginSyncFakeBackend`/`loginSyncTracker`/`rawArr` from Task 4):
+
+```go
+func newSyncStore(t *testing.T, fake loginSyncFakeBackend, mappings map[string][]config.ClaimMapping, allowlist []string) *pgIdentityStore {
+	t.Helper()
+	r, err := NewIdentityStore(IdentityStoreConfig{
+		Users:                   fake,
+		Tracker:                 loginSyncTracker{},
+		LoginSyncEnabled:        true,
+		KnownRoles:              map[Role]bool{RoleReader: true, RoleWriter: true, RoleAdmin: true},
+		JITDefaultRole:          RoleReader,
+		JITClaimsMapping:        mappings,
+		JITEmailDomainAllowlist: allowlist,
+	})
+	require.NoError(t, err)
+	return r.(*pgIdentityStore)
+}
+
+func TestApplyLoginSync_PromotesAndRefreshesMetadata(t *testing.T) {
+	var gotRole, gotName, gotEmail string
+	fake := loginSyncFakeBackend{updateUserOnLogin: func(_ context.Context, _, dn, em, role string) error {
+		gotName, gotEmail, gotRole = dn, em, role
+		return nil
+	}}
+	s := newSyncStore(t, fake, map[string][]config.ClaimMapping{
+		"iss": {{Claim: "roles", Value: "app.admin", Role: "admin"}},
+	}, nil)
+	user := &storage.User{ID: "u1", DisplayName: "sub-1", Email: "old@x.io", Role: "reader"}
+	claims := &OIDCClaims{Issuer: "iss", Subject: "sub-1", Email: "new@x.io", Name: "Ada",
+		Raw: map[string]json.RawMessage{"roles": rawArr("app.admin")}}
+
+	out, err := s.applyLoginSync(context.Background(), claims, user)
+	require.NoError(t, err)
+	require.Equal(t, "admin", string(out.Role))
+	require.Equal(t, "admin", gotRole)
+	require.Equal(t, "Ada", gotName) // DisplayName updated (stored was == subject)
+	require.Equal(t, "new@x.io", gotEmail)
+}
+
+func TestApplyLoginSync_PreservesOperatorRename(t *testing.T) {
+	fake := loginSyncFakeBackend{updateUserOnLogin: func(_ context.Context, _, dn, _, _ string) error {
+		require.Equal(t, "Operator Set Name", dn) // unchanged because stored != subject
+		return nil
+	}}
+	s := newSyncStore(t, fake, map[string][]config.ClaimMapping{"iss": {{Claim: "roles", Value: "x", Role: "admin"}}}, nil)
+	user := &storage.User{ID: "u1", DisplayName: "Operator Set Name", Email: "e@x.io", Role: "reader"}
+	claims := &OIDCClaims{Issuer: "iss", Subject: "sub-1", Email: "e@x.io", Name: "Token Name",
+		Raw: map[string]json.RawMessage{"roles": rawArr("x")}}
+	_, err := s.applyLoginSync(context.Background(), claims, user)
+	require.NoError(t, err)
+}
+
+func TestApplyLoginSync_NoOpSkipsWrite(t *testing.T) {
+	fake := loginSyncFakeBackend{updateUserOnLogin: func(_ context.Context, _, _, _, _ string) error {
+		t.Fatal("UpdateUserOnLogin must not be called on a no-op login")
+		return nil
+	}}
+	s := newSyncStore(t, fake, nil, nil) // no mappings -> rule 1 unchanged
+	user := &storage.User{ID: "u1", DisplayName: "sub-1", Email: "e@x.io", Role: "admin"}
+	claims := &OIDCClaims{Issuer: "iss", Subject: "sub-1", Email: "e@x.io", Name: "", Raw: map[string]json.RawMessage{}}
+	out, err := s.applyLoginSync(context.Background(), claims, user)
+	require.NoError(t, err)
+	require.Equal(t, "admin", string(out.Role))
+}
+
+func TestApplyLoginSync_DemotionPersistFailure_Denies(t *testing.T) {
+	fake := loginSyncFakeBackend{updateUserOnLogin: func(_ context.Context, _, _, _, _ string) error {
+		return errors.New("db down")
+	}}
+	s := newSyncStore(t, fake, map[string][]config.ClaimMapping{"iss": {{Claim: "roles", Value: "app.admin", Role: "admin"}}}, nil)
+	// current admin, token no longer grants admin -> rule 3 demote to reader -> persist fails -> deny.
+	user := &storage.User{ID: "u1", DisplayName: "sub-1", Email: "e@x.io", Role: "admin"}
+	claims := &OIDCClaims{Issuer: "iss", Subject: "sub-1", Email: "e@x.io",
+		Raw: map[string]json.RawMessage{"roles": rawArr("app.other")}}
+	out, err := s.applyLoginSync(context.Background(), claims, user)
+	require.Error(t, err)
+	require.Nil(t, out)
+	require.ErrorIs(t, err, ErrTransient)
+}
+
+func TestApplyLoginSync_PromotionPersistFailure_BestEffort(t *testing.T) {
+	fake := loginSyncFakeBackend{updateUserOnLogin: func(_ context.Context, _, _, _, _ string) error {
+		return errors.New("db down")
+	}}
+	s := newSyncStore(t, fake, map[string][]config.ClaimMapping{"iss": {{Claim: "roles", Value: "app.admin", Role: "admin"}}}, nil)
+	user := &storage.User{ID: "u1", DisplayName: "sub-1", Email: "e@x.io", Role: "reader"}
+	claims := &OIDCClaims{Issuer: "iss", Subject: "sub-1", Email: "e@x.io",
+		Raw: map[string]json.RawMessage{"roles": rawArr("app.admin")}}
+	out, err := s.applyLoginSync(context.Background(), claims, user)
+	require.NoError(t, err)                       // login proceeds
+	require.Equal(t, "reader", string(out.Role)) // at the OLD lower role
+}
+
+func TestApplyLoginSync_MetadataOnlyFailure_BestEffort(t *testing.T) {
+	fake := loginSyncFakeBackend{updateUserOnLogin: func(_ context.Context, _, _, _, _ string) error {
+		return errors.New("db down")
+	}}
+	s := newSyncStore(t, fake, nil, nil) // no mappings -> role unchanged (changed=false)
+	user := &storage.User{ID: "u1", DisplayName: "sub-1", Email: "old@x.io", Role: "admin"}
+	claims := &OIDCClaims{Issuer: "iss", Subject: "sub-1", Email: "new@x.io", // email changed, role not
+		Raw: map[string]json.RawMessage{}}
+	out, err := s.applyLoginSync(context.Background(), claims, user)
+	require.NoError(t, err) // metadata-only write failure must NOT deny
+	require.Equal(t, "admin", string(out.Role))
+}
+
+func TestApplyLoginSync_AllowlistMiss_Denies(t *testing.T) {
+	s := newSyncStore(t, loginSyncFakeBackend{}, nil, []string{"allowed.io"})
+	user := &storage.User{ID: "u1", DisplayName: "sub-1", Email: "e@blocked.io", Role: "reader"}
+	claims := &OIDCClaims{Issuer: "iss", Subject: "sub-1", Email: "e@blocked.io", Raw: map[string]json.RawMessage{}}
+	out, err := s.applyLoginSync(context.Background(), claims, user)
+	require.ErrorIs(t, err, ErrUnauthenticated)
+	require.Nil(t, out)
+}
+
+func TestApplyLoginSync_AllowlistSkippedOnAbsentEmail(t *testing.T) {
+	// no mappings + no metadata change -> no write expected, just must not deny.
+	s := newSyncStore(t, loginSyncFakeBackend{}, nil, []string{"allowed.io"})
+	user := &storage.User{ID: "u1", DisplayName: "sub-1", Email: "e@allowed.io", Role: "reader"}
+	claims := &OIDCClaims{Issuer: "iss", Subject: "sub-1", Email: "", Raw: map[string]json.RawMessage{}} // no email claim
+	out, err := s.applyLoginSync(context.Background(), claims, user)
+	require.NoError(t, err) // absent email skips the allowlist re-check
+	require.Equal(t, "reader", string(out.Role))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/auth/ -run TestApplyLoginSync`
+Expected: FAIL — `s.applyLoginSync undefined`.
+
+- [ ] **Step 3: Implement `applyLoginSync`**
+
+Append to `internal/auth/loginsync.go` (add `"context"`, `"fmt"`, `"log/slog"`, and `storage "github.com/specgraph/specgraph/internal/storage"` to imports):
+
+```go
+// applyLoginSync re-enforces the email allowlist, refreshes profile metadata,
+// and re-derives the role from the issuer just authenticated for an existing
+// OIDC user on interactive login. Returns the user to surface as the resolved
+// Identity, or an error that DENIES the login.
+//
+// Error model (classification is gated on `changed` FIRST):
+//   - allowlist domain miss (present email)   -> deny (ErrUnauthenticated)
+//   - changed && !isPromotion, persist fails  -> deny (ErrTransient), fail closed
+//   - changed && isPromotion, persist fails   -> best-effort, old role
+//   - !changed (metadata-only), persist fails -> best-effort
+func (s *pgIdentityStore) applyLoginSync(ctx context.Context, claims *OIDCClaims, user *storage.User) (*storage.User, error) {
+	// 1. Re-enforce the email-domain allowlist. Skip when the token carries no
+	// email claim — an existing binding already passed at bind time, and some
+	// providers intermittently omit email.
+	if len(s.jitEmailAllowlist) > 0 && claims.Email != "" {
+		domain := emailDomain(claims.Email)
+		if domain == "" || !s.jitEmailAllowlist[domain] {
+			slog.LogAttrs(ctx, slog.LevelWarn, "auth: login-sync refused — email domain not in allowlist",
+				slog.String("issuer", claims.Issuer), slog.String("domain", domain))
+			return nil, ErrUnauthenticated
+		}
+	}
+
+	// 2. Compute the new role and metadata.
+	newRole, changed := resolveLoginRole(s.jitClaimsMapping[claims.Issuer], claims.Raw, user.Role, string(s.jitDefaultRole))
+
+	newDisplay := user.DisplayName
+	if user.DisplayName == claims.Subject && claims.Name != "" {
+		newDisplay = claims.Name // update only if never renamed by an operator
+	}
+	newEmail := user.Email
+	if claims.Email != "" {
+		newEmail = claims.Email
+	}
+
+	// 3. No-op skip: nothing to persist.
+	if newDisplay == user.DisplayName && newEmail == user.Email && newRole == user.Role {
+		return user, nil
+	}
+
+	// 4. Persist (single atomic UPDATE).
+	if err := s.users.UpdateUserOnLogin(ctx, user.ID, newDisplay, newEmail, newRole); err != nil {
+		// 5. Classify on `changed` first.
+		if !changed {
+			slog.LogAttrs(ctx, slog.LevelWarn, "auth: login-sync metadata update failed (proceeding)",
+				slog.String("user_id", user.ID), slog.Any("error", err))
+			return user, nil // best-effort
+		}
+		if isPromotion(user.Role, newRole) {
+			slog.LogAttrs(ctx, slog.LevelWarn, "auth: login-sync promotion persist failed (proceeding at old role)",
+				slog.String("user_id", user.ID), slog.String("old", user.Role), slog.String("new", newRole), slog.Any("error", err))
+			return user, nil // best-effort, OLD (lower) role
+		}
+		slog.LogAttrs(ctx, slog.LevelError, "auth: login-sync demotion persist failed — denying login",
+			slog.Bool("audit", true), slog.String("user_id", user.ID), slog.String("subject", claims.Subject),
+			slog.String("issuer", claims.Issuer), slog.String("old", user.Role), slog.String("new", newRole), slog.Any("error", err))
+		return nil, fmt.Errorf("%w: login-sync demotion persist failed", ErrTransient) // fail closed
+	}
+
+	// Success: mutate the returned user from the persisted values; audit role changes.
+	if changed {
+		slog.LogAttrs(ctx, slog.LevelInfo, "auth: login-sync role change",
+			slog.Bool("audit", true), slog.String("user_id", user.ID), slog.String("subject", claims.Subject),
+			slog.String("issuer", claims.Issuer), slog.String("old", user.Role), slog.String("new", newRole))
+	}
+	user.DisplayName = newDisplay
+	user.Email = newEmail
+	user.Role = newRole
+	return user, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/auth/ -run TestApplyLoginSync`
+Expected: PASS (all subtests).
+
+- [ ] **Step 5: Hook into `resolveJWT`**
+
+In `internal/auth/identitystore.go`, in the existing-binding branch, insert immediately **after** the `user.DeletedAt != nil` soft-delete block (right before `return &Identity{...}` at ~459):
+
+```go
+	if s.loginSyncEnabled && InteractiveLoginFromContext(ctx) {
+		synced, syncErr := s.applyLoginSync(ctx, claims, user)
+		if syncErr != nil {
+			return nil, syncErr // deny: allowlist miss or failed demotion
+		}
+		user = synced
+	}
+```
+
+- [ ] **Step 6: Verify the gate is correct by inspection + existing coverage**
+
+The two-line gate (`if s.loginSyncEnabled && InteractiveLoginFromContext(ctx)`) is exercised end-to-end by the existing OIDC resolve integration tests, which mint real signed tokens (`internal/auth/identitystore_integration_test.go`, build tag `//go:build integration`). Add one assertion there: in the existing interactive-login test path, after a second login through the same binding, assert the user's role/metadata reflect the current token (sync ran); in a non-interactive bearer-resolve test, assert the role is unchanged (sync did not run). Reuse that file's existing token-minting helpers — do **not** write a new signed-token unit test in `loginsync_internal_test.go` (token verification needs the test JWKS harness those integration tests already set up).
+
+Run: `go test -tags integration ./internal/auth/ -run Integration` (Docker/JWKS harness as the existing tests require)
+Expected: PASS.
+
+- [ ] **Step 7: Run the full auth package unit tests**
+
+Run: `go test ./internal/auth/`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/auth/loginsync.go internal/auth/loginsync_internal_test.go internal/auth/identitystore.go internal/auth/identitystore_integration_test.go
+git commit -s -m "feat(auth): apply login-sync (metadata + role) on interactive OIDC login"
+```
+
+---
+
+## Task 7: Defensive comment on `WithInteractiveLogin`
+
+**Files:**
+
+- Modify: `internal/auth/context.go` (~71-85)
+
+- [ ] **Step 1: Add the comment**
+
+In `internal/auth/context.go`, expand the doc comment on `WithInteractiveLogin`:
+
+```go
+// WithInteractiveLogin marks the context as originating from the interactive
+// OIDC browser/CLI login flow (the auth_oidc_handler callback). It is the SOLE
+// gate distinguishing a login event from a per-request bearer JWT. Login-sync
+// (role + metadata re-evaluation) fires only when this is set.
+//
+// SECURITY: do NOT call this on any per-request/bearer/API-key/MCP code path. A
+// single misplaced caller would let an ordinary request mutate a user's role.
+// The only production caller is internal/server/auth_oidc_handler.go.
+func WithInteractiveLogin(ctx context.Context) context.Context {
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `go build ./internal/auth/`
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/auth/context.go
+git commit -s -m "docs(auth): warn WithInteractiveLogin is the sole login-sync gate"
+```
+
+---
+
+## Task 8: Documentation
+
+**Files:**
+
+- Modify: `site/docs/guides/oidc-login.md`
+
+- [ ] **Step 1: Add an "App roles and login-sync" section**
+
+Append a section to `site/docs/guides/oidc-login.md` covering (prose, scaled to fit the existing doc style):
+
+- **Prefer app roles over `groups`.** Entra caps inline group memberships (the "groups overage" pattern), so `claims_mapping` on `groups` silently fails for users in many groups. App roles are emitted inline in the `roles` claim and are never subject to overage. Target `claim: "roles"` with the app role's **Value** string.
+- Example config block (copy the example from the design doc's "Example operator config").
+- **`sync_on_login` (default `true`):** on each interactive login, `DisplayName`/`Email` are refreshed and the role is re-derived from the login issuer's `claims_mapping`. Set `false` to keep the legacy JIT-only behavior.
+- **Demotion semantics:** if a mapping is configured and no rule matches, the user is set to `default_role` on next login through that issuer. Losing an app role demotes you.
+- **Migration warning:** before enabling against existing deployments, re-target rules from `groups` to `roles`, verify every `Value` exactly (case-sensitive), assign app roles to admins, and keep the bootstrap admin key — otherwise a misconfig can demote all OIDC admins. To *revoke* via app roles keep ≥1 rule (deleting the whole block freezes roles).
+- **Requirements/caveats:** `Value`s must be strings (numeric claims never match); order rules most-privileged-first (first match wins); the issuer **must be tenant-pinned** (not `common`/`organizations`).
+- **MCP boundary:** role changes reach MCP/API-key usage only after the user next logs in interactively (web dashboard or `specgraph login`); app-key-paste web sessions never sync.
+
+- [ ] **Step 2: Lint the docs**
+
+Run: `task lint` (or `rumdl check site/docs/guides/oidc-login.md` if you only want the markdown linter)
+Expected: no errors for the edited file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add site/docs/guides/oidc-login.md
+git commit -s -m "docs(oidc): document app-roles and sync_on_login"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Run the quality gate**
+
+Run: `task check`
+Expected: fmt/license/lint/build/unit-tests all pass.
+
+- [ ] **Step 2: Run the Postgres integration test for the new storage method (Docker)**
+
+Run: `go test -tags integration ./internal/storage/postgres/ -run TestAuthStore_UpdateUserOnLogin`
+Expected: PASS.
+
+- [ ] **Step 3: Full pre-PR pipeline (Docker)**
+
+Run: `task pr-prep`
+Expected: check + integration + e2e all pass.
+
+---
+
+## Notes for the implementer
+
+- **No DB migration is required** — `UpdateUserOnLogin` writes existing `users` columns (`display_name`, `email`, `role`). The single-issuer design deliberately avoids a new column.
+- **`Role` is a `string` type** (`auth.go:8`): use `string(role)` / `Role(s)` to convert; there is no `.s()` method.
+- **Test packaging:** unexported helpers (`nameFromClaims`, `resolveLoginRole`, `isPromotion`, `applyLoginSync`) are tested **white-box** in `*_internal_test.go` files (`package auth`), following the existing `clampedrole_internal_test.go` convention. These files define their **own** local fakes (`loginSyncFakeBackend`, `loginSyncTracker`) because the existing `usersBackendStub`/`noopTracker` live in `package auth_test` and aren't visible from `package auth`. The interface-growth stub updates in Task 3 are still required so `package auth_test` keeps compiling.
+- **`applyClaimsMapping`, `matchClaimValue`, `roleLessThan`, `emailDomain`** already exist in `identitystore.go` — reuse, do not duplicate.
+- **DCO:** every commit needs `Signed-off-by:` — use `git commit -s` (shown above) or `jj describe` with the trailer.
+- **jj-colocated repo:** if using jj, use `jj --no-pager` and `-m`; never `git push` (use `jj bookmark set` + `jj git push --bookmark`).

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -71,10 +71,15 @@ func ProjectFromContext(ctx context.Context) (string, bool) {
 type interactiveLoginKey struct{}
 
 // WithInteractiveLogin marks the context as originating from the interactive
-// OIDC login callback. Consumed by jitResolve to bypass the per-issuer JIT
-// rate limiter (the limiter targets unsolicited bearer-JWT JIT; an interactive
-// login is user-driven and IdP+PKCE+nonce authenticated). Set ONLY by the
-// callback handler — bearer entry points never set it.
+// OIDC login callback. It is the SOLE gate distinguishing a login event from a
+// per-request bearer JWT: jitResolve uses it to bypass the per-issuer JIT rate
+// limiter, and login-sync (applyLoginSync — metadata + role re-evaluation) fires
+// only when it is set.
+//
+// SECURITY: set ONLY by the OIDC callback handler
+// (internal/server/auth_oidc_handler.go). Do NOT call it on any
+// per-request/bearer/API-key/MCP path — a single misplaced caller would let an
+// ordinary request mutate a user's role.
 func WithInteractiveLogin(ctx context.Context) context.Context {
 	return context.WithValue(ctx, interactiveLoginKey{}, true)
 }

--- a/internal/auth/identitystore.go
+++ b/internal/auth/identitystore.go
@@ -466,6 +466,13 @@ func (s *pgIdentityStore) resolveJWT(ctx context.Context, token string) (*Identi
 			slog.String("user_id", user.ID), slog.String("subject", claims.Subject))
 		return nil, ErrUnauthenticated
 	}
+	if s.loginSyncEnabled && InteractiveLoginFromContext(ctx) {
+		synced, syncErr := s.applyLoginSync(ctx, claims, user)
+		if syncErr != nil {
+			return nil, syncErr // deny: allowlist miss or failed demotion
+		}
+		user = synced
+	}
 	return &Identity{
 		UserID:        user.ID,
 		Subject:       "oidc:" + claims.Subject,

--- a/internal/auth/identitystore.go
+++ b/internal/auth/identitystore.go
@@ -47,6 +47,7 @@ type pgIdentityStore struct {
 	jitRateBurst       int
 	jitRateRefillPerHr int
 	jitEmailAllowlist  map[string]bool // domain -> true; empty = no allowlist
+	loginSyncEnabled   bool
 
 	now func() time.Time
 }
@@ -81,6 +82,11 @@ type IdentityStoreConfig struct {
 	JITRateBurstPerHour     int      // bucket capacity AND refill rate (1:1)
 	JITEmailDomainAllowlist []string // empty = no allowlist
 
+	// LoginSyncEnabled turns on metadata + role re-evaluation on interactive
+	// login (see loginsync.go). When true, claims-mapping roles are validated
+	// at startup even if JITEnabled is false.
+	LoginSyncEnabled bool
+
 	Now func() time.Time // optional; defaults to time.Now
 }
 
@@ -106,13 +112,16 @@ func NewIdentityStore(cfg IdentityStoreConfig) (Resolver, error) { //nolint:gocr
 	}
 	// Validate JIT-related role references against KnownRoles. Catches
 	// operator typos (e.g. "reder" instead of "reader") that would create
-	// users whose role can never match any rolePerms entry.
+	// users whose role can never match any rolePerms entry. Login-sync
+	// consumes the same JITClaimsMapping/JITDefaultRole, so validation also
+	// runs when login-sync is enabled even if JIT is off.
 	//
-	// The len(cfg.KnownRoles) > 0 guard is deliberate: when JIT is enabled
-	// but no known-role set is supplied, validation is skipped rather than
-	// failing closed. Callers SHOULD pass KnownRoles whenever JIT is enabled
-	// (see the field doc) so these typos are caught here.
-	if cfg.JITEnabled && len(cfg.KnownRoles) > 0 {
+	// The len(cfg.KnownRoles) > 0 guard is deliberate: when JIT or login-sync
+	// is enabled but no known-role set is supplied, validation is skipped
+	// rather than failing closed. Callers SHOULD pass KnownRoles whenever JIT
+	// or login-sync is enabled (see the field docs) so these typos are caught
+	// here.
+	if (cfg.JITEnabled || cfg.LoginSyncEnabled) && len(cfg.KnownRoles) > 0 {
 		if cfg.JITDefaultRole != "" && !cfg.KnownRoles[cfg.JITDefaultRole] {
 			return nil, fmt.Errorf("auth: JITDefaultRole %q not in KnownRoles", cfg.JITDefaultRole)
 		}
@@ -148,6 +157,7 @@ func NewIdentityStore(cfg IdentityStoreConfig) (Resolver, error) { //nolint:gocr
 		jitRateBurst:       burst,
 		jitRateRefillPerHr: burst,
 		jitEmailAllowlist:  allowlist,
+		loginSyncEnabled:   cfg.LoginSyncEnabled,
 		now:                now,
 	}, nil
 }

--- a/internal/auth/identitystore_authn_integration_test.go
+++ b/internal/auth/identitystore_authn_integration_test.go
@@ -134,3 +134,81 @@ func TestIdentityStore_JWT_JITCreatesThenResolvesViaBinding(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, bindings, 1, "second login must resolve via the binding, not create a duplicate")
 }
+
+// TestIdentityStore_JWT_LoginSync_GateRunsOnlyInteractive exercises the
+// resolveJWT login-sync gate end-to-end through the existing-binding branch
+// against a real AuthStore + OIDCVerifier. A login-sync-enabled resolver with a
+// claims mapping that grants admin must:
+//   - leave the persisted role untouched on a NON-interactive bearer resolve
+//     (sync did not run); and
+//   - re-derive + persist the elevated role on an INTERACTIVE login resolve
+//     (sync ran). The applyLoginSync algorithm itself is fully covered by the
+//     white-box tests in loginsync_internal_test.go; this asserts only the
+//     two-line gate.
+func TestIdentityStore_JWT_LoginSync_GateRunsOnlyInteractive(t *testing.T) {
+	ctx := context.Background()
+	issuer := newOIDCTestIssuer(t)
+
+	pool := postgrestest.SharedPool(t, ctx)
+	store, err := postgres.NewAuth(ctx, pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close(ctx) })
+
+	_, err = pool.Exec(ctx, `TRUNCATE users CASCADE`)
+	require.NoError(t, err)
+
+	verifier, err := auth.NewOIDCVerifier(ctx, config.OIDCProviderConfig{
+		ID: "test", Issuer: issuer.server.URL, ClientID: "aud-1",
+	})
+	require.NoError(t, err)
+
+	tracker := usagetracker.NewManager(store, usagetracker.Config{})
+	t.Cleanup(func() { _ = tracker.Close(ctx) })
+
+	resolver, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users:            store,
+		Tracker:          tracker,
+		Verifiers:        []*auth.OIDCVerifier{verifier},
+		LoginSyncEnabled: true,
+		JITDefaultRole:   auth.RoleReader,
+		KnownRoles:       auth.KnownRolesFrom(nil),
+		JITClaimsMapping: map[string][]config.ClaimMapping{
+			issuer.server.URL: {{Claim: "roles", Value: "app.admin", Role: "admin"}},
+		},
+	})
+	require.NoError(t, err)
+
+	const subject = "oidc-subject-loginsync"
+	user, err := store.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "Carol", Email: "carol@example.com", Role: "reader",
+	}, &storage.OIDCBinding{
+		Issuer: issuer.server.URL, Subject: subject, EmailAtBind: "carol@example.com",
+	})
+	require.NoError(t, err)
+
+	token := issuer.mintToken(t, map[string]any{
+		"iss": issuer.server.URL, "sub": subject, "aud": "aud-1",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"email": "carol@example.com", "roles": []string{"app.admin"},
+	})
+
+	// Non-interactive bearer resolve: the gate is closed, so login-sync does
+	// not run and the persisted reader role is surfaced unchanged.
+	id, err := resolver.Resolve(ctx, token)
+	require.NoError(t, err)
+	require.Equal(t, user.ID, id.UserID)
+	require.Equal(t, auth.Role("reader"), id.Role, "non-interactive resolve must not run login-sync")
+	persisted, err := store.GetUserByID(ctx, user.ID)
+	require.NoError(t, err)
+	require.Equal(t, "reader", persisted.Role, "persisted role must be untouched without interactive login")
+
+	// Interactive login resolve: the gate opens, login-sync re-derives the
+	// admin role from the roles claim and persists it.
+	id, err = resolver.Resolve(auth.WithInteractiveLogin(ctx), token)
+	require.NoError(t, err)
+	require.Equal(t, user.ID, id.UserID)
+	require.Equal(t, auth.RoleAdmin, id.Role, "interactive login must run login-sync and elevate the role")
+	persisted, err = store.GetUserByID(ctx, user.ID)
+	require.NoError(t, err)
+	require.Equal(t, "admin", persisted.Role, "interactive login must persist the re-derived role")
+}

--- a/internal/auth/identitystore_test.go
+++ b/internal/auth/identitystore_test.go
@@ -748,3 +748,18 @@ func TestWithIdentity_Nil(t *testing.T) {
 		t.Error("IdentityFromContext returned true after WithIdentity(nil)")
 	}
 }
+
+func TestNewIdentityStore_ValidatesMappingRoles_WhenLoginSyncOnAndJITOff(t *testing.T) {
+	_, err := auth.NewIdentityStore(auth.IdentityStoreConfig{
+		Users:            &usersBackendStub{},
+		Tracker:          &noopTracker{},
+		JITEnabled:       false, // JIT off…
+		LoginSyncEnabled: true,  // …but login-sync on
+		KnownRoles:       map[auth.Role]bool{auth.RoleReader: true, auth.RoleWriter: true, auth.RoleAdmin: true},
+		JITClaimsMapping: map[string][]config.ClaimMapping{
+			"https://issuer": {{Claim: "roles", Value: "x", Role: "admln"}}, // typo
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown role")
+}

--- a/internal/auth/loginsync.go
+++ b/internal/auth/loginsync.go
@@ -6,6 +6,7 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -57,6 +58,9 @@ func isPromotion(current, next string) bool {
 //
 // Error model (classification is gated on `changed` FIRST):
 //   - allowlist domain miss (present email)   -> deny (ErrUnauthenticated)
+//   - persist returns ErrUserNotFound         -> deny (ErrUnauthenticated): the
+//     user was concurrently soft-deleted between load and write; fail closed
+//     regardless of changed/promotion
 //   - changed && !isPromotion, persist fails  -> deny (ErrTransient), fail closed
 //   - changed && isPromotion, persist fails   -> best-effort, old role
 //   - !changed (metadata-only), persist fails -> best-effort
@@ -92,6 +96,15 @@ func (s *pgIdentityStore) applyLoginSync(ctx context.Context, claims *OIDCClaims
 
 	// 4. Persist (single atomic UPDATE).
 	if err := s.users.UpdateUserOnLogin(ctx, user.ID, newDisplay, newEmail, newRole); err != nil {
+		// ErrUserNotFound means the active-row guard (deleted_at IS NULL) matched
+		// nothing: the user was concurrently soft-deleted between the load in
+		// resolveJWT and this write. Fail closed regardless of changed/promotion —
+		// a deleted user must not finish authenticating.
+		if errors.Is(err, storage.ErrUserNotFound) {
+			slog.LogAttrs(ctx, slog.LevelWarn, "auth: login-sync target user not active — denying login",
+				slog.String("user_id", user.ID), slog.String("issuer", claims.Issuer), slog.String("subject", claims.Subject))
+			return nil, ErrUnauthenticated
+		}
 		// 5. Classify on `changed` first.
 		if !changed {
 			slog.LogAttrs(ctx, slog.LevelWarn, "auth: login-sync metadata update failed (proceeding)",

--- a/internal/auth/loginsync.go
+++ b/internal/auth/loginsync.go
@@ -4,9 +4,13 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"log/slog"
 
 	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/storage"
 )
 
 // resolveLoginRole computes the role for an interactive login from the issuer's
@@ -16,9 +20,9 @@ import (
 // conflating "no mappings" with "no match" would mass-demote mapping-less
 // providers):
 //
-//	1. len(mappings) == 0           -> currentRole unchanged.
-//	2. a rule matches               -> that rule's role.
-//	3. mappings exist, none match   -> defaultRole (or "reader" if unset).
+//  1. len(mappings) == 0           -> currentRole unchanged.
+//  2. a rule matches               -> that rule's role.
+//  3. mappings exist, none match   -> defaultRole (or "reader" if unset).
 func resolveLoginRole(mappings []config.ClaimMapping, claims map[string]json.RawMessage, currentRole, defaultRole string) (string, bool) {
 	if len(mappings) == 0 {
 		return currentRole, false // rule 1
@@ -41,4 +45,78 @@ func resolveLoginRole(mappings []config.ClaimMapping, claims map[string]json.Raw
 // for incomparable custom roles.
 func isPromotion(current, next string) bool {
 	return roleLessThan(Role(current), Role(next))
+}
+
+// applyLoginSync re-enforces the email allowlist, refreshes profile metadata,
+// and re-derives the role from the issuer just authenticated for an existing
+// OIDC user on interactive login. Returns the user to surface as the resolved
+// Identity. On a successful change it mutates the passed-in user in place AND
+// returns it; callers must pass a non-shared instance (resolveJWT passes the
+// freshly-scanned struct from GetUserByID). Returns an error that DENIES the
+// login on an allowlist miss or a failed demotion.
+//
+// Error model (classification is gated on `changed` FIRST):
+//   - allowlist domain miss (present email)   -> deny (ErrUnauthenticated)
+//   - changed && !isPromotion, persist fails  -> deny (ErrTransient), fail closed
+//   - changed && isPromotion, persist fails   -> best-effort, old role
+//   - !changed (metadata-only), persist fails -> best-effort
+func (s *pgIdentityStore) applyLoginSync(ctx context.Context, claims *OIDCClaims, user *storage.User) (*storage.User, error) {
+	// 1. Re-enforce the email-domain allowlist. Skip when the token carries no
+	// email claim — an existing binding already passed at bind time, and some
+	// providers intermittently omit email.
+	if len(s.jitEmailAllowlist) > 0 && claims.Email != "" {
+		domain := emailDomain(claims.Email)
+		if domain == "" || !s.jitEmailAllowlist[domain] {
+			slog.LogAttrs(ctx, slog.LevelWarn, "auth: login-sync refused — email domain not in allowlist",
+				slog.String("issuer", claims.Issuer), slog.String("domain", domain))
+			return nil, ErrUnauthenticated
+		}
+	}
+
+	// 2. Compute the new role and metadata.
+	newRole, changed := resolveLoginRole(s.jitClaimsMapping[claims.Issuer], claims.Raw, user.Role, string(s.jitDefaultRole))
+
+	newDisplay := user.DisplayName
+	if user.DisplayName == claims.Subject && claims.Name != "" {
+		newDisplay = claims.Name // update only if never renamed by an operator
+	}
+	newEmail := user.Email
+	if claims.Email != "" {
+		newEmail = claims.Email
+	}
+
+	// 3. No-op skip: nothing to persist.
+	if newDisplay == user.DisplayName && newEmail == user.Email && newRole == user.Role {
+		return user, nil
+	}
+
+	// 4. Persist (single atomic UPDATE).
+	if err := s.users.UpdateUserOnLogin(ctx, user.ID, newDisplay, newEmail, newRole); err != nil {
+		// 5. Classify on `changed` first.
+		if !changed {
+			slog.LogAttrs(ctx, slog.LevelWarn, "auth: login-sync metadata update failed (proceeding)",
+				slog.String("user_id", user.ID), slog.Any("error", err))
+			return user, nil // best-effort
+		}
+		if isPromotion(user.Role, newRole) {
+			slog.LogAttrs(ctx, slog.LevelWarn, "auth: login-sync promotion persist failed (proceeding at old role)",
+				slog.String("user_id", user.ID), slog.String("old", user.Role), slog.String("new", newRole), slog.Any("error", err))
+			return user, nil // best-effort, OLD (lower) role
+		}
+		slog.LogAttrs(ctx, slog.LevelError, "auth: login-sync demotion persist failed — denying login",
+			slog.Bool("audit", true), slog.String("user_id", user.ID), slog.String("subject", claims.Subject),
+			slog.String("issuer", claims.Issuer), slog.String("old", user.Role), slog.String("new", newRole), slog.Any("error", err))
+		return nil, fmt.Errorf("%w: login-sync demotion persist failed", ErrTransient) // fail closed
+	}
+
+	// Success: mutate the returned user from the persisted values; audit role changes.
+	if changed {
+		slog.LogAttrs(ctx, slog.LevelInfo, "auth: login-sync role change",
+			slog.Bool("audit", true), slog.String("user_id", user.ID), slog.String("subject", claims.Subject),
+			slog.String("issuer", claims.Issuer), slog.String("old", user.Role), slog.String("new", newRole))
+	}
+	user.DisplayName = newDisplay
+	user.Email = newEmail
+	user.Role = newRole
+	return user, nil
 }

--- a/internal/auth/loginsync.go
+++ b/internal/auth/loginsync.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"encoding/json"
+
+	"github.com/specgraph/specgraph/internal/config"
+)
+
+// resolveLoginRole computes the role for an interactive login from the issuer's
+// claims_mapping and the verified claims. Returns (newRole, changed).
+//
+// Rules, evaluated in this exact order (the ordering is the correctness hinge —
+// conflating "no mappings" with "no match" would mass-demote mapping-less
+// providers):
+//
+//	1. len(mappings) == 0           -> currentRole unchanged.
+//	2. a rule matches               -> that rule's role.
+//	3. mappings exist, none match   -> defaultRole (or "reader" if unset).
+func resolveLoginRole(mappings []config.ClaimMapping, claims map[string]json.RawMessage, currentRole, defaultRole string) (string, bool) {
+	if len(mappings) == 0 {
+		return currentRole, false // rule 1
+	}
+	if matched := applyClaimsMapping(claims, mappings); matched != "" {
+		return matched, matched != currentRole // rule 2
+	}
+	floor := defaultRole // rule 3
+	if floor == "" {
+		floor = string(RoleReader)
+	}
+	return floor, floor != currentRole
+}
+
+// isPromotion reports true ONLY when both roles are ranked built-ins and the
+// new built-in rank is strictly higher than the current. Every other change — a
+// rank decrease, equal roles, or ANY transition involving a custom/unranked
+// role — returns false, so the login-sync error model treats it as a potential
+// demotion and fails closed. This mirrors clampedRole's fail-closed philosophy
+// for incomparable custom roles.
+func isPromotion(current, next string) bool {
+	return roleLessThan(Role(current), Role(next))
+}

--- a/internal/auth/loginsync_internal_test.go
+++ b/internal/auth/loginsync_internal_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/specgraph/specgraph/internal/config"
+)
+
+func rawArr(vals ...string) json.RawMessage {
+	b, _ := json.Marshal(vals)
+	return b
+}
+
+func TestResolveLoginRole(t *testing.T) {
+	adminRule := []config.ClaimMapping{{Claim: "roles", Value: "specgraph.admin", Role: "admin"}}
+	claimsAdmin := map[string]json.RawMessage{"roles": rawArr("specgraph.admin")}
+	claimsNone := map[string]json.RawMessage{"roles": rawArr("specgraph.other")}
+
+	cases := []struct {
+		name        string
+		mappings    []config.ClaimMapping
+		claims      map[string]json.RawMessage
+		current     string
+		defaultRole string
+		wantRole    string
+		wantChanged bool
+	}{
+		{"rule1 no mappings -> unchanged", nil, claimsNone, "admin", "reader", "admin", false},
+		{"rule1 empty slice -> unchanged", []config.ClaimMapping{}, claimsNone, "writer", "reader", "writer", false},
+		{"rule2 match", adminRule, claimsAdmin, "reader", "reader", "admin", true},
+		{"rule2 match no change -> changed=false", adminRule, claimsAdmin, "admin", "reader", "admin", false},
+		{"rule3 no match -> default_role", adminRule, claimsNone, "admin", "reader", "reader", true},
+		{"rule3 default unset -> reader", adminRule, claimsNone, "admin", "", "reader", true},
+		{"rule3 numeric claim never matches", adminRule, map[string]json.RawMessage{"roles": json.RawMessage(`[1]`)}, "admin", "reader", "reader", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			role, changed := resolveLoginRole(tc.mappings, tc.claims, tc.current, tc.defaultRole)
+			require.Equal(t, tc.wantRole, role)
+			require.Equal(t, tc.wantChanged, changed)
+		})
+	}
+}
+
+func TestIsPromotion(t *testing.T) {
+	cases := []struct {
+		current, next string
+		want          bool
+	}{
+		{"reader", "writer", true},
+		{"writer", "admin", true},
+		{"reader", "admin", true},
+		{"admin", "writer", false},     // demotion
+		{"writer", "writer", false},    // equal
+		{"reader", "auditor", false},   // builtin -> custom (incomparable)
+		{"auditor", "admin", false},    // custom -> builtin
+		{"auditor", "releaser", false}, // custom -> custom
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, isPromotion(tc.current, tc.next), "%s->%s", tc.current, tc.next)
+	}
+}

--- a/internal/auth/loginsync_internal_test.go
+++ b/internal/auth/loginsync_internal_test.go
@@ -4,13 +4,32 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/specgraph/specgraph/internal/config"
+	"github.com/specgraph/specgraph/internal/storage"
 )
+
+// loginSyncFakeBackend satisfies storage.UsersBackend via an embedded (nil)
+// interface; only UpdateUserOnLogin is exercised by applyLoginSync. Any other
+// method call would nil-panic, which correctly flags an unexpected dependency.
+type loginSyncFakeBackend struct {
+	storage.UsersBackend
+	updateUserOnLogin func(ctx context.Context, userID, displayName, email, role string) error
+}
+
+func (f loginSyncFakeBackend) UpdateUserOnLogin(ctx context.Context, userID, displayName, email, role string) error {
+	return f.updateUserOnLogin(ctx, userID, displayName, email, role)
+}
+
+type loginSyncTracker struct{}
+
+func (loginSyncTracker) Touch(string) {}
 
 func rawArr(vals ...string) json.RawMessage {
 	b, _ := json.Marshal(vals)
@@ -65,4 +84,153 @@ func TestIsPromotion(t *testing.T) {
 	for _, tc := range cases {
 		require.Equalf(t, tc.want, isPromotion(tc.current, tc.next), "%s->%s", tc.current, tc.next)
 	}
+}
+
+func newSyncStore(t *testing.T, fake loginSyncFakeBackend, mappings map[string][]config.ClaimMapping, allowlist []string) *pgIdentityStore {
+	t.Helper()
+	r, err := NewIdentityStore(IdentityStoreConfig{
+		Users:                   fake,
+		Tracker:                 loginSyncTracker{},
+		LoginSyncEnabled:        true,
+		KnownRoles:              map[Role]bool{RoleReader: true, RoleWriter: true, RoleAdmin: true},
+		JITDefaultRole:          RoleReader,
+		JITClaimsMapping:        mappings,
+		JITEmailDomainAllowlist: allowlist,
+	})
+	require.NoError(t, err)
+	return r.(*pgIdentityStore)
+}
+
+func TestApplyLoginSync_PromotesAndRefreshesMetadata(t *testing.T) {
+	var gotRole, gotName, gotEmail string
+	fake := loginSyncFakeBackend{updateUserOnLogin: func(_ context.Context, _, dn, em, role string) error {
+		gotName, gotEmail, gotRole = dn, em, role
+		return nil
+	}}
+	s := newSyncStore(t, fake, map[string][]config.ClaimMapping{
+		"iss": {{Claim: "roles", Value: "app.admin", Role: "admin"}},
+	}, nil)
+	user := &storage.User{ID: "u1", DisplayName: "sub-1", Email: "old@x.io", Role: "reader"}
+	claims := &OIDCClaims{
+		Issuer: "iss", Subject: "sub-1", Email: "new@x.io", Name: "Ada",
+		Raw: map[string]json.RawMessage{"roles": rawArr("app.admin")},
+	}
+
+	out, err := s.applyLoginSync(context.Background(), claims, user)
+	require.NoError(t, err)
+	require.Equal(t, "admin", out.Role)
+	require.Equal(t, "admin", gotRole)
+	require.Equal(t, "Ada", gotName) // DisplayName updated (stored was == subject)
+	require.Equal(t, "new@x.io", gotEmail)
+}
+
+func TestApplyLoginSync_PreservesOperatorRename(t *testing.T) {
+	fake := loginSyncFakeBackend{updateUserOnLogin: func(_ context.Context, _, dn, _, _ string) error {
+		require.Equal(t, "Operator Set Name", dn) // unchanged because stored != subject
+		return nil
+	}}
+	s := newSyncStore(t, fake, map[string][]config.ClaimMapping{"iss": {{Claim: "roles", Value: "x", Role: "admin"}}}, nil)
+	user := &storage.User{ID: "u1", DisplayName: "Operator Set Name", Email: "e@x.io", Role: "reader"}
+	claims := &OIDCClaims{
+		Issuer: "iss", Subject: "sub-1", Email: "e@x.io", Name: "Token Name",
+		Raw: map[string]json.RawMessage{"roles": rawArr("x")},
+	}
+	_, err := s.applyLoginSync(context.Background(), claims, user)
+	require.NoError(t, err)
+}
+
+func TestApplyLoginSync_NoOpSkipsWrite(t *testing.T) {
+	fake := loginSyncFakeBackend{updateUserOnLogin: func(_ context.Context, _, _, _, _ string) error {
+		t.Fatal("UpdateUserOnLogin must not be called on a no-op login")
+		return nil
+	}}
+	s := newSyncStore(t, fake, nil, nil) // no mappings -> rule 1 unchanged
+	user := &storage.User{ID: "u1", DisplayName: "sub-1", Email: "e@x.io", Role: "admin"}
+	claims := &OIDCClaims{Issuer: "iss", Subject: "sub-1", Email: "e@x.io", Name: "", Raw: map[string]json.RawMessage{}}
+	out, err := s.applyLoginSync(context.Background(), claims, user)
+	require.NoError(t, err)
+	require.Equal(t, "admin", out.Role)
+}
+
+func TestApplyLoginSync_DemotionPersistFailure_Denies(t *testing.T) {
+	fake := loginSyncFakeBackend{updateUserOnLogin: func(_ context.Context, _, _, _, _ string) error {
+		return errors.New("db down")
+	}}
+	s := newSyncStore(t, fake, map[string][]config.ClaimMapping{"iss": {{Claim: "roles", Value: "app.admin", Role: "admin"}}}, nil)
+	// current admin, token no longer grants admin -> rule 3 demote to reader -> persist fails -> deny.
+	user := &storage.User{ID: "u1", DisplayName: "sub-1", Email: "e@x.io", Role: "admin"}
+	claims := &OIDCClaims{
+		Issuer: "iss", Subject: "sub-1", Email: "e@x.io",
+		Raw: map[string]json.RawMessage{"roles": rawArr("app.other")},
+	}
+	out, err := s.applyLoginSync(context.Background(), claims, user)
+	require.Error(t, err)
+	require.Nil(t, out)
+	require.ErrorIs(t, err, ErrTransient)
+}
+
+func TestApplyLoginSync_DemotionSucceeds(t *testing.T) {
+	var gotRole string
+	fake := loginSyncFakeBackend{updateUserOnLogin: func(_ context.Context, _, _, _, role string) error {
+		gotRole = role
+		return nil
+	}}
+	s := newSyncStore(t, fake, map[string][]config.ClaimMapping{"iss": {{Claim: "roles", Value: "app.admin", Role: "admin"}}}, nil)
+	// current admin, token no longer grants admin -> rule 3 demote to default_role (reader), persists.
+	user := &storage.User{ID: "u1", DisplayName: "sub-1", Email: "e@x.io", Role: "admin"}
+	claims := &OIDCClaims{
+		Issuer: "iss", Subject: "sub-1", Email: "e@x.io",
+		Raw: map[string]json.RawMessage{"roles": rawArr("app.other")},
+	}
+	out, err := s.applyLoginSync(context.Background(), claims, user)
+	require.NoError(t, err)
+	require.Equal(t, "reader", out.Role)
+	require.Equal(t, "reader", gotRole)
+}
+
+func TestApplyLoginSync_PromotionPersistFailure_BestEffort(t *testing.T) {
+	fake := loginSyncFakeBackend{updateUserOnLogin: func(_ context.Context, _, _, _, _ string) error {
+		return errors.New("db down")
+	}}
+	s := newSyncStore(t, fake, map[string][]config.ClaimMapping{"iss": {{Claim: "roles", Value: "app.admin", Role: "admin"}}}, nil)
+	user := &storage.User{ID: "u1", DisplayName: "sub-1", Email: "e@x.io", Role: "reader"}
+	claims := &OIDCClaims{
+		Issuer: "iss", Subject: "sub-1", Email: "e@x.io",
+		Raw: map[string]json.RawMessage{"roles": rawArr("app.admin")},
+	}
+	out, err := s.applyLoginSync(context.Background(), claims, user)
+	require.NoError(t, err)                      // login proceeds
+	require.Equal(t, "reader", out.Role) // at the OLD lower role
+}
+
+func TestApplyLoginSync_MetadataOnlyFailure_BestEffort(t *testing.T) {
+	fake := loginSyncFakeBackend{updateUserOnLogin: func(_ context.Context, _, _, _, _ string) error {
+		return errors.New("db down")
+	}}
+	s := newSyncStore(t, fake, nil, nil) // no mappings -> role unchanged (changed=false)
+	user := &storage.User{ID: "u1", DisplayName: "sub-1", Email: "old@x.io", Role: "admin"}
+	claims := &OIDCClaims{Issuer: "iss", Subject: "sub-1", Email: "new@x.io", // email changed, role not
+		Raw: map[string]json.RawMessage{}}
+	out, err := s.applyLoginSync(context.Background(), claims, user)
+	require.NoError(t, err) // metadata-only write failure must NOT deny
+	require.Equal(t, "admin", out.Role)
+}
+
+func TestApplyLoginSync_AllowlistMiss_Denies(t *testing.T) {
+	s := newSyncStore(t, loginSyncFakeBackend{}, nil, []string{"allowed.io"})
+	user := &storage.User{ID: "u1", DisplayName: "sub-1", Email: "e@blocked.io", Role: "reader"}
+	claims := &OIDCClaims{Issuer: "iss", Subject: "sub-1", Email: "e@blocked.io", Raw: map[string]json.RawMessage{}}
+	out, err := s.applyLoginSync(context.Background(), claims, user)
+	require.ErrorIs(t, err, ErrUnauthenticated)
+	require.Nil(t, out)
+}
+
+func TestApplyLoginSync_AllowlistSkippedOnAbsentEmail(t *testing.T) {
+	// no mappings + no metadata change -> no write expected, just must not deny.
+	s := newSyncStore(t, loginSyncFakeBackend{}, nil, []string{"allowed.io"})
+	user := &storage.User{ID: "u1", DisplayName: "sub-1", Email: "e@allowed.io", Role: "reader"}
+	claims := &OIDCClaims{Issuer: "iss", Subject: "sub-1", Email: "", Raw: map[string]json.RawMessage{}} // no email claim
+	out, err := s.applyLoginSync(context.Background(), claims, user)
+	require.NoError(t, err) // absent email skips the allowlist re-check
+	require.Equal(t, "reader", out.Role)
 }

--- a/internal/auth/loginsync_internal_test.go
+++ b/internal/auth/loginsync_internal_test.go
@@ -169,6 +169,25 @@ func TestApplyLoginSync_DemotionPersistFailure_Denies(t *testing.T) {
 	require.ErrorIs(t, err, ErrTransient)
 }
 
+func TestApplyLoginSync_UserNotFound_Denies(t *testing.T) {
+	// User concurrently soft-deleted between load and write: the active-row
+	// guard makes UpdateUserOnLogin return ErrUserNotFound. Must fail closed
+	// even on a best-effort (metadata-only) change, not let the user through.
+	fake := loginSyncFakeBackend{updateUserOnLogin: func(_ context.Context, _, _, _, _ string) error {
+		return storage.ErrUserNotFound
+	}}
+	s := newSyncStore(t, fake, nil, nil) // no mappings -> role unchanged (metadata-only path)
+	user := &storage.User{ID: "u1", DisplayName: "sub-1", Email: "old@x.io", Role: "admin"}
+	claims := &OIDCClaims{
+		Issuer: "iss", Subject: "sub-1", Email: "new@x.io", // metadata-only change
+		Raw: map[string]json.RawMessage{},
+	}
+	out, err := s.applyLoginSync(context.Background(), claims, user)
+	require.Error(t, err)
+	require.Nil(t, out)
+	require.ErrorIs(t, err, ErrUnauthenticated)
+}
+
 func TestApplyLoginSync_DemotionSucceeds(t *testing.T) {
 	var gotRole string
 	fake := loginSyncFakeBackend{updateUserOnLogin: func(_ context.Context, _, _, _, role string) error {
@@ -199,7 +218,7 @@ func TestApplyLoginSync_PromotionPersistFailure_BestEffort(t *testing.T) {
 		Raw: map[string]json.RawMessage{"roles": rawArr("app.admin")},
 	}
 	out, err := s.applyLoginSync(context.Background(), claims, user)
-	require.NoError(t, err)                      // login proceeds
+	require.NoError(t, err)              // login proceeds
 	require.Equal(t, "reader", out.Role) // at the OLD lower role
 }
 

--- a/internal/auth/oidc_verifier.go
+++ b/internal/auth/oidc_verifier.go
@@ -24,6 +24,7 @@ type OIDCClaims struct {
 	Issuer  string
 	Subject string
 	Email   string
+	Name    string // parsed display name: "name" claim, falling back to "preferred_username"
 	Nonce   string
 	Raw     map[string]json.RawMessage
 }
@@ -107,6 +108,7 @@ func (v *OIDCVerifier) Verify(ctx context.Context, rawToken string) (*OIDCClaims
 			break
 		}
 	}
+	c.Name = nameFromClaims(raw)
 	c.Nonce = idToken.Nonce
 	return c, nil
 }
@@ -118,6 +120,23 @@ func nonceMatches(got, want string) bool {
 		return false
 	}
 	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+}
+
+// nameFromClaims resolves a human-friendly display name from the claims,
+// preferring the standard "name" claim and falling back to
+// "preferred_username". Returns "" when neither is present or both are empty.
+func nameFromClaims(raw map[string]json.RawMessage) string {
+	for _, claim := range []string{"name", "preferred_username"} {
+		rawVal, ok := raw[claim]
+		if !ok {
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(rawVal, &s); err == nil && s != "" {
+			return s
+		}
+	}
+	return ""
 }
 
 // VerifyWithNonce validates the token like Verify and additionally requires

--- a/internal/auth/oidc_verifier_internal_test.go
+++ b/internal/auth/oidc_verifier_internal_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Sean Brandt
+
+package auth
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNameFromClaims(t *testing.T) {
+	raw := func(s string) json.RawMessage { return json.RawMessage(`"` + s + `"`) }
+	cases := []struct {
+		name   string
+		claims map[string]json.RawMessage
+		want   string
+	}{
+		{"name preferred", map[string]json.RawMessage{"name": raw("Ada Lovelace"), "preferred_username": raw("ada@x.io")}, "Ada Lovelace"},
+		{"name only", map[string]json.RawMessage{"name": raw("Ada Lovelace")}, "Ada Lovelace"},
+		{"falls back to preferred_username", map[string]json.RawMessage{"preferred_username": raw("ada@x.io")}, "ada@x.io"},
+		{"both absent", map[string]json.RawMessage{}, ""},
+		{"empty name falls through", map[string]json.RawMessage{"name": raw(""), "preferred_username": raw("ada@x.io")}, "ada@x.io"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, nameFromClaims(tc.claims))
+		})
+	}
+}

--- a/internal/auth/usersbackend_stub_test.go
+++ b/internal/auth/usersbackend_stub_test.go
@@ -69,6 +69,7 @@ type usersBackendStub struct {
 	jitCreateHuman    func(ctx context.Context, u *storage.User, b *storage.OIDCBinding) (*storage.User, *storage.OIDCBinding, error)
 	touchLastUsed     func(ctx context.Context, keyID string) error
 	listUsers         func(ctx context.Context, f storage.ListUsersFilter) ([]*storage.User, error)
+	updateUserOnLogin func(ctx context.Context, userID, displayName, email, role string) error
 }
 
 func (s *usersBackendStub) LookupAPIKeyByPrefix(ctx context.Context, prefix string) (*storage.APIKey, error) {
@@ -130,6 +131,12 @@ func (s *usersBackendStub) CreateServiceAccount(_ context.Context, _ *storage.Us
 }
 func (s *usersBackendStub) UpdateUserRole(_ context.Context, _, _ string) error {
 	return errUnexpectedCall("UpdateUserRole")
+}
+func (s *usersBackendStub) UpdateUserOnLogin(ctx context.Context, userID, displayName, email, role string) error {
+	if s.updateUserOnLogin != nil {
+		return s.updateUserOnLogin(ctx, userID, displayName, email, role)
+	}
+	return errUnexpectedCall("UpdateUserOnLogin")
 }
 func (s *usersBackendStub) SoftDeleteUser(_ context.Context, _ string) error {
 	return errUnexpectedCall("SoftDeleteUser")

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -216,6 +216,11 @@ type OIDCConfig struct {
 	// CLILoginEnabled gates the `specgraph login` broker (loopback redirect +
 	// /api/auth/cli/exchange). Defaults to true (set in globalDefaults).
 	CLILoginEnabled bool `yaml:"cli_login_enabled" koanf:"cli_login_enabled"`
+	// SyncOnLogin enables refreshing DisplayName/Email and re-evaluating the
+	// role from token claims on each interactive login. Default true (set in
+	// globalDefaults). MUST NOT be defaulted in applyPostLoad: a default-true
+	// bool cannot be distinguished there from an explicit `false`.
+	SyncOnLogin bool `yaml:"sync_on_login" koanf:"sync_on_login"`
 }
 
 // JITCreateConfig parametrizes just-in-time Human creation on first
@@ -425,7 +430,7 @@ func globalDefaults() *GlobalConfig {
 			DefaultServer: "http://127.0.0.1:9090",
 		},
 		Auth: AuthConfig{
-			OIDC: OIDCConfig{CLILoginEnabled: true},
+			OIDC: OIDCConfig{CLILoginEnabled: true, SyncOnLogin: true},
 		},
 		Log: LogConfig{
 			Level:    "info",

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -649,3 +649,23 @@ func TestLogConfig_Build_InvalidOutput(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid log output")
 	assert.Contains(t, err.Error(), "file")
 }
+
+func TestSyncOnLogin_DefaultsTrue_WhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("auth:\n  oidc:\n    providers: []\n"), 0o600))
+
+	cfg, err := config.LoadGlobalExplicit(path)
+	require.NoError(t, err)
+	require.True(t, cfg.Auth.OIDC.SyncOnLogin, "absent sync_on_login must default to true")
+}
+
+func TestSyncOnLogin_ExplicitFalse_Honored(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("auth:\n  oidc:\n    sync_on_login: false\n"), 0o600))
+
+	cfg, err := config.LoadGlobalExplicit(path)
+	require.NoError(t, err)
+	require.False(t, cfg.Auth.OIDC.SyncOnLogin, "explicit false must survive the default merge")
+}

--- a/internal/server/usersbackend_stub_test.go
+++ b/internal/server/usersbackend_stub_test.go
@@ -41,6 +41,7 @@ type usersBackendStub struct {
 	getUserByID          func(ctx context.Context, id string) (*storage.User, error)
 	createServiceAccount func(ctx context.Context, u *storage.User) (*storage.User, error)
 	updateUserRole       func(ctx context.Context, userID, role string) error
+	updateUserOnLogin    func(ctx context.Context, userID, displayName, email, role string) error
 	softDeleteUser       func(ctx context.Context, userID string) error
 	purgeUser            func(ctx context.Context, userID string) error
 	createAPIKey         func(ctx context.Context, k *storage.APIKey) (*storage.APIKey, error)
@@ -82,6 +83,13 @@ func (s *usersBackendStub) UpdateUserRole(ctx context.Context, userID, role stri
 		return s.updateUserRole(ctx, userID, role)
 	}
 	return errUnexpected("UpdateUserRole")
+}
+
+func (s *usersBackendStub) UpdateUserOnLogin(ctx context.Context, userID, displayName, email, role string) error {
+	if s.updateUserOnLogin != nil {
+		return s.updateUserOnLogin(ctx, userID, displayName, email, role)
+	}
+	return errUnexpected("UpdateUserOnLogin")
 }
 
 func (s *usersBackendStub) SoftDeleteUser(ctx context.Context, userID string) error {

--- a/internal/storage/postgres/users.go
+++ b/internal/storage/postgres/users.go
@@ -236,6 +236,22 @@ func (s *AuthStore) UpdateUserRole(ctx context.Context, userID, role string) err
 	return nil
 }
 
+// UpdateUserOnLogin sets display_name, email, and role on an active user in a
+// single statement. Returns ErrUserNotFound if no active user has the given ID.
+func (s *AuthStore) UpdateUserOnLogin(ctx context.Context, userID, displayName, email, role string) error {
+	const q = `
+		UPDATE users SET display_name = $1, email = $2, role = $3
+		WHERE id = $4::uuid AND deleted_at IS NULL`
+	tag, err := s.pool.Exec(ctx, q, displayName, email, role, userID)
+	if err != nil {
+		return fmt.Errorf("update user on login: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return storage.ErrUserNotFound
+	}
+	return nil
+}
+
 // SoftDeleteUser sets deleted_at on the user and revokes all their active
 // keys in the same transaction. Idempotent on already-deleted users (the
 // user UPDATE matches zero rows, the keys UPDATE matches zero rows; both

--- a/internal/storage/postgres/users_test.go
+++ b/internal/storage/postgres/users_test.go
@@ -298,6 +298,35 @@ func TestAuthStore_UpdateUserRole(t *testing.T) {
 	require.ErrorIs(t, err, storage.ErrUserNotFound)
 }
 
+func TestAuthStore_UpdateUserOnLogin(t *testing.T) {
+	ctx := context.Background()
+	auth := authTestSetup(t)
+	pool := sharedTestPool(t, ctx)
+	truncateAuthTables(t, pool)
+
+	u, err := auth.CreateHuman(ctx, &storage.User{
+		Kind: storage.KindHuman, DisplayName: "old-sub", Email: "old@x.io", Role: "reader",
+	}, nil)
+	require.NoError(t, err)
+
+	// Happy path: all three columns update.
+	require.NoError(t, auth.UpdateUserOnLogin(ctx, u.ID, "Ada", "ada@x.io", "admin"))
+	got, err := auth.GetUserByID(ctx, u.ID)
+	require.NoError(t, err)
+	require.Equal(t, "Ada", got.DisplayName)
+	require.Equal(t, "ada@x.io", got.Email)
+	require.Equal(t, "admin", got.Role)
+
+	// Unknown user -> ErrUserNotFound.
+	err = auth.UpdateUserOnLogin(ctx, "00000000-0000-0000-0000-aaaaaaaaaaaa", "x", "x@x.io", "reader")
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+
+	// Soft-deleted user -> ErrUserNotFound (active-row guard).
+	require.NoError(t, auth.SoftDeleteUser(ctx, u.ID))
+	err = auth.UpdateUserOnLogin(ctx, u.ID, "y", "y@x.io", "writer")
+	require.ErrorIs(t, err, storage.ErrUserNotFound)
+}
+
 func TestAuthStore_SoftDeleteUser(t *testing.T) {
 	ctx := context.Background()
 	auth := authTestSetup(t)

--- a/internal/storage/users.go
+++ b/internal/storage/users.go
@@ -50,6 +50,12 @@ type UsersBackend interface {
 	// against the YAML config is the caller's responsibility.
 	UpdateUserRole(ctx context.Context, userID, role string) error
 
+	// UpdateUserOnLogin sets display_name, email, AND role on an active user in
+	// a single UPDATE (deleted_at IS NULL guard, like UpdateUserRole). Used by
+	// the OIDC login-sync path. Returns ErrUserNotFound if no active row matched.
+	// Role validation is the caller's responsibility.
+	UpdateUserOnLogin(ctx context.Context, userID, displayName, email, role string) error
+
 	// SoftDeleteUser sets deleted_at and revokes all active keys in one tx.
 	// Idempotent (re-deleting already-deleted user is a no-op). An
 	// unknown/nonexistent userID is also treated as a no-op: it returns nil,

--- a/site/docs/guides/oidc-login.md
+++ b/site/docs/guides/oidc-login.md
@@ -301,7 +301,7 @@ auth:
       - id: entra
         issuer: "https://login.microsoftonline.com/<tenant>/v2.0"
         client_id: "<client-id>"
-        audience: "<client-id>"
+        audience: "<client-id>"   # optional; defaults to client_id
         client_secret: "<secret>"
         interactive: true
         display_name: "Entra"

--- a/site/docs/guides/oidc-login.md
+++ b/site/docs/guides/oidc-login.md
@@ -272,6 +272,114 @@ registered at the **broker**, not at GitHub.
     does not require an ID token — is a deferred follow-up and is not yet
     available.
 
+## App roles and login-sync
+
+`claims_mapping` derives a SpecGraph role from an inbound token claim. Two
+related concerns make this robust against the Entra "groups overage" problem and
+keep roles current across logins: **prefer app roles over `groups`**, and
+**`sync_on_login`**, which re-derives the role on every interactive login rather
+than only at first sign-in.
+
+### Prefer app roles over `groups`
+
+Entra caps how many group memberships it will emit inline in a token. Once a
+user belongs to more groups than that cap, Entra replaces the inline list with a
+**"groups overage"** pointer to the Graph API, and a `claims_mapping` on
+`groups` silently stops matching for exactly those users. **App roles** are the
+Microsoft-recommended fix: they ride inline in the `roles` array claim and are
+**never** subject to overage — assigning an app role to a large group still
+emits the flattened role values in `roles`.
+
+Target `claim: "roles"` and set `value` to the app role's **Value** string from
+the Entra app registration (e.g. `specgraph.admin`), **not** its display name:
+
+```yaml
+auth:
+  oidc:
+    sync_on_login: true   # default true
+    providers:
+      - id: entra
+        issuer: "https://login.microsoftonline.com/<tenant>/v2.0"
+        client_id: "<client-id>"
+        audience: "<client-id>"
+        client_secret: "<secret>"
+        interactive: true
+        display_name: "Entra"
+        claims_mapping:
+          - claim: "roles"
+            value: "specgraph.admin"
+            role: "admin"
+          - claim: "roles"
+            value: "specgraph.user"
+            role: "writer"
+```
+
+`admin` and `writer` are built-in roles, validated at startup against the known
+roles. Define the matching app roles under **App registration → App roles**, and
+assign them to users or groups under **Enterprise application → Users and
+groups**.
+
+### `sync_on_login`
+
+`auth.oidc.sync_on_login` (default `true`) controls whether SpecGraph refreshes
+an existing user on each **interactive** login. When on, every interactive
+login (the web sign-in callback or `specgraph login`) refreshes the user's
+`DisplayName` and `Email` from the verified token and **re-derives the role**
+from the login issuer's `claims_mapping`. (`DisplayName` is only refreshed while
+it still matches the OIDC subject — a name an operator set manually is never
+overwritten.) Set it to `false` to keep the legacy
+behavior, where the role and metadata are only set once, at just-in-time (JIT)
+account creation.
+
+```yaml
+auth:
+  oidc:
+    sync_on_login: false   # legacy: only set role/metadata at JIT creation
+```
+
+### Demotion semantics
+
+Re-derivation is two-sided. If an issuer has a `claims_mapping` configured and
+**no rule matches** the token, the user is set to `default_role` (from
+`jit_create.default_role`, falling back to `reader`) on their next login through
+that issuer. Losing an app role therefore demotes the user on their next
+interactive login — that is how revocation propagates.
+
+To **revoke** access via app roles, keep **at least one** rule in
+`claims_mapping`. Deleting the whole block means "no mappings configured," which
+freezes existing roles (no rule ever runs) rather than demoting anyone.
+
+### Migrating an existing deployment
+
+!!! warning "A bad migration can demote every OIDC admin"
+    Enabling `sync_on_login` against a live deployment re-evaluates roles on the
+    next login, and a misconfigured mapping demotes real admins. Work through the
+    checklist below before enabling.
+
+Before enabling `sync_on_login` against an existing deployment:
+
+1. **Re-target rules from `groups` to `roles`** so admins keep matching.
+2. **Verify every `value` exactly** — matching is **case-sensitive** against the
+   app role's **Value** string.
+3. **Assign the app roles to your admins** in the directory before they next log
+   in.
+4. **Keep the bootstrap admin key** so you can recover if a mapping is wrong and
+   locks you out of the dashboard.
+
+### Requirements and caveats
+
+- **`value`s must be strings.** Numeric claim values never match; the app role
+  **Value** is a string (e.g. `specgraph.admin`).
+- **Order rules most-privileged-first.** The **first** matching rule wins, so
+  list `admin` before `writer` before `reader`.
+- **The issuer must be tenant-pinned.** Use a tenant-specific Entra issuer
+  (`.../<tenant-id>/v2.0`), **not** the multi-tenant `common` or `organizations`
+  endpoints — SpecGraph routes by exact `iss` match.
+- **MCP and API-key boundary.** A role change only reaches MCP and API-key usage
+  after the user next logs in **interactively** (the web dashboard or `specgraph
+  login`). Sessions established by pasting an API key in the web UI never sync,
+  and per-request bearer/API-key calls never sync.
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |


### PR DESCRIPTION
## Summary

Fixes #996 (OIDC `claims_mapping` groups-overage gap) by pivoting to **app roles** and **re-evaluating role + metadata on each interactive login**, instead of only at JIT account creation.

On each interactive OIDC login (web callback or `specgraph login`), for an existing OIDC user, SpecGraph now:

- **Re-enforces the email-domain allowlist** (deny on miss; skips the check when the token omits `email` so an existing binding isn't locked out).
- **Refreshes `DisplayName`/`Email`** from the verified token (DisplayName only while it still matches the subject — operator renames are preserved).
- **Re-derives the role** from the login issuer's `claims_mapping` (target the inline `roles` app-role claim, which is never subject to Entra groups-overage).

Gated by a new `auth.oidc.sync_on_login` flag (**default true**; set `false` for legacy JIT-only behavior).

### Security model
- **Fail-closed demotions:** a demotion whose persist fails (or an allowlist miss) **denies** the login. Promotions and metadata-only writes are best-effort. The returned identity's role never exceeds what's persisted.
- **Interactive-only:** the sync fires only on the OIDC callback path (`WithInteractiveLogin`); per-request bearer JWTs, API keys, and MCP traffic never trigger a role change.
- **Custom roles fail closed:** `isPromotion` treats any custom/incomparable role transition as a potential demotion.
- **Startup validation** of `claims_mapping` roles now runs when login-sync is on (even if JIT is off), catching typos before they cause a silent lockout.

### Commits
1. `feat(auth)`: parse `Name` claim into `OIDCClaims`
2. `feat(config)`: add `auth.oidc.sync_on_login` (default true)
3. `feat(storage)`: add `UpdateUserOnLogin`
4. `feat(auth)`: `resolveLoginRole` + `isPromotion` helpers
5. `feat(auth)`: wire `loginSyncEnabled` + startup validation
6. `feat(auth)`: `applyLoginSync` + `resolveJWT` hook
7. `docs(auth)`: `WithInteractiveLogin` sole-gate warning
8. `docs(oidc)`: app-roles + `sync_on_login` guide

Design + plan: `docs/plans/2026-06-15-oidc-app-roles-login-sync-{design,implementation-plan}.md`.

### Follow-ups (filed)
- `spgr-g7st` — self-service / auto MCP API-key provisioning
- `spgr-c2lb` — enforce app-role revocation on standing API/MCP keys (force re-sync)

## Test Plan
- [x] `task check` (fmt, license, golangci-lint, markdown, build, unit tests) — green
- [x] Docker integration: `go test -tags integration ./internal/auth/ -run 'LoginSync|GateRunsOnlyInteractive'` — pass
- [x] Docker integration: `go test -tags integration ./internal/storage/postgres/ -run UpdateUserOnLogin` — pass
- [ ] Reviewer: confirm fail-closed demotion + interactive-only gate