### PR TITLE
ci(release): grant issues:write and restore autorelease labels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
           permission-contents: write
           permission-packages: write
           permission-pull-requests: write
+          permission-issues: write
       - name: Run release-please
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
@@ -35,14 +36,6 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          # The App token is scoped to contents+packages+pull-requests only (no
-          # issues:write). release-please's default autorelease:* PR labels are
-          # written via the issues API and would 403 without issues:write, crashing
-          # the step on the first release. Release detection here is manifest- and
-          # branch-based (not label-based), so skipping labels is functionally safe.
-          # To restore the labels: grant the release App Issues:write, add
-          # `permission-issues: write` to the app-token step above, and remove this.
-          skip-labeling: true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: ${{ steps.release.outputs.release_created }}
         with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,12 +25,18 @@ single action:
 4. Ordinary pushes/merges to `main` that do not create a release
    (`release_created` is falsy) run none of the build/publish steps.
 
-> **Release PR labels:** the release App token is scoped without `issues:write`,
-> so release-please runs with `skip-labeling: true` — release PRs won't carry the
-> `autorelease: pending` / `autorelease: tagged` labels. This is cosmetic;
-> release detection is manifest/branch-based, not label-based. To restore the
-> labels, grant the release App `Issues: write` and follow the inline comment on
-> the release-please step in `.github/workflows/release.yml`.
+The App token is granted `contents` + `packages` + `pull-requests` + `issues`
+write, so release-please applies its `autorelease: pending` / `autorelease: tagged`
+labels to the release PR.
+
+### Forcing a specific version (`Release-As`)
+
+release-please only opens a release PR when it finds releasable Conventional
+Commits since the last tag. To cut a release regardless (e.g. for work whose
+merge commits weren't conventional), land a commit on `main` whose message body
+contains a `Release-As: X.Y.Z` footer — on squash-merge, put that footer in the
+squash commit body. release-please's next run then opens a release PR for that
+exact version.
 
 ## Version bump cadence
 


### PR DESCRIPTION
## Summary

Two things, following up on the first release-please run (which correctly opened no PR — the only commits since `v0.13.0` had non-Conventional-Commit titles like `Phase 9: …`):

1. **Restore autorelease labels.** The release App token is scoped via `permission-*` inputs, so it excluded `issues:write` even though the App has the capability — hence the earlier `skip-labeling: true`. This adds `permission-issues: write` and removes `skip-labeling`, so release-please applies its `autorelease: pending` / `autorelease: tagged` labels to the release PR.
2. **Force the first release (`v0.14.0`).** This commit carries a `Release-As: 0.14.0` footer so release-please cuts `v0.14.0` for the accumulated Phase 6–9 work despite those merge titles not being conventional. Also documents the `Release-As` escape hatch in `RELEASING.md`.

## ⚠️ How to merge this PR so `Release-As` takes effect

The `Release-As: 0.14.0` footer must land in the commit that hits `main`. Pick either:

- **Easiest — "Create a merge commit"**: preserves this commit's body (including the footer) verbatim. No editing needed.
- **Squash & merge**: add this line to the squash commit **message body** in the merge box (a plain squash of a `ci:` title won't bump):

  ```
  Release-As: 0.14.0
  ```

## What happens after merge

1. The push to `main` runs `release.yml` → release-please sees `Release-As: 0.14.0` → **opens a `chore(main): release 0.14.0` release PR** (bumps `.release-please-manifest.json` to `0.14.0`, regenerates `CHANGELOG.md`). The auto-changelog will be sparse (the Phase 6–9 commits don't parse) — **edit the release PR's `CHANGELOG.md` before merging** if you want richer notes.
2. **Merging that release PR** cuts the `v0.14.0` tag + GitHub Release, then GoReleaser uploads binaries/images/attestations to it.

## ⚠️ Confirm before merging the *release* PR (out-of-band, not code)

These are exercised for the first time by the release PR merge:

- [ ] release-please App is a **bypass actor** on the `main` branch-protection ruleset
- [ ] Squash **"default commit message" = "Pull request title"** (Settings → General → Pull Requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
