### PR TITLE
fix: approve-stage teaching content drift (v0.14.0 audit gap)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -7,8 +7,8 @@ current_phase_name: BACKLOG
 status: verifying
 stopped_at: Completed 09-02-PLAN.md
 last_updated: "2026-07-16T20:50:56.638Z"
-last_activity: 2026-07-16
-last_activity_desc: "Quick task 260716-neg — switched releases to release-please"
+last_activity: 2026-07-17
+last_activity_desc: "Quick task 260717-i4b — fixed approve-stage teaching content drift (v0.14.0 audit gap)"
 progress:
   total_phases: 4
   completed_phases: 4
@@ -34,7 +34,7 @@ engines can trust the spec graph as ground truth instead of static, decaying mar
 Phase: 999.2 — confluence integration (BACKLOG)
 Plan: Not started
 Status: Phase complete — ready for verification
-Last activity: 2026-07-16 — Quick task 260716-neg: switched releases to release-please (branch `release-please-migration`, PR pending)
+Last activity: 2026-07-17 — Quick task 260717-i4b: fixed approve-stage teaching content drift found by the v0.14.0 milestone audit
 
 ## Performance Metrics
 
@@ -186,6 +186,7 @@ None yet.
 | # | Description | Date | Commit | Status | Directory |
 |---|-------------|------|--------|--------|-----------|
 | 260716-neg | Switch releases to release-please (reverses cog+goreleaser decision) | 2026-07-16 | 1df1ccc8 | Needs Review (code verified 17/17; 2 out-of-band repo settings pending) | [260716-neg-switch-releases-to-release-please-revers](./quick/260716-neg-switch-releases-to-release-please-revers/) |
+| 260717-i4b | Fix approve-stage teaching content drift (v0.14.0 milestone-audit gap: conversation-recording.md + stage-approve.md taught clean approvals need no exchanges, contradicting Phase 8 enforcement) | 2026-07-17 | 8fd8151e | — | [260717-i4b-fix-approve-stage-teaching-content-drift](./quick/260717-i4b-fix-approve-stage-teaching-content-drift/) |
 
 ## Deferred Items
 

--- a/.planning/quick/260717-i4b-fix-approve-stage-teaching-content-drift/260717-i4b-PLAN.md
+++ b/.planning/quick/260717-i4b-fix-approve-stage-teaching-content-drift/260717-i4b-PLAN.md
@@ -1,0 +1,195 @@
+---
+phase: 260717-i4b
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - internal/authoring/content/conversation-recording.md
+  - internal/authoring/content/stage-approve.md
+autonomous: true
+requirements: [CONV-01]
+
+must_haves:
+  truths:
+    - "A fresh MCP-only agent following the composed approve-stage guidance records exchanges on a clean acceptance instead of attempting a zero-exchange approve and getting server-rejected."
+    - "Both composed content files teach exchanges as REQUIRED on approve for BOTH the accept and reject dispositions, matching the server/MCP enforcement shipped in CONV-01."
+    - "No composed content file claims an MCP standalone conversation-record tool action exists; post-hoc amendment is described (if at all) as a CLI capability only."
+  artifacts:
+    - internal/authoring/content/conversation-recording.md
+    - internal/authoring/content/stage-approve.md
+  key_links:
+    - "composer.go composes conversation-recording.md + stage-approve.md into every approve-stage author_start_stage response — the served prose must match the ValidateExchanges enforcement in authoring_handler.go (ACCEPT branch) and the hard-reject in tools_authoring.go handleApprove."
+    - "SKILL.md lines 176-179 are the already-correct reference wording; the two content files must not contradict them."
+---
+
+<objective>
+Fix approve-stage teaching content drift. Two embedded markdown files composed
+into every MCP `author_start_stage` response for the approve stage still teach
+the pre-CONV-01 behavior — that a clean approval needs no recorded conversation
+exchanges. Phase 8 (CONV-01) made exchanges REQUIRED on approve for BOTH the
+accept and reject dispositions, enforced server-side (authoring_handler.go
+ACCEPT branch calls ValidateExchanges) and client-side (tools_authoring.go
+handleApprove hard-rejects empty exchanges unconditionally). A fresh MCP-only
+agent following only the served guidance will attempt a zero-exchange approve
+and get an immediate rejection.
+
+This is a documentation-only fix to two `//go:embed`'d prose files under
+internal/authoring/content/. No Go, proto, or test changes. The canonical
+correct wording already exists in
+internal/mcp/skills/embedded/specgraph-authoring/SKILL.md (lines 176-179) —
+align the two content files to it.
+
+Purpose: Restore consistency between the self-teaching MCP guidance and the
+enforced behavior so MCP-only agents can complete a clean approve on the first try.
+Output: Corrected conversation-recording.md and stage-approve.md.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@./CLAUDE.md
+
+# Reference wording (already-correct — do NOT edit, mirror its language):
+@internal/mcp/skills/embedded/specgraph-authoring/SKILL.md
+
+# Files to edit:
+@internal/authoring/content/conversation-recording.md
+@internal/authoring/content/stage-approve.md
+
+# Enforcement source of truth (read to confirm the required behavior; do NOT edit):
+@internal/server/authoring_handler.go
+@internal/mcp/tools_authoring.go
+@cmd/specgraph/conversation.go
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Correct conversation-recording.md — approve requires exchanges on accept AND reject; drop the dangling MCP standalone-record reference</name>
+  <files>internal/authoring/content/conversation-recording.md</files>
+  <action>
+Rewrite the "## Approve Special Case" section so it teaches the CONV-01
+enforced behavior: conversation exchanges are REQUIRED on approve for BOTH the
+accept disposition and the reject disposition (hold/decline), rather than only
+when the disposition is a hold or decline. On a clean acceptance, exchanges
+capture the approval rationale and
+commit atomically with the approve call — the server and the MCP client both
+enforce at least one exchange and reject an empty payload. Mirror the wording
+and stance of SKILL.md lines 176-179 (approve REQUIRES exchanges on a clean
+acceptance, recorded inline with the approve call, enforced server-side; approve
+still does not require an `output`). Remove the current claim that recording
+happens only when the outcome is negative and that a clean approval is
+self-explanatory / skips recording.
+
+In the "## Persisting Exchanges" blockquote, remove the final sentence that
+describes a separate conversation-recording tool being reserved for post-hoc
+amendments to prior recordings. That MCP action no longer exists —
+tools_authoring.go's conversation tool now supports only the `list` action
+(the `record` case was deleted in Phase 8).
+Either delete the sentence entirely, or, if a pointer to the amendment
+capability is worth keeping, replace it with one that makes explicit the
+capability is CLI-only via `specgraph conversation record <slug>` (see
+cmd/specgraph/conversation.go) and is NOT an MCP tool action. Do not imply any
+MCP `record` action exists.
+
+Verify the remaining line in "## Persisting Exchanges" that lists the stages at
+which exchanges persist atomically ("Shape, Specify, Decompose, and Approve")
+is still accurate and leave it as-is if so (it is correct — those four persist
+exchanges atomically with stage output).
+
+Keep the "## Amend Semantics" section and the JSON exchange-format example
+unchanged. Do not introduce any camelCase field names in fenced examples.
+  </action>
+  <verify>
+    <automated>test $(grep -ci 'only on rejection' internal/authoring/content/conversation-recording.md) -eq 0 && test $(grep -ci 'self-evident' internal/authoring/content/conversation-recording.md) -eq 0 && test $(grep -c 'standalone conversation-record tool' internal/authoring/content/conversation-recording.md) -eq 0 && grep -qi 'accept' internal/authoring/content/conversation-recording.md && grep -qi 'REQUIRED' internal/authoring/content/conversation-recording.md && go build ./...</automated>
+  </verify>
+  <done>
+The "Approve Special Case" section states exchanges are REQUIRED on both accept
+and reject dispositions; the prior restrictive / self-explanatory framing is
+gone. No reference to a separate conversation-recording MCP tool action remains;
+any amendment pointer is clearly CLI-only. `go build ./...` succeeds (go:embed
+content still compiles).
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Correct stage-approve.md — Accept path states exchanges are REQUIRED, matching the Reject path</name>
+  <files>internal/authoring/content/stage-approve.md</files>
+  <action>
+Rewrite the "### Accept path" subsection under "## Persistence Contract" so it
+explicitly states that conversation exchanges capturing the approval rationale
+and the checklist discussion are REQUIRED on the accept path — not optional,
+not merely implied by omission. They commit atomically with the accept
+disposition and are load-bearing for audit. Match the strength and phrasing of
+the adjacent "### Reject path" subsection (which already says exchanges are
+REQUIRED, commit atomically, and must not be omitted) and SKILL.md lines
+176-179. Keep the existing accept-path behavior text (present the final approval
+summary, wait for explicit human sign-off, record provenance: who reviewed,
+agent-facilitated, overrides) — add the required-exchanges statement into that
+flow.
+
+Do not weaken or change the "### Reject path" subsection; it is already correct.
+Do not change the human-review-gate, self-approval-prohibition, or checklist
+sections.
+  </action>
+  <verify>
+    <automated>test $(grep -c 'REQUIRED' internal/authoring/content/stage-approve.md) -ge 2 && awk '/### Accept path/{f=1} /### Reject path/{f=0} f' internal/authoring/content/stage-approve.md | grep -qi 'exchange' && awk '/### Accept path/{f=1} /### Reject path/{f=0} f' internal/authoring/content/stage-approve.md | grep -q 'REQUIRED' && go build ./...</automated>
+  </verify>
+  <done>
+The "Accept path" subsection contains explicit REQUIRED-exchanges language
+(the file now has REQUIRED in both the Accept and Reject path subsections). The
+Reject path subsection is unchanged. `go build ./...` succeeds.
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| (none new) | Documentation-only change to embedded prose. No executable behavior, no input parsing, no network/DB surface, no dependency installs. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-260717i4b-01 | Tampering (guidance) | Composed approve-stage MCP content | low | mitigate | Aligning served guidance to enforced CONV-01 behavior removes a correctness gap where agents were mis-taught; verified via grep gates + `go build`. No package installs, so no supply-chain threat applies. |
+</threat_model>
+
+<verification>
+Run the authoring content test suite to confirm the `//go:embed` files still
+load, are non-empty, and no fenced example drifts to camelCase:
+
+```
+go test ./internal/authoring/...
+```
+
+Expected: `TestEmbeddedContent_Present` and `TestContentPersistenceContractSnakeCase`
+pass. Both edited files remain present and embeddable. (No existing test
+snapshots the specific approve-stage wording, so grep gates in each task are the
+primary consistency check against SKILL.md.)
+
+Then confirm the whole tree still builds:
+
+```
+go build ./...
+```
+</verification>
+
+<success_criteria>
+- conversation-recording.md "Approve Special Case" teaches exchanges REQUIRED on both accept and reject dispositions.
+- No MCP standalone conversation-record tool action is referenced anywhere in conversation-recording.md; any amendment pointer is CLI-only.
+- stage-approve.md "Accept path" states exchanges are REQUIRED, matching the Reject path and SKILL.md.
+- `go build ./...` and `go test ./internal/authoring/...` pass.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260717-i4b-fix-approve-stage-teaching-content-drift/260717-i4b-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260717-i4b-fix-approve-stage-teaching-content-drift/260717-i4b-PLAN.md
+++ b/.planning/quick/260717-i4b-fix-approve-stage-teaching-content-drift/260717-i4b-PLAN.md
@@ -35,8 +35,11 @@ agent following only the served guidance will attempt a zero-exchange approve
 and get an immediate rejection.
 
 This is a documentation-only fix to two `//go:embed`'d prose files under
-internal/authoring/content/. No Go, proto, or test changes. The canonical
-correct wording already exists in
+internal/authoring/content/. No Go, proto, or test *source* changes — the
+`internal/authoring/testdata/golden/*.md` fixture snapshots are expected to be
+regenerated as a mechanical consequence, since `TestComposeGolden` snapshots
+the exact composed prose these edits change (see the note in `<verification>`
+below). The canonical correct wording already exists in
 internal/mcp/skills/embedded/specgraph-authoring/SKILL.md (lines 176-179) —
 align the two content files to it.
 
@@ -172,15 +175,24 @@ go test ./internal/authoring/...
 ```
 
 Expected: `TestEmbeddedContent_Present` and `TestContentPersistenceContractSnakeCase`
-pass. Both edited files remain present and embeddable. (No existing test
-snapshots the specific approve-stage wording, so grep gates in each task are the
-primary consistency check against SKILL.md.)
+pass. Both edited files remain present and embeddable. `TestComposeGolden`
+snapshots the fully-composed per-stage prose in
+`internal/authoring/testdata/golden/*.md` — since these two content files are
+composed into every stage (conversation-recording.md) or the approve stage
+(stage-approve.md), that test will fail against the stale fixtures until they
+are regenerated with `-update`. The grep gates in each task remain the primary
+targeted consistency check against SKILL.md's wording; the golden snapshot is
+the broader regression backstop.
 
 Then confirm the whole tree still builds:
 
 ```
 go build ./...
 ```
+
+Finally, this repo's mandatory pre-push gate (`task check` — fmt:check →
+license:check → lint → build → unit tests) MUST be run and pass before this
+branch is pushed, per project CLAUDE.md.
 </verification>
 
 <success_criteria>

--- a/.planning/quick/260717-i4b-fix-approve-stage-teaching-content-drift/260717-i4b-SUMMARY.md
+++ b/.planning/quick/260717-i4b-fix-approve-stage-teaching-content-drift/260717-i4b-SUMMARY.md
@@ -1,0 +1,143 @@
+---
+phase: 260717-i4b
+plan: 01
+subsystem: authoring
+tags: [mcp, embedded-content, conversation-recording, approve-stage]
+
+# Dependency graph
+requires:
+  - phase: 08 (Authoring Lifecycle Semantics — CONV-01)
+    provides: Server/client enforcement making conversation exchanges REQUIRED on approve for both accept and reject dispositions (ValidateExchanges, handleApprove hard-reject)
+provides:
+  - Corrected `conversation-recording.md` Approve Special Case section teaching exchanges REQUIRED on both accept and reject
+  - Removed dangling reference to a standalone MCP conversation-record tool action (deleted in Phase 8); amendment described as CLI-only
+  - Corrected `stage-approve.md` Accept path subsection stating exchanges are REQUIRED, matching the Reject path and SKILL.md
+  - Regenerated golden fixtures (`testdata/golden/*.md`) to match corrected composed content
+affects: [authoring, mcp-composer, approve-stage-teaching]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: []
+
+key-files:
+  created: []
+  modified:
+    - internal/authoring/content/conversation-recording.md
+    - internal/authoring/content/stage-approve.md
+    - internal/authoring/testdata/golden/spark.md
+    - internal/authoring/testdata/golden/shape.md
+    - internal/authoring/testdata/golden/specify.md
+    - internal/authoring/testdata/golden/decompose.md
+    - internal/authoring/testdata/golden/approve.md
+
+key-decisions:
+  - "Mirrored SKILL.md lines 176-179 wording exactly rather than inventing new phrasing, per plan instruction to align to the already-correct reference"
+  - "Post-hoc amendment of a prior recording described as CLI-only (`specgraph conversation record <slug>`) rather than deleted outright, since the capability genuinely exists via CLI"
+
+patterns-established: []
+
+requirements-completed: [CONV-01]
+
+coverage:
+  - id: D1
+    description: "conversation-recording.md Approve Special Case teaches exchanges REQUIRED on both accept and reject dispositions; no dangling MCP standalone conversation-record tool reference remains"
+    requirement: "CONV-01"
+    verification:
+      - kind: unit
+        ref: "grep gates (no 'only on rejection', no 'self-evident', no 'standalone conversation-record tool'; presence of 'accept' and 'REQUIRED') + go build ./..."
+        status: pass
+      - kind: unit
+        ref: "go test ./internal/authoring/... (TestComposeGolden, TestEmbeddedContent_Present, TestContentPersistenceContractSnakeCase)"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "stage-approve.md Accept path subsection explicitly states exchanges are REQUIRED, matching the Reject path and SKILL.md; Reject path left unchanged"
+    requirement: "CONV-01"
+    verification:
+      - kind: unit
+        ref: "grep gates (>=2 REQUIRED occurrences; Accept-path-scoped awk/grep for 'exchange' and 'REQUIRED') + go build ./..."
+        status: pass
+      - kind: unit
+        ref: "go test ./internal/authoring/... (TestComposeGolden approve subtest)"
+        status: pass
+    human_judgment: false
+
+duration: 15min
+completed: 2026-07-17
+status: complete
+---
+
+# Quick Task 260717-i4b: Fix Approve-Stage Teaching Content Drift Summary
+
+**Aligned two `//go:embed`'d MCP teaching files to CONV-01's enforced behavior — conversation exchanges are now taught as REQUIRED on approve for both accept and reject, matching SKILL.md and the server/client enforcement shipped in Phase 8.**
+
+## Performance
+
+- **Duration:** ~15 min
+- **Completed:** 2026-07-17
+- **Tasks:** 2 completed
+- **Files modified:** 7 (2 content files + 5 golden fixtures)
+
+## Accomplishments
+- `conversation-recording.md`'s "Approve Special Case" section now teaches exchanges REQUIRED on approve for BOTH accept and reject dispositions, replacing the stale "record only on rejection / clean approvals self-evident" framing.
+- Removed the dangling claim that a standalone MCP conversation-record tool action exists; the amendment capability is now correctly described as CLI-only (`specgraph conversation record <slug>`), matching the actual `tools_authoring.go` surface (only `list` action remains — `record` was deleted in Phase 8).
+- `stage-approve.md`'s "Accept path" subsection now explicitly states exchanges capturing the approval rationale are REQUIRED and load-bearing for audit, matching the strength of the adjacent (already-correct) "Reject path" subsection and SKILL.md lines 176-179.
+- Regenerated `TestComposeGolden` fixtures for all five stages (conversation-recording.md is composed into every stage's `author_start_stage` response) to reflect the corrected prose.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Correct conversation-recording.md** - `9552ff62` (fix)
+2. **Task 2: Correct stage-approve.md** - `8fd8151e` (fix)
+
+**Plan metadata:** committed separately by the orchestrator (SUMMARY.md, STATE.md not committed by this executor per constraints)
+
+## Files Created/Modified
+- `internal/authoring/content/conversation-recording.md` - Approve Special Case rewritten (REQUIRED on both dispositions); standalone MCP record-tool reference replaced with CLI-only pointer
+- `internal/authoring/content/stage-approve.md` - Accept path subsection now states exchanges REQUIRED, matching Reject path
+- `internal/authoring/testdata/golden/spark.md` - Regenerated to reflect conversation-recording.md change
+- `internal/authoring/testdata/golden/shape.md` - Regenerated to reflect conversation-recording.md change
+- `internal/authoring/testdata/golden/specify.md` - Regenerated to reflect conversation-recording.md change
+- `internal/authoring/testdata/golden/decompose.md` - Regenerated to reflect conversation-recording.md change
+- `internal/authoring/testdata/golden/approve.md` - Regenerated twice (once per task) to reflect both content changes
+
+## Decisions Made
+- Mirrored SKILL.md's existing correct wording rather than composing fresh phrasing, per the plan's explicit instruction to treat SKILL.md lines 176-179 as the reference source of truth.
+- Kept the amendment-capability pointer in `conversation-recording.md` rather than deleting it outright, since `specgraph conversation record <slug>` genuinely exists as a CLI-only path (verified against `cmd/specgraph/conversation.go`).
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Regenerated `TestComposeGolden` fixtures after content edits broke golden-diff assertions**
+- **Found during:** Task 1 verification (running `go test ./internal/authoring/...` per the plan's overall `<verification>` block)
+- **Issue:** `internal/authoring/composer_golden_test.go` snapshots the fully-composed per-stage MCP content into `testdata/golden/*.md`. Editing `conversation-recording.md` (composed into all 5 stages) and `stage-approve.md` (composed into the approve stage) caused `TestComposeGolden` to fail for all 5 stage subtests, since the golden fixtures still held the pre-edit prose. This wasn't explicitly called out in the plan's task-level `<verify>` blocks (which only grep-gate the source `.md` files + `go build`), but the plan's overall `<verification>` block does say to run `go test ./internal/authoring/...` and expects it to pass.
+- **Fix:** Regenerated fixtures via `go test ./internal/authoring/ -run TestComposeGolden -update`, run twice to keep the two tasks' golden-fixture changes atomic and scoped: once after Task 1's edit alone (updating spark/shape/specify/decompose/approve), and again after Task 2's edit (updating only approve.md further, since stage-approve.md is composed only into the approve stage).
+- **Files modified:** `internal/authoring/testdata/golden/{spark,shape,specify,decompose,approve}.md`
+- **Verification:** Diffed each golden file to confirm changes matched only the intended prose edits (no unrelated drift); reran `go test ./internal/authoring/...` and `go build ./...` — both pass.
+- **Committed in:** `9552ff62` (Task 1 commit, 4 golden files + spark/shape/specify/decompose/approve conversation-recording delta) and `8fd8151e` (Task 2 commit, approve.md's additional stage-approve.md delta)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 blocking test-infrastructure fix)
+**Impact on plan:** Necessary to keep `go test ./internal/authoring/...` green as required by the plan's own verification block. No scope creep — golden fixtures are generated test data reflecting the exact same prose changes the plan specified, nothing additional.
+
+## Issues Encountered
+None beyond the golden-fixture regeneration documented above.
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- A fresh MCP-only agent following the composed approve-stage guidance will now be taught to record exchanges on a clean acceptance, matching what the server and MCP client actually enforce (CONV-01).
+- No further follow-up needed; this was a scoped documentation-only fix with no Go/proto/test-suite changes beyond fixture regeneration.
+
+---
+*Quick task: 260717-i4b*
+*Completed: 2026-07-17*
+
+## Self-Check: PASSED
+
+All created/modified files verified present on disk; both task commit hashes (`9552ff62`, `8fd8151e`) verified present in git log.

--- a/.planning/quick/260717-i4b-fix-approve-stage-teaching-content-drift/260717-i4b-SUMMARY.md
+++ b/.planning/quick/260717-i4b-fix-approve-stage-teaching-content-drift/260717-i4b-SUMMARY.md
@@ -48,7 +48,10 @@ coverage:
         ref: "grep gates (no 'only on rejection', no 'self-evident', no 'standalone conversation-record tool'; presence of 'accept' and 'REQUIRED') + go build ./..."
         status: pass
       - kind: unit
-        ref: "go test ./internal/authoring/... (TestComposeGolden, TestEmbeddedContent_Present, TestContentPersistenceContractSnakeCase)"
+        ref: "go test ./internal/authoring/... (TestComposeGolden — snapshots the composed prose these edits change, regenerated via -update; TestEmbeddedContent_Present; TestContentPersistenceContractSnakeCase)"
+        status: pass
+      - kind: unit
+        ref: "task check (fmt:check, license:check, lint, build, unit tests) — run on the PR branch after CodeRabbit review"
         status: pass
     human_judgment: false
   - id: D2
@@ -59,7 +62,10 @@ coverage:
         ref: "grep gates (>=2 REQUIRED occurrences; Accept-path-scoped awk/grep for 'exchange' and 'REQUIRED') + go build ./..."
         status: pass
       - kind: unit
-        ref: "go test ./internal/authoring/... (TestComposeGolden approve subtest)"
+        ref: "go test ./internal/authoring/... (TestComposeGolden approve subtest — snapshots composed approve-stage prose, regenerated via -update)"
+        status: pass
+      - kind: unit
+        ref: "task check (fmt:check, license:check, lint, build, unit tests) — run on the PR branch after CodeRabbit review"
         status: pass
     human_judgment: false
 
@@ -126,6 +132,18 @@ Each task was committed atomically:
 
 ## Issues Encountered
 None beyond the golden-fixture regeneration documented above.
+
+## Post-Review Follow-up (PR #1011, CodeRabbit)
+
+CodeRabbit flagged 4 items on the PR: two documentation-accuracy issues in this
+PLAN.md/SUMMARY.md (the "no test changes" scope statement and the "no existing
+test snapshots approve wording" claim, both corrected in PLAN.md and above),
+one request to record `task check` (added above and confirmed passing on this
+branch), and one content-correctness item — `conversation-recording.md`'s
+Approve Special Case didn't state that Approve has no `output` payload at all
+(unlike Shape/Specify/Decompose), which the original plan's task action had
+specified but the executed edit omitted. Fixed in commit `0611d9b7`, with
+golden fixtures regenerated again.
 
 ## User Setup Required
 None - no external service configuration required.

--- a/.planning/v0.14.0-MILESTONE-AUDIT.md
+++ b/.planning/v0.14.0-MILESTONE-AUDIT.md
@@ -1,0 +1,129 @@
+---
+milestone: v0.14.0
+audited: 2026-07-17T15:36:54Z
+status: gaps_found
+scores:
+  requirements: 4/5
+  phases: 4/4
+  integration: 3/5
+  flows: 4/5
+gaps:
+  requirements:
+    - id: "MCP-01"
+      status: "partial"
+      phase: "6"
+      claimed_by_plans: ["06-01", "06-02", "06-03", "06-04", "06-05"]
+      completed_by_plans: ["06-01", "06-02", "06-03", "06-04", "06-05"]
+      verification_status: "passed"
+      evidence: "Phase 6's own VERIFICATION.md passed (code + skills correctly MCP-first). But internal/authoring/composer.go composes conversation-recording.md + stage-approve.md into the author_start_stage/prime teaching surface Phase 6 delivers for MCP-01, and Phase 8 (later) made those two files factually wrong without updating them. A pure MCP-only agent following only that composed guidance will attempt a clean approve with no exchanges and get an immediate CodeInvalidArgument — an avoidable, milestone-introduced failure of the exact self-teaching path this requirement promises."
+    - id: "CONV-01"
+      status: "partial"
+      phase: "8"
+      claimed_by_plans: ["08-01", "08-02", "08-03", "08-04"]
+      completed_by_plans: ["08-01", "08-02", "08-03", "08-04"]
+      verification_status: "passed"
+      evidence: "Server (authoring_handler.go Approve ACCEPT branch) and MCP handler (tools_authoring.go handleApprove) both correctly enforce non-empty exchanges on approve/accept — this part is real and test-proven. But internal/authoring/content/conversation-recording.md ('Approve Special Case') and stage-approve.md ('Accept path') still teach that clean approvals require no conversation record, directly contradicting the enforcement and undermining 'enforced by protocol rather than left to agent discretion' — the docs themselves hand back the discretion the requirement is supposed to remove."
+  integration:
+    - from: "internal/authoring/composer.go (Phase 6 teaching surface)"
+      to: "internal/server/authoring_handler.go Approve ACCEPT (Phase 8 enforcement)"
+      issue: "conversation-recording.md and stage-approve.md were not updated when Phase 8 made approve-accept exchanges required; SKILL.md (also Phase 6-owned) was correctly updated, so the two MCP-served teaching surfaces now disagree with each other and with the server."
+    - from: "internal/mcp/tools_authoring.go conversationTool (Phase 8 — record action removed)"
+      to: "internal/authoring/content/conversation-recording.md"
+      issue: "Content still references 'the standalone conversation-record tool ... reserved for post-hoc amendments' and an amend:true tool argument; no MCP tool surface exposes a record/amend action anymore (only CLI cmd/specgraph/conversation.go does). Dangling/ambiguous guidance served to MCP-only agents."
+  flows:
+    - flow: "MCP-only agent completes spark→shape→specify→decompose→approve using only specgraph://prime + author_start_stage guidance (no external knowledge)"
+      breaks_at: "approve (clean accept)"
+      detail: "Guidance says exchanges are optional on clean approval; actual call with no exchanges is hard-rejected client-side and server-side. Not a hard dead-end (the error message names the fix and a capable agent recovers by retrying with exchanges), but it is a documented, milestone-introduced contradiction on the exact flow MCP-01/CONV-01 exist to guarantee."
+tech_debt:
+  - phase: 09-jit-display-name-reconciliation
+    items:
+      - "WR-01/WR-02 (09-REVIEW.md): reconciliation write and applyLoginSync write are two independent non-transactional UpdateUserOnLogin calls in one login flow. Narrow TOCTOU on soft-delete handling (WR-01) and a denied-login-can-still-persist-display-name edge case (WR-02). Both scoped outside this phase's 4 stated success criteria; carried forward as backlog, not blocking."
+nyquist:
+  compliant_phases: 4
+  partial_phases: 0
+  not_validated_phases: 0
+  missing_phases: 0
+  overall: "compliant (4/4 phases nyquist_compliant: true; Phase 6/9 wave_0_complete false but their Docker-gated items are tracked and closed via UAT — see 06-VERIFICATION.md 'Human Verification Completed' and 09-VERIFICATION.md live-Postgres reruns)"
+---
+
+# Milestone v0.14.0 "Authoring Surface Correctness" — Audit Report
+
+**Audited:** 2026-07-17
+**Scope:** Phases 6-9 (06-mcp-authoring-self-teaching-path, 07-authoring-lifecycle-semantics, 08-authoring-conversation-fidelity, 09-jit-display-name-reconciliation)
+**Status:** ⚠ gaps_found
+
+## Phase Verification Summary
+
+| Phase | Goal | Verification Status | Human Verification |
+|-------|------|---------------------|---------------------|
+| 6 — MCP Authoring Self-Teaching Path | MCP-only agent authors constitution to completion via prime + skills only | passed (initially `human_needed`; Docker e2e run live 2026-07-14, 4/4 + 205/205 full suite, promoted to passed) | Complete |
+| 7 — Authoring Lifecycle Semantics | amend/supersede match natural lifecycle; re-entry lands one stage before target | passed (7/7 truths, all behavioral tests run first-hand under Docker) | None needed |
+| 8 — Authoring Conversation Fidelity | Every authoring stage records its conversation, enforced by protocol | passed (initially `human_needed`; 08-UAT.md closed both Docker-gated tests 2026-07-15, storage integration + MCP-only e2e both pass) | Complete |
+| 9 — JIT Display Name Reconciliation | display_name reconciled on every login, replacing stale subject-hash fallback | passed (4/4 truths, live Postgres integration reruns in-session) | None needed |
+
+All 4 phases individually verified passed. **The gaps below are cross-phase drift that no single phase's isolated verification could catch** — exactly what this milestone audit exists to find.
+
+## Requirements Coverage (3-Source Cross-Reference)
+
+| Requirement | Issue | Phase | REQUIREMENTS.md | SUMMARY frontmatter | VERIFICATION.md | Integration check | Final Status |
+|-------------|-------|-------|------------------|----------------------|-------------------|--------------------|---------------|
+| MCP-01 | #1002 | 6 | [x] | ✓ (06-01..05) | ✓ SATISFIED | ⚠ PARTIAL (stale composed content) | **partial** |
+| LIFE-01 | #900 | 7 | [x] | ✓ (07-01,02,03,04,05) | ✓ SATISFIED | ✓ WIRED | **satisfied** |
+| LIFE-02 | #899 | 7 | [x] | ✓ (07-02,03,05) | ✓ SATISFIED | ✓ WIRED | **satisfied** |
+| CONV-01 | #906 | 8 | [x] | ✓ (08-01..04) | ✓ SATISFIED | ⚠ AT RISK (stale composed content) | **partial** |
+| AUTH-06 | #994 | 9 | [x] | ✓ (09-01,02) | ✓ SATISFIED | ✓ WIRED (isolated) | **satisfied** |
+
+**Score:** 3/5 cleanly satisfied, 2/5 partial (same root cause). No orphaned requirements — all 5 traced through all 3 sources.
+
+> Note: REQUIREMENTS.md traceability table's status column still reads "Pending" for all 5 rows — stale relative to the checked-off `[x]` boxes above it. Should be updated to reflect actual status during archival.
+
+## Cross-Phase Integration Findings
+
+### BLOCKER — Composed teaching content drifted from Phase 8's approve-accept contract
+
+`internal/authoring/composer.go` builds every stage prompt — including `approve` — from a fixed file list (`persona.md`, `orchestration.md`, `conversation-recording.md`, `quality-heuristics.md`, `stage-<stage>.md`). This exact composition is what Phase 6 ships as the MCP-only self-teaching surface (`author_start_stage` / `specgraph://prime`).
+
+- `internal/authoring/content/conversation-recording.md` ("Approve Special Case", ~L52-54): *"Record conversation only on rejection... Clean approvals... do not require a separate conversation record."*
+- `internal/authoring/content/stage-approve.md` ("Accept path", ~L85-93): describes persisting an accept with no mention of exchanges, while the adjacent "Reject path" explicitly marks exchanges REQUIRED — teaching by omission that accept doesn't need them.
+
+Both are now factually wrong: Phase 8 made `internal/server/authoring_handler.go` (`Approve` ACCEPT branch, `ValidateExchanges`) and `internal/mcp/tools_authoring.go` (`handleApprove`) hard-reject empty exchanges on **both** accept and reject. `internal/mcp/skills/embedded/specgraph-authoring/SKILL.md` *was* correctly updated to say approve requires exchanges on clean acceptance — so the two MCP-served teaching surfaces (skill vs. composed stage prompt) now contradict each other and the server.
+
+Confirmed by the integration checker reading current source directly (not just VERIFICATION.md claims), and independently re-confirmed here by reading `composer.go` L156-171, `conversation-recording.md`, `stage-approve.md`, `tools_authoring.go` L349-359, and `authoring_handler.go` L470-480.
+
+**Practical impact:** A fresh MCP-only agent (exactly the MCP-01 scenario) following only the served guidance will attempt a clean approve with zero exchanges, hit `CodeInvalidArgument` / "exchanges is required for approve" on its first try. Not a hard dead-end (the error names the fix; a capable agent retries and succeeds), but it's an avoidable, milestone-introduced contradiction on the two requirements (MCP-01, CONV-01) this exact milestone added.
+
+### WARNING — Dangling reference to removed MCP `conversation record` action
+
+`conversation-recording.md` still references "the standalone conversation-record tool ... reserved for post-hoc amendments" and an `amend: true` tool argument. Phase 8 deleted the MCP `conversation` tool's `record` action (`tools_authoring.go` — `list` only now); only the CLI (`cmd/specgraph/conversation.go`) retains a post-hoc record path. This is CLI-only guidance leaking into MCP-facing content, contrary to MCP-01's "no out-of-band CLI knowledge" intent.
+
+### Verified clean (no gaps)
+
+- Phase 7 ↔ Phase 8 in `tools_authoring.go`: no conflict — `handleAmend`/`handleSupersede` never touch the `exchanges` param; orthogonal to `handleApprove`'s stricter check.
+- No dangling references to the retired `Authoring.Amend`/`Authoring.Supersede` RPCs anywhere in production code (only in historical `docs/plans/` and phase artifacts, which is expected).
+- Full E2E flow spark→shape→specify→decompose→approve→amend→re-author→supersede verified working in `e2e/api/mcp_only_lifecycle_test.go` (walkToApproved → amend re-entry → re-author → supersede; negative cases correctly rejected).
+- Phase 9 (identity/auth) is genuinely isolated — no shared code paths with Phases 6-8's authoring surface.
+
+## Nyquist Coverage
+
+| Phase | VALIDATION.md | nyquist_compliant | Notes |
+|-------|----------------|--------------------|-------|
+| 6 | exists (`status: locked`) | true | Docker-gated e2e items closed via 06-VERIFICATION.md "Human Verification Completed" (live run, 2026-07-14) |
+| 7 | exists (`status: verified`) | true | wave_0_complete: true |
+| 8 | exists (`status: verified`) | true | wave_0_complete: true; remaining Docker items closed via 08-UAT.md |
+| 9 | exists (`status: approved`) | true | Docker-gated integration test reran live in-session during verification |
+
+No missing VALIDATION.md files; no phases need `/gsd-validate-phase` re-runs.
+
+## Tech Debt (non-blocking)
+
+- **Phase 9:** 09-REVIEW.md WR-01/WR-02 — non-transactional display-name write vs. login-sync write. Narrow edge cases outside the phase's 4 success criteria. Backlog candidate, not a milestone blocker.
+
+## Gaps Summary
+
+The milestone's code-level work is solid: all 4 phases pass isolated verification, all 5 requirements trace cleanly through REQUIREMENTS.md/SUMMARY/VERIFICATION, the lifecycle and conversation-enforcement mechanisms are real and test-proven, and Phase 9 is correctly isolated. The one substantive gap is a **documentation/teaching-content regression**: Phase 8 changed the approve-accept contract but didn't update the two Phase-6-owned content files (`conversation-recording.md`, `stage-approve.md`) that get composed into the exact MCP-only teaching surface MCP-01 promises. This is a small, well-scoped fix (rewrite two sections in two markdown files to match `SKILL.md`'s already-correct language, plus remove the dangling `record`-action reference) — not a re-architecture.
+
+**Recommended closure:** insert a small closure phase (or a quick task) to fix `conversation-recording.md`'s "Approve Special Case" section and `stage-approve.md`'s "Accept path" section to state exchanges are required on both accept and reject, and to remove/clarify the dangling standalone-record-tool reference — then re-verify the `author_start_stage`-composed approve prompt matches actual server behavior.
+
+---
+_Audited: 2026-07-17T15:36:54Z_
+_Auditor: the agent (gsd-audit-milestone), with gsd-integration-checker (subagent) cross-phase pass_

--- a/internal/authoring/content/conversation-recording.md
+++ b/internal/authoring/content/conversation-recording.md
@@ -59,3 +59,7 @@ and reject an empty payload. For approve-stage rejections, pass the
 rejection-reason exchanges alongside the rejection on the same persistence
 call — the coupling is atomic, same as the other stages. In both cases, set
 `stage` to `approve` on the exchange entries.
+
+Approve is otherwise unlike Shape, Specify, and Decompose: it does not accept
+or require a stage `output` payload. Exchanges are the only required input
+beyond the disposition itself.

--- a/internal/authoring/content/conversation-recording.md
+++ b/internal/authoring/content/conversation-recording.md
@@ -40,8 +40,8 @@ As the agent conducts elicitation, track each probe/response pair with an increm
 > Shape, Specify, Decompose, and Approve transitions — pass the accumulated
 > exchange list as part of the same persistence call that saves the stage
 > output. No separate conversation-recording call is needed after a stage
-> transition. The standalone conversation-record tool is reserved for
-> post-hoc amendments to prior recordings.
+> transition. Post-hoc amendment of a prior recording is a CLI-only capability
+> (`specgraph conversation record <slug>`) — there is no MCP tool action for it.
 
 Pass the complete list of exchange objects alongside the stage output on the same persistence call. The stage output and the conversation log are committed together — either both succeed or neither does.
 
@@ -51,4 +51,11 @@ Omit the amend flag on first-pass recordings. Set `amend: true` (or the equivale
 
 ## Approve Special Case
 
-Record conversation only on rejection (hold or decline). The approval flow's discussion carries decision-trail value when the outcome is negative. Clean approvals are self-evident from the approval call itself and do not require a separate conversation record. For approve-stage rejections, pass the rejection-reason exchanges alongside the rejection on the same persistence call — the coupling is atomic, same as the other stages.
+Conversation exchanges are REQUIRED on approve for BOTH dispositions — a clean
+acceptance and a rejection (hold or decline). On a clean acceptance, the
+exchanges capture the approval rationale and commit atomically with the
+approve call; the server and the MCP client both enforce at least one exchange
+and reject an empty payload. For approve-stage rejections, pass the
+rejection-reason exchanges alongside the rejection on the same persistence
+call — the coupling is atomic, same as the other stages. In both cases, set
+`stage` to `approve` on the exchange entries.

--- a/internal/authoring/content/stage-approve.md
+++ b/internal/authoring/content/stage-approve.md
@@ -89,8 +89,11 @@ confirmed each one, present the final approval summary and ask: "All checkpoints
 reviewed. When you're ready, confirm approval and I'll record it."
 
 When the human confirms, persist the approval with the accept disposition.
-Record provenance: who reviewed, that the review was agent-facilitated, and
-any overrides noted.
+Exchanges capturing the approval rationale and the checklist discussion are
+REQUIRED on the accept path — they commit atomically with the accept
+disposition and are load-bearing for audit. Do NOT omit exchanges on a clean
+acceptance. Record provenance: who reviewed, that the review was
+agent-facilitated, and any overrides noted.
 
 ### Reject path
 

--- a/internal/authoring/testdata/golden/approve.md
+++ b/internal/authoring/testdata/golden/approve.md
@@ -223,6 +223,10 @@ rejection-reason exchanges alongside the rejection on the same persistence
 call — the coupling is atomic, same as the other stages. In both cases, set
 `stage` to `approve` on the exchange entries.
 
+Approve is otherwise unlike Shape, Specify, and Decompose: it does not accept
+or require a stage `output` payload. Exchanges are the only required input
+beyond the disposition itself.
+
 
 # Quality Heuristics
 

--- a/internal/authoring/testdata/golden/approve.md
+++ b/internal/authoring/testdata/golden/approve.md
@@ -387,8 +387,11 @@ confirmed each one, present the final approval summary and ask: "All checkpoints
 reviewed. When you're ready, confirm approval and I'll record it."
 
 When the human confirms, persist the approval with the accept disposition.
-Record provenance: who reviewed, that the review was agent-facilitated, and
-any overrides noted.
+Exchanges capturing the approval rationale and the checklist discussion are
+REQUIRED on the accept path — they commit atomically with the accept
+disposition and are load-bearing for audit. Do NOT omit exchanges on a clean
+acceptance. Record provenance: who reviewed, that the review was
+agent-facilitated, and any overrides noted.
 
 ### Reject path
 

--- a/internal/authoring/testdata/golden/approve.md
+++ b/internal/authoring/testdata/golden/approve.md
@@ -203,8 +203,8 @@ As the agent conducts elicitation, track each probe/response pair with an increm
 > Shape, Specify, Decompose, and Approve transitions — pass the accumulated
 > exchange list as part of the same persistence call that saves the stage
 > output. No separate conversation-recording call is needed after a stage
-> transition. The standalone conversation-record tool is reserved for
-> post-hoc amendments to prior recordings.
+> transition. Post-hoc amendment of a prior recording is a CLI-only capability
+> (`specgraph conversation record <slug>`) — there is no MCP tool action for it.
 
 Pass the complete list of exchange objects alongside the stage output on the same persistence call. The stage output and the conversation log are committed together — either both succeed or neither does.
 
@@ -214,7 +214,14 @@ Omit the amend flag on first-pass recordings. Set `amend: true` (or the equivale
 
 ## Approve Special Case
 
-Record conversation only on rejection (hold or decline). The approval flow's discussion carries decision-trail value when the outcome is negative. Clean approvals are self-evident from the approval call itself and do not require a separate conversation record. For approve-stage rejections, pass the rejection-reason exchanges alongside the rejection on the same persistence call — the coupling is atomic, same as the other stages.
+Conversation exchanges are REQUIRED on approve for BOTH dispositions — a clean
+acceptance and a rejection (hold or decline). On a clean acceptance, the
+exchanges capture the approval rationale and commit atomically with the
+approve call; the server and the MCP client both enforce at least one exchange
+and reject an empty payload. For approve-stage rejections, pass the
+rejection-reason exchanges alongside the rejection on the same persistence
+call — the coupling is atomic, same as the other stages. In both cases, set
+`stage` to `approve` on the exchange entries.
 
 
 # Quality Heuristics

--- a/internal/authoring/testdata/golden/decompose.md
+++ b/internal/authoring/testdata/golden/decompose.md
@@ -223,6 +223,10 @@ rejection-reason exchanges alongside the rejection on the same persistence
 call — the coupling is atomic, same as the other stages. In both cases, set
 `stage` to `approve` on the exchange entries.
 
+Approve is otherwise unlike Shape, Specify, and Decompose: it does not accept
+or require a stage `output` payload. Exchanges are the only required input
+beyond the disposition itself.
+
 
 # Quality Heuristics
 

--- a/internal/authoring/testdata/golden/decompose.md
+++ b/internal/authoring/testdata/golden/decompose.md
@@ -203,8 +203,8 @@ As the agent conducts elicitation, track each probe/response pair with an increm
 > Shape, Specify, Decompose, and Approve transitions — pass the accumulated
 > exchange list as part of the same persistence call that saves the stage
 > output. No separate conversation-recording call is needed after a stage
-> transition. The standalone conversation-record tool is reserved for
-> post-hoc amendments to prior recordings.
+> transition. Post-hoc amendment of a prior recording is a CLI-only capability
+> (`specgraph conversation record <slug>`) — there is no MCP tool action for it.
 
 Pass the complete list of exchange objects alongside the stage output on the same persistence call. The stage output and the conversation log are committed together — either both succeed or neither does.
 
@@ -214,7 +214,14 @@ Omit the amend flag on first-pass recordings. Set `amend: true` (or the equivale
 
 ## Approve Special Case
 
-Record conversation only on rejection (hold or decline). The approval flow's discussion carries decision-trail value when the outcome is negative. Clean approvals are self-evident from the approval call itself and do not require a separate conversation record. For approve-stage rejections, pass the rejection-reason exchanges alongside the rejection on the same persistence call — the coupling is atomic, same as the other stages.
+Conversation exchanges are REQUIRED on approve for BOTH dispositions — a clean
+acceptance and a rejection (hold or decline). On a clean acceptance, the
+exchanges capture the approval rationale and commit atomically with the
+approve call; the server and the MCP client both enforce at least one exchange
+and reject an empty payload. For approve-stage rejections, pass the
+rejection-reason exchanges alongside the rejection on the same persistence
+call — the coupling is atomic, same as the other stages. In both cases, set
+`stage` to `approve` on the exchange entries.
 
 
 # Quality Heuristics

--- a/internal/authoring/testdata/golden/shape.md
+++ b/internal/authoring/testdata/golden/shape.md
@@ -223,6 +223,10 @@ rejection-reason exchanges alongside the rejection on the same persistence
 call — the coupling is atomic, same as the other stages. In both cases, set
 `stage` to `approve` on the exchange entries.
 
+Approve is otherwise unlike Shape, Specify, and Decompose: it does not accept
+or require a stage `output` payload. Exchanges are the only required input
+beyond the disposition itself.
+
 
 # Quality Heuristics
 

--- a/internal/authoring/testdata/golden/shape.md
+++ b/internal/authoring/testdata/golden/shape.md
@@ -203,8 +203,8 @@ As the agent conducts elicitation, track each probe/response pair with an increm
 > Shape, Specify, Decompose, and Approve transitions — pass the accumulated
 > exchange list as part of the same persistence call that saves the stage
 > output. No separate conversation-recording call is needed after a stage
-> transition. The standalone conversation-record tool is reserved for
-> post-hoc amendments to prior recordings.
+> transition. Post-hoc amendment of a prior recording is a CLI-only capability
+> (`specgraph conversation record <slug>`) — there is no MCP tool action for it.
 
 Pass the complete list of exchange objects alongside the stage output on the same persistence call. The stage output and the conversation log are committed together — either both succeed or neither does.
 
@@ -214,7 +214,14 @@ Omit the amend flag on first-pass recordings. Set `amend: true` (or the equivale
 
 ## Approve Special Case
 
-Record conversation only on rejection (hold or decline). The approval flow's discussion carries decision-trail value when the outcome is negative. Clean approvals are self-evident from the approval call itself and do not require a separate conversation record. For approve-stage rejections, pass the rejection-reason exchanges alongside the rejection on the same persistence call — the coupling is atomic, same as the other stages.
+Conversation exchanges are REQUIRED on approve for BOTH dispositions — a clean
+acceptance and a rejection (hold or decline). On a clean acceptance, the
+exchanges capture the approval rationale and commit atomically with the
+approve call; the server and the MCP client both enforce at least one exchange
+and reject an empty payload. For approve-stage rejections, pass the
+rejection-reason exchanges alongside the rejection on the same persistence
+call — the coupling is atomic, same as the other stages. In both cases, set
+`stage` to `approve` on the exchange entries.
 
 
 # Quality Heuristics

--- a/internal/authoring/testdata/golden/spark.md
+++ b/internal/authoring/testdata/golden/spark.md
@@ -223,6 +223,10 @@ rejection-reason exchanges alongside the rejection on the same persistence
 call — the coupling is atomic, same as the other stages. In both cases, set
 `stage` to `approve` on the exchange entries.
 
+Approve is otherwise unlike Shape, Specify, and Decompose: it does not accept
+or require a stage `output` payload. Exchanges are the only required input
+beyond the disposition itself.
+
 
 # Quality Heuristics
 

--- a/internal/authoring/testdata/golden/spark.md
+++ b/internal/authoring/testdata/golden/spark.md
@@ -203,8 +203,8 @@ As the agent conducts elicitation, track each probe/response pair with an increm
 > Shape, Specify, Decompose, and Approve transitions — pass the accumulated
 > exchange list as part of the same persistence call that saves the stage
 > output. No separate conversation-recording call is needed after a stage
-> transition. The standalone conversation-record tool is reserved for
-> post-hoc amendments to prior recordings.
+> transition. Post-hoc amendment of a prior recording is a CLI-only capability
+> (`specgraph conversation record <slug>`) — there is no MCP tool action for it.
 
 Pass the complete list of exchange objects alongside the stage output on the same persistence call. The stage output and the conversation log are committed together — either both succeed or neither does.
 
@@ -214,7 +214,14 @@ Omit the amend flag on first-pass recordings. Set `amend: true` (or the equivale
 
 ## Approve Special Case
 
-Record conversation only on rejection (hold or decline). The approval flow's discussion carries decision-trail value when the outcome is negative. Clean approvals are self-evident from the approval call itself and do not require a separate conversation record. For approve-stage rejections, pass the rejection-reason exchanges alongside the rejection on the same persistence call — the coupling is atomic, same as the other stages.
+Conversation exchanges are REQUIRED on approve for BOTH dispositions — a clean
+acceptance and a rejection (hold or decline). On a clean acceptance, the
+exchanges capture the approval rationale and commit atomically with the
+approve call; the server and the MCP client both enforce at least one exchange
+and reject an empty payload. For approve-stage rejections, pass the
+rejection-reason exchanges alongside the rejection on the same persistence
+call — the coupling is atomic, same as the other stages. In both cases, set
+`stage` to `approve` on the exchange entries.
 
 
 # Quality Heuristics

--- a/internal/authoring/testdata/golden/specify.md
+++ b/internal/authoring/testdata/golden/specify.md
@@ -223,6 +223,10 @@ rejection-reason exchanges alongside the rejection on the same persistence
 call — the coupling is atomic, same as the other stages. In both cases, set
 `stage` to `approve` on the exchange entries.
 
+Approve is otherwise unlike Shape, Specify, and Decompose: it does not accept
+or require a stage `output` payload. Exchanges are the only required input
+beyond the disposition itself.
+
 
 # Quality Heuristics
 

--- a/internal/authoring/testdata/golden/specify.md
+++ b/internal/authoring/testdata/golden/specify.md
@@ -203,8 +203,8 @@ As the agent conducts elicitation, track each probe/response pair with an increm
 > Shape, Specify, Decompose, and Approve transitions — pass the accumulated
 > exchange list as part of the same persistence call that saves the stage
 > output. No separate conversation-recording call is needed after a stage
-> transition. The standalone conversation-record tool is reserved for
-> post-hoc amendments to prior recordings.
+> transition. Post-hoc amendment of a prior recording is a CLI-only capability
+> (`specgraph conversation record <slug>`) — there is no MCP tool action for it.
 
 Pass the complete list of exchange objects alongside the stage output on the same persistence call. The stage output and the conversation log are committed together — either both succeed or neither does.
 
@@ -214,7 +214,14 @@ Omit the amend flag on first-pass recordings. Set `amend: true` (or the equivale
 
 ## Approve Special Case
 
-Record conversation only on rejection (hold or decline). The approval flow's discussion carries decision-trail value when the outcome is negative. Clean approvals are self-evident from the approval call itself and do not require a separate conversation record. For approve-stage rejections, pass the rejection-reason exchanges alongside the rejection on the same persistence call — the coupling is atomic, same as the other stages.
+Conversation exchanges are REQUIRED on approve for BOTH dispositions — a clean
+acceptance and a rejection (hold or decline). On a clean acceptance, the
+exchanges capture the approval rationale and commit atomically with the
+approve call; the server and the MCP client both enforce at least one exchange
+and reject an empty payload. For approve-stage rejections, pass the
+rejection-reason exchanges alongside the rejection on the same persistence
+call — the coupling is atomic, same as the other stages. In both cases, set
+`stage` to `approve` on the exchange entries.
 
 
 # Quality Heuristics


### PR DESCRIPTION
## Summary

- Fixes a cross-phase gap found by the v0.14.0 milestone audit: `internal/authoring/content/conversation-recording.md` and `internal/authoring/content/stage-approve.md` still taught that clean approvals need no conversation exchanges, contradicting Phase 8's enforcement (server `ValidateExchanges` + MCP `handleApprove`, both hard-reject empty exchanges on accept).
- Both content files now correctly state exchanges are REQUIRED on both accept and reject, matching `internal/mcp/skills/embedded/specgraph-authoring/SKILL.md`'s already-correct wording.
- Removes a dangling reference to a standalone MCP `conversation record` tool action that was deleted in Phase 8 (that capability is CLI-only now).
- Regenerates `internal/authoring/testdata/golden/*.md` snapshot fixtures to match the corrected composed content.
- Adds `.planning/v0.14.0-MILESTONE-AUDIT.md`, the audit report that surfaced this gap.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/authoring/...` (includes `TestComposeGolden`)
- [x] Manually diffed regenerated golden fixtures to confirm only the intended prose changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)