### PR TITLE
fix(release): correct Homebrew cask license to Apache-2.0

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,7 +40,7 @@ homebrew_casks:
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     homepage: https://specgraph.io
     description: Live spec-driven development framework
-    license: MIT
+    license: Apache-2.0
 dockers_v2:
   - ids: [specgraph]
     images:


### PR DESCRIPTION
## What

`.goreleaser.yaml`'s `homebrew_casks:` block declared `license: MIT`, but this project is licensed **Apache-2.0** (see `LICENSE` and the SPDX header on every source file). This corrects the cask metadata to match reality.

```diff
     homepage: https://specgraph.io
     description: Live spec-driven development framework
-    license: MIT
+    license: Apache-2.0
```

## Why

Found while auditing the Homebrew distribution path. The license value is inert in the generated **cask** output today (casks don't render a `license` stanza the way formulae do), but it's factually wrong and would surface incorrectly if the tap ever moved to a `brews:` formula.

## Context (no change needed — already live)

The Homebrew tap itself is fully operational and has been since **v0.11.2**: GoReleaser pushes `Casks/specgraph.rb` to `specgraph/homebrew-tap` on every release, covering macOS + Linux × amd64 + arm64. `brew install specgraph/tap/specgraph` works today.

## Verification

- `goreleaser check` — passes
- `task check` — passes (fmt / lint / build / unit tests)

## Follow-up (separate, not in this PR)

The tap repo still carries a stale root-level `specgraph.rb` **formula** frozen at v0.1.6 (leftover from the pre-v2 `brews:` → `homebrew_casks:` migration). Being cleaned up directly in the tap repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)